### PR TITLE
Relative paths support, increase postgres commands timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
+# 1.4.0
+
+## Features
+- Include field `cwd` for modules `process_facts` and `win_process_facts`.
+- When a relative path is given to plugins `read_remote_file` or `add_file_info`, the process `cwd` will be
+  appended to the path to convert it from a relative path to an absolute path, avoiding potential errors.
+- Increase `postgres` commands timeout from `5` seconds to `10` seconds.
+
 # 1.3.1
 
 ## Fixes
-- Unexpected errors handling for SQL Server and IIS
+- Unexpected errors handling for SQL Server and IIS.
 
 # 1.3.0
 
@@ -12,21 +20,21 @@
 # 1.2.0
 
 ## Features
-- win_hyperv_facts module now shows hard_drives by default
+- win_hyperv_facts module now shows hard_drives by default.
 
 ## Fixes
-- win_process_facts module now uses same field types as process_facts
+- win_process_facts module now uses same field types as process_facts.
 
 # 1.1.1
 
 ## Fixes
-- Fixed a problem with the system identification when running tasks
+- Fixed a problem with the system identification when running tasks.
 
 # 1.1.0
 
 ## Features
-- New win_hyperv_facts module
-- New hyperv_vms role
+- New win_hyperv_facts module.
+- New hyperv_vms role.
 
 # 1.0.2
 

--- a/docs/modules/process_facts.md
+++ b/docs/modules/process_facts.md
@@ -32,6 +32,9 @@ Facts to add to ansible_facts:
   * cmdline (always, str):
         Command line of the process.
 
+  * cwd (always, str):
+        Working directory of the process.
+
 # License
 
 GNU General Public License v3.0 or later

--- a/docs/modules/software_facts.md
+++ b/docs/modules/software_facts.md
@@ -59,6 +59,8 @@ List of processes running in the host. Each element of the list has to have the 
 * cmdline (True, str, None):
       Command line of the process.
 
+* cwd (True, str, None):
+      Working directory of the process.
 
 ### tcp_listen (True, list, None)
 List of tcp ports listening in the host.

--- a/docs/modules/win_process_facts.md
+++ b/docs/modules/win_process_facts.md
@@ -12,13 +12,14 @@ Establishes the format of the date fields gathered when the extended_data option
 Applies to the following fields: creation_date, install_date and termination_date.
 
 ### extended_data (optional, bool, False)
-By default, the module gathers: cmdline, pid, ppid and user. 
+By default, the module gathers: cmdline, cwd, pid, ppid and user. 
 By setting this option to true, all the information related to the process is gathered, extending the module's output.
 
 
 ## Notes
 
    - The extended_data flag is disabled by default as the gathered information that is collected by default is usually enough to achieve the goal of the module.
+   - Due to Windows limitations, the field 'cwd' refers to the path of the executable and not the actual path the process is working on for interoperability purposes, since it's not possible to gather de working directory in a stable, standard way.
 
 ## Examples
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: datadope
 name: discovery
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.3.1
+version: 1.4.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/action_utils/software_facts/plugins/builtin/read_remote_file.py
+++ b/plugins/action_utils/software_facts/plugins/builtin/read_remote_file.py
@@ -2,6 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 DOCUMENTATION = r'''
@@ -82,6 +83,9 @@ parsed:
 '''
 
 import base64  # noqa: E402
+import ntpath  # noqa: E402
+import os  # noqa: E402
+import posixpath  # noqa: E402
 import traceback  # noqa: E402
 
 from ansible.module_utils.common.text.converters import to_text  # noqa: E402
@@ -119,6 +123,11 @@ class ReadRemoteFile(SoftwareFactsPlugin):
             parser = get_software_facts_parser(parser_name, self._action_module, self._task_vars)
         else:
             parser = None
+
+        path_module = ntpath if self._task_vars.get('ansible_facts', {}) \
+            .get('os_family', '').lower().startswith('windows') else posixpath
+        if not path_module.isabs(path) and software_instance.get('process', {}).get("cwd"):
+            path = os.path.normpath(os.path.join(software_instance['process']['cwd'], path))
 
         path_prefix = ''
         if in_docker \

--- a/plugins/action_utils/software_facts/plugins/builtin/run_command.py
+++ b/plugins/action_utils/software_facts/plugins/builtin/run_command.py
@@ -100,7 +100,8 @@ class RunCommand(SoftwareFactsPlugin):
                 module_args[key] = value
 
         # win_command module '_raw_params' and 'argv' arguments are mutually exclusive, avoid using them both if present
-        if 'win_command' in module_name and '_raw_params' in module_args and 'argv' in module_args:
+        if 'win_command' in module_name and module_args.get('_raw_params') is not None \
+                and module_args.get('argv') is not None:
             display.warning("'_raw_params' and 'argv' are mutually exclusive when using the"
                             " 'win_command' ansible module, 'argv' will be ignored")
             module_args.pop('argv')

--- a/plugins/modules/software_facts.py
+++ b/plugins/modules/software_facts.py
@@ -97,6 +97,10 @@ options:
         description: Command line of the process.
         required: true
         type: str
+      cwd:
+        description: Working directory of the process.
+        required: true
+        type: str
   tcp_listen:
     description:
       - List of tcp ports listening in the host.

--- a/plugins/modules/win_process_facts.ps1
+++ b/plugins/modules/win_process_facts.ps1
@@ -62,9 +62,14 @@ try {
     Get-CimInstance -ClassName Win32_Process | ForEach-Object {
         $process_data = @{
             cmdline = $_.CommandLine
+            cwd = $null
             pid = $_.ProcessId.ToString()
             ppid = $_.ParentProcessId.ToString()
             user = Get-Owner $_
+        }
+
+        if ($null -ne $_.ExecutablePath) {
+            $process_data.cwd = Split-Path -LiteralPath $_.ExecutablePath
         }
 
         if ($extended_data) {

--- a/plugins/modules/win_process_facts.py
+++ b/plugins/modules/win_process_facts.py
@@ -22,7 +22,7 @@ options:
     default: '%c'
   extended_data:
     description:
-      - "By default, the module gathers: cmdline, pid, ppid and user. By setting
+      - "By default, the module gathers: cmdline, cwd, pid, ppid and user. By setting
         this option to true, all the information related to the process is gathered,
         extending the module's output."
     type: bool
@@ -30,6 +30,9 @@ options:
 notes:
 - The extended_data flag is disabled by default as the gathered information that is
   collected by default is usually enough to achieve the goal of the module.
+- Due to Windows limitations, the field 'cwd' refers to the path of the executable and not the
+  actual path the process is working on for interoperability purposes, since it's not possible
+  to gather de working directory in a stable, standard way.
 author:
 - David Nieto (@david-ns)
 '''
@@ -57,6 +60,7 @@ processes:
     sample: [
         {
             "cmdline": "\"C:\\Program Files\\Microsoft SQL Server\\MSSQL14.SQLEXPRESS\\MSSQL\\Binn\\sqlservr.exe",
+            "cwd": "\"C:\\Program Files\\Microsoft SQL Server\\MSSQL14.SQLEXPRESS\\MSSQL\\Binn\\",
             "pid": "1560",
             "ppid": "444",
             "user": "NT SERVICE\\MSSQL$SQLEXPRESS"

--- a/roles/software_discovery/files/tasks_definitions/postgresql.yaml
+++ b/roles/software_discovery/files/tasks_definitions/postgresql.yaml
@@ -297,7 +297,7 @@
                   run_command:
                     cmd: << __db_command__ >>
                   register: result
-                  timeout: 5
+                  timeout: 10
                   environment:
                     PGPASSWORD: << __user_info__.password | default('') >>
                   ignore_errors: yes

--- a/tests/integration/targets/process_facts/tasks/main.yml
+++ b/tests/integration/targets/process_facts/tasks/main.yml
@@ -32,5 +32,6 @@
           - item.pid is defined
           - item.ppid is defined
           - item.cmdline is defined
+          - item.cwd is defined
         fail_msg: Wrong process info
       loop: "{{ processes }}"

--- a/tests/integration/targets/software_facts/defaults/main.yml
+++ b/tests/integration/targets/software_facts/defaults/main.yml
@@ -95,30 +95,39 @@ postgres_software_list:
 
 postgres_processes:
   - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+    cwd: /usr/lib/systemd/
     pid: '1'
     ppid: '0'
   - cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
+    cwd: /usr/pgsql-11/bin/
     pid: '24895'
     ppid: '1'
   - cmdline: 'postgres: logger'
+    cwd: /
     pid: '24898'
     ppid: '24895'
   - cmdline: 'postgres: checkpointer'
+    cwd: /
     pid: '24900'
     ppid: '24895'
   - cmdline: 'postgres: background writer'
+    cwd: /
     pid: '24901'
     ppid: '24895'
   - cmdline: 'postgres: walwriter'
+    cwd: /
     pid: '24902'
     ppid: '24895'
   - cmdline: 'postgres: autovacuum launcher'
+    cwd: /
     pid: '24903'
     ppid: '24895'
   - cmdline: 'postgres: stats collector'
+    cwd: /
     pid: '24904'
     ppid: '24895'
   - cmdline: 'postgres: logical replication launcher'
+    cwd: /
     pid: '24905'
     ppid: '24895'
 

--- a/tests/integration/targets/software_facts/tasks/main.yml
+++ b/tests/integration/targets/software_facts/tasks/main.yml
@@ -84,6 +84,7 @@
       - item.process.pid is defined
       - item.process.ppid is defined
       - item.process.cmdline is defined
+      - item.process.cwd is defined
       - item.process.children is defined
       - item.process.listening_ports is defined
       - item.listening_ports is defined

--- a/tests/unit/plugins/action/auto/resources/apache_activemq/apacheactivemq5.14.3_centos.yaml
+++ b/tests/unit/plugins/action/auto/resources/apache_activemq/apacheactivemq5.14.3_centos.yaml
@@ -1,5041 +1,4940 @@
+dockers:
+  containers: []
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 5672
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 42825
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 61613
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 61614
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 61616
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 1883
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8161
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 8161
+  discovery_time: '2022-07-06T10:55:21+02:00'
+  files:
+  - path: /opt/apache-activemq-5.14.3/
+    subtype: home
+    type: config
+  listening_ports:
+  - 1883
+  - 5672
+  - 8161
+  - 42825
+  - 61613
+  - 61614
+  - 61616
+  packages: []
+  process:
+    cmdline: '/usr/bin/java -Xms64M -Xmx1G -Djava.util.logging.config.file=logging.properties
+      -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config
+      -Dcom.sun.management.jmxremote -Djava.awt.headless=true -Djava.io.tmpdir=/opt/apache-activemq-5.14.3//tmp
+      -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/:
+      -Dactivemq.home=/opt/apache-activemq-5.14.3/ -Dactivemq.base=/opt/apache-activemq-5.14.3/
+      -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf -Dactivemq.data=/opt/apache-activemq-5.14.3//data
+      -jar /opt/apache-activemq-5.14.3//bin/activemq.jar start'
+    cwd: /usr/bin/
+    listening_ports:
+    - 1883
+    - 5672
+    - 8161
+    - 42825
+    - 61613
+    - 61614
+    - 61616
+    pid: '967'
+    ppid: '1'
+    user: root
+  type: Apache ActiveMQ
+  version:
+  - number: 5.14.3
+    type: active
+expected_tasks_calls:
+  Access XML file: 1
+  Check if bin/activemq is accessible: 1
+  Check if jetty_config is accessible: 1
+  Read process environment: 1
+  Run version command: 1
 mocked_plugin_tasks:
-  Read process environment:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      parsed: {
-        "SHELL": "/bin/sh",
-        "USER": "root",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
-        "_": "/usr/bin/java",
-        "PWD": "/",
-        "LANG": "en_US.UTF-8",
-        "HOME": "/root",
-        "SHLVL": "2",
-        "LOGNAME": "root"
-      }
-  Check if bin/activemq is accessible:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-  Run version command:
-    number_of_calls: 1
-    expected_args:
-      argv: null
-      cmd: '/opt/apache-activemq-5.14.3/bin/activemq --version'
-      in_docker: true
-    plugin_result:
-      failed: false
-      stdout: "INFO: Loading '/opt/apache-activemq-5.14.3//bin/env'\nINFO: Using java '/bin/java'\nJava Runtime: Red Hat, Inc. 1.8.0_322 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre\n  Heap sizes: current=63360k  free=62311k  max=1013632k\n    JVM args: -Xms64M -Xmx1G -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/: -Dactivemq.home=/opt/apache-activemq-5.14.3/ -Dactivemq.base=/opt/apache-activemq-5.14.3/ -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf -Dactivemq.data=/opt/apache-activemq-5.14.3//data\nExtensions classpath:\n  [/opt/apache-activemq-5.14.3/lib,/opt/apache-activemq-5.14.3/lib/camel,/opt/apache-activemq-5.14.3/lib/optional,/opt/apache-activemq-5.14.3/lib/web,/opt/apache-activemq-5.14.3/lib/extra]\nACTIVEMQ_HOME: /opt/apache-activemq-5.14.3\nACTIVEMQ_BASE: /opt/apache-activemq-5.14.3\nACTIVEMQ_CONF: /opt/apache-activemq-5.14.3/conf\nACTIVEMQ_DATA: /opt/apache-activemq-5.14.3/data\n\nActiveMQ 5.14.3\nFor help or more information please see: http://activemq.apache.org"
-  Check if jetty_config is accessible:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
   Access XML file:
     number_of_calls: 1
     plugin_result:
       failed: false
-      parsed: {
-        "beans": {
-            "attr-xmlns": "http://www.springframework.org/schema/beans",
-            "attr-xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-            "attr-xsi:schemaLocation": "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd",
-            "bean": [
-                {
-                    "attr-id": "securityLoginService",
-                    "attr-class": "org.eclipse.jetty.security.HashLoginService",
-                    "property": [
-                        {
-                            "attr-name": "name",
-                            "attr-value": "ActiveMQRealm"
-                        },
-                        {
-                            "attr-name": "config",
-                            "attr-value": "${activemq.conf}/jetty-realm.properties"
-                        }
-                    ]
-                },
-                {
-                    "attr-id": "securityConstraint",
-                    "attr-class": "org.eclipse.jetty.util.security.Constraint",
-                    "property": [
-                        {
-                            "attr-name": "name",
-                            "attr-value": "BASIC"
-                        },
-                        {
-                            "attr-name": "roles",
-                            "attr-value": "user,admin"
-                        },
-                        {
-                            "attr-name": "authenticate",
-                            "attr-value": "true"
-                        }
-                    ]
-                },
-                {
-                    "attr-id": "adminSecurityConstraint",
-                    "attr-class": "org.eclipse.jetty.util.security.Constraint",
-                    "property": [
-                        {
-                            "attr-name": "name",
-                            "attr-value": "BASIC"
-                        },
-                        {
-                            "attr-name": "roles",
-                            "attr-value": "admin"
-                        },
-                        {
-                            "attr-name": "authenticate",
-                            "attr-value": "true"
-                        }
-                    ]
-                },
-                {
-                    "attr-id": "securityConstraintMapping",
-                    "attr-class": "org.eclipse.jetty.security.ConstraintMapping",
-                    "property": [
-                        {
-                            "attr-name": "constraint",
-                            "attr-ref": "securityConstraint"
-                        },
-                        {
-                            "attr-name": "pathSpec",
-                            "attr-value": "/api/*,/admin/*,*.jsp"
-                        }
-                    ]
-                },
-                {
-                    "attr-id": "adminSecurityConstraintMapping",
-                    "attr-class": "org.eclipse.jetty.security.ConstraintMapping",
-                    "property": [
-                        {
-                            "attr-name": "constraint",
-                            "attr-ref": "adminSecurityConstraint"
-                        },
-                        {
-                            "attr-name": "pathSpec",
-                            "attr-value": "*.action"
-                        }
-                    ]
-                },
-                {
-                    "attr-id": "rewriteHandler",
-                    "attr-class": "org.eclipse.jetty.rewrite.handler.RewriteHandler",
-                    "property": {
-                        "attr-name": "rules",
-                        "list": {
-                            "bean": {
-                                "attr-id": "header",
-                                "attr-class": "org.eclipse.jetty.rewrite.handler.HeaderPatternRule",
-                                "property": [
-                                    {
-                                        "attr-name": "pattern",
-                                        "attr-value": "*"
-                                    },
-                                    {
-                                        "attr-name": "name",
-                                        "attr-value": "X-FRAME-OPTIONS"
-                                    },
-                                    {
-                                        "attr-name": "value",
-                                        "attr-value": "SAMEORIGIN"
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                {
-                    "attr-id": "secHandlerCollection",
-                    "attr-class": "org.eclipse.jetty.server.handler.HandlerCollection",
-                    "property": {
-                        "attr-name": "handlers",
-                        "list": {
-                            "ref": {
-                                "attr-bean": "rewriteHandler"
-                            },
-                            "bean": [
-                                {
-                                    "attr-class": "org.eclipse.jetty.webapp.WebAppContext",
-                                    "property": [
-                                        {
-                                            "attr-name": "contextPath",
-                                            "attr-value": "/admin"
-                                        },
-                                        {
-                                            "attr-name": "resourceBase",
-                                            "attr-value": "${activemq.home}/webapps/admin"
-                                        },
-                                        {
-                                            "attr-name": "logUrlOnStart",
-                                            "attr-value": "true"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "attr-class": "org.eclipse.jetty.webapp.WebAppContext",
-                                    "property": [
-                                        {
-                                            "attr-name": "contextPath",
-                                            "attr-value": "/api"
-                                        },
-                                        {
-                                            "attr-name": "resourceBase",
-                                            "attr-value": "${activemq.home}/webapps/api"
-                                        },
-                                        {
-                                            "attr-name": "logUrlOnStart",
-                                            "attr-value": "true"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "attr-class": "org.eclipse.jetty.server.handler.ResourceHandler",
-                                    "property": [
-                                        {
-                                            "attr-name": "directoriesListed",
-                                            "attr-value": "false"
-                                        },
-                                        {
-                                            "attr-name": "welcomeFiles",
-                                            "list": {
-                                                "value": "index.html"
-                                            }
-                                        },
-                                        {
-                                            "attr-name": "resourceBase",
-                                            "attr-value": "${activemq.home}/webapps/"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "attr-id": "defaultHandler",
-                                    "attr-class": "org.eclipse.jetty.server.handler.DefaultHandler",
-                                    "property": {
-                                        "attr-name": "serveIcon",
-                                        "attr-value": "false"
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "attr-id": "securityHandler",
-                    "attr-class": "org.eclipse.jetty.security.ConstraintSecurityHandler",
-                    "property": [
-                        {
-                            "attr-name": "loginService",
-                            "attr-ref": "securityLoginService"
-                        },
-                        {
-                            "attr-name": "authenticator",
-                            "bean": {
-                                "attr-class": "org.eclipse.jetty.security.authentication.BasicAuthenticator"
-                            }
-                        },
-                        {
-                            "attr-name": "constraintMappings",
-                            "list": {
-                                "ref": [
-                                    {
-                                        "attr-bean": "adminSecurityConstraintMapping"
-                                    },
-                                    {
-                                        "attr-bean": "securityConstraintMapping"
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "attr-name": "handler",
-                            "attr-ref": "secHandlerCollection"
-                        }
-                    ]
-                },
-                {
-                    "attr-id": "contexts",
-                    "attr-class": "org.eclipse.jetty.server.handler.ContextHandlerCollection"
-                },
-                {
-                    "attr-id": "jettyPort",
-                    "attr-class": "org.apache.activemq.web.WebConsolePort",
-                    "attr-init-method": "start",
-                    "property": [
-                        {
-                            "attr-name": "host",
-                            "attr-value": "0.0.0.0"
-                        },
-                        {
-                            "attr-name": "port",
-                            "attr-value": "8161"
-                        }
-                    ]
-                },
-                {
-                    "attr-id": "Server",
-                    "attr-depends-on": "jettyPort",
-                    "attr-class": "org.eclipse.jetty.server.Server",
-                    "attr-destroy-method": "stop",
-                    "property": {
-                        "attr-name": "handler",
-                        "bean": {
-                            "attr-id": "handlers",
-                            "attr-class": "org.eclipse.jetty.server.handler.HandlerCollection",
-                            "property": {
-                                "attr-name": "handlers",
-                                "list": {
-                                    "ref": [
-                                        {
-                                            "attr-bean": "contexts"
-                                        },
-                                        {
-                                            "attr-bean": "securityHandler"
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "attr-id": "invokeConnectors",
-                    "attr-class": "org.springframework.beans.factory.config.MethodInvokingFactoryBean",
-                    "property": [
-                        {
-                            "attr-name": "targetObject",
-                            "attr-ref": "Server"
-                        },
-                        {
-                            "attr-name": "targetMethod",
-                            "attr-value": "setConnectors"
-                        },
-                        {
-                            "attr-name": "arguments",
-                            "list": {
-                                "bean": {
-                                    "attr-id": "Connector",
-                                    "attr-class": "org.eclipse.jetty.server.ServerConnector",
-                                    "constructor-arg": {
-                                        "attr-ref": "Server"
-                                    },
-                                    "property": [
-                                        {
-                                            "attr-name": "host",
-                                            "attr-value": "#{systemProperties['jetty.host']}"
-                                        },
-                                        {
-                                            "attr-name": "port",
-                                            "attr-value": "#{systemProperties['jetty.port']}"
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "attr-id": "configureJetty",
-                    "attr-class": "org.springframework.beans.factory.config.MethodInvokingFactoryBean",
-                    "property": [
-                        {
-                            "attr-name": "staticMethod",
-                            "attr-value": "org.apache.activemq.web.config.JspConfigurer.configureJetty"
-                        },
-                        {
-                            "attr-name": "arguments",
-                            "list": {
-                                "ref": [
-                                    {
-                                        "attr-bean": "Server"
-                                    },
-                                    {
-                                        "attr-bean": "secHandlerCollection"
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                },
-                {
-                    "attr-id": "invokeStart",
-                    "attr-class": "org.springframework.beans.factory.config.MethodInvokingFactoryBean",
-                    "attr-depends-on": "configureJetty, invokeConnectors",
-                    "property": [
-                        {
-                            "attr-name": "targetObject",
-                            "attr-ref": "Server"
-                        },
-                        {
-                            "attr-name": "targetMethod",
-                            "attr-value": "start"
-                        }
-                    ]
-                }
-            ]
-        }
-    }
-expected_tasks_calls:
-  Read process environment: 1
-  Check if bin/activemq is accessible: 1
-  Run version command: 1
-  Check if jetty_config is accessible: 1
-  Access XML file: 1
-
-expected_result:
-  - bindings:
-      - address: '::'
-        class: service
-        port: 5672
-        protocol: tcp
-      - address: '::'
-        class: service
-        port: 42825
-        protocol: tcp
-      - address: '::'
-        class: service
-        port: 61613
-        protocol: tcp
-      - address: '::'
-        class: service
-        port: 61614
-        protocol: tcp
-      - address: '::'
-        class: service
-        port: 61616
-        protocol: tcp
-      - address: '::'
-        class: service
-        port: 1883
-        protocol: tcp
-      - address: '::'
-        class: service
-        port: 8161
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        port: 8161
-    discovery_time: '2022-07-06T10:55:21+02:00'
-    files:
-      - path: /opt/apache-activemq-5.14.3/
-        subtype: home
-        type: config
-    listening_ports:
-      - 1883
-      - 5672
-      - 8161
-      - 42825
-      - 61613
-      - 61614
-      - 61616
-    packages: []
-    process:
-      cmdline: >-
-        /usr/bin/java -Xms64M -Xmx1G
-        -Djava.util.logging.config.file=logging.properties
-        -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config
-        -Dcom.sun.management.jmxremote -Djava.awt.headless=true
-        -Djava.io.tmpdir=/opt/apache-activemq-5.14.3//tmp
-        -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/:
-        -Dactivemq.home=/opt/apache-activemq-5.14.3/
-        -Dactivemq.base=/opt/apache-activemq-5.14.3/
-        -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf
-        -Dactivemq.data=/opt/apache-activemq-5.14.3//data -jar
-        /opt/apache-activemq-5.14.3//bin/activemq.jar start
-      listening_ports:
-        - 1883
-        - 5672
-        - 8161
-        - 42825
-        - 61613
-        - 61614
-        - 61616
-      pid: '967'
-      ppid: '1'
-      user: root
-    type: Apache ActiveMQ
-    version:
-      - number: 5.14.3
-        type: active
-software_list:
-  - name: Apache ActiveMQ
-    cmd_regexp: activemq\.ja
-    pkg_regexp: activemq
-    process_type: parent
-    return_children: false
-    return_packages: true
-    custom_tasks:
-      - name: Include Apache ActiveMQ specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/apache_activemq.yaml"
-dockers:
-  containers: []
+      parsed:
+        beans:
+          attr-xmlns: http://www.springframework.org/schema/beans
+          attr-xmlns:xsi: http://www.w3.org/2001/XMLSchema-instance
+          attr-xsi:schemaLocation: http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+          bean:
+          - attr-class: org.eclipse.jetty.security.HashLoginService
+            attr-id: securityLoginService
+            property:
+            - attr-name: name
+              attr-value: ActiveMQRealm
+            - attr-name: config
+              attr-value: ${activemq.conf}/jetty-realm.properties
+          - attr-class: org.eclipse.jetty.util.security.Constraint
+            attr-id: securityConstraint
+            property:
+            - attr-name: name
+              attr-value: BASIC
+            - attr-name: roles
+              attr-value: user,admin
+            - attr-name: authenticate
+              attr-value: 'true'
+          - attr-class: org.eclipse.jetty.util.security.Constraint
+            attr-id: adminSecurityConstraint
+            property:
+            - attr-name: name
+              attr-value: BASIC
+            - attr-name: roles
+              attr-value: admin
+            - attr-name: authenticate
+              attr-value: 'true'
+          - attr-class: org.eclipse.jetty.security.ConstraintMapping
+            attr-id: securityConstraintMapping
+            property:
+            - attr-name: constraint
+              attr-ref: securityConstraint
+            - attr-name: pathSpec
+              attr-value: /api/*,/admin/*,*.jsp
+          - attr-class: org.eclipse.jetty.security.ConstraintMapping
+            attr-id: adminSecurityConstraintMapping
+            property:
+            - attr-name: constraint
+              attr-ref: adminSecurityConstraint
+            - attr-name: pathSpec
+              attr-value: '*.action'
+          - attr-class: org.eclipse.jetty.rewrite.handler.RewriteHandler
+            attr-id: rewriteHandler
+            property:
+              attr-name: rules
+              list:
+                bean:
+                  attr-class: org.eclipse.jetty.rewrite.handler.HeaderPatternRule
+                  attr-id: header
+                  property:
+                  - attr-name: pattern
+                    attr-value: '*'
+                  - attr-name: name
+                    attr-value: X-FRAME-OPTIONS
+                  - attr-name: value
+                    attr-value: SAMEORIGIN
+          - attr-class: org.eclipse.jetty.server.handler.HandlerCollection
+            attr-id: secHandlerCollection
+            property:
+              attr-name: handlers
+              list:
+                bean:
+                - attr-class: org.eclipse.jetty.webapp.WebAppContext
+                  property:
+                  - attr-name: contextPath
+                    attr-value: /admin
+                  - attr-name: resourceBase
+                    attr-value: ${activemq.home}/webapps/admin
+                  - attr-name: logUrlOnStart
+                    attr-value: 'true'
+                - attr-class: org.eclipse.jetty.webapp.WebAppContext
+                  property:
+                  - attr-name: contextPath
+                    attr-value: /api
+                  - attr-name: resourceBase
+                    attr-value: ${activemq.home}/webapps/api
+                  - attr-name: logUrlOnStart
+                    attr-value: 'true'
+                - attr-class: org.eclipse.jetty.server.handler.ResourceHandler
+                  property:
+                  - attr-name: directoriesListed
+                    attr-value: 'false'
+                  - attr-name: welcomeFiles
+                    list:
+                      value: index.html
+                  - attr-name: resourceBase
+                    attr-value: ${activemq.home}/webapps/
+                - attr-class: org.eclipse.jetty.server.handler.DefaultHandler
+                  attr-id: defaultHandler
+                  property:
+                    attr-name: serveIcon
+                    attr-value: 'false'
+                ref:
+                  attr-bean: rewriteHandler
+          - attr-class: org.eclipse.jetty.security.ConstraintSecurityHandler
+            attr-id: securityHandler
+            property:
+            - attr-name: loginService
+              attr-ref: securityLoginService
+            - attr-name: authenticator
+              bean:
+                attr-class: org.eclipse.jetty.security.authentication.BasicAuthenticator
+            - attr-name: constraintMappings
+              list:
+                ref:
+                - attr-bean: adminSecurityConstraintMapping
+                - attr-bean: securityConstraintMapping
+            - attr-name: handler
+              attr-ref: secHandlerCollection
+          - attr-class: org.eclipse.jetty.server.handler.ContextHandlerCollection
+            attr-id: contexts
+          - attr-class: org.apache.activemq.web.WebConsolePort
+            attr-id: jettyPort
+            attr-init-method: start
+            property:
+            - attr-name: host
+              attr-value: 0.0.0.0
+            - attr-name: port
+              attr-value: '8161'
+          - attr-class: org.eclipse.jetty.server.Server
+            attr-depends-on: jettyPort
+            attr-destroy-method: stop
+            attr-id: Server
+            property:
+              attr-name: handler
+              bean:
+                attr-class: org.eclipse.jetty.server.handler.HandlerCollection
+                attr-id: handlers
+                property:
+                  attr-name: handlers
+                  list:
+                    ref:
+                    - attr-bean: contexts
+                    - attr-bean: securityHandler
+          - attr-class: org.springframework.beans.factory.config.MethodInvokingFactoryBean
+            attr-id: invokeConnectors
+            property:
+            - attr-name: targetObject
+              attr-ref: Server
+            - attr-name: targetMethod
+              attr-value: setConnectors
+            - attr-name: arguments
+              list:
+                bean:
+                  attr-class: org.eclipse.jetty.server.ServerConnector
+                  attr-id: Connector
+                  constructor-arg:
+                    attr-ref: Server
+                  property:
+                  - attr-name: host
+                    attr-value: '#{systemProperties[''jetty.host'']}'
+                  - attr-name: port
+                    attr-value: '#{systemProperties[''jetty.port'']}'
+          - attr-class: org.springframework.beans.factory.config.MethodInvokingFactoryBean
+            attr-id: configureJetty
+            property:
+            - attr-name: staticMethod
+              attr-value: org.apache.activemq.web.config.JspConfigurer.configureJetty
+            - attr-name: arguments
+              list:
+                ref:
+                - attr-bean: Server
+                - attr-bean: secHandlerCollection
+          - attr-class: org.springframework.beans.factory.config.MethodInvokingFactoryBean
+            attr-depends-on: configureJetty, invokeConnectors
+            attr-id: invokeStart
+            property:
+            - attr-name: targetObject
+              attr-ref: Server
+            - attr-name: targetMethod
+              attr-value: start
+  Check if bin/activemq is accessible:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+  Check if jetty_config is accessible:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+  Read process environment:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      parsed:
+        HOME: /root
+        LANG: en_US.UTF-8
+        LOGNAME: root
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+        PWD: /
+        SHELL: /bin/sh
+        SHLVL: '2'
+        USER: root
+        _: /usr/bin/java
+  Run version command:
+    expected_args:
+      argv: null
+      cmd: /opt/apache-activemq-5.14.3/bin/activemq --version
+      in_docker: true
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      stdout: "INFO: Loading '/opt/apache-activemq-5.14.3//bin/env'\nINFO: Using java\
+        \ '/bin/java'\nJava Runtime: Red Hat, Inc. 1.8.0_322 /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre\n\
+        \  Heap sizes: current=63360k  free=62311k  max=1013632k\n    JVM args: -Xms64M\
+        \ -Xmx1G -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config\
+        \ -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/:\
+        \ -Dactivemq.home=/opt/apache-activemq-5.14.3/ -Dactivemq.base=/opt/apache-activemq-5.14.3/\
+        \ -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf -Dactivemq.data=/opt/apache-activemq-5.14.3//data\n\
+        Extensions classpath:\n  [/opt/apache-activemq-5.14.3/lib,/opt/apache-activemq-5.14.3/lib/camel,/opt/apache-activemq-5.14.3/lib/optional,/opt/apache-activemq-5.14.3/lib/web,/opt/apache-activemq-5.14.3/lib/extra]\n\
+        ACTIVEMQ_HOME: /opt/apache-activemq-5.14.3\nACTIVEMQ_BASE: /opt/apache-activemq-5.14.3\n\
+        ACTIVEMQ_CONF: /opt/apache-activemq-5.14.3/conf\nACTIVEMQ_DATA: /opt/apache-activemq-5.14.3/data\n\
+        \nActiveMQ 5.14.3\nFor help or more information please see: http://activemq.apache.org"
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   aether-api:
-    - arch: noarch
-      epoch: null
-      name: aether-api
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-api
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   aether-connector-wagon:
-    - arch: noarch
-      epoch: null
-      name: aether-connector-wagon
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-connector-wagon
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   aether-impl:
-    - arch: noarch
-      epoch: null
-      name: aether-impl
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-impl
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   aether-spi:
-    - arch: noarch
-      epoch: null
-      name: aether-spi
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-spi
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   aether-util:
-    - arch: noarch
-      epoch: null
-      name: aether-util
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-util
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   aopalliance:
-    - arch: noarch
-      epoch: 0
-      name: aopalliance
-      release: 8.el7
-      source: rpm
-      version: '1.0'
+  - arch: noarch
+    epoch: 0
+    name: aopalliance
+    release: 8.el7
+    source: rpm
+    version: '1.0'
   apache-commons-cli:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-cli
-      release: 13.el7
-      source: rpm
-      version: '1.2'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-cli
+    release: 13.el7
+    source: rpm
+    version: '1.2'
   apache-commons-codec:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-codec
-      release: 7.el7
-      source: rpm
-      version: '1.8'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-codec
+    release: 7.el7
+    source: rpm
+    version: '1.8'
   apache-commons-io:
-    - arch: noarch
-      epoch: 1
-      name: apache-commons-io
-      release: 12.el7
-      source: rpm
-      version: '2.4'
+  - arch: noarch
+    epoch: 1
+    name: apache-commons-io
+    release: 12.el7
+    source: rpm
+    version: '2.4'
   apache-commons-lang:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-lang
-      release: 15.el7
-      source: rpm
-      version: '2.6'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-lang
+    release: 15.el7
+    source: rpm
+    version: '2.6'
   apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
   apache-commons-net:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-net
-      release: 8.el7.centos
-      source: rpm
-      version: '3.2'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-net
+    release: 8.el7.centos
+    source: rpm
+    version: '3.2'
   apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   atinject:
-    - arch: noarch
-      epoch: null
-      name: atinject
-      release: 13.20100611svn86.el7
-      source: rpm
-      version: '1'
+  - arch: noarch
+    epoch: null
+    name: atinject
+    release: 13.20100611svn86.el7
+    source: rpm
+    version: '1'
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
   avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 35.el7_9
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 35.el7_9
+    source: rpm
+    version: 4.2.46
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bcel:
-    - arch: noarch
-      epoch: 0
-      name: bcel
-      release: 18.el7
-      source: rpm
-      version: '5.2'
+  - arch: noarch
+    epoch: 0
+    name: bcel
+    release: 18.el7
+    source: rpm
+    version: '5.2'
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 72.el7_9
-      source: rpm
-      version: 2021.2.50
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 72.el7_9
+    source: rpm
+    version: 2021.2.50
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   cal10n:
-    - arch: noarch
-      epoch: null
-      name: cal10n
-      release: 4.el7
-      source: rpm
-      version: 0.7.7
+  - arch: noarch
+    epoch: null
+    name: cal10n
+    release: 4.el7
+    source: rpm
+    version: 0.7.7
   cdi-api:
-    - arch: noarch
-      epoch: null
-      name: cdi-api
-      release: 11.SP4.el7
-      source: rpm
-      version: '1.0'
+  - arch: noarch
+    epoch: null
+    name: cdi-api
+    release: 11.SP4.el7
+    source: rpm
+    version: '1.0'
   centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
   cglib:
-    - arch: noarch
-      epoch: null
-      name: cglib
-      release: 18.el7
-      source: rpm
-      version: '2.2'
+  - arch: noarch
+    epoch: null
+    name: cglib
+    release: 18.el7
+    source: rpm
+    version: '2.2'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 7.el7.centos.6
-      source: rpm
-      version: '19.4'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 7.el7.centos.6
+    source: rpm
+    version: '19.4'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-gssapi:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-gssapi
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-gssapi
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-plain:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-plain
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-plain
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  easymock2:
-    - arch: noarch
-      epoch: null
-      name: easymock2
-      release: 12.el7
-      source: rpm
-      version: 2.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '14'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  felix-framework:
-    - arch: noarch
-      epoch: null
-      name: felix-framework
-      release: 5.el7
-      source: rpm
-      version: 4.2.1
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  geronimo-annotation:
-    - arch: noarch
-      epoch: null
-      name: geronimo-annotation
-      release: 15.el7
-      source: rpm
-      version: '1.0'
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  google-guice:
-    - arch: noarch
-      epoch: null
-      name: google-guice
-      release: 9.el7
-      source: rpm
-      version: 3.1.3
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 61b8bab7
-      source: rpm
-      version: 3a79bd29
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 5c4058fb
-      source: rpm
-      version: 5072e1f5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 5eb44ee6
-      source: rpm
-      version: a3219f7b
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 602c28d5
-      source: rpm
-      version: e2c63c11
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 5ced7aac
-      source: rpm
-      version: 90cfb1f5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  guava:
-    - arch: noarch
-      epoch: null
-      name: guava
-      release: 6.el7
-      source: rpm
-      version: '13.0'
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hamcrest:
-    - arch: noarch
-      epoch: 0
-      name: hamcrest
-      release: 6.el7
-      source: rpm
-      version: '1.3'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  httpcomponents-client:
-    - arch: noarch
-      epoch: null
-      name: httpcomponents-client
-      release: 5.el7_0
-      source: rpm
-      version: 4.2.5
-  httpcomponents-core:
-    - arch: noarch
-      epoch: null
-      name: httpcomponents-core
-      release: 6.el7
-      source: rpm
-      version: 4.2.4
-  httpd:
-    - arch: x86_64
-      epoch: null
-      name: httpd
-      release: 97.el7.centos.4
-      source: rpm
-      version: 2.4.6
-  httpd-tools:
-    - arch: x86_64
-      epoch: null
-      name: httpd-tools
-      release: 97.el7.centos.4
-      source: rpm
-      version: 2.4.6
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-commons-httpclient:
-    - arch: noarch
-      epoch: 1
-      name: jakarta-commons-httpclient
-      release: 16.el7_0
-      source: rpm
-      version: '3.1'
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-devel:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-devel
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  javassist:
-    - arch: noarch
-      epoch: null
-      name: javassist
-      release: 10.el7
-      source: rpm
-      version: 3.16.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  jboss-ejb-3.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-ejb-3.1-api
-      release: 10.el7
-      source: rpm
-      version: 1.0.2
-  jboss-el-2.2-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-el-2.2-api
-      release: 0.7.20120212git2fabd8.el7
-      source: rpm
-      version: 1.0.1
-  jboss-interceptors-1.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-interceptors-1.1-api
-      release: 0.9.20120319git49a904.el7
-      source: rpm
-      version: 1.0.2
-  jboss-jaxrpc-1.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-jaxrpc-1.1-api
-      release: 7.el7
-      source: rpm
-      version: 1.0.1
-  jboss-servlet-3.0-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-servlet-3.0-api
-      release: 9.el7
-      source: rpm
-      version: 1.0.1
-  jboss-transaction-1.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-transaction-1.1-api
-      release: 8.el7
-      source: rpm
-      version: 1.0.1
-  jline:
-    - arch: noarch
-      epoch: null
-      name: jline
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  jsch:
-    - arch: noarch
-      epoch: 0
-      name: jsch
-      release: 5.el7
-      source: rpm
-      version: 0.1.50
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  jsoup:
-    - arch: noarch
-      epoch: null
-      name: jsoup
-      release: 10.el7
-      source: rpm
-      version: 1.6.1
-  junit:
-    - arch: noarch
-      epoch: 0
-      name: junit
-      release: 8.el7
-      source: rpm
-      version: '4.11'
-  jzlib:
-    - arch: noarch
-      epoch: 0
-      name: jzlib
-      release: 6.el7
-      source: rpm
-      version: 1.1.1
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.49.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.3
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 135.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 18.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  maven:
-    - arch: noarch
-      epoch: null
-      name: maven
-      release: 17.el7
-      source: rpm
-      version: 3.0.5
-  maven-wagon:
-    - arch: noarch
-      epoch: 0
-      name: maven-wagon
-      release: 3.el7
-      source: rpm
-      version: '2.4'
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mongodb-database-tools:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-database-tools
-      release: '1'
-      source: rpm
-      version: 100.5.2
-  mongodb-org:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-database-tools-extra:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-database-tools-extra
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-mongos:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-mongos
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-server:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-server
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-shell:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-shell
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-tools:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-tools
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mysql-community-client:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-client
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-client-plugins:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-client-plugins
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-common:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-common
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-icu-data-files:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-icu-data-files
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-libs:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-libs
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-libs-compat:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-libs-compat
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-server:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-server
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql80-community-release:
-    - arch: noarch
-      epoch: null
-      name: mysql80-community-release
-      release: '3'
-      source: rpm
-      version: el8
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  nekohtml:
-    - arch: noarch
-      epoch: 0
-      name: nekohtml
-      release: 13.el7
-      source: rpm
-      version: 1.9.14
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7.2
-      source: rpm
-      version: 1.3.0
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  objectweb-asm:
-    - arch: noarch
-      epoch: 0
-      name: objectweb-asm
-      release: 9.el7
-      source: rpm
-      version: 3.3.1
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 25.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  packer:
-    - arch: x86_64
-      epoch: null
-      name: packer
-      release: '1'
-      source: rpm
-      version: 1.7.10
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  plexus-cipher:
-    - arch: noarch
-      epoch: null
-      name: plexus-cipher
-      release: 5.el7
-      source: rpm
-      version: '1.7'
-  plexus-classworlds:
-    - arch: noarch
-      epoch: null
-      name: plexus-classworlds
-      release: 8.el7
-      source: rpm
-      version: 2.4.2
-  plexus-component-api:
-    - arch: noarch
-      epoch: null
-      name: plexus-component-api
-      release: 0.16.alpha15.el7
-      source: rpm
-      version: '1.0'
-  plexus-containers-component-annotations:
-    - arch: noarch
-      epoch: null
-      name: plexus-containers-component-annotations
-      release: 14.el7
-      source: rpm
-      version: 1.5.5
-  plexus-containers-container-default:
-    - arch: noarch
-      epoch: null
-      name: plexus-containers-container-default
-      release: 14.el7
-      source: rpm
-      version: 1.5.5
-  plexus-interactivity:
-    - arch: noarch
-      epoch: 0
-      name: plexus-interactivity
-      release: 0.14.alpha6.el7
-      source: rpm
-      version: '1.0'
-  plexus-interpolation:
-    - arch: noarch
-      epoch: null
-      name: plexus-interpolation
-      release: 8.el7
-      source: rpm
-      version: '1.15'
-  plexus-sec-dispatcher:
-    - arch: noarch
-      epoch: null
-      name: plexus-sec-dispatcher
-      release: 13.el7
-      source: rpm
-      version: '1.4'
-  plexus-utils:
-    - arch: noarch
-      epoch: null
-      name: plexus-utils
-      release: 9.el7
-      source: rpm
-      version: 3.0.9
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 10.el7
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qdox:
-    - arch: noarch
-      epoch: 0
-      name: qdox
-      release: 10.el7
-      source: rpm
-      version: 1.12.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  regexp:
-    - arch: noarch
-      epoch: 0
-      name: regexp
-      release: 13.el7
-      source: rpm
-      version: '1.5'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9.1
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  sisu-inject-bean:
-    - arch: noarch
-      epoch: null
-      name: sisu-inject-bean
-      release: 11.el7
-      source: rpm
-      version: 2.3.0
-  sisu-inject-plexus:
-    - arch: noarch
-      epoch: null
-      name: sisu-inject-plexus
-      release: 11.el7
-      source: rpm
-      version: 2.3.0
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slf4j:
-    - arch: noarch
-      epoch: 0
-      name: slf4j
-      release: 4.el7_4
-      source: rpm
-      version: 1.7.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.2
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 66.el7
-      source: rpm
-      version: '0.17'
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 24.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7_9.1
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xbean:
-    - arch: noarch
-      epoch: null
-      name: xbean
-      release: 6.el7
-      source: rpm
-      version: '3.13'
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '113'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '192'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '193'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '260'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '266'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '267'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '281'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '282'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '283'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '408'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '447'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '471'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '512'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '539'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '548'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /sbin/rpcbind -w
-    pid: '550'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '554'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '562'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '563'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/sbin/chronyd
-    pid: '566'
-    ppid: '1'
-    user: chrony
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H test-norm01 eth0
-    pid: '808'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '864'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '866'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/java -Xms64M -Xmx1G
-      -Djava.util.logging.config.file=logging.properties
-      -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config
-      -Dcom.sun.management.jmxremote -Djava.awt.headless=true
-      -Djava.io.tmpdir=/opt/apache-activemq-5.14.3//tmp
-      -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/:
-      -Dactivemq.home=/opt/apache-activemq-5.14.3/
-      -Dactivemq.base=/opt/apache-activemq-5.14.3/
-      -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf
-      -Dactivemq.data=/opt/apache-activemq-5.14.3//data -jar
-      /opt/apache-activemq-5.14.3//bin/activemq.jar start
-    pid: '967'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1100'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1106'
-    ppid: '1100'
-    user: postfix
-  - cmdline: >-
-      /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml
-      -path.home /usr/share/filebeat -path.config /etc/filebeat -path.data
-      /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '1147'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1148'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1159'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1181'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1182'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1183'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/mongod -f /etc/mongod.conf
-    pid: '1239'
-    ppid: '1'
-    user: mongod
-  - cmdline: /usr/sbin/mysqld
-    pid: '1535'
-    ppid: '1'
-    user: mysql
-  - cmdline: ''
-    pid: '1993'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '3183'
-    ppid: '1100'
-    user: postfix
-  - cmdline: ''
-    pid: '3613'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '4364'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '4868'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5134'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '5361'
-    ppid: '1159'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '5364'
-    ppid: '5361'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-kzjhunintzyuuudwdmbontatxnepriby ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1657097709.5033789-20592-66687050083535/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '5517'
-    ppid: '5364'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-kzjhunintzyuuudwdmbontatxnepriby ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1657097709.5033789-20592-66687050083535/AnsiballZ_process_facts.py
-    pid: '5530'
-    ppid: '5517'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-kzjhunintzyuuudwdmbontatxnepriby ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1657097709.5033789-20592-66687050083535/AnsiballZ_process_facts.py
-    pid: '5532'
-    ppid: '5530'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1657097709.5033789-20592-66687050083535/AnsiballZ_process_facts.py
-    pid: '5533'
-    ppid: '5532'
-    user: root
-  - cmdline: >-
-      /bin/bash /opt/wildfly/bin/launch.sh standalone standalone.xml 0.0.0.0
-      0.0.0.0
-    pid: '16731'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /bin/sh /opt/wildfly/bin/standalone.sh -c standalone.xml -b 0.0.0.0
-      -bmanagement 0.0.0.0 -Djboss.node.name=jbossnode
-      -Djboss.bind.address=0.0.0.0
-    pid: '16732'
-    ppid: '16731'
-    user: root
-  - cmdline: >-
-      java -D[Standalone] -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M
-      -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true
-      -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true
-      -Dorg.jboss.boot.log.file=/opt/wildfly/standalone/log/server.log
-      -Dlogging.configuration=file:/opt/wildfly/standalone/configuration/logging.properties
-      -jar /opt/wildfly/jboss-modules.jar -mp /opt/wildfly/modules
-      org.jboss.as.standalone -Djboss.home.dir=/opt/wildfly
-      -Djboss.server.base.dir=/opt/wildfly/standalone -c standalone.xml -b
-      0.0.0.0 -bmanagement 0.0.0.0 -Djboss.node.name=jbossnode
-      -Djboss.bind.address=0.0.0.0
-    pid: '16804'
-    ppid: '16732'
-    user: root
-  - cmdline: >-
-      /bin/sh /opt/jboss/bin/domain.sh --domain-config=domain.xml
-      --host-config=host.xml
-    pid: '17678'
-    ppid: '1'
-    user: wildfly
-  - cmdline: >-
-      java -D[Process Controller] -server -Xms64m -Xmx512m
-      -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true
-      -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true
-      -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/process-controller.log
-      -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
-      -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules
-      org.jboss.as.process-controller -jboss-home /opt/jboss -jvm java -mp
-      /opt/jboss/modules --
-      -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log
-      -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
-      -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m
-      -Djava.net.preferIPv4Stack=true
-      -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true --
-      -default-jvm java --domain-config=domain.xml --host-config=host.xml
-    pid: '17764'
-    ppid: '17678'
-    user: wildfly
-  - cmdline: >-
-      java -D[Host Controller]
-      -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log
-      -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
-      -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m
-      -Djava.net.preferIPv4Stack=true
-      -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true
-      -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules
-      org.jboss.as.host-controller -mp /opt/jboss/modules --pc-address 127.0.0.1
-      --pc-port 42816 -default-jvm java --domain-config=domain.xml
-      --host-config=host.xml -Djboss.home.dir=/opt/jboss
-    pid: '17780'
-    ppid: '17764'
-    user: wildfly
-  - cmdline: >-
-      /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/java
-      -D[Server:nodo1-server1] -D[pcid:1449119893] -Xms1000m -Xmx1000m -server
-      -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true
-      -Djava.net.preferIPv4Stack=true -Djboss.home.dir=/opt/jboss
-      -Djboss.modules.system.pkgs=org.jboss.byteman
-      -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo1-server1/log
-      -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo1-server1/tmp
-      -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo1-server1/data
-      -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo1-server1/data/logging.properties
-      -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules
-      org.jboss.as.server
-    pid: '17878'
-    ppid: '17764'
-    user: wildfly
-  - cmdline: >-
-      /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/java
-      -D[Server:nodo1-server2] -D[pcid:1585598268] -Xms1000m -Xmx1000m -server
-      -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true
-      -Djava.net.preferIPv4Stack=true -Djboss.home.dir=/opt/jboss
-      -Djboss.modules.system.pkgs=org.jboss.byteman
-      -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo1-server2/log
-      -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo1-server2/tmp
-      -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo1-server2/data
-      -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo1-server2/data/logging.properties
-      -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules
-      org.jboss.as.server
-    pid: '17924'
-    ppid: '17764'
-    user: wildfly
-  - cmdline: ''
-    pid: '21509'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '27956'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '27957'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '27958'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '27959'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '27960'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '30851'
-    ppid: '866'
-    user: apache
-tcp_listen:
-  - address: 0.0.0.0
-    name: java
-    pid: 16804
-    port: 29990
-    protocol: tcp
-    stime: 'Thu Jun 23 18:52:06 2022'
-    user: root
-  - address: 0.0.0.0
-    name: java
-    pid: 17924
-    port: 8230
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:35 2022'
-    user: wildfly
-  - address: 0.0.0.0
-    name: java
-    pid: 17780
-    port: 9990
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:15 2022'
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17878
-    port: 3528
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:29 2022'
-    user: wildfly
-  - address: 0.0.0.0
-    name: java
-    pid: 17878
-    port: 8009
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:29 2022'
-    user: wildfly
-  - address: 0.0.0.0
-    name: mongod
-    pid: 1239
-    port: 27017
-    protocol: tcp
-    stime: 'Thu Jun 16 14:10:00 2022'
-    user: mongod
-  - address: 0.0.0.0
-    name: java
-    pid: 17780
-    port: 9999
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:15 2022'
-    user: wildfly
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 550
-    port: 111
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:45 2022'
-    user: rpc
-  - address: 0.0.0.0
-    name: java
-    pid: 16804
-    port: 28080
-    protocol: tcp
-    stime: 'Thu Jun 23 18:52:06 2022'
-    user: root
-  - address: 0.0.0.0
-    name: java
-    pid: 17878
-    port: 8080
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:29 2022'
-    user: wildfly
-  - address: 0.0.0.0
-    name: java
-    pid: 17924
-    port: 8593
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:35 2022'
-    user: wildfly
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1159
-    port: 22
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:58 2022'
-    user: root
-  - address: 127.0.0.1
-    name: java
-    pid: 17878
-    port: 54200
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:29 2022'
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17924
-    port: 54201
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:35 2022'
-    user: wildfly
-  - address: 127.0.0.1
-    name: master
-    pid: 1100
-    port: 25
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:57 2022'
-    user: root
-  - address: 0.0.0.0
-    name: java
-    pid: 16804
-    port: 28443
-    protocol: tcp
-    stime: 'Thu Jun 23 18:52:06 2022'
-    user: root
-  - address: 0.0.0.0
-    name: java
-    pid: 17878
-    port: 8443
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:29 2022'
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17924
-    port: 3678
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:35 2022'
-    user: wildfly
-  - address: 0.0.0.0
-    name: java
-    pid: 17924
-    port: 8159
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:35 2022'
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17764
-    port: 42816
-    protocol: tcp
-    stime: 'Thu Jun 23 09:01:13 2022'
-    user: wildfly
-  - address: '::'
-    name: java
-    pid: 967
-    port: 5672
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:54 2022'
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 42825
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:54 2022'
-    user: root
-  - address: '::'
-    name: mysqld
-    pid: 1535
-    port: 3306
-    protocol: tcp
-    stime: 'Thu Jun 16 14:10:11 2022'
-    user: mysql
-  - address: '::'
-    name: java
-    pid: 967
-    port: 61613
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:54 2022'
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 61614
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:54 2022'
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 550
-    port: 111
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:45 2022'
-    user: rpc
-  - address: '::'
-    name: java
-    pid: 967
-    port: 61616
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:54 2022'
-    user: root
-  - address: '::'
-    name: httpd
-    pid: 866
-    port: 80
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:53 2022'
-    user: root
-  - address: '::'
-    name: httpd
-    pid: 866
-    port: 81
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:53 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1159
-    port: 22
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:58 2022'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1100
-    port: 25
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:57 2022'
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 1883
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:54 2022'
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 8161
-    protocol: tcp
-    stime: 'Thu Jun 16 14:09:54 2022'
-    user: root
-udp_listen:
-  - address: 230.0.0.4
-    name: java
-    pid: 17924
-    port: 45688
-    protocol: udp
-    stime: 'Thu Jun 23 09:01:35 2022'
-    user: wildfly
-  - address: 230.0.0.4
-    name: java
-    pid: 17878
-    port: 45688
-    protocol: udp
-    stime: 'Thu Jun 23 09:01:29 2022'
-    user: wildfly
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 550
-    port: 721
-    protocol: udp
-    stime: 'Thu Jun 16 14:09:45 2022'
-    user: rpc
-  - address: 224.0.1.105
-    name: java
-    pid: 17924
-    port: 23364
-    protocol: udp
-    stime: 'Thu Jun 23 09:01:35 2022'
-    user: wildfly
-  - address: 224.0.1.105
-    name: java
-    pid: 17878
-    port: 23364
-    protocol: udp
-    stime: 'Thu Jun 23 09:01:29 2022'
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17878
-    port: 55200
-    protocol: udp
-    stime: 'Thu Jun 23 09:01:29 2022'
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17924
-    port: 55350
-    protocol: udp
-    stime: 'Thu Jun 23 09:01:35 2022'
-    user: wildfly
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 808
-    port: 68
-    protocol: udp
-    stime: 'Thu Jun 16 14:09:53 2022'
-    user: root
-  - address: 0.0.0.0
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  easymock2:
+  - arch: noarch
+    epoch: null
+    name: easymock2
+    release: 12.el7
+    source: rpm
+    version: 2.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '14'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  felix-framework:
+  - arch: noarch
+    epoch: null
+    name: felix-framework
+    release: 5.el7
+    source: rpm
+    version: 4.2.1
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  geronimo-annotation:
+  - arch: noarch
+    epoch: null
+    name: geronimo-annotation
+    release: 15.el7
+    source: rpm
+    version: '1.0'
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  google-guice:
+  - arch: noarch
+    epoch: null
+    name: google-guice
+    release: 9.el7
+    source: rpm
+    version: 3.1.3
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 61b8bab7
+    source: rpm
+    version: 3a79bd29
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 5c4058fb
+    source: rpm
+    version: 5072e1f5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 5eb44ee6
+    source: rpm
+    version: a3219f7b
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 602c28d5
+    source: rpm
+    version: e2c63c11
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 5ced7aac
+    source: rpm
+    version: 90cfb1f5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  guava:
+  - arch: noarch
+    epoch: null
+    name: guava
+    release: 6.el7
+    source: rpm
+    version: '13.0'
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hamcrest:
+  - arch: noarch
+    epoch: 0
+    name: hamcrest
+    release: 6.el7
+    source: rpm
+    version: '1.3'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  httpcomponents-client:
+  - arch: noarch
+    epoch: null
+    name: httpcomponents-client
+    release: 5.el7_0
+    source: rpm
+    version: 4.2.5
+  httpcomponents-core:
+  - arch: noarch
+    epoch: null
+    name: httpcomponents-core
+    release: 6.el7
+    source: rpm
+    version: 4.2.4
+  httpd:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos.4
+    source: rpm
+    version: 2.4.6
+  httpd-tools:
+  - arch: x86_64
+    epoch: null
+    name: httpd-tools
+    release: 97.el7.centos.4
+    source: rpm
+    version: 2.4.6
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-commons-httpclient:
+  - arch: noarch
+    epoch: 1
+    name: jakarta-commons-httpclient
+    release: 16.el7_0
+    source: rpm
+    version: '3.1'
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-devel:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-devel
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  javassist:
+  - arch: noarch
+    epoch: null
+    name: javassist
+    release: 10.el7
+    source: rpm
+    version: 3.16.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  jboss-ejb-3.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-ejb-3.1-api
+    release: 10.el7
+    source: rpm
+    version: 1.0.2
+  jboss-el-2.2-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-el-2.2-api
+    release: 0.7.20120212git2fabd8.el7
+    source: rpm
+    version: 1.0.1
+  jboss-interceptors-1.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-interceptors-1.1-api
+    release: 0.9.20120319git49a904.el7
+    source: rpm
+    version: 1.0.2
+  jboss-jaxrpc-1.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-jaxrpc-1.1-api
+    release: 7.el7
+    source: rpm
+    version: 1.0.1
+  jboss-servlet-3.0-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-servlet-3.0-api
+    release: 9.el7
+    source: rpm
+    version: 1.0.1
+  jboss-transaction-1.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-transaction-1.1-api
+    release: 8.el7
+    source: rpm
+    version: 1.0.1
+  jline:
+  - arch: noarch
+    epoch: null
+    name: jline
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  jsch:
+  - arch: noarch
+    epoch: 0
+    name: jsch
+    release: 5.el7
+    source: rpm
+    version: 0.1.50
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  jsoup:
+  - arch: noarch
+    epoch: null
+    name: jsoup
+    release: 10.el7
+    source: rpm
+    version: 1.6.1
+  junit:
+  - arch: noarch
+    epoch: 0
+    name: junit
+    release: 8.el7
+    source: rpm
+    version: '4.11'
+  jzlib:
+  - arch: noarch
+    epoch: 0
+    name: jzlib
+    release: 6.el7
+    source: rpm
+    version: 1.1.1
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.49.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.3
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 135.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 18.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  maven:
+  - arch: noarch
+    epoch: null
+    name: maven
+    release: 17.el7
+    source: rpm
+    version: 3.0.5
+  maven-wagon:
+  - arch: noarch
+    epoch: 0
+    name: maven-wagon
+    release: 3.el7
+    source: rpm
+    version: '2.4'
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mongodb-database-tools:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-database-tools
+    release: '1'
+    source: rpm
+    version: 100.5.2
+  mongodb-org:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-database-tools-extra:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-database-tools-extra
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-mongos:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-mongos
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-server:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-server
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-shell:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-shell
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-tools:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-tools
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mysql-community-client:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-client
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-client-plugins:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-client-plugins
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-common:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-common
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-icu-data-files:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-icu-data-files
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-libs:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-libs
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-libs-compat:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-libs-compat
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-server:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-server
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql80-community-release:
+  - arch: noarch
+    epoch: null
+    name: mysql80-community-release
+    release: '3'
+    source: rpm
+    version: el8
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  nekohtml:
+  - arch: noarch
+    epoch: 0
+    name: nekohtml
+    release: 13.el7
+    source: rpm
+    version: 1.9.14
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7.2
+    source: rpm
+    version: 1.3.0
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  objectweb-asm:
+  - arch: noarch
+    epoch: 0
+    name: objectweb-asm
+    release: 9.el7
+    source: rpm
+    version: 3.3.1
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 25.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  packer:
+  - arch: x86_64
+    epoch: null
+    name: packer
+    release: '1'
+    source: rpm
+    version: 1.7.10
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  plexus-cipher:
+  - arch: noarch
+    epoch: null
+    name: plexus-cipher
+    release: 5.el7
+    source: rpm
+    version: '1.7'
+  plexus-classworlds:
+  - arch: noarch
+    epoch: null
+    name: plexus-classworlds
+    release: 8.el7
+    source: rpm
+    version: 2.4.2
+  plexus-component-api:
+  - arch: noarch
+    epoch: null
+    name: plexus-component-api
+    release: 0.16.alpha15.el7
+    source: rpm
+    version: '1.0'
+  plexus-containers-component-annotations:
+  - arch: noarch
+    epoch: null
+    name: plexus-containers-component-annotations
+    release: 14.el7
+    source: rpm
+    version: 1.5.5
+  plexus-containers-container-default:
+  - arch: noarch
+    epoch: null
+    name: plexus-containers-container-default
+    release: 14.el7
+    source: rpm
+    version: 1.5.5
+  plexus-interactivity:
+  - arch: noarch
+    epoch: 0
+    name: plexus-interactivity
+    release: 0.14.alpha6.el7
+    source: rpm
+    version: '1.0'
+  plexus-interpolation:
+  - arch: noarch
+    epoch: null
+    name: plexus-interpolation
+    release: 8.el7
+    source: rpm
+    version: '1.15'
+  plexus-sec-dispatcher:
+  - arch: noarch
+    epoch: null
+    name: plexus-sec-dispatcher
+    release: 13.el7
+    source: rpm
+    version: '1.4'
+  plexus-utils:
+  - arch: noarch
+    epoch: null
+    name: plexus-utils
+    release: 9.el7
+    source: rpm
+    version: 3.0.9
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 10.el7
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qdox:
+  - arch: noarch
+    epoch: 0
+    name: qdox
+    release: 10.el7
+    source: rpm
+    version: 1.12.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  regexp:
+  - arch: noarch
+    epoch: 0
+    name: regexp
+    release: 13.el7
+    source: rpm
+    version: '1.5'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 550
-    port: 111
-    protocol: udp
-    stime: 'Thu Jun 16 14:09:45 2022'
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 566
-    port: 323
-    protocol: udp
-    stime: 'Thu Jun 16 14:09:49 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 550
-    port: 721
-    protocol: udp
-    stime: 'Thu Jun 16 14:09:45 2022'
-    user: rpc
-  - address: '::'
-    name: rpcbind
-    pid: 550
-    port: 111
-    protocol: udp
-    stime: 'Thu Jun 16 14:09:45 2022'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 566
-    port: 323
-    protocol: udp
-    stime: 'Thu Jun 16 14:09:49 2022'
-    user: chrony
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9.1
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  sisu-inject-bean:
+  - arch: noarch
+    epoch: null
+    name: sisu-inject-bean
+    release: 11.el7
+    source: rpm
+    version: 2.3.0
+  sisu-inject-plexus:
+  - arch: noarch
+    epoch: null
+    name: sisu-inject-plexus
+    release: 11.el7
+    source: rpm
+    version: 2.3.0
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slf4j:
+  - arch: noarch
+    epoch: 0
+    name: slf4j
+    release: 4.el7_4
+    source: rpm
+    version: 1.7.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.2
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 66.el7
+    source: rpm
+    version: '0.17'
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 24.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7_9.1
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xbean:
+  - arch: noarch
+    epoch: null
+    name: xbean
+    release: 6.el7
+    source: rpm
+    version: '3.13'
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '113'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '192'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '193'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '260'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '266'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '281'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '282'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '408'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '447'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '471'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '512'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '539'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '548'
+  ppid: '1'
+  user: polkitd
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '550'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '554'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '562'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '563'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '566'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H test-norm01 eth0
+  cwd: /sbin/
+  pid: '808'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '864'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '866'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/java -Xms64M -Xmx1G -Djava.util.logging.config.file=logging.properties
+    -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config
+    -Dcom.sun.management.jmxremote -Djava.awt.headless=true -Djava.io.tmpdir=/opt/apache-activemq-5.14.3//tmp
+    -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/:
+    -Dactivemq.home=/opt/apache-activemq-5.14.3/ -Dactivemq.base=/opt/apache-activemq-5.14.3/
+    -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf -Dactivemq.data=/opt/apache-activemq-5.14.3//data
+    -jar /opt/apache-activemq-5.14.3//bin/activemq.jar start'
+  cwd: /usr/bin/
+  pid: '967'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1100'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1106'
+  ppid: '1100'
+  user: postfix
+- cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '1147'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1148'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1159'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1181'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1182'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1183'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/mongod -f /etc/mongod.conf
+  cwd: /usr/bin/
+  pid: '1239'
+  ppid: '1'
+  user: mongod
+- cmdline: /usr/sbin/mysqld
+  cwd: /usr/sbin/
+  pid: '1535'
+  ppid: '1'
+  user: mysql
+- cmdline: ''
+  cwd: /
+  pid: '1993'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '3183'
+  ppid: '1100'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '3613'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4364'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4868'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5134'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '5361'
+  ppid: '1159'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '5364'
+  ppid: '5361'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-kzjhunintzyuuudwdmbontatxnepriby
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657097709.5033789-20592-66687050083535/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '5517'
+  ppid: '5364'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-kzjhunintzyuuudwdmbontatxnepriby
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657097709.5033789-20592-66687050083535/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '5530'
+  ppid: '5517'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-kzjhunintzyuuudwdmbontatxnepriby ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1657097709.5033789-20592-66687050083535/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '5532'
+  ppid: '5530'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657097709.5033789-20592-66687050083535/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '5533'
+  ppid: '5532'
+  user: root
+- cmdline: /bin/bash /opt/wildfly/bin/launch.sh standalone standalone.xml 0.0.0.0
+    0.0.0.0
+  cwd: /bin/
+  pid: '16731'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh /opt/wildfly/bin/standalone.sh -c standalone.xml -b 0.0.0.0 -bmanagement
+    0.0.0.0 -Djboss.node.name=jbossnode -Djboss.bind.address=0.0.0.0
+  cwd: /bin/
+  pid: '16732'
+  ppid: '16731'
+  user: root
+- cmdline: java -D[Standalone] -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m
+    -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman
+    -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/wildfly/standalone/log/server.log
+    -Dlogging.configuration=file:/opt/wildfly/standalone/configuration/logging.properties
+    -jar /opt/wildfly/jboss-modules.jar -mp /opt/wildfly/modules org.jboss.as.standalone
+    -Djboss.home.dir=/opt/wildfly -Djboss.server.base.dir=/opt/wildfly/standalone
+    -c standalone.xml -b 0.0.0.0 -bmanagement 0.0.0.0 -Djboss.node.name=jbossnode
+    -Djboss.bind.address=0.0.0.0
+  cwd: /
+  pid: '16804'
+  ppid: '16732'
+  user: root
+- cmdline: /bin/sh /opt/jboss/bin/domain.sh --domain-config=domain.xml --host-config=host.xml
+  cwd: /bin/
+  pid: '17678'
+  ppid: '1'
+  user: wildfly
+- cmdline: java -D[Process Controller] -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m
+    -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman
+    -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/process-controller.log
+    -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
+    -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.process-controller
+    -jboss-home /opt/jboss -jvm java -mp /opt/jboss/modules -- -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log
+    -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
+    -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true
+    -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -- -default-jvm
+    java --domain-config=domain.xml --host-config=host.xml
+  cwd: /
+  pid: '17764'
+  ppid: '17678'
+  user: wildfly
+- cmdline: java -D[Host Controller] -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log
+    -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
+    -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true
+    -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -jar /opt/jboss/jboss-modules.jar
+    -mp /opt/jboss/modules org.jboss.as.host-controller -mp /opt/jboss/modules --pc-address
+    127.0.0.1 --pc-port 42816 -default-jvm java --domain-config=domain.xml --host-config=host.xml
+    -Djboss.home.dir=/opt/jboss
+  cwd: /
+  pid: '17780'
+  ppid: '17764'
+  user: wildfly
+- cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/java
+    -D[Server:nodo1-server1] -D[pcid:1449119893] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m
+    -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true
+    -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo1-server1/log
+    -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo1-server1/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo1-server1/data
+    -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo1-server1/data/logging.properties
+    -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
+  cwd: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/
+  pid: '17878'
+  ppid: '17764'
+  user: wildfly
+- cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/java
+    -D[Server:nodo1-server2] -D[pcid:1585598268] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m
+    -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true
+    -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo1-server2/log
+    -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo1-server2/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo1-server2/data
+    -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo1-server2/data/logging.properties
+    -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
+  cwd: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/
+  pid: '17924'
+  ppid: '17764'
+  user: wildfly
+- cmdline: ''
+  cwd: /
+  pid: '21509'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '27956'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '27957'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '27958'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '27959'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '27960'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '30851'
+  ppid: '866'
+  user: apache
+software_list:
+- cmd_regexp: activemq\.ja
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/apache_activemq.yaml'
+    name: Include Apache ActiveMQ specific plugins
+  name: Apache ActiveMQ
+  pkg_regexp: activemq
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 0.0.0.0
+  name: java
+  pid: 16804
+  port: 29990
+  protocol: tcp
+  stime: Thu Jun 23 18:52:06 2022
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: 17924
+  port: 8230
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: java
+  pid: 17780
+  port: 9990
+  protocol: tcp
+  stime: Thu Jun 23 09:01:15 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17878
+  port: 3528
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: java
+  pid: 17878
+  port: 8009
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: mongod
+  pid: 1239
+  port: 27017
+  protocol: tcp
+  stime: Thu Jun 16 14:10:00 2022
+  user: mongod
+- address: 0.0.0.0
+  name: java
+  pid: 17780
+  port: 9999
+  protocol: tcp
+  stime: Thu Jun 23 09:01:15 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: 0.0.0.0
+  name: java
+  pid: 16804
+  port: 28080
+  protocol: tcp
+  stime: Thu Jun 23 18:52:06 2022
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: 17878
+  port: 8080
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: java
+  pid: 17924
+  port: 8593
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: sshd
+  pid: 1159
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 16 14:09:58 2022
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: 17878
+  port: 54200
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17924
+  port: 54201
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: master
+  pid: 1100
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 16 14:09:57 2022
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: 16804
+  port: 28443
+  protocol: tcp
+  stime: Thu Jun 23 18:52:06 2022
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: 17878
+  port: 8443
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17924
+  port: 3678
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: java
+  pid: 17924
+  port: 8159
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17764
+  port: 42816
+  protocol: tcp
+  stime: Thu Jun 23 09:01:13 2022
+  user: wildfly
+- address: '::'
+  name: java
+  pid: 967
+  port: 5672
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 42825
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: mysqld
+  pid: 1535
+  port: 3306
+  protocol: tcp
+  stime: Thu Jun 16 14:10:11 2022
+  user: mysql
+- address: '::'
+  name: java
+  pid: 967
+  port: 61613
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 61614
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: '::'
+  name: java
+  pid: 967
+  port: 61616
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: httpd
+  pid: 866
+  port: 80
+  protocol: tcp
+  stime: Thu Jun 16 14:09:53 2022
+  user: root
+- address: '::'
+  name: httpd
+  pid: 866
+  port: 81
+  protocol: tcp
+  stime: Thu Jun 16 14:09:53 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1159
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 16 14:09:58 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1100
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 16 14:09:57 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 1883
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 8161
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+udp_listen:
+- address: 230.0.0.4
+  name: java
+  pid: 17924
+  port: 45688
+  protocol: udp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 230.0.0.4
+  name: java
+  pid: 17878
+  port: 45688
+  protocol: udp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 550
+  port: 721
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: 224.0.1.105
+  name: java
+  pid: 17924
+  port: 23364
+  protocol: udp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 224.0.1.105
+  name: java
+  pid: 17878
+  port: 23364
+  protocol: udp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17878
+  port: 55200
+  protocol: udp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17924
+  port: 55350
+  protocol: udp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: dhclient
+  pid: 808
+  port: 68
+  protocol: udp
+  stime: Thu Jun 16 14:09:53 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 566
+  port: 323
+  protocol: udp
+  stime: Thu Jun 16 14:09:49 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 550
+  port: 721
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: '::'
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 566
+  port: 323
+  protocol: udp
+  stime: Thu Jun 16 14:09:49 2022
+  user: chrony

--- a/tests/unit/plugins/action/auto/resources/apache_webserver/apache2.4.6_centos7.6.yaml
+++ b/tests/unit/plugins/action/auto/resources/apache_webserver/apache2.4.6_centos7.6.yaml
@@ -1,4650 +1,4732 @@
-mocked_plugin_tasks:
-  "Get conf_file_path from cmdline":
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-  "Run command with binary":
-    plugin_result:
-      failed: false
-      stdout: |-
-        Server version: Apache/2.4.6 (CentOS)
-        Server built:   Nov 16 2020 16:18:20
-        Server's Module Magic Number: 20120211:24
-        Server loaded:  APR 1.4.8, APR-UTIL 1.5.2
-        Compiled using: APR 1.4.8, APR-UTIL 1.5.2
-        Architecture:   64-bit
-        Server MPM:     prefork
-          threaded:     no
-            forked:     yes (variable process count)
-        Server compiled with....
-         -D APR_HAS_SENDFILE
-         -D APR_HAS_MMAP
-         -D APR_HAVE_IPV6 (IPv4-mapped addresses enabled)
-         -D APR_USE_SYSVSEM_SERIALIZE
-         -D APR_USE_PTHREAD_SERIALIZE
-         -D SINGLE_LISTEN_UNSERIALIZED_ACCEPT
-         -D APR_HAS_OTHER_CHILD
-         -D AP_HAVE_RELIABLE_PIPED_LOGS
-         -D DYNAMIC_MODULE_LIMIT=256
-         -D HTTPD_ROOT="/etc/httpd"
-         -D SUEXEC_BIN="/usr/sbin/suexec"
-         -D DEFAULT_PIDLOG="/run/httpd/httpd.pid"
-         -D DEFAULT_SCOREBOARD="logs/apache_runtime_status"
-         -D DEFAULT_ERRORLOG="logs/error_log"
-         -D AP_TYPES_CONFIG_FILE="conf/mime.types"
-         -D SERVER_CONFIG_FILE="conf/httpd.conf"
-  "Check if conf_file_path is accesible":
-    plugin_result:
-      failed: true
-  "Run command version":
-    plugin_result:
-      failed: false
-      stdout: |-
-        Server version: Apache/2.4.6 (CentOS)
-        Server built:   Nov 16 2020 16:18:20
-  "Read process environment":
-    plugin_result:
-      failed: false
-      parsed: {
-        "LANG": "C",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
-        "NOTIFY_SOCKET": "/run/systemd/notify"
-      }
-  "Parse config file":
-    plugin_result:
-      failed: false
-      parsed: {
-        "Group": "apache",
-        "AddDefaultCharset": "UTF-8",
-        "JkMount": "/tomcat/* tomcat",
-        "ServerAdmin": "root@localhost",
-        "DocumentRoot": "/var/www/html",
-        "JkLogLevel": "info",
-        "Files": {
-          ".ht*": {
-            "Require": "all denied"
-          }
-        },
-        "DefaultIcon": "/icons/unknown.gif",
-        "ServerRoot": "/etc/httpd",
-        "LogLevel": "warn",
-        "JkShmFile": "/var/log/httpd/mod_jk.shm",
-        "JkLogStampFormat": "[%a %b %d %H:%M:%S %Y]",
-        "AddIcon": "/icons/blank.gif ^^BLANKICON^^",
-        "User": "apache",
-        "LoadModule": "jk_module modules/mod_jk.so",
-        "Listen": "80",
-        "ReadmeName": "README.html",
-        "HeaderName": "HEADER.html",
-        "Alias": "/icons/ \"/usr/share/httpd/icons/\"",
-        "Directory": {
-          "/var/www/html": {
-            "Require": "all granted",
-            "Options": "Indexes FollowSymLinks",
-            "AllowOverride": "None"
-          },
-          "/var/www": {
-            "Require": "all granted",
-            "AllowOverride": "None"
-          },
-          "Alias": "/images/poweredby.png /usr/share/httpd/noindex/images/poweredby.png",
-          "/usr/share/httpd/noindex": {
-            "Require": "all granted",
-            "AllowOverride": "None"
-          },
-          "IfModule": {
-            "mod_userdir.c": {
-              "UserDir": "disabled"
-            }
-          },
-          "/usr/share/httpd/icons": {
-            "Require": "all granted",
-            "Options": "Indexes MultiViews FollowSymlinks",
-            "AllowOverride": "None"
-          },
-          "/var/www/cgi-bin": {
-            "Require": "all granted",
-            "Options": "None",
-            "AllowOverride": "None"
-          },
-          "/": {
-            "Require": "all denied",
-            "AllowOverride": "none"
-          },
-          "IndexIgnore": ".??* *~ *",
-          "/home/*/public_html": {
-            "Require": "method GET POST OPTIONS",
-            "Options": "MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec",
-            "AllowOverride": "FileInfo AuthConfig Limit Indexes"
-          },
-          "IndexOptions": "FancyIndexing HTMLTable VersionSort",
-          "AddIconByType": "(VID,/icons/movie.gif) video/*",
-          "LocationMatch": {
-            "^/+$": {
-              "ErrorDocument": "403 /.noindex.html",
-              "Options": "-Indexes"
-            }
-          },
-          "AddIconByEncoding": "(CMP,/icons/compressed.gif) x-compress x-gzip"
-        },
-        "EnableSendfile": "on",
-        "JkLogFile": "/var/log/httpd/mod_jk.log",
-        "JKWorkers": {
-          "JKLoadbalancers": {
-            "jkstatus": {
-              "type": "status",
-              "name": "jkstatus"
-            },
-            "tomcat": {
-              "name": "tomcat",
-              "socket_connect_timeout": "3000",
-              "socket_timeout": "30",
-              "balance_workers": "loadbalancer-1,loadbalancer-2",
-              "type": "lb",
-              "ping_mode": "A"
-            }
-          },
-          "JKBalanceWorkers": {
-            "loadbalancer-2": {
-              "host": "192.168.0.223",
-              "lbfactor": "10",
-              "type": "ajp13",
-              "port": "8009",
-              "name": "loadbalancer-2"
-            },
-            "loadbalancer-1": {
-              "port": "8009",
-              "host": "192.168.0.142",
-              "type": "ajp13",
-              "name": "loadbalancer-1",
-              "lbfactor": "10"
-            }
-          }
-        },
-        "IfModule": {
-          "mpm_worker_module": {
-            "LoadModule": "cgid_module modules/mod_cgid.so"
-          },
-          "mime_magic_module": {
-            "MIMEMagicFile": "conf/magic"
-          },
-          "mpm_prefork_module": {
-            "LoadModule": "cgi_module modules/mod_cgi.so"
-          },
-          "alias_module": {
-            "ScriptAlias": "/cgi-bin/ \"/var/www/cgi-bin/\""
-          },
-          "dir_module": {
-            "DirectoryIndex": "index.html"
-          },
-          "log_config_module": {
-            "CustomLog": "\"logs/access_log\" combined",
-            "IfModule": {
-              "logio_module": {
-                "LogFormat": "\"%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O\" combinedio"
-              }
-            },
-            "LogFormat": "\"%h %l %u %t \"%r\" %>s %b\" common"
-          },
-          "mpm_event_module": {
-            "LoadModule": "cgid_module modules/mod_cgid.so"
-          },
-          "mime_module": {
-            "TypesConfig": "/etc/mime.types",
-            "AddType": "text/html .shtml",
-            "AddOutputFilter": "INCLUDES .shtml"
-          }
-        },
-        "ErrorLog": "logs/error_log"
-      }
-  "Get instance_name from conf_file_name":
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-  "Run regex on the current item for custom_log_files":
-    number_of_calls: 1
-  "Check custom_log_files file":
-    plugin_result:
-      failed: true
-  "Check custom_log_file file in conf_path":
-    plugin_result:
-      failed: true
-  "Check custom_log_file file in parent_conf_path":
-    plugin_result:
-      failed: false
-  "Run regex on the current item for error_log_files":
-    number_of_calls: 1
-  "Check error_log_file file":
-    plugin_result:
-      failed: true
-  "Check error_log_file file in conf_path":
-    plugin_result:
-      failed: true
-  "Check error_log_file file in parent_conf_path":
-    plugin_result:
-      failed: false
-
-expected_tasks_calls_mode_strict: false
-expected_tasks_calls:
-  Run regex on the current item for custom_log_files: 1
-  Run regex on the current item for error_log_files: 1
-
-expected_result:
-  - bindings:
-      - address: '::'
-        class: service
-        port: 80
-        protocol: tcp
-      - address: localhost
-        class: http
-        port: 80
-    configuration:
-      AddDefaultCharset: UTF-8
-      AddIcon: /icons/blank.gif ^^BLANKICON^^
-      Alias: /icons/ "/usr/share/httpd/icons/"
-      DefaultIcon: /icons/unknown.gif
-      Directory:
-        /:
-          AllowOverride: none
-          Require: all denied
-        /home/*/public_html:
-          AllowOverride: FileInfo AuthConfig Limit Indexes
-          Options: MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
-          Require: method GET POST OPTIONS
-        /usr/share/httpd/icons:
-          AllowOverride: None
-          Options: Indexes MultiViews FollowSymlinks
-          Require: all granted
-        /usr/share/httpd/noindex:
-          AllowOverride: None
-          Require: all granted
-        /var/www:
-          AllowOverride: None
-          Require: all granted
-        /var/www/cgi-bin:
-          AllowOverride: None
-          Options: None
-          Require: all granted
-        /var/www/html:
-          AllowOverride: None
-          Options: Indexes FollowSymLinks
-          Require: all granted
-        AddIconByEncoding: (CMP,/icons/compressed.gif) x-compress x-gzip
-        AddIconByType: (VID,/icons/movie.gif) video/*
-        Alias: /images/poweredby.png /usr/share/httpd/noindex/images/poweredby.png
-        IfModule:
-          mod_userdir.c:
-            UserDir: disabled
-        IndexIgnore: .??* *~ *
-        IndexOptions: FancyIndexing HTMLTable VersionSort
-        LocationMatch:
-          ^/+$:
-            ErrorDocument: 403 /.noindex.html
-            Options: -Indexes
-      DocumentRoot: /var/www/html
-      EnableSendfile: 'on'
-      ErrorLog: logs/error_log
-      Files:
-        .ht*:
-          Require: all denied
-      Group: apache
-      HeaderName: HEADER.html
-      IfModule:
-        alias_module:
-          ScriptAlias: /cgi-bin/ "/var/www/cgi-bin/"
-        dir_module:
-          DirectoryIndex: index.html
-        log_config_module:
-          CustomLog: '"logs/access_log" combined'
-          IfModule:
-            logio_module:
-              LogFormat: '"%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i" %I %O" combinedio'
-          LogFormat: '"%h %l %u %t "%r" %>s %b" common'
-        mime_magic_module:
-          MIMEMagicFile: conf/magic
-        mime_module:
-          AddOutputFilter: INCLUDES .shtml
-          AddType: text/html .shtml
-          TypesConfig: /etc/mime.types
-        mpm_event_module:
-          LoadModule: cgid_module modules/mod_cgid.so
-        mpm_prefork_module:
-          LoadModule: cgi_module modules/mod_cgi.so
-        mpm_worker_module:
-          LoadModule: cgid_module modules/mod_cgid.so
-      JKWorkers:
-        JKBalanceWorkers:
-          loadbalancer-1:
-            host: 192.168.0.142
-            lbfactor: '10'
-            name: loadbalancer-1
-            port: '8009'
-            type: ajp13
-          loadbalancer-2:
-            host: 192.168.0.223
-            lbfactor: '10'
-            name: loadbalancer-2
-            port: '8009'
-            type: ajp13
-        JKLoadbalancers:
-          jkstatus:
-            name: jkstatus
-            type: status
-          tomcat:
-            balance_workers: loadbalancer-1,loadbalancer-2
-            name: tomcat
-            ping_mode: A
-            socket_connect_timeout: '3000'
-            socket_timeout: '30'
-            type: lb
-      JkLogFile: /var/log/httpd/mod_jk.log
-      JkLogLevel: info
-      JkLogStampFormat: '[%a %b %d %H:%M:%S %Y]'
-      JkMount: /tomcat/* tomcat
-      JkShmFile: /var/log/httpd/mod_jk.shm
-      Listen: '80'
-      LoadModule: jk_module modules/mod_jk.so
-      LogLevel: warn
-      ReadmeName: README.html
-      ServerAdmin: root@localhost
-      ServerRoot: /etc/httpd
-      User: apache
-    discovery_time: '2022-06-08T19:34:47+02:00'
-    extra_data:
-      instance_name: '80.80'
-      instance_name_uppercase: '80.80'
-    files:
-      - path: /usr/sbin
-        name: httpd
-        subtype: generic
-        type: binary
-      - name: httpd.conf
-        path: /etc/httpd/conf
-        subtype: generic
-        type: config
-      - name: access_log
-        path: /etc/httpd/logs
-        subtype: access
-        type: log
-      - name: error_log
-        path: /etc/httpd/logs
-        subtype: error
-        type: log
-    listening_ports:
-      - 80
-    type: Apache WebServer
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: httpd
-        release: 97.el7.centos
-        source: rpm
-        version: 2.4.6
-    process:
-      children:
-        - children: []
-          cmdline: /usr/sbin/httpd -DFOREGROUND
-          pid: '21138'
-          ppid: '889'
-          user: apache
-        - children: []
-          cmdline: /usr/sbin/httpd -DFOREGROUND
-          pid: '21139'
-          ppid: '889'
-          user: apache
-        - children: []
-          cmdline: /usr/sbin/httpd -DFOREGROUND
-          pid: '21140'
-          ppid: '889'
-          user: apache
-        - children: []
-          cmdline: /usr/sbin/httpd -DFOREGROUND
-          pid: '21141'
-          ppid: '889'
-          user: apache
-        - children: []
-          cmdline: /usr/sbin/httpd -DFOREGROUND
-          pid: '21142'
-          ppid: '889'
-          user: apache
-      cmdline: /usr/sbin/httpd -DFOREGROUND
-      listening_ports:
-        - 80
-      pid: '889'
-      ppid: '1'
-      user: root
-    version:
-      - number: 2.4.6
-        type: active
-      - number: 2.4.6
-        type: package
-
-software_list:
-  - cmd_regexp: "^.*/(?:sbin|bin)/(?:httpd|apache2)(?:[-_](?:prefork|worker))?(?:.*)?"
-    name: Apache WebServer
-    pkg_regexp: apache2|^httpd$
-    process_type: parent
-    return_children: true
-    return_packages: true
-    custom_tasks:
-      - name: Include Apache Webserver specific plugins
-        include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/apache_webserver.yaml"
-
 dockers:
-  containers: [ ]
-packages:
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
-  apache-commons-collections:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-collections
-      release: 22.el7_2
-      source: rpm
-      version: 3.2.1
-  apache-commons-daemon:
-    - arch: x86_64
-      epoch: null
-      name: apache-commons-daemon
-      release: 7.el7
-      source: rpm
-      version: 1.0.13
-  apache-commons-dbcp:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-dbcp
-      release: 17.el7
-      source: rpm
-      version: '1.4'
-  apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
-  apache-commons-pool:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-pool
-      release: 9.el7
-      source: rpm
-      version: '1.6'
-  apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
-  apr-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-devel
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
-  apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
-  apr-util-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-util-devel
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
-  atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autoconf:
-    - arch: noarch
-      epoch: null
-      name: autoconf
-      release: 11.el7
-      source: rpm
-      version: '2.69'
-  automake:
-    - arch: noarch
-      epoch: null
-      name: automake
-      release: 3.el7
-      source: rpm
-      version: 1.13.4
-  avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
-  avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
-  avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 16.P2.el7_8.2
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 43.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 76.el7_7
-      source: rpm
-      version: 2019.2.32
-  cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
-  centos-indexhtml:
-    - arch: noarch
-      epoch: null
-      name: centos-indexhtml
-      release: 9.el7.centos
-      source: rpm
-      version: '7'
-  centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 8.2003.0.el7.centos
-      source: rpm
-      version: '7'
-  centos-release-scl-rh:
-    - arch: noarch
-      epoch: null
-      name: centos-release-scl-rh
-      release: 3.el7.centos
-      source: rpm
-      version: '2'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 6.el7.centos
-      source: rpm
-      version: '18.5'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
-  copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
-  cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  cyrus-sasl-devel:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-devel
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
-  devtoolset-7-binutils:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-binutils
-      release: 11.el7
-      source: rpm
-      version: '2.28'
-  devtoolset-7-gcc:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
-  devtoolset-7-gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc-c++
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
-  devtoolset-7-libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-libstdc++-devel
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
-  devtoolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: '7.1'
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 3.el7
-      source: rpm
-      version: '3.2'
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dwz:
-    - arch: x86_64
-      epoch: null
-      name: dwz
-      release: 3.el7
-      source: rpm
-      version: '0.11'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  ecj:
-    - arch: x86_64
-      epoch: 1
-      name: ecj
-      release: 3.el7
-      source: rpm
-      version: 4.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  expat-devel:
-    - arch: x86_64
-      epoch: null
-      name: expat-devel
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  geronimo-jta:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jta
-      release: 17.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 5.el7
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gperftools-libs:
-    - arch: x86_64
-      epoch: null
-      name: gperftools-libs
-      release: 1.el7
-      source: rpm
-      version: 2.6.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 608c8351
-      source: rpm
-      version: 442df0f8
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 560cfc0a
-      source: rpm
-      version: f2ee9d55
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 28.el7
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  haproxy:
-    - arch: x86_64
-      epoch: null
-      name: haproxy
-      release: 9.el7_9.1
-      source: rpm
-      version: 1.5.18
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  httpd:
-    - arch: x86_64
-      epoch: null
-      name: httpd
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-devel:
-    - arch: x86_64
-      epoch: null
-      name: httpd-devel
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-tools:
-    - arch: x86_64
-      epoch: null
-      name: httpd-tools
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.5.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.49
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 25.el7_7.2
-      source: rpm
-      version: 4.11.0
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 34.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-taglibs-standard:
-    - arch: noarch
-      epoch: 0
-      name: jakarta-taglibs-standard
-      release: 14.el7_1
-      source: rpm
-      version: 1.1.2
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  keepalived:
-    - arch: x86_64
-      epoch: null
-      name: keepalived
-      release: 19.el7
-      source: rpm
-      version: 1.3.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.42.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 43.el7
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 131.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-devel:
-    - arch: x86_64
-      epoch: null
-      name: libdb-devel
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libedit-devel:
-    - arch: x86_64
-      epoch: null
-      name: libedit-devel
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libicu-devel:
-    - arch: x86_64
-      epoch: null
-      name: libicu-devel
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 3.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libtool:
-    - arch: x86_64
-      epoch: null
-      name: libtool
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  llvm-toolset-7-clang:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-clang-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang-libs
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-compiler-rt:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-compiler-rt
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-libomp:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-libomp
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-llvm-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-llvm-libs
-      release: 8.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-devel:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-devel
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-libs
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 16.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 14.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.65
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 61.el7
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-devel:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-devel
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.66.el7
-      source: rpm
-      version: 1.3.0
-  nginx:
-    - arch: x86_64
-      epoch: 1
-      name: nginx
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: nginx-filesystem
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-mod-stream:
-    - arch: x86_64
-      epoch: 1
-      name: nginx-mod-stream
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7
-      source: rpm
-      version: 4.21.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 4.el7_7
-      source: rpm
-      version: 3.44.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openldap-devel:
-    - arch: x86_64
-      epoch: null
-      name: openldap-devel
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Thread-Queue:
-    - arch: noarch
-      epoch: null
-      name: perl-Thread-Queue
-      release: 2.el7
-      source: rpm
-      version: '3.02'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: perl-srpm-macros
-      release: 8.el7
-      source: rpm
-      version: '1'
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pgdg-redhat-repo:
-    - arch: noarch
-      epoch: null
-      name: pgdg-redhat-repo
-      release: '24'
-      source: rpm
-      version: '42.0'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql11:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-contrib
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-devel:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-devel
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-libs
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-server
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 27.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-devel:
-    - arch: x86_64
-      epoch: null
-      name: python-devel
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 9.el7_8
-      source: rpm
-      version: 2.6.0
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python2-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python2-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-devel:
-    - arch: x86_64
-      epoch: null
-      name: python3-devel
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-rpm-generators:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-generators
-      release: 2.el7
-      source: rpm
-      version: '6'
-  python3-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redhat-rpm-config:
-    - arch: noarch
-      epoch: null
-      name: redhat-rpm-config
-      release: 88.el7.centos
-      source: rpm
-      version: 9.1.0
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 52.el7
-      source: rpm
-      version: 8.24.0
-  scl-utils:
-    - arch: x86_64
-      epoch: null
-      name: scl-utils
-      release: 19.el7
-      source: rpm
-      version: '20130529'
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 6.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 9.el7
-      source: rpm
-      version: 1.8.23
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  tomcat:
-    - arch: noarch
-      epoch: 0
-      name: tomcat
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-admin-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-admin-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-el-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-el-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-jsp-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-jsp-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-lib:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-lib
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 8.el7
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019c
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021a
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 20.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 167.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  zip:
-    - arch: x86_64
-      epoch: null
-      name: zip
-      release: 11.el7
-      source: rpm
-      version: '3.0'
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '50'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '65'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '197'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '198'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '274'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '275'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '276'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '277'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '279'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '294'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '295'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '297'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '298'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '299'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '412'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '444'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '466'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '469'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '511'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '513'
-    ppid: '1'
-    user: dbus
-  - cmdline: ''
-    pid: '514'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '556'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '559'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '564'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '566'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '567'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '581'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/rpcbind -w
-    pid: '582'
-    ppid: '1'
-    user: rpc
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H loadbalancer-2 eth0
-    pid: '830'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap start
-    pid: '887'
-    ppid: '1'
-    user: tomcat
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '888'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
+  containers: []
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 80
+    protocol: tcp
+  - address: localhost
+    class: http
+    port: 80
+  configuration:
+    AddDefaultCharset: UTF-8
+    AddIcon: /icons/blank.gif ^^BLANKICON^^
+    Alias: /icons/ "/usr/share/httpd/icons/"
+    DefaultIcon: /icons/unknown.gif
+    Directory:
+      /:
+        AllowOverride: none
+        Require: all denied
+      /home/*/public_html:
+        AllowOverride: FileInfo AuthConfig Limit Indexes
+        Options: MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
+        Require: method GET POST OPTIONS
+      /usr/share/httpd/icons:
+        AllowOverride: None
+        Options: Indexes MultiViews FollowSymlinks
+        Require: all granted
+      /usr/share/httpd/noindex:
+        AllowOverride: None
+        Require: all granted
+      /var/www:
+        AllowOverride: None
+        Require: all granted
+      /var/www/cgi-bin:
+        AllowOverride: None
+        Options: None
+        Require: all granted
+      /var/www/html:
+        AllowOverride: None
+        Options: Indexes FollowSymLinks
+        Require: all granted
+      AddIconByEncoding: (CMP,/icons/compressed.gif) x-compress x-gzip
+      AddIconByType: (VID,/icons/movie.gif) video/*
+      Alias: /images/poweredby.png /usr/share/httpd/noindex/images/poweredby.png
+      IfModule:
+        mod_userdir.c:
+          UserDir: disabled
+      IndexIgnore: .??* *~ *
+      IndexOptions: FancyIndexing HTMLTable VersionSort
+      LocationMatch:
+        ^/+$:
+          ErrorDocument: 403 /.noindex.html
+          Options: -Indexes
+    DocumentRoot: /var/www/html
+    EnableSendfile: 'on'
+    ErrorLog: logs/error_log
+    Files:
+      .ht*:
+        Require: all denied
+    Group: apache
+    HeaderName: HEADER.html
+    IfModule:
+      alias_module:
+        ScriptAlias: /cgi-bin/ "/var/www/cgi-bin/"
+      dir_module:
+        DirectoryIndex: index.html
+      log_config_module:
+        CustomLog: '"logs/access_log" combined'
+        IfModule:
+          logio_module:
+            LogFormat: '"%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i" %I
+              %O" combinedio'
+        LogFormat: '"%h %l %u %t "%r" %>s %b" common'
+      mime_magic_module:
+        MIMEMagicFile: conf/magic
+      mime_module:
+        AddOutputFilter: INCLUDES .shtml
+        AddType: text/html .shtml
+        TypesConfig: /etc/mime.types
+      mpm_event_module:
+        LoadModule: cgid_module modules/mod_cgid.so
+      mpm_prefork_module:
+        LoadModule: cgi_module modules/mod_cgi.so
+      mpm_worker_module:
+        LoadModule: cgid_module modules/mod_cgid.so
+    JKWorkers:
+      JKBalanceWorkers:
+        loadbalancer-1:
+          host: 192.168.0.142
+          lbfactor: '10'
+          name: loadbalancer-1
+          port: '8009'
+          type: ajp13
+        loadbalancer-2:
+          host: 192.168.0.223
+          lbfactor: '10'
+          name: loadbalancer-2
+          port: '8009'
+          type: ajp13
+      JKLoadbalancers:
+        jkstatus:
+          name: jkstatus
+          type: status
+        tomcat:
+          balance_workers: loadbalancer-1,loadbalancer-2
+          name: tomcat
+          ping_mode: A
+          socket_connect_timeout: '3000'
+          socket_timeout: '30'
+          type: lb
+    JkLogFile: /var/log/httpd/mod_jk.log
+    JkLogLevel: info
+    JkLogStampFormat: '[%a %b %d %H:%M:%S %Y]'
+    JkMount: /tomcat/* tomcat
+    JkShmFile: /var/log/httpd/mod_jk.shm
+    Listen: '80'
+    LoadModule: jk_module modules/mod_jk.so
+    LogLevel: warn
+    ReadmeName: README.html
+    ServerAdmin: root@localhost
+    ServerRoot: /etc/httpd
+    User: apache
+  discovery_time: '2022-06-08T19:34:47+02:00'
+  extra_data:
+    instance_name: '80.80'
+    instance_name_uppercase: '80.80'
+  files:
+  - name: httpd
+    path: /usr/sbin
+    subtype: generic
+    type: binary
+  - name: httpd.conf
+    path: /etc/httpd/conf
+    subtype: generic
+    type: config
+  - name: access_log
+    path: /etc/httpd/logs
+    subtype: access
+    type: log
+  - name: error_log
+    path: /etc/httpd/logs
+    subtype: error
+    type: log
+  listening_ports:
+  - 80
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  process:
+    children:
+    - children: []
+      cmdline: /usr/sbin/httpd -DFOREGROUND
+      cwd: /usr/sbin/
+      pid: '21138'
+      ppid: '889'
+      user: apache
+    - children: []
+      cmdline: /usr/sbin/httpd -DFOREGROUND
+      cwd: /usr/sbin/
+      pid: '21139'
+      ppid: '889'
+      user: apache
+    - children: []
+      cmdline: /usr/sbin/httpd -DFOREGROUND
+      cwd: /usr/sbin/
+      pid: '21140'
+      ppid: '889'
+      user: apache
+    - children: []
+      cmdline: /usr/sbin/httpd -DFOREGROUND
+      cwd: /usr/sbin/
+      pid: '21141'
+      ppid: '889'
+      user: apache
+    - children: []
+      cmdline: /usr/sbin/httpd -DFOREGROUND
+      cwd: /usr/sbin/
+      pid: '21142'
+      ppid: '889'
+      user: apache
+    cmdline: /usr/sbin/httpd -DFOREGROUND
+    cwd: /usr/sbin/
+    listening_ports:
+    - 80
     pid: '889'
     ppid: '1'
     user: root
-  - cmdline: /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
-    pid: '891'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-    pid: '896'
-    ppid: '891'
-    user: haproxy
-  - cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-    pid: '905'
-    ppid: '896'
-    user: haproxy
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1074'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1077'
-    ppid: '1074'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1079'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1083'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1089'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1090'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1092'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: master process /usr/sbin/nginx'
-    pid: '1151'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '1156'
-    ppid: '1151'
-    user: nginx
-  - cmdline: 'nginx: worker process'
-    pid: '1157'
-    ppid: '1151'
-    user: nginx
-  - cmdline: ''
-    pid: '2661'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13336'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20808'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20809'
-    ppid: '20808'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20810'
-    ppid: '20808'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21138'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21139'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21140'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21141'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21142'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
-    pid: '21221'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: logger'
-    pid: '21223'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: checkpointer'
-    pid: '21225'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: background writer'
-    pid: '21226'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: walwriter'
-    pid: '21227'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '21228'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: stats collector'
-    pid: '21229'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '21230'
-    ppid: '21221'
-    user: postgres
-  - cmdline: pickup -l -t unix -u
-    pid: '22136'
-    ppid: '1074'
-    user: postfix
-  - cmdline: ''
-    pid: '27432'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27459'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27471'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27493'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '27504'
-    ppid: '1079'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '27506'
-    ppid: '27504'
-    user: centos
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-jbhxccrldenkccmzgfwjjudscrmcprzi ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654709672.819474-91517-177085645838257/AnsiballZ_process_facts.py' && sleep 0
-    pid: '27654'
-    ppid: '27506'
-    user: centos
-  - cmdline: ''
-    pid: '27662'
-    ppid: '2'
-    user: root
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-jbhxccrldenkccmzgfwjjudscrmcprzi ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654709672.819474-91517-177085645838257/AnsiballZ_process_facts.py
-    pid: '27668'
-    ppid: '27654'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-jbhxccrldenkccmzgfwjjudscrmcprzi ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654709672.819474-91517-177085645838257/AnsiballZ_process_facts.py
-    pid: '27669'
-    ppid: '27668'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654709672.819474-91517-177085645838257/AnsiballZ_process_facts.py
-    pid: '27670'
-    ppid: '27669'
-    user: root
-tcp_listen:
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: tcp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 1151
-    port: 81
-    protocol: tcp
-    stime: Wed Apr 27 08:37:54 2022
-    user: root
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 1151
-    port: 82
-    protocol: tcp
-    stime: Wed Apr 27 08:37:54 2022
-    user: root
-  - address: 0.0.0.0
-    name: haproxy
-    pid: 905
-    port: 83
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: haproxy
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1079
-    port: 22
-    protocol: tcp
-    stime: Wed Apr 27 08:37:53 2022
-    user: root
-  - address: 127.0.0.1
-    name: postmaster
-    pid: 21221
-    port: 5432
-    protocol: tcp
-    stime: Thu Apr 28 13:53:52 2022
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1074
-    port: 25
-    protocol: tcp
-    stime: Wed Apr 27 08:37:53 2022
-    user: root
-  - address: 0.0.0.0
-    name: haproxy
-    pid: 905
-    port: 5000
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: haproxy
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: tcp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: '::'
-    name: java
-    pid: 887
-    port: 8080
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: tomcat
-  - address: '::'
-    name: httpd
-    pid: 889
-    port: 80
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: root
-  - address: '::'
-    name: 'nginx:'
-    pid: 1151
-    port: 81
-    protocol: tcp
-    stime: Wed Apr 27 08:37:54 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1079
-    port: 22
-    protocol: tcp
-    stime: Wed Apr 27 08:37:53 2022
-    user: root
-  - address: ::1
-    name: postmaster
-    pid: 21221
-    port: 5432
-    protocol: tcp
-    stime: Thu Apr 28 13:53:52 2022
-    user: postgres
-  - address: ::1
-    name: master
-    pid: 1074
-    port: 25
-    protocol: tcp
-    stime: Wed Apr 27 08:37:53 2022
-    user: root
-  - address: 127.0.0.1
-    name: java
-    pid: 887
-    port: 8005
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 887
-    port: 8009
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: tomcat
-udp_listen:
-  - address: 0.0.0.0
+  type: Apache WebServer
+  version:
+  - number: 2.4.6
+    type: active
+  - number: 2.4.6
+    type: package
+expected_tasks_calls:
+  Run regex on the current item for custom_log_files: 1
+  Run regex on the current item for error_log_files: 1
+expected_tasks_calls_mode_strict: false
+mocked_plugin_tasks:
+  Check custom_log_file file in conf_path:
+    plugin_result:
+      failed: true
+  Check custom_log_file file in parent_conf_path:
+    plugin_result:
+      failed: false
+  Check custom_log_files file:
+    plugin_result:
+      failed: true
+  Check error_log_file file:
+    plugin_result:
+      failed: true
+  Check error_log_file file in conf_path:
+    plugin_result:
+      failed: true
+  Check error_log_file file in parent_conf_path:
+    plugin_result:
+      failed: false
+  Check if conf_file_path is accesible:
+    plugin_result:
+      failed: true
+  Get conf_file_path from cmdline:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Get instance_name from conf_file_name:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Parse config file:
+    plugin_result:
+      failed: false
+      parsed:
+        AddDefaultCharset: UTF-8
+        AddIcon: /icons/blank.gif ^^BLANKICON^^
+        Alias: /icons/ "/usr/share/httpd/icons/"
+        DefaultIcon: /icons/unknown.gif
+        Directory:
+          /:
+            AllowOverride: none
+            Require: all denied
+          /home/*/public_html:
+            AllowOverride: FileInfo AuthConfig Limit Indexes
+            Options: MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
+            Require: method GET POST OPTIONS
+          /usr/share/httpd/icons:
+            AllowOverride: None
+            Options: Indexes MultiViews FollowSymlinks
+            Require: all granted
+          /usr/share/httpd/noindex:
+            AllowOverride: None
+            Require: all granted
+          /var/www:
+            AllowOverride: None
+            Require: all granted
+          /var/www/cgi-bin:
+            AllowOverride: None
+            Options: None
+            Require: all granted
+          /var/www/html:
+            AllowOverride: None
+            Options: Indexes FollowSymLinks
+            Require: all granted
+          AddIconByEncoding: (CMP,/icons/compressed.gif) x-compress x-gzip
+          AddIconByType: (VID,/icons/movie.gif) video/*
+          Alias: /images/poweredby.png /usr/share/httpd/noindex/images/poweredby.png
+          IfModule:
+            mod_userdir.c:
+              UserDir: disabled
+          IndexIgnore: .??* *~ *
+          IndexOptions: FancyIndexing HTMLTable VersionSort
+          LocationMatch:
+            ^/+$:
+              ErrorDocument: 403 /.noindex.html
+              Options: -Indexes
+        DocumentRoot: /var/www/html
+        EnableSendfile: 'on'
+        ErrorLog: logs/error_log
+        Files:
+          .ht*:
+            Require: all denied
+        Group: apache
+        HeaderName: HEADER.html
+        IfModule:
+          alias_module:
+            ScriptAlias: /cgi-bin/ "/var/www/cgi-bin/"
+          dir_module:
+            DirectoryIndex: index.html
+          log_config_module:
+            CustomLog: '"logs/access_log" combined'
+            IfModule:
+              logio_module:
+                LogFormat: '"%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"
+                  %I %O" combinedio'
+            LogFormat: '"%h %l %u %t "%r" %>s %b" common'
+          mime_magic_module:
+            MIMEMagicFile: conf/magic
+          mime_module:
+            AddOutputFilter: INCLUDES .shtml
+            AddType: text/html .shtml
+            TypesConfig: /etc/mime.types
+          mpm_event_module:
+            LoadModule: cgid_module modules/mod_cgid.so
+          mpm_prefork_module:
+            LoadModule: cgi_module modules/mod_cgi.so
+          mpm_worker_module:
+            LoadModule: cgid_module modules/mod_cgid.so
+        JKWorkers:
+          JKBalanceWorkers:
+            loadbalancer-1:
+              host: 192.168.0.142
+              lbfactor: '10'
+              name: loadbalancer-1
+              port: '8009'
+              type: ajp13
+            loadbalancer-2:
+              host: 192.168.0.223
+              lbfactor: '10'
+              name: loadbalancer-2
+              port: '8009'
+              type: ajp13
+          JKLoadbalancers:
+            jkstatus:
+              name: jkstatus
+              type: status
+            tomcat:
+              balance_workers: loadbalancer-1,loadbalancer-2
+              name: tomcat
+              ping_mode: A
+              socket_connect_timeout: '3000'
+              socket_timeout: '30'
+              type: lb
+        JkLogFile: /var/log/httpd/mod_jk.log
+        JkLogLevel: info
+        JkLogStampFormat: '[%a %b %d %H:%M:%S %Y]'
+        JkMount: /tomcat/* tomcat
+        JkShmFile: /var/log/httpd/mod_jk.shm
+        Listen: '80'
+        LoadModule: jk_module modules/mod_jk.so
+        LogLevel: warn
+        ReadmeName: README.html
+        ServerAdmin: root@localhost
+        ServerRoot: /etc/httpd
+        User: apache
+  Read process environment:
+    plugin_result:
+      failed: false
+      parsed:
+        LANG: C
+        NOTIFY_SOCKET: /run/systemd/notify
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+  Run command version:
+    plugin_result:
+      failed: false
+      stdout: 'Server version: Apache/2.4.6 (CentOS)
+
+        Server built:   Nov 16 2020 16:18:20'
+  Run command with binary:
+    plugin_result:
+      failed: false
+      stdout: "Server version: Apache/2.4.6 (CentOS)\nServer built:   Nov 16 2020\
+        \ 16:18:20\nServer's Module Magic Number: 20120211:24\nServer loaded:  APR\
+        \ 1.4.8, APR-UTIL 1.5.2\nCompiled using: APR 1.4.8, APR-UTIL 1.5.2\nArchitecture:\
+        \   64-bit\nServer MPM:     prefork\n  threaded:     no\n    forked:     yes\
+        \ (variable process count)\nServer compiled with....\n -D APR_HAS_SENDFILE\n\
+        \ -D APR_HAS_MMAP\n -D APR_HAVE_IPV6 (IPv4-mapped addresses enabled)\n -D\
+        \ APR_USE_SYSVSEM_SERIALIZE\n -D APR_USE_PTHREAD_SERIALIZE\n -D SINGLE_LISTEN_UNSERIALIZED_ACCEPT\n\
+        \ -D APR_HAS_OTHER_CHILD\n -D AP_HAVE_RELIABLE_PIPED_LOGS\n -D DYNAMIC_MODULE_LIMIT=256\n\
+        \ -D HTTPD_ROOT=\"/etc/httpd\"\n -D SUEXEC_BIN=\"/usr/sbin/suexec\"\n -D DEFAULT_PIDLOG=\"\
+        /run/httpd/httpd.pid\"\n -D DEFAULT_SCOREBOARD=\"logs/apache_runtime_status\"\
+        \n -D DEFAULT_ERRORLOG=\"logs/error_log\"\n -D AP_TYPES_CONFIG_FILE=\"conf/mime.types\"\
+        \n -D SERVER_CONFIG_FILE=\"conf/httpd.conf\""
+  Run regex on the current item for custom_log_files:
+    number_of_calls: 1
+  Run regex on the current item for error_log_files:
+    number_of_calls: 1
+packages:
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  alsa-lib:
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
+  apache-commons-collections:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
+  apache-commons-daemon:
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
+  apache-commons-dbcp:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
+  apache-commons-logging:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
+  apache-commons-pool:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
+  apr:
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
+  apr-devel:
+  - arch: x86_64
+    epoch: null
+    name: apr-devel
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
+  apr-util:
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
+  apr-util-devel:
+  - arch: x86_64
+    epoch: null
+    name: apr-util-devel
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
+  atk:
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autoconf:
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
+  automake:
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
+  avahi-libs:
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  avalon-framework:
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
+  avalon-logkit:
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 16.P2.el7_8.2
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 43.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 76.el7_7
+    source: rpm
+    version: 2019.2.32
+  cairo:
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
+  centos-indexhtml:
+  - arch: noarch
+    epoch: null
+    name: centos-indexhtml
+    release: 9.el7.centos
+    source: rpm
+    version: '7'
+  centos-logos:
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 8.2003.0.el7.centos
+    source: rpm
+    version: '7'
+  centos-release-scl-rh:
+  - arch: noarch
+    epoch: null
+    name: centos-release-scl-rh
+    release: 3.el7.centos
+    source: rpm
+    version: '2'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 6.el7.centos
+    source: rpm
+    version: '18.5'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
+  copy-jdk-configs:
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
+  cups-libs:
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-devel:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-devel
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  dejavu-fonts-common:
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  dejavu-sans-fonts:
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
+  devtoolset-7-binutils:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-binutils
+    release: 11.el7
+    source: rpm
+    version: '2.28'
+  devtoolset-7-gcc:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
+  devtoolset-7-gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc-c++
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
+  devtoolset-7-libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-libstdc++-devel
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
+  devtoolset-7-runtime:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: '7.1'
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 830
-    port: 68
-    protocol: udp
-    stime: Wed Apr 27 08:37:52 2022
-    user: root
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 581
-    port: 323
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: chrony
-  - address: 0.0.0.0
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 3.el7
+    source: rpm
+    version: '3.2'
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dwz:
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  expat-devel:
+  - arch: x86_64
+    epoch: null
+    name: expat-devel
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 5.el7
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gperftools-libs:
+  - arch: x86_64
+    epoch: null
+    name: gperftools-libs
+    release: 1.el7
+    source: rpm
+    version: 2.6.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 560cfc0a
+    source: rpm
+    version: f2ee9d55
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 28.el7
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  haproxy:
+  - arch: x86_64
+    epoch: null
     name: haproxy
-    pid: 896
-    port: 49899
-    protocol: udp
-    stime: Wed Apr 27 08:37:52 2022
-    user: haproxy
-  - address: 0.0.0.0
+    release: 9.el7_9.1
+    source: rpm
+    version: 1.5.18
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  httpd:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-devel:
+  - arch: x86_64
+    epoch: null
+    name: httpd-devel
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-tools:
+  - arch: x86_64
+    epoch: null
+    name: httpd-tools
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.5.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.49
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 25.el7_7.2
+    source: rpm
+    version: 4.11.0
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 34.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  keepalived:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 19.el7
+    source: rpm
+    version: 1.3.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.42.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 43.el7
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 131.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-devel:
+  - arch: x86_64
+    epoch: null
+    name: libdb-devel
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libedit-devel:
+  - arch: x86_64
+    epoch: null
+    name: libedit-devel
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libicu-devel:
+  - arch: x86_64
+    epoch: null
+    name: libicu-devel
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 3.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libtool:
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  llvm-toolset-7-clang:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-clang-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang-libs
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-compiler-rt:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-compiler-rt
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-libomp:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-libomp
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-llvm-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-llvm-libs
+    release: 8.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-runtime:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-devel:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-devel
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-libs
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 16.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 14.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.65
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 61.el7
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-devel:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-devel
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.66.el7
+    source: rpm
+    version: 1.3.0
+  nginx:
+  - arch: x86_64
+    epoch: 1
+    name: nginx
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: nginx-filesystem
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-mod-stream:
+  - arch: x86_64
+    epoch: 1
+    name: nginx-mod-stream
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7
+    source: rpm
+    version: 4.21.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 4.el7_7
+    source: rpm
+    version: 3.44.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openldap-devel:
+  - arch: x86_64
+    epoch: null
+    name: openldap-devel
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Thread-Queue:
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pgdg-redhat-repo:
+  - arch: noarch
+    epoch: null
+    name: pgdg-redhat-repo
+    release: '24'
+    source: rpm
+    version: '42.0'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql11:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-devel:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-devel
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 27.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-devel:
+  - arch: x86_64
+    epoch: null
+    name: python-devel
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 9.el7_8
+    source: rpm
+    version: 2.6.0
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python2-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python2-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 582
-    port: 750
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: ::1
-    name: chronyd
-    pid: 581
-    port: 323
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 750
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 52.el7
+    source: rpm
+    version: 8.24.0
+  scl-utils:
+  - arch: x86_64
+    epoch: null
+    name: scl-utils
+    release: 19.el7
+    source: rpm
+    version: '20130529'
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 6.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 9.el7
+    source: rpm
+    version: 1.8.23
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 8.el7
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019c
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 20.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 167.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '197'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '198'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '275'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '276'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '277'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '279'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '295'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '297'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '412'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '444'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '466'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '469'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '511'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '513'
+  ppid: '1'
+  user: dbus
+- cmdline: ''
+  cwd: /
+  pid: '514'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '556'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '559'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '564'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '566'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '567'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '581'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '582'
+  ppid: '1'
+  user: rpc
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H loadbalancer-2 eth0
+  cwd: /sbin/
+  pid: '830'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+    -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+    -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+    -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+    start
+  cwd: /usr/lib/jvm/jre/bin/
+  pid: '887'
+  ppid: '1'
+  user: tomcat
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '888'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '889'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
+  cwd: /usr/sbin/
+  pid: '891'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '896'
+  ppid: '891'
+  user: haproxy
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '905'
+  ppid: '896'
+  user: haproxy
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1074'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1077'
+  ppid: '1074'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1079'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1083'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1089'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1090'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1092'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: master process /usr/sbin/nginx'
+  cwd: /
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1156'
+  ppid: '1151'
+  user: nginx
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1157'
+  ppid: '1151'
+  user: nginx
+- cmdline: ''
+  cwd: /
+  pid: '2661'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13336'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20808'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20809'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20810'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21138'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21139'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21140'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21141'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21142'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
+  cwd: /usr/pgsql-11/bin/
+  pid: '21221'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: logger'
+  cwd: /
+  pid: '21223'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '21225'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '21226'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '21227'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '21228'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '21229'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '21230'
+  ppid: '21221'
+  user: postgres
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '22136'
+  ppid: '1074'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '27432'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27459'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27471'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27493'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '27504'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '27506'
+  ppid: '27504'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-jbhxccrldenkccmzgfwjjudscrmcprzi
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654709672.819474-91517-177085645838257/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '27654'
+  ppid: '27506'
+  user: centos
+- cmdline: ''
+  cwd: /
+  pid: '27662'
+  ppid: '2'
+  user: root
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-jbhxccrldenkccmzgfwjjudscrmcprzi
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654709672.819474-91517-177085645838257/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '27668'
+  ppid: '27654'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-jbhxccrldenkccmzgfwjjudscrmcprzi ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1654709672.819474-91517-177085645838257/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '27669'
+  ppid: '27668'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654709672.819474-91517-177085645838257/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '27670'
+  ppid: '27669'
+  user: root
+software_list:
+- cmd_regexp: ^.*/(?:sbin|bin)/(?:httpd|apache2)(?:[-_](?:prefork|worker))?(?:.*)?
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/apache_webserver.yaml
+    name: Include Apache Webserver specific plugins
+  name: Apache WebServer
+  pkg_regexp: apache2|^httpd$
+  process_type: parent
+  return_children: true
+  return_packages: true
+tcp_listen:
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 82
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 83
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 5000
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: java
+  pid: 887
+  port: 8080
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: httpd
+  pid: 889
+  port: 80
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: '::'
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: ::1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: ::1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: 887
+  port: 8005
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 887
+  port: 8009
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 830
+  port: 68
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: 0.0.0.0
+  name: haproxy
+  pid: 896
+  port: 49899
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/awx_task/awx_task_centos7.yaml
+++ b/tests/unit/plugins/action/auto/resources/awx_task/awx_task_centos7.yaml
@@ -1,5375 +1,5439 @@
-expected_result:
-  - discovery_time: '2022-06-29T11:47:36+02:00'
-    bindings: [ ]
-    docker:
-      exposed_ports:
-        8052/tcp: { }
-      id: efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
-      image: 'nexusregistry.opensolutions.cloud/awx_task:11.2.0'
-      name: /awx_awx01_task_tower_1
-      network_mode: 'default'
-      port_bindings: { }
-    listening_ports: [ ]
-    packages: [ ]
-    process:
-      cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
-      pid: '8448'
-      ppid: '7943'
-      user: root
-    type: AWX Task
-    version:
-      - number: 11.2.0
-        type: docker
-  - discovery_time: '2022-06-29T11:47:36+02:00'
-    bindings: [ ]
-    docker:
-      exposed_ports:
-        8052/tcp: { }
-      id: d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
-      image: 'nexusregistry.opensolutions.cloud/awx_task:11.2.0'
-      name: /awx_awx01_task_1
-      network_mode: 'default'
-      port_bindings: { }
-    listening_ports: [ ]
-    packages: [ ]
-    process:
-      cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
-      pid: '8441'
-      ppid: '7877'
-      user: root
-    type: AWX Task
-    version:
-      - number: 11.2.0
-        type: docker
-software_list:
-  - cmd_regexp: launch_awx_task.sh
-    name: AWX Task
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - '--'
-        - /bin/sh
-        - '-c'
-        - /usr/bin/launch_awx_task.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - /usr/bin/launch_awx_task.sh
-        Domainname: ''
-        Entrypoint:
-          - tini
-          - '--'
-        Env:
-          - TASK_HOSTNAME=awx_awx01_task_1
-          - DATABASE_PORT=5432
-          - DATABASE_NAME=awx
-          - AWX_QUEUE_NAME=runners
-          - AWX_ADMIN_USER=datadope
-          - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
-          - AWX_ADMIN_PASSWORD=the_password
-          - DATABASE_PASSWORD=the_password
-          - SECRET_KEY=the_key
-          - DATABASE_HOST=192.168.0.252
-          - DATABASE_USER=awx
-          - >-
-            PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=en_US.UTF-8
-          - 'LANGUAGE=en_US:en'
-          - LC_ALL=en_US.UTF-8
-          - HOME=/home/awx
-        ExposedPorts:
-          8052/tcp: { }
-        Hostname: awx_awx01_task_1
-        Image: 'nexusregistry.opensolutions.cloud/awx_task:11.2.0'
-        Labels:
-          org.label-schema.build-date: '20200114'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: CentOS Base Image
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vendor: CentOS
-          org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
-          org.opencontainers.image.licenses: GPL-2.0-only
-          org.opencontainers.image.title: CentOS Base Image
-          org.opencontainers.image.vendor: CentOS
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: root
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/tower/SECRET_KEY: { }
-          /etc/tower/conf.d/credentials.py: { }
-          /etc/tower/conf.d/environment.sh: { }
-          /etc/ucmdb.auth: { }
-          /usr/bin/launch_awx_task.sh: { }
-          /var/lib/awx/projects: { }
-          /var/lib/awx/rsyslog/: { }
-          /var/lib/nginx: { }
-          /var/run/awx-rsyslog: { }
-          /var/run/memcached: { }
-          /var/run/redis: { }
-          /var/run/supervisor: { }
-        WorkingDir: /var/lib/awx
-      Created: '2021-10-18T11:44:59.182845248Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro'
-          - '/etc/localtime:/etc/localtime:ro'
-          - '/var/run/awx_memcached:/var/run/memcached:rw'
-          - '/var/run/awx_rsyslog:/var/run/awx-rsyslog:rw'
-          - '/var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw'
-          - >-
-            /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
-          - >-
-            /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
-          - '/var/lib/awx/projects/awx01__runners__1:/var/lib/awx/projects:rw'
-          - >-
-            /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro'
-          - '/var/run/awx_supervisor:/var/run/supervisor:rw'
-          - '/var/run/awx_redis:/var/run/redis:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/hostname
-      HostsPath: /etc/hosts
-      Id: d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
-      Image: 'sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7'
-      LogPath: >-
-        /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/tower/SECRET_KEY
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/SECRET_KEY
-          Type: bind
-        - Destination: /var/lib/nginx
-          Driver: local
-          Mode: ''
-          Name: 7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6/_data
-          Type: volume
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /var/lib/awx/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/projects/awx01__runners__1
-          Type: bind
-        - Destination: /var/lib/awx/rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/lib/awx/rsyslog
-          Type: bind
-        - Destination: /etc/ucmdb.auth
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/ucmdb.auth
-          Type: bind
-        - Destination: /etc/tower/conf.d/environment.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/environment.sh
-          Type: bind
-        - Destination: /var/run/awx-rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_rsyslog
-          Type: bind
-        - Destination: /var/run/supervisor
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_supervisor
-          Type: bind
-        - Destination: /etc/tower/conf.d/credentials.py
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/credentials.py
-          Type: bind
-        - Destination: /usr/bin/launch_awx_task.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/launch_awx_task.sh
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-      Name: /awx_awx01_task_1
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          awx:
-            Aliases:
-              - d13b4e9fdb7e
-            DriverOpts: null
-            EndpointID: 85027b2a5efa749aa7c8e87269e8803be0c4f0b5a75520aff51ab68492f91a7d
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:02'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-        Ports:
-          8052/tcp: null
-        SandboxID: b952a5e659a2bad6bef04200378542419a1ab00bffee6fb12ffefdf90ea009eb
-        SandboxKey: /var/run/docker/netns/b952a5e659a2
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.691239226Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8441
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.062811086Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '--'
-        - /bin/sh
-        - '-c'
-        - /usr/bin/launch_awx_task.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - /usr/bin/launch_awx_task.sh
-        Domainname: ''
-        Entrypoint:
-          - tini
-          - '--'
-        Env:
-          - TASK_HOSTNAME=awx_awx01_task_tower_1
-          - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
-          - DATABASE_NAME=awx
-          - AWX_QUEUE_NAME=tower
-          - AWX_ADMIN_USER=datadope
-          - AWX_HOSTNAME=awx01
-          - DATABASE_PORT=5432
-          - AWX_ADMIN_PASSWORD=the_password
-          - DATABASE_PASSWORD=the_password
-          - SECRET_KEY=the_key
-          - DATABASE_HOST=192.168.0.252
-          - DATABASE_USER=awx
-          - >-
-            PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=en_US.UTF-8
-          - 'LANGUAGE=en_US:en'
-          - LC_ALL=en_US.UTF-8
-          - HOME=/home/awx
-        ExposedPorts:
-          8052/tcp: { }
-        Hostname: awx_awx01_task_tower_1
-        Image: 'nexusregistry.opensolutions.cloud/awx_task:11.2.0'
-        Labels:
-          org.label-schema.build-date: '20200114'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: CentOS Base Image
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vendor: CentOS
-          org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
-          org.opencontainers.image.licenses: GPL-2.0-only
-          org.opencontainers.image.title: CentOS Base Image
-          org.opencontainers.image.vendor: CentOS
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: root
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/tower/SECRET_KEY: { }
-          /etc/tower/conf.d/credentials.py: { }
-          /etc/tower/conf.d/environment.sh: { }
-          /etc/tower/iometrics: { }
-          /etc/ucmdb.auth: { }
-          /usr/bin/launch_awx_task.sh: { }
-          /var/lib/awx/projects: { }
-          /var/lib/awx/rsyslog/: { }
-          /var/lib/nginx: { }
-          /var/run/awx-rsyslog: { }
-          /var/run/memcached: { }
-          /var/run/redis: { }
-          /var/run/supervisor: { }
-          /var/tmp/projects: { }
-        WorkingDir: /var/lib/awx
-      Created: '2021-10-18T11:44:40.881348712Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro'
-          - '/var/lib/awx/projects/awx01__tower_task__1:/var/lib/awx/projects:rw'
-          - '/etc/localtime:/etc/localtime:ro'
-          - '/var/run/awx_memcached:/var/run/memcached:rw'
-          - '/var/run/awx_rsyslog:/var/run/awx-rsyslog:rw'
-          - >-
-            /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
-          - >-
-            /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
-          - '/var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw'
-          - >-
-            /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro'
-          - '/var/lib/awx/var/tmp/projects:/var/tmp/projects:rw'
-          - '/var/run/awx_supervisor:/var/run/supervisor:rw'
-          - '/var/run/awx_redis:/var/run/redis:rw'
-          - '/var/lib/awx/etc/awx/iometrics:/etc/tower/iometrics:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/hostname
-      HostsPath: /etc/hosts
-      Id: efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
-      Image: 'sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7'
-      LogPath: >-
-        /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/bin/launch_awx_task.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/launch_awx_task.sh
-          Type: bind
-        - Destination: /var/lib/nginx
-          Driver: local
-          Mode: ''
-          Name: 8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e/_data
-          Type: volume
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/tower/SECRET_KEY
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/SECRET_KEY
-          Type: bind
-        - Destination: /var/lib/awx/rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/lib/awx/rsyslog
-          Type: bind
-        - Destination: /var/tmp/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/tmp/projects
-          Type: bind
-        - Destination: /var/run/supervisor
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_supervisor
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/tower/conf.d/credentials.py
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/credentials.py
-          Type: bind
-        - Destination: /etc/tower/iometrics
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/iometrics
-          Type: bind
-        - Destination: /etc/ucmdb.auth
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/ucmdb.auth
-          Type: bind
-        - Destination: /var/lib/awx/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/projects/awx01__tower_task__1
-          Type: bind
-        - Destination: /var/run/awx-rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_rsyslog
-          Type: bind
-        - Destination: /etc/tower/conf.d/environment.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/environment.sh
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-      Name: /awx_awx01_task_tower_1
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          awx:
-            Aliases:
-              - efdbe7e2ed56
-            DriverOpts: null
-            EndpointID: 793c5d8df433bbb806037f28add3fb99b4b1deb2a738cd38a8b3432dabec6683
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.3
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:03'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-        Ports:
-          8052/tcp: null
-        SandboxID: c8b6987031aa99ac901a2ec3ec5eff6490a8fc6163a78728e1e72c7b07ba5f36
-        SandboxKey: /var/run/docker/netns/c8b6987031aa
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.666814215Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8448
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.066062167Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '--'
-        - /bin/sh
-        - '-c'
-        - /usr/bin/launch_awx.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - /usr/bin/launch_awx.sh
-        Domainname: ''
-        Entrypoint:
-          - tini
-          - '--'
-        Env:
-          - DATABASE_NAME=awx
-          - AWX_QUEUE_NAME=tower
-          - AWX_ADMIN_USER=datadope
-          - DATABASE_PORT=5432
-          - AWX_ADMIN_PASSWORD=the_password
-          - DATABASE_PASSWORD=the_password
-          - SECRET_KEY=the_key
-          - DATABASE_HOST=192.168.0.252
-          - DATABASE_USER=awx
-          - >-
-            PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=en_US.UTF-8
-          - 'LANGUAGE=en_US:en'
-          - LC_ALL=en_US.UTF-8
-          - HOME=/home/awx
-        ExposedPorts:
-          8052/tcp: { }
-          8053/tcp: { }
-        Hostname: awx_web_tower_1
-        Image: 'nexusregistry.opensolutions.cloud/awx_web:11.2.0'
-        Labels:
-          org.label-schema.build-date: '20200114'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: CentOS Base Image
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vendor: CentOS
-          org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
-          org.opencontainers.image.licenses: GPL-2.0-only
-          org.opencontainers.image.title: CentOS Base Image
-          org.opencontainers.image.vendor: CentOS
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: root
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/nginx/awxweb.pem: { }
-          /etc/nginx/nginx.conf: { }
-          /etc/tower/SECRET_KEY: { }
-          /etc/tower/conf.d/credentials.py: { }
-          /etc/tower/conf.d/environment.sh: { }
-          /etc/ucmdb.auth: { }
-          /var/lib/awx/projects: { }
-          /var/lib/awx/rsyslog/: { }
-          /var/lib/nginx: { }
-          /var/run/awx-rsyslog: { }
-          /var/run/memcached: { }
-          /var/run/redis: { }
-          /var/run/supervisor: { }
-        WorkingDir: /var/lib/awx
-      Created: '2021-10-18T10:22:23.792332427Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2-init/diff:/var/lib/docker/overlay2/3c13fb2448c4706f60677e56fabf13eee05734ec5a9766eee43659261dab90a3/diff:/var/lib/docker/overlay2/91b427dfbb443e5fd41e123d6b65806881f1527b05e897537808332da3c65afc/diff:/var/lib/docker/overlay2/37f36c6664c7d70bb927546ad358b46f72fa603c0511aab5625546c4fbaf4224/diff:/var/lib/docker/overlay2/cb747a616cd72b17e0277b27cd036ff79f061d2bf1ec49f6f7576a513ff1f454/diff:/var/lib/docker/overlay2/1f5a7c255f9d87a97f18408553cc5ea8a3e57b803d58d444684e77065992886c/diff:/var/lib/docker/overlay2/701b839302666be2d93bcec208db2b10bfc64f25b9dd3edbb4b6f5beeb0ff215/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro'
-          - '/etc/localtime:/etc/localtime:ro'
-          - '/var/run/awx_memcached:/var/run/memcached:rw'
-          - '/var/run/awx_rsyslog:/var/run/awx-rsyslog:rw'
-          - '/var/run/awx_supervisor:/var/run/supervisor:rw'
-          - >-
-            /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
-          - >-
-            /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
-          - '/var/lib/awx/etc/awx/nginx.conf:/etc/nginx/nginx.conf:ro'
-          - '/var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw'
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro'
-          - '/var/lib/awx/etc/awx/awxweb.pem:/etc/nginx/awxweb.pem:ro'
-          - '/var/lib/awx/projects/awx01__tower_web_1:/var/lib/awx/projects:rw'
-          - '/var/run/awx_redis:/var/run/redis:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths: null
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8052/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '80'
-          8053/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '443'
-        Privileged: true
-        PublishAllPorts: false
-        ReadonlyPaths: null
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt:
-          - label=disable
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/hostname
-      HostsPath: /etc/hosts
-      Id: b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
-      Image: 'sha256:71ea5e1b1b2f382bd0b0560464ea9c77dc30e396e8c6e9b8958b33b94416b708'
-      LogPath: >-
-        /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/tower/conf.d/credentials.py
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/credentials.py
-          Type: bind
-        - Destination: /etc/ucmdb.auth
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/ucmdb.auth
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx/nginx.conf
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/nginx.conf
-          Type: bind
-        - Destination: /var/lib/awx/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/projects/awx01__tower_web_1
-          Type: bind
-        - Destination: /var/lib/nginx
-          Driver: local
-          Mode: ''
-          Name: 9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd/_data
-          Type: volume
-        - Destination: /var/run/awx-rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_rsyslog
-          Type: bind
-        - Destination: /etc/tower/SECRET_KEY
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/SECRET_KEY
-          Type: bind
-        - Destination: /etc/tower/conf.d/environment.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/environment.sh
-          Type: bind
-        - Destination: /var/run/supervisor
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_supervisor
-          Type: bind
-        - Destination: /etc/nginx/awxweb.pem
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/awxweb.pem
-          Type: bind
-        - Destination: /var/lib/awx/rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/lib/awx/rsyslog
-          Type: bind
-      Name: /awx_web_tower_1
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          awx:
-            Aliases:
-              - awx_web
-              - b7972b752e85
-            DriverOpts: null
-            EndpointID: 68e96dfb1a48497323aabc5ffbad6da682bbd271778ed383ed3c9cbf86ddb732
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.4
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:04'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-        Ports:
-          8052/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '80'
-          8053/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '443'
-        SandboxID: 82cf34c71f29edf07f8bfba5e104fe5715f8195c1c5d6af30843be7315149a93
-        SandboxKey: /var/run/docker/netns/82cf34c71f29
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.713044964Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8455
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.064174569Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-s'
-        - /var/run/memcached/memcached.sock
-        - '-a'
-        - '0666'
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-s'
-          - /var/run/memcached/memcached.sock
-          - '-a'
-          - '0666'
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - MEMCACHED_VERSION=1.6.6
-          - MEMCACHED_SHA1=d8895b12dc9fc82b389f1713e2c09cc6ca3d03e4
-        ExposedPorts:
-          11211/tcp: { }
-        Hostname: 1c624b0d7c73
-        Image: 'nexusregistry.opensolutions.cloud/monitorizacion/memcached:alpine'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: memcache
-        Volumes:
-          /etc/localtime: { }
-          /var/run/memcached: { }
-        WorkingDir: ''
-      Created: '2020-06-03T10:16:16.67286319Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d-init/diff:/var/lib/docker/overlay2/d8877c054116b5ee97ee53c893117c6fb2dfff8ecd5f7de53f12ae1a64c9e063/diff:/var/lib/docker/overlay2/09557cecc7a0ad7866cb864928e034e550f8e97703d629f1f16287ebc96056ca/diff:/var/lib/docker/overlay2/e26535172b18e8ba64dfeb361e9a74d224ba94487968fff19550ae35baa09f1b/diff:/var/lib/docker/overlay2/005ea37c98a59f97323add0a2222945ef78f4af4abc0478bfd68a0de5805ee3a/diff:/var/lib/docker/overlay2/7b303f0c79fd7aa2e61f9f75e0fd0cc48375e353dc577c2ddbc819d1d42e1144/diff:/var/lib/docker/overlay2/5e13e12e87f251e2cf30736940f53a5b2a922d1b8fbab5fdb529c204d56010e3/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/var/run/awx_memcached:/var/run/memcached:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths: null
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          11211/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '11211'
-        Privileged: true
-        PublishAllPorts: false
-        ReadonlyPaths: null
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt:
-          - label=disable
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hosts
-      Id: 1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
-      Image: 'sha256:35acd9837d07e6369afd8683ae08f7da10de93ea5d50e74050abbdeece1e6754'
-      LogPath: >-
-        /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-      Name: /awx_memcached
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: '02:42:ac:11:00:02'
-        Networks:
-          awx:
-            Aliases:
-              - memcached
-              - 1c624b0d7c73
-            DriverOpts: null
-            EndpointID: 1918e2a1786dc68318500c7bb707bd61536735c440afa195359d798150cd924e
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.5
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:05'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:11:00:02'
-            NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
-        Ports:
-          11211/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '11211'
-        SandboxID: 6b1d0adc35d952fa492b943f4104aa574aa23454c9b23be2ff55da2e148d9879
-        SandboxKey: /var/run/docker/netns/6b1d0adc35d9
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.690727633Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8510
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:10.809715881Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - /usr/local/etc/redis/redis.conf
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /usr/local/etc/redis/redis.conf
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.0.4
-          - >-
-            REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.4.tar.gz
-          - >-
-            REDIS_DOWNLOAD_SHA=3337005a1e0c3aa293c87c313467ea8ac11984921fab08807998ba765c9943de
-        ExposedPorts:
-          6379/tcp: { }
-        Hostname: 46897b6fb532
-        Image: 'nexusregistry.opensolutions.cloud/monitorizacion/redis:6.0.4'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: { }
-          /etc/localtime: { }
-          /usr/local/etc/redis/redis.conf: { }
-          /var/run/redis: { }
-        WorkingDir: /data
-      Created: '2020-06-03T10:08:34.836826924Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5-init/diff:/var/lib/docker/overlay2/f195086ba7e5c223584dc55602eabac57e67456493d3adcbaa39c5734cc1aed6/diff:/var/lib/docker/overlay2/69a5b254a5f5034b01f48dfca65e3a9350da9ef3d39afa86378af53f17773bbc/diff:/var/lib/docker/overlay2/e7bc5968d1154c270b86fc6c25dff4cc0cd6445fd93053648cc6f647d108ac5d/diff:/var/lib/docker/overlay2/5acabe980feecd71fcb74ff02e49f3b54ea1274abfcc2901ac6aaf29bc76c00f/diff:/var/lib/docker/overlay2/1943e56b8ae64a1d3392bb93a86e20b8240ee27400cbfbc0f859909ed75d1b1c/diff:/var/lib/docker/overlay2/7c53990c945f93e734234bf43cdb0ba2ecce49b3b66c9abe18f529aef297e1c3/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/var/run/awx_redis:/var/run/redis:rw'
-          - '/usr/local/etc/redis/redis.conf:/usr/local/etc/redis/redis.conf:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          6379/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '6379'
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hosts
-      Id: 46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
-      Image: 'sha256:36304d3b4540c5143673b2cefaba583a0426b57c709b5a35363f96a3510058cd'
-      LogPath: >-
-        /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data
-          Driver: local
-          Mode: ''
-          Name: 6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330/_data
-          Type: volume
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /usr/local/etc/redis/redis.conf
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /usr/local/etc/redis/redis.conf
-          Type: bind
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-      Name: /awx_redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.3
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: '02:42:ac:11:00:03'
-        Networks:
-          awx:
-            Aliases:
-              - redis
-              - 46897b6fb532
-            DriverOpts: null
-            EndpointID: 484b6930ad5e400adc2c0bd5d5c0072f63b82cb3d210d25dbdf2776e30583828
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.6
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:06'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.3
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:11:00:03'
-            NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
-        Ports:
-          6379/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '6379'
-        SandboxID: e3c098aa78f830407f21419ab0f92eccc5d1f533c2c37be76db60452521346cd
-        SandboxKey: /var/run/docker/netns/e3c098aa78f8
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.690312533Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8576
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.070796868Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-devel:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-devel
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 2.el7
-      source: rpm
-      version: 0.8.5
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  git:
-    - arch: x86_64
-      epoch: null
-      name: git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  htop:
-    - arch: x86_64
-      epoch: null
-      name: htop
-      release: 3.el7
-      source: rpm
-      version: 2.2.0
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1127.13.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs-devel:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs-devel
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-devel:
-    - arch: x86_64
-      epoch: null
-      name: krb5-devel
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcom_err-devel:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err-devel
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libffi-devel:
-    - arch: x86_64
-      epoch: null
-      name: libffi-devel
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libkadm5:
-    - arch: x86_64
-      epoch: null
-      name: libkadm5
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnet:
-    - arch: x86_64
-      epoch: null
-      name: libnet
-      release: 7.el7
-      source: rpm
-      version: 1.1.6
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-devel:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-devel
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsepol-devel:
-    - arch: x86_64
-      epoch: null
-      name: libsepol-devel
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-devel:
-    - arch: x86_64
-      epoch: null
-      name: libverto-devel
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 7.el7_8.2
-      source: rpm
-      version: 2.02.186
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 2.02.186
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  ngrep:
-    - arch: x86_64
-      epoch: null
-      name: ngrep
-      release: 1.1.20180101git9b59468.el7
-      source: rpm
-      version: '1.47'
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-devel:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-devel
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcre-devel:
-    - arch: x86_64
-      epoch: null
-      name: pcre-devel
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Error:
-    - arch: noarch
-      epoch: 1
-      name: perl-Error
-      release: 2.el7
-      source: rpm
-      version: '0.17020'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-Git:
-    - arch: noarch
-      epoch: null
-      name: perl-Git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-TermReadKey:
-    - arch: x86_64
-      epoch: null
-      name: perl-TermReadKey
-      release: 20.el7
-      source: rpm
-      version: '2.30'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 6.el7
-      source: rpm
-      version: '4.24'
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 65.el7_8
-      source: rpm
-      version: '0.17'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 1.el7
-      source: rpm
-      version: 3.2.11
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 1.el7
-      source: rpm
-      version: 4.0.19
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-  zlib-devel:
-    - arch: x86_64
-      epoch: null
-      name: zlib-devel
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '63'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '130'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '179'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '180'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '281'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '304'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '347'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '426'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '443'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '452'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '560'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '561'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '588'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '617'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '619'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '621'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '624'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '629'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '639'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '646'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H awx01 eth0
-    pid: '872'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '931'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '933'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '941'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '950'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '953'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '954'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '955'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '956'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '957'
-    ppid: '950'
-    user: zabbix
-  - cmdline: ''
-    pid: '1028'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1034'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1036'
-    ppid: '1034'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1096'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/vault server -config=/etc/vault.d/vault_main.hcl
-      -log-level=info
-    pid: '1135'
-    ppid: '1'
-    user: vault
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1136'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1137'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1139'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1140'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1154'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
-    pid: '2678'
-    ppid: '9043'
-    user: root
-  - cmdline: python3 /usr/bin/config-watcher
-    pid: '2745'
-    ppid: '2678'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '2747'
-    ppid: '2678'
-    user: root
-  - cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
-    pid: '2763'
-    ppid: '9045'
-    user: root
-  - cmdline: python3 /usr/bin/config-watcher
-    pid: '2811'
-    ppid: '2763'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '2814'
-    ppid: '2763'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '5442'
-    ppid: '26058'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '7506'
-    ppid: '19428'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '7647'
-    ppid: '1096'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 443
-      -container-ip 192.168.2.4 -container-port 8053
-    pid: '7659'
-    ppid: '1136'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '7669'
-    ppid: '7647'
-    user: centos
-  - cmdline: '-bash'
-    pid: '7673'
-    ppid: '7669'
-    user: centos
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 80
-      -container-ip 192.168.2.4 -container-port 8052
-    pid: '7676'
-    ppid: '1136'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7706'
-    ppid: '2747'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7811'
-    ppid: '2747'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7814'
-    ppid: '2814'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 11211
-      -container-ip 192.168.2.5 -container-port 11211
-    pid: '7816'
-    ppid: '1136'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7850'
-    ppid: '2814'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7851'
-    ppid: '2747'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '7877'
-    ppid: '941'
-    user: root
-  - cmdline: sudo su -
-    pid: '7904'
-    ppid: '7673'
-    user: root
-  - cmdline: su -
-    pid: '7905'
-    ppid: '7904'
-    user: root
-  - cmdline: '-bash'
-    pid: '7906'
-    ppid: '7905'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '7943'
-    ppid: '941'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7965'
-    ppid: '2814'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7966'
-    ppid: '2747'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '8027'
-    ppid: '2814'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654723362
-    pid: '8313'
-    ppid: '933'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8384'
-    ppid: '941'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 6379
-      -container-ip 192.168.2.6 -container-port 6379
-    pid: '8401'
-    ppid: '1136'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '8430'
-    ppid: '1096'
-    user: root
-  - cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
-    pid: '8441'
-    ppid: '7877'
-    user: root
-  - cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /bin/sh
+    - -c
+    - /usr/bin/launch_awx_task.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - /usr/bin/launch_awx_task.sh
+      Domainname: ''
+      Entrypoint:
+      - tini
+      - --
+      Env:
+      - TASK_HOSTNAME=awx_awx01_task_1
+      - DATABASE_PORT=5432
+      - DATABASE_NAME=awx
+      - AWX_QUEUE_NAME=runners
+      - AWX_ADMIN_USER=datadope
+      - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
+      - AWX_ADMIN_PASSWORD=the_password
+      - DATABASE_PASSWORD=the_password
+      - SECRET_KEY=the_key
+      - DATABASE_HOST=192.168.0.252
+      - DATABASE_USER=awx
+      - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
+      - LC_ALL=en_US.UTF-8
+      - HOME=/home/awx
+      ExposedPorts:
+        8052/tcp: {}
+      Hostname: awx_awx01_task_1
+      Image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
+      Labels:
+        org.label-schema.build-date: '20200114'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: CentOS Base Image
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vendor: CentOS
+        org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
+        org.opencontainers.image.licenses: GPL-2.0-only
+        org.opencontainers.image.title: CentOS Base Image
+        org.opencontainers.image.vendor: CentOS
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: root
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/tower/SECRET_KEY: {}
+        /etc/tower/conf.d/credentials.py: {}
+        /etc/tower/conf.d/environment.sh: {}
+        /etc/ucmdb.auth: {}
+        /usr/bin/launch_awx_task.sh: {}
+        /var/lib/awx/projects: {}
+        /var/lib/awx/rsyslog/: {}
+        /var/lib/nginx: {}
+        /var/run/awx-rsyslog: {}
+        /var/run/memcached: {}
+        /var/run/redis: {}
+        /var/run/supervisor: {}
+      WorkingDir: /var/lib/awx
+    Created: '2021-10-18T11:44:59.182845248Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
+        MergedDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/merged
+        UpperDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/diff
+        WorkDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
+      - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
+      - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
+      - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
+      - /var/lib/awx/projects/awx01__runners__1:/var/lib/awx/projects:rw
+      - /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
+      - /etc/hosts:/etc/hosts:ro
+      - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
+      - /var/run/awx_supervisor:/var/run/supervisor:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/hostname
+    HostsPath: /etc/hosts
+    Id: d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
+    Image: sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7
+    LogPath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/tower/SECRET_KEY
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/SECRET_KEY
+      Type: bind
+    - Destination: /var/lib/nginx
+      Driver: local
+      Mode: ''
+      Name: 7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6/_data
+      Type: volume
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /var/lib/awx/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/projects/awx01__runners__1
+      Type: bind
+    - Destination: /var/lib/awx/rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/lib/awx/rsyslog
+      Type: bind
+    - Destination: /etc/ucmdb.auth
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/ucmdb.auth
+      Type: bind
+    - Destination: /etc/tower/conf.d/environment.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/environment.sh
+      Type: bind
+    - Destination: /var/run/awx-rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_rsyslog
+      Type: bind
+    - Destination: /var/run/supervisor
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_supervisor
+      Type: bind
+    - Destination: /etc/tower/conf.d/credentials.py
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/credentials.py
+      Type: bind
+    - Destination: /usr/bin/launch_awx_task.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/launch_awx_task.sh
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    Name: /awx_awx01_task_1
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        awx:
+          Aliases:
+          - d13b4e9fdb7e
+          DriverOpts: null
+          EndpointID: 85027b2a5efa749aa7c8e87269e8803be0c4f0b5a75520aff51ab68492f91a7d
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:02
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+      Ports:
+        8052/tcp: null
+      SandboxID: b952a5e659a2bad6bef04200378542419a1ab00bffee6fb12ffefdf90ea009eb
+      SandboxKey: /var/run/docker/netns/b952a5e659a2
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.691239226Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8441
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.062811086Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /bin/sh
+    - -c
+    - /usr/bin/launch_awx_task.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - /usr/bin/launch_awx_task.sh
+      Domainname: ''
+      Entrypoint:
+      - tini
+      - --
+      Env:
+      - TASK_HOSTNAME=awx_awx01_task_tower_1
+      - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
+      - DATABASE_NAME=awx
+      - AWX_QUEUE_NAME=tower
+      - AWX_ADMIN_USER=datadope
+      - AWX_HOSTNAME=awx01
+      - DATABASE_PORT=5432
+      - AWX_ADMIN_PASSWORD=the_password
+      - DATABASE_PASSWORD=the_password
+      - SECRET_KEY=the_key
+      - DATABASE_HOST=192.168.0.252
+      - DATABASE_USER=awx
+      - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
+      - LC_ALL=en_US.UTF-8
+      - HOME=/home/awx
+      ExposedPorts:
+        8052/tcp: {}
+      Hostname: awx_awx01_task_tower_1
+      Image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
+      Labels:
+        org.label-schema.build-date: '20200114'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: CentOS Base Image
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vendor: CentOS
+        org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
+        org.opencontainers.image.licenses: GPL-2.0-only
+        org.opencontainers.image.title: CentOS Base Image
+        org.opencontainers.image.vendor: CentOS
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: root
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/tower/SECRET_KEY: {}
+        /etc/tower/conf.d/credentials.py: {}
+        /etc/tower/conf.d/environment.sh: {}
+        /etc/tower/iometrics: {}
+        /etc/ucmdb.auth: {}
+        /usr/bin/launch_awx_task.sh: {}
+        /var/lib/awx/projects: {}
+        /var/lib/awx/rsyslog/: {}
+        /var/lib/nginx: {}
+        /var/run/awx-rsyslog: {}
+        /var/run/memcached: {}
+        /var/run/redis: {}
+        /var/run/supervisor: {}
+        /var/tmp/projects: {}
+      WorkingDir: /var/lib/awx
+    Created: '2021-10-18T11:44:40.881348712Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
+        MergedDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/merged
+        UpperDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/diff
+        WorkDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
+      - /var/lib/awx/projects/awx01__tower_task__1:/var/lib/awx/projects:rw
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
+      - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
+      - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
+      - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
+      - /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
+      - /etc/hosts:/etc/hosts:ro
+      - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
+      - /var/lib/awx/var/tmp/projects:/var/tmp/projects:rw
+      - /var/run/awx_supervisor:/var/run/supervisor:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      - /var/lib/awx/etc/awx/iometrics:/etc/tower/iometrics:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/hostname
+    HostsPath: /etc/hosts
+    Id: efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
+    Image: sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7
+    LogPath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/bin/launch_awx_task.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/launch_awx_task.sh
+      Type: bind
+    - Destination: /var/lib/nginx
+      Driver: local
+      Mode: ''
+      Name: 8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e/_data
+      Type: volume
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/tower/SECRET_KEY
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/SECRET_KEY
+      Type: bind
+    - Destination: /var/lib/awx/rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/lib/awx/rsyslog
+      Type: bind
+    - Destination: /var/tmp/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/tmp/projects
+      Type: bind
+    - Destination: /var/run/supervisor
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_supervisor
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/tower/conf.d/credentials.py
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/credentials.py
+      Type: bind
+    - Destination: /etc/tower/iometrics
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/iometrics
+      Type: bind
+    - Destination: /etc/ucmdb.auth
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/ucmdb.auth
+      Type: bind
+    - Destination: /var/lib/awx/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/projects/awx01__tower_task__1
+      Type: bind
+    - Destination: /var/run/awx-rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_rsyslog
+      Type: bind
+    - Destination: /etc/tower/conf.d/environment.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/environment.sh
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    Name: /awx_awx01_task_tower_1
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        awx:
+          Aliases:
+          - efdbe7e2ed56
+          DriverOpts: null
+          EndpointID: 793c5d8df433bbb806037f28add3fb99b4b1deb2a738cd38a8b3432dabec6683
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.3
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:03
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+      Ports:
+        8052/tcp: null
+      SandboxID: c8b6987031aa99ac901a2ec3ec5eff6490a8fc6163a78728e1e72c7b07ba5f36
+      SandboxKey: /var/run/docker/netns/c8b6987031aa
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.666814215Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8448
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.066062167Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /bin/sh
+    - -c
+    - /usr/bin/launch_awx.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - /usr/bin/launch_awx.sh
+      Domainname: ''
+      Entrypoint:
+      - tini
+      - --
+      Env:
+      - DATABASE_NAME=awx
+      - AWX_QUEUE_NAME=tower
+      - AWX_ADMIN_USER=datadope
+      - DATABASE_PORT=5432
+      - AWX_ADMIN_PASSWORD=the_password
+      - DATABASE_PASSWORD=the_password
+      - SECRET_KEY=the_key
+      - DATABASE_HOST=192.168.0.252
+      - DATABASE_USER=awx
+      - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
+      - LC_ALL=en_US.UTF-8
+      - HOME=/home/awx
+      ExposedPorts:
+        8052/tcp: {}
+        8053/tcp: {}
+      Hostname: awx_web_tower_1
+      Image: nexusregistry.opensolutions.cloud/awx_web:11.2.0
+      Labels:
+        org.label-schema.build-date: '20200114'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: CentOS Base Image
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vendor: CentOS
+        org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
+        org.opencontainers.image.licenses: GPL-2.0-only
+        org.opencontainers.image.title: CentOS Base Image
+        org.opencontainers.image.vendor: CentOS
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: root
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx/awxweb.pem: {}
+        /etc/nginx/nginx.conf: {}
+        /etc/tower/SECRET_KEY: {}
+        /etc/tower/conf.d/credentials.py: {}
+        /etc/tower/conf.d/environment.sh: {}
+        /etc/ucmdb.auth: {}
+        /var/lib/awx/projects: {}
+        /var/lib/awx/rsyslog/: {}
+        /var/lib/nginx: {}
+        /var/run/awx-rsyslog: {}
+        /var/run/memcached: {}
+        /var/run/redis: {}
+        /var/run/supervisor: {}
+      WorkingDir: /var/lib/awx
+    Created: '2021-10-18T10:22:23.792332427Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2-init/diff:/var/lib/docker/overlay2/3c13fb2448c4706f60677e56fabf13eee05734ec5a9766eee43659261dab90a3/diff:/var/lib/docker/overlay2/91b427dfbb443e5fd41e123d6b65806881f1527b05e897537808332da3c65afc/diff:/var/lib/docker/overlay2/37f36c6664c7d70bb927546ad358b46f72fa603c0511aab5625546c4fbaf4224/diff:/var/lib/docker/overlay2/cb747a616cd72b17e0277b27cd036ff79f061d2bf1ec49f6f7576a513ff1f454/diff:/var/lib/docker/overlay2/1f5a7c255f9d87a97f18408553cc5ea8a3e57b803d58d444684e77065992886c/diff:/var/lib/docker/overlay2/701b839302666be2d93bcec208db2b10bfc64f25b9dd3edbb4b6f5beeb0ff215/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
+        MergedDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/merged
+        UpperDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/diff
+        WorkDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
+      - /var/run/awx_supervisor:/var/run/supervisor:rw
+      - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
+      - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
+      - /var/lib/awx/etc/awx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
+      - /etc/hosts:/etc/hosts:ro
+      - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
+      - /var/lib/awx/etc/awx/awxweb.pem:/etc/nginx/awxweb.pem:ro
+      - /var/lib/awx/projects/awx01__tower_web_1:/var/lib/awx/projects:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths: null
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8052/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '80'
+        8053/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '443'
+      Privileged: true
+      PublishAllPorts: false
+      ReadonlyPaths: null
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt:
+      - label=disable
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/hostname
+    HostsPath: /etc/hosts
+    Id: b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
+    Image: sha256:71ea5e1b1b2f382bd0b0560464ea9c77dc30e396e8c6e9b8958b33b94416b708
+    LogPath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/tower/conf.d/credentials.py
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/credentials.py
+      Type: bind
+    - Destination: /etc/ucmdb.auth
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/ucmdb.auth
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx/nginx.conf
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/nginx.conf
+      Type: bind
+    - Destination: /var/lib/awx/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/projects/awx01__tower_web_1
+      Type: bind
+    - Destination: /var/lib/nginx
+      Driver: local
+      Mode: ''
+      Name: 9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd/_data
+      Type: volume
+    - Destination: /var/run/awx-rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_rsyslog
+      Type: bind
+    - Destination: /etc/tower/SECRET_KEY
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/SECRET_KEY
+      Type: bind
+    - Destination: /etc/tower/conf.d/environment.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/environment.sh
+      Type: bind
+    - Destination: /var/run/supervisor
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_supervisor
+      Type: bind
+    - Destination: /etc/nginx/awxweb.pem
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/awxweb.pem
+      Type: bind
+    - Destination: /var/lib/awx/rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/lib/awx/rsyslog
+      Type: bind
+    Name: /awx_web_tower_1
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        awx:
+          Aliases:
+          - awx_web
+          - b7972b752e85
+          DriverOpts: null
+          EndpointID: 68e96dfb1a48497323aabc5ffbad6da682bbd271778ed383ed3c9cbf86ddb732
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.4
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:04
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+      Ports:
+        8052/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '80'
+        8053/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '443'
+      SandboxID: 82cf34c71f29edf07f8bfba5e104fe5715f8195c1c5d6af30843be7315149a93
+      SandboxKey: /var/run/docker/netns/82cf34c71f29
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.713044964Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8455
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.064174569Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -s
+    - /var/run/memcached/memcached.sock
+    - -a
+    - '0666'
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -s
+      - /var/run/memcached/memcached.sock
+      - -a
+      - '0666'
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - MEMCACHED_VERSION=1.6.6
+      - MEMCACHED_SHA1=d8895b12dc9fc82b389f1713e2c09cc6ca3d03e4
+      ExposedPorts:
+        11211/tcp: {}
+      Hostname: 1c624b0d7c73
+      Image: nexusregistry.opensolutions.cloud/monitorizacion/memcached:alpine
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: memcache
+      Volumes:
+        /etc/localtime: {}
+        /var/run/memcached: {}
+      WorkingDir: ''
+    Created: '2020-06-03T10:16:16.67286319Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d-init/diff:/var/lib/docker/overlay2/d8877c054116b5ee97ee53c893117c6fb2dfff8ecd5f7de53f12ae1a64c9e063/diff:/var/lib/docker/overlay2/09557cecc7a0ad7866cb864928e034e550f8e97703d629f1f16287ebc96056ca/diff:/var/lib/docker/overlay2/e26535172b18e8ba64dfeb361e9a74d224ba94487968fff19550ae35baa09f1b/diff:/var/lib/docker/overlay2/005ea37c98a59f97323add0a2222945ef78f4af4abc0478bfd68a0de5805ee3a/diff:/var/lib/docker/overlay2/7b303f0c79fd7aa2e61f9f75e0fd0cc48375e353dc577c2ddbc819d1d42e1144/diff:/var/lib/docker/overlay2/5e13e12e87f251e2cf30736940f53a5b2a922d1b8fbab5fdb529c204d56010e3/diff
+        MergedDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/merged
+        UpperDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/diff
+        WorkDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/localtime:/etc/localtime:rw
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths: null
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        11211/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '11211'
+      Privileged: true
+      PublishAllPorts: false
+      ReadonlyPaths: null
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt:
+      - label=disable
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hostname
+    HostsPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hosts
+    Id: 1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
+    Image: sha256:35acd9837d07e6369afd8683ae08f7da10de93ea5d50e74050abbdeece1e6754
+    LogPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    Name: /awx_memcached
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        awx:
+          Aliases:
+          - memcached
+          - 1c624b0d7c73
+          DriverOpts: null
+          EndpointID: 1918e2a1786dc68318500c7bb707bd61536735c440afa195359d798150cd924e
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.5
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:05
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
+      Ports:
+        11211/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '11211'
+      SandboxID: 6b1d0adc35d952fa492b943f4104aa574aa23454c9b23be2ff55da2e148d9879
+      SandboxKey: /var/run/docker/netns/6b1d0adc35d9
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.690727633Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8510
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:10.809715881Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - /usr/local/etc/redis/redis.conf
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /usr/local/etc/redis/redis.conf
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.0.4
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.4.tar.gz
+      - REDIS_DOWNLOAD_SHA=3337005a1e0c3aa293c87c313467ea8ac11984921fab08807998ba765c9943de
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: 46897b6fb532
+      Image: nexusregistry.opensolutions.cloud/monitorizacion/redis:6.0.4
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+        /etc/localtime: {}
+        /usr/local/etc/redis/redis.conf: {}
+        /var/run/redis: {}
+      WorkingDir: /data
+    Created: '2020-06-03T10:08:34.836826924Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5-init/diff:/var/lib/docker/overlay2/f195086ba7e5c223584dc55602eabac57e67456493d3adcbaa39c5734cc1aed6/diff:/var/lib/docker/overlay2/69a5b254a5f5034b01f48dfca65e3a9350da9ef3d39afa86378af53f17773bbc/diff:/var/lib/docker/overlay2/e7bc5968d1154c270b86fc6c25dff4cc0cd6445fd93053648cc6f647d108ac5d/diff:/var/lib/docker/overlay2/5acabe980feecd71fcb74ff02e49f3b54ea1274abfcc2901ac6aaf29bc76c00f/diff:/var/lib/docker/overlay2/1943e56b8ae64a1d3392bb93a86e20b8240ee27400cbfbc0f859909ed75d1b1c/diff:/var/lib/docker/overlay2/7c53990c945f93e734234bf43cdb0ba2ecce49b3b66c9abe18f529aef297e1c3/diff
+        MergedDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/merged
+        UpperDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/diff
+        WorkDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/localtime:/etc/localtime:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      - /usr/local/etc/redis/redis.conf:/usr/local/etc/redis/redis.conf:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        6379/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '6379'
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hostname
+    HostsPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hosts
+    Id: 46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
+    Image: sha256:36304d3b4540c5143673b2cefaba583a0426b57c709b5a35363f96a3510058cd
+    LogPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data
+      Driver: local
+      Mode: ''
+      Name: 6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330/_data
+      Type: volume
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /usr/local/etc/redis/redis.conf
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /usr/local/etc/redis/redis.conf
+      Type: bind
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    Name: /awx_redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.3
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:03
+      Networks:
+        awx:
+          Aliases:
+          - redis
+          - 46897b6fb532
+          DriverOpts: null
+          EndpointID: 484b6930ad5e400adc2c0bd5d5c0072f63b82cb3d210d25dbdf2776e30583828
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.6
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:06
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.3
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:03
+          NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
+      Ports:
+        6379/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '6379'
+      SandboxID: e3c098aa78f830407f21419ab0f92eccc5d1f533c2c37be76db60452521346cd
+      SandboxKey: /var/run/docker/netns/e3c098aa78f8
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.690312533Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8576
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.070796868Z'
+      Status: running
+expected_result:
+- bindings: []
+  discovery_time: '2022-06-29T11:47:36+02:00'
+  docker:
+    exposed_ports:
+      8052/tcp: {}
+    id: efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
+    image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
+    name: /awx_awx01_task_tower_1
+    network_mode: default
+    port_bindings: {}
+  listening_ports: []
+  packages: []
+  process:
+    cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
+    cwd: /
     pid: '8448'
     ppid: '7943'
     user: root
-  - cmdline: 'sshd: centos@pts/2'
-    pid: '8451'
-    ppid: '8430'
-    user: centos
-  - cmdline: tini -- /bin/sh -c /usr/bin/launch_awx.sh
-    pid: '8455'
-    ppid: '8384'
+  type: AWX Task
+  version:
+  - number: 11.2.0
+    type: docker
+- bindings: []
+  discovery_time: '2022-06-29T11:47:36+02:00'
+  docker:
+    exposed_ports:
+      8052/tcp: {}
+    id: d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
+    image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
+    name: /awx_awx01_task_1
+    network_mode: default
+    port_bindings: {}
+  listening_ports: []
+  packages: []
+  process:
+    cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
+    cwd: /
+    pid: '8441'
+    ppid: '7877'
     user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8484'
-    ppid: '941'
-    user: root
-  - cmdline: memcached -s /var/run/memcached/memcached.sock -a 0666
-    pid: '8510'
-    ppid: '8484'
-    user: '11211'
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8531'
-    ppid: '941'
-    user: root
-  - cmdline: 'redis-server 127.0.0.1:0'
-    pid: '8576'
-    ppid: '8531'
-    user: polkitd
-  - cmdline: pickup -l -t unix -u
-    pid: '8888'
-    ppid: '1034'
-    user: postfix
-  - cmdline: /usr/bin/docker start -a awx_cleaner
-    pid: '8925'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8934'
-    ppid: '941'
-    user: root
-  - cmdline: >-
-      /root/.local/share/virtualenvs/app-4PlAip0Q/bin/python3 cli.py -c
-      /app/etc/awx_cleaner_conf.yml
-    pid: '8960'
-    ppid: '8934'
-    user: root
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-azcnlusawzosvebbqdzuvnpqxambommd ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656496033.5179331-15691-192382700702312/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '9012'
-    ppid: '8451'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-azcnlusawzosvebbqdzuvnpqxambommd ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656496033.5179331-15691-192382700702312/AnsiballZ_process_facts.py
-    pid: '9027'
-    ppid: '9012'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-azcnlusawzosvebbqdzuvnpqxambommd ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656496033.5179331-15691-192382700702312/AnsiballZ_process_facts.py
-    pid: '9028'
-    ppid: '9027'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656496033.5179331-15691-192382700702312/AnsiballZ_process_facts.py
-    pid: '9029'
-    ppid: '9028'
-    user: root
-  - cmdline: bash /usr/bin/launch_awx.sh
-    pid: '9042'
-    ppid: '8455'
-    user: root
-  - cmdline: bash /usr/bin/launch_awx_task.sh
-    pid: '9043'
-    ppid: '8448'
-    user: root
-  - cmdline: bash /usr/bin/launch_awx_task.sh
-    pid: '9045'
-    ppid: '8441'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_awx01_task_tower_1
-    pid: '9274'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_redis
-    pid: '9279'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_awx01_task_1
-    pid: '9285'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_memcached
-    pid: '9287'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_web_tower_1
-    pid: '9288'
-    ppid: '1'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '11040'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '11622'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '11658'
-    ppid: '26058'
-    user: root
-  - cmdline: ''
-    pid: '13171'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15846'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '18195'
-    ppid: '26058'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '18557'
-    ppid: '19428'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '19267'
-    ppid: '19428'
-    user: root
-  - cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor.conf
-    pid: '19383'
-    ppid: '9042'
-    user: root
-  - cmdline: python3 /usr/bin/config-watcher
-    pid: '19426'
-    ppid: '19383'
-    user: root
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '19427'
-    ppid: '19383'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '19428'
-    ppid: '19383'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /var/lib/awx/venv/awx/bin/daphne -b
-      127.0.0.1 -p 8051 --websocket_timeout -1 awx.asgi:channel_layer
-    pid: '19429'
-    ppid: '19383'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '19432'
-    ppid: '19427'
-    user: zabbix
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '19437'
-    ppid: '19428'
-    user: root
-  - cmdline: ''
-    pid: '21726'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23574'
-    ppid: '25981'
-    user: root
-  - cmdline: ''
-    pid: '24024'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24657'
-    ppid: '26058'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '24660'
-    ppid: '26058'
-    user: root
-  - cmdline: ''
-    pid: '25741'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_wsbroadcast
-    pid: '25923'
-    ppid: '19383'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '25981'
-    ppid: '2678'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '26058'
-    ppid: '2763'
-    user: root
-  - cmdline: ''
-    pid: '26495'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '27319'
-    ppid: '26058'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '27324'
-    ppid: '25981'
-    user: root
-  - cmdline: >-
-      rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f
-      /var/lib/awx/rsyslog/rsyslog.conf
-    pid: '27383'
-    ppid: '19383'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '29086'
-    ppid: '1096'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '29090'
-    ppid: '29086'
-    user: centos
-  - cmdline: '-bash'
-    pid: '29095'
-    ppid: '29090'
-    user: centos
-  - cmdline: sudo su
-    pid: '29173'
-    ppid: '29095'
-    user: root
-  - cmdline: su
-    pid: '29174'
-    ppid: '29173'
-    user: root
-  - cmdline: bash
-    pid: '29175'
-    ppid: '29174'
-    user: root
-  - cmdline: ''
-    pid: '29455'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '30100'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '31223'
-    ppid: '25981'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '31706'
-    ppid: '19428'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1034
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:05 2022'
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 950
-    port: 10050
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:03 2022'
-    user: zabbix
-  - address: 192.168.0.145
-    name: vault
-    pid: 1135
-    port: 8200
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:12 2022'
-    user: vault
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:27 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1096
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:11 2022'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1034
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:05 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 7659
-    port: 443
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:05 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 8401
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:07 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 7816
-    port: 11211
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:06 2022'
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:27 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 7676
-    port: 80
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:05 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1096
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:11 2022'
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: AWX Task
+  version:
+  - number: 11.2.0
+    type: docker
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-devel:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-devel
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-event:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-event-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-persistent-data:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 2.el7
+    source: rpm
+    version: 0.8.5
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 872
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:02 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:27 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 639
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:49 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  git:
+  - arch: x86_64
+    epoch: null
+    name: git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  htop:
+  - arch: x86_64
+    epoch: null
+    name: htop
+    release: 3.el7
+    source: rpm
+    version: 2.2.0
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1127.13.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs-devel:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs-devel
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-devel:
+  - arch: x86_64
+    epoch: null
+    name: krb5-devel
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcom_err-devel:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err-devel
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libffi-devel:
+  - arch: x86_64
+    epoch: null
+    name: libffi-devel
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libkadm5:
+  - arch: x86_64
+    epoch: null
+    name: libkadm5
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnet:
+  - arch: x86_64
+    epoch: null
+    name: libnet
+    release: 7.el7
+    source: rpm
+    version: 1.1.6
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-devel:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-devel
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsepol-devel:
+  - arch: x86_64
+    epoch: null
+    name: libsepol-devel
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-devel:
+  - arch: x86_64
+    epoch: null
+    name: libverto-devel
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 7.el7_8.2
+    source: rpm
+    version: 2.02.186
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 2.02.186
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  ngrep:
+  - arch: x86_64
+    epoch: null
+    name: ngrep
+    release: 1.1.20180101git9b59468.el7
+    source: rpm
+    version: '1.47'
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-devel:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-devel
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcre-devel:
+  - arch: x86_64
+    epoch: null
+    name: pcre-devel
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Error:
+  - arch: noarch
+    epoch: 1
+    name: perl-Error
+    release: 2.el7
+    source: rpm
+    version: '0.17020'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-Git:
+  - arch: noarch
+    epoch: null
+    name: perl-Git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-TermReadKey:
+  - arch: x86_64
+    epoch: null
+    name: perl-TermReadKey
+    release: 20.el7
+    source: rpm
+    version: '2.30'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 619
-    port: 788
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:47 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 6.el7
+    source: rpm
+    version: '4.24'
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:27 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 639
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:49 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 619
-    port: 788
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:47 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 65.el7_8
+    source: rpm
+    version: '0.17'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 1.el7
+    source: rpm
+    version: 3.2.11
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 1.el7
+    source: rpm
+    version: 4.0.19
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  zlib-devel:
+  - arch: x86_64
+    epoch: null
+    name: zlib-devel
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '130'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '179'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '180'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '281'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '304'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '347'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '426'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '443'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '452'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '560'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '561'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '588'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '617'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '619'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '621'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '624'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '629'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '639'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '646'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H awx01 eth0
+  cwd: /sbin/
+  pid: '872'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '931'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '933'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '941'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '950'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '953'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '954'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '955'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '956'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '957'
+  ppid: '950'
+  user: zabbix
+- cmdline: ''
+  cwd: /
+  pid: '1028'
+  ppid: '2'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1034'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1036'
+  ppid: '1034'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1096'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/bin/vault server -config=/etc/vault.d/vault_main.hcl -log-level=info
+  cwd: /usr/local/bin/
+  pid: '1135'
+  ppid: '1'
+  user: vault
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1136'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1137'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1139'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1140'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1154'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
+  cwd: /usr/bin/
+  pid: '2678'
+  ppid: '9043'
+  user: root
+- cmdline: python3 /usr/bin/config-watcher
+  cwd: /
+  pid: '2745'
+  ppid: '2678'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '2747'
+  ppid: '2678'
+  user: root
+- cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
+  cwd: /usr/bin/
+  pid: '2763'
+  ppid: '9045'
+  user: root
+- cmdline: python3 /usr/bin/config-watcher
+  cwd: /
+  pid: '2811'
+  ppid: '2763'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '2814'
+  ppid: '2763'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '5442'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7506'
+  ppid: '19428'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '7647'
+  ppid: '1096'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 443 -container-ip
+    192.168.2.4 -container-port 8053
+  cwd: /usr/bin/
+  pid: '7659'
+  ppid: '1136'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '7669'
+  ppid: '7647'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '7673'
+  ppid: '7669'
+  user: centos
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 80 -container-ip
+    192.168.2.4 -container-port 8052
+  cwd: /usr/bin/
+  pid: '7676'
+  ppid: '1136'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7706'
+  ppid: '2747'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7811'
+  ppid: '2747'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7814'
+  ppid: '2814'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 11211 -container-ip
+    192.168.2.5 -container-port 11211
+  cwd: /usr/bin/
+  pid: '7816'
+  ppid: '1136'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7850'
+  ppid: '2814'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7851'
+  ppid: '2747'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '7877'
+  ppid: '941'
+  user: root
+- cmdline: sudo su -
+  cwd: /
+  pid: '7904'
+  ppid: '7673'
+  user: root
+- cmdline: su -
+  cwd: /
+  pid: '7905'
+  ppid: '7904'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '7906'
+  ppid: '7905'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '7943'
+  ppid: '941'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7965'
+  ppid: '2814'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7966'
+  ppid: '2747'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '8027'
+  ppid: '2814'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654723362
+  cwd: /usr/lib64/sa/
+  pid: '8313'
+  ppid: '933'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8384'
+  ppid: '941'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 6379 -container-ip
+    192.168.2.6 -container-port 6379
+  cwd: /usr/bin/
+  pid: '8401'
+  ppid: '1136'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '8430'
+  ppid: '1096'
+  user: root
+- cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '8441'
+  ppid: '7877'
+  user: root
+- cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '8448'
+  ppid: '7943'
+  user: root
+- cmdline: 'sshd: centos@pts/2'
+  cwd: /
+  pid: '8451'
+  ppid: '8430'
+  user: centos
+- cmdline: tini -- /bin/sh -c /usr/bin/launch_awx.sh
+  cwd: /
+  pid: '8455'
+  ppid: '8384'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8484'
+  ppid: '941'
+  user: root
+- cmdline: memcached -s /var/run/memcached/memcached.sock -a 0666
+  cwd: /
+  pid: '8510'
+  ppid: '8484'
+  user: '11211'
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8531'
+  ppid: '941'
+  user: root
+- cmdline: redis-server 127.0.0.1:0
+  cwd: /
+  pid: '8576'
+  ppid: '8531'
+  user: polkitd
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '8888'
+  ppid: '1034'
+  user: postfix
+- cmdline: /usr/bin/docker start -a awx_cleaner
+  cwd: /usr/bin/
+  pid: '8925'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8934'
+  ppid: '941'
+  user: root
+- cmdline: /root/.local/share/virtualenvs/app-4PlAip0Q/bin/python3 cli.py -c /app/etc/awx_cleaner_conf.yml
+  cwd: /root/.local/share/virtualenvs/app-4PlAip0Q/bin/
+  pid: '8960'
+  ppid: '8934'
+  user: root
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-azcnlusawzosvebbqdzuvnpqxambommd
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656496033.5179331-15691-192382700702312/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '9012'
+  ppid: '8451'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-azcnlusawzosvebbqdzuvnpqxambommd
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656496033.5179331-15691-192382700702312/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '9027'
+  ppid: '9012'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-azcnlusawzosvebbqdzuvnpqxambommd ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656496033.5179331-15691-192382700702312/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '9028'
+  ppid: '9027'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656496033.5179331-15691-192382700702312/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '9029'
+  ppid: '9028'
+  user: root
+- cmdline: bash /usr/bin/launch_awx.sh
+  cwd: /
+  pid: '9042'
+  ppid: '8455'
+  user: root
+- cmdline: bash /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '9043'
+  ppid: '8448'
+  user: root
+- cmdline: bash /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '9045'
+  ppid: '8441'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_awx01_task_tower_1
+  cwd: /usr/bin/
+  pid: '9274'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_redis
+  cwd: /usr/bin/
+  pid: '9279'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_awx01_task_1
+  cwd: /usr/bin/
+  pid: '9285'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_memcached
+  cwd: /usr/bin/
+  pid: '9287'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_web_tower_1
+  cwd: /usr/bin/
+  pid: '9288'
+  ppid: '1'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '11040'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '11622'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '11658'
+  ppid: '26058'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13171'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15846'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '18195'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '18557'
+  ppid: '19428'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19267'
+  ppid: '19428'
+  user: root
+- cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor.conf
+  cwd: /usr/bin/
+  pid: '19383'
+  ppid: '9042'
+  user: root
+- cmdline: python3 /usr/bin/config-watcher
+  cwd: /
+  pid: '19426'
+  ppid: '19383'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '19427'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19428'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /var/lib/awx/venv/awx/bin/daphne -b 127.0.0.1
+    -p 8051 --websocket_timeout -1 awx.asgi:channel_layer
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19429'
+  ppid: '19383'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '19432'
+  ppid: '19427'
+  user: zabbix
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19437'
+  ppid: '19428'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21726'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23574'
+  ppid: '25981'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24024'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24657'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '24660'
+  ppid: '26058'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25741'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_wsbroadcast
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '25923'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '25981'
+  ppid: '2678'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '26058'
+  ppid: '2763'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26495'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '27319'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '27324'
+  ppid: '25981'
+  user: root
+- cmdline: rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
+  cwd: /
+  pid: '27383'
+  ppid: '19383'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '29086'
+  ppid: '1096'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '29090'
+  ppid: '29086'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '29095'
+  ppid: '29090'
+  user: centos
+- cmdline: sudo su
+  cwd: /
+  pid: '29173'
+  ppid: '29095'
+  user: root
+- cmdline: su
+  cwd: /
+  pid: '29174'
+  ppid: '29173'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '29175'
+  ppid: '29174'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29455'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '30100'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '31223'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '31706'
+  ppid: '19428'
+  user: root
+software_list:
+- cmd_regexp: launch_awx_task.sh
+  name: AWX Task
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1034
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:05 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 950
+  port: 10050
+  protocol: tcp
+  stime: Tue Apr 26 15:55:03 2022
+  user: zabbix
+- address: 192.168.0.145
+  name: vault
+  pid: 1135
+  port: 8200
+  protocol: tcp
+  stime: Tue Apr 26 15:55:12 2022
+  user: vault
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1096
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:11 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1034
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:05 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 7659
+  port: 443
+  protocol: tcp
+  stime: Tue Apr 26 15:56:05 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 8401
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 15:56:07 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 7816
+  port: 11211
+  protocol: tcp
+  stime: Tue Apr 26 15:56:06 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 7676
+  port: 80
+  protocol: tcp
+  stime: Tue Apr 26 15:56:05 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1096
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:11 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 872
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:02 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 639
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 619
+  port: 788
+  protocol: udp
+  stime: Tue Apr 26 15:54:47 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 639
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 619
+  port: 788
+  protocol: udp
+  stime: Tue Apr 26 15:54:47 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/awx_web/awx_web_centos7.yaml
+++ b/tests/unit/plugins/action/auto/resources/awx_web/awx_web_centos7.yaml
@@ -1,5573 +1,5620 @@
-expected_result:
-  - discovery_time: '2022-06-29T12:38:53+02:00'
-    bindings:
-      - address: '::'
-        class: service
-        port: 443
-        protocol: tcp
-      - address: '::'
-        class: service
-        port: 80
-        protocol: tcp
-    docker:
-      exposed_ports:
-        8052/tcp: { }
-        8053/tcp: { }
-      id: b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
-      image: 'nexusregistry.opensolutions.cloud/awx_web:11.2.0'
-      name: /awx_web_tower_1
-      network_mode: 'default'
-      port_bindings:
-        '8052/tcp':
-          - 'HostIp': '0.0.0.0'
-            'HostPort': '80'
-        '8053/tcp':
-          - 'HostIp': '0.0.0.0'
-            'HostPort': '443'
-    listening_ports:
-      - 80
-      - 443
-    packages: [ ]
-    process:
-      cmdline: tini -- /bin/sh -c /usr/bin/launch_awx.sh
-      listening_ports:
-        - 80
-        - 443
-      pid: '8455'
-      ppid: '8384'
-      user: root
-    type: AWX Web
-    version:
-      - number: 11.2.0
-        type: docker
-software_list:
-  - cmd_regexp: launch_awx.sh
-    name: AWX Web
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - run
-        - python3
-        - cli.py
-        - '-c'
-        - /app/etc/awx_cleaner_conf.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/awx_cleaner_conf.yml
-        Domainname: ''
-        Entrypoint:
-          - pipenv
-          - run
-          - python3
-          - cli.py
-        Env:
-          - AWX_CLEANER_PASSWORD=
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=the_gpg_key
-          - PYTHON_VERSION=3.7.9
-          - PYTHON_PIP_VERSION=20.2.2
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
-          - PYTHONUNBUFFERED=true
-        Hostname: awx01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/awx-cleaner:1.2.1'
-        Labels:
-          maintainer: oromeu
-          os_contianer_type: awx_cleaner
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: { }
-        WorkingDir: /app
-      Created: '2021-10-18T11:45:16.316785262Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976-init/diff:/var/lib/docker/overlay2/22df782a1cbd5e34a3d5776753b2a807f00ba47e6013551e8b95f7e2ed93db35/diff:/var/lib/docker/overlay2/312b95522dd6921da5c2d5289fb7f32e63ceb5e10ba2143adbbc4c99d35023a9/diff:/var/lib/docker/overlay2/6300a0d70ac3252c87a6be17df77e286b97b4db13ba9be1526f70834f50875e1/diff:/var/lib/docker/overlay2/fd460f916e69c1b50a62212515f5b8bc8a8d29472da602c7c4cb37a16eb20137/diff:/var/lib/docker/overlay2/f1d776f54a392e59db855bf36785245f6d6774c0d16951e72d5ef172007b3fb9/diff:/var/lib/docker/overlay2/a68da68959434fd6261752e9e627f939d0d4b2b2ccbac7f32d663f915b67b07d/diff:/var/lib/docker/overlay2/6705a2fe1186389824def98c101d6b9b14b6d32e920c3c874e43208cb067f5f1/diff:/var/lib/docker/overlay2/2fe2d6a4cb1c5d9f55c98910a5ea422b2f8e7d8fefedefc8b1913aed66fe7ed2/diff:/var/lib/docker/overlay2/5fabbebbda1b3e287dc88fa6f41f6e1cb3e63553bb07ce5e0f945eea1bfe255d/diff:/var/lib/docker/overlay2/5d678a8dc7b4f4a16fd7a36e567ea771d528ac34407935769ebfd7e1bac68eb4/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/hosts
-      Id: 19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941
-      Image: 'sha256:9e588379d3c89b34839fda2502e557249b103a4b22fd1b80c37097ad0488fdf6'
-      LogPath: >-
-        /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics
-          Type: bind
-      Name: /awx_cleaner
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ''
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 9f8b86b22be78ec095186dd5f8afda1a02d9c56c4e2bbb6a334825173f523943
-        Ports: { }
-        SandboxID: b51930dfcc56796bad98dfb651ad63bb5ac26cf16ef4294558378f9bb1466bd8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: pipenv
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 1
-        FinishedAt: '2022-06-08T22:18:50.484288029Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 0
-        Restarting: false
-        Running: false
-        StartedAt: '2022-06-08T22:18:48.743921162Z'
-        Status: exited
-    - AppArmorProfile: ''
-      Args:
-        - '--'
-        - /bin/sh
-        - '-c'
-        - /usr/bin/launch_awx_task.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - /usr/bin/launch_awx_task.sh
-        Domainname: ''
-        Entrypoint:
-          - tini
-          - '--'
-        Env:
-          - TASK_HOSTNAME=awx_awx01_task_1
-          - DATABASE_PORT=5432
-          - DATABASE_NAME=awx
-          - AWX_QUEUE_NAME=runners
-          - AWX_ADMIN_USER=datadope
-          - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
-          - AWX_ADMIN_PASSWORD=the_password
-          - DATABASE_PASSWORD=the_password
-          - SECRET_KEY=the_key
-          - DATABASE_HOST=192.168.0.252
-          - DATABASE_USER=awx
-          - >-
-            PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=en_US.UTF-8
-          - 'LANGUAGE=en_US:en'
-          - LC_ALL=en_US.UTF-8
-          - HOME=/home/awx
-        ExposedPorts:
-          8052/tcp: { }
-        Hostname: awx_awx01_task_1
-        Image: 'nexusregistry.opensolutions.cloud/awx_task:11.2.0'
-        Labels:
-          org.label-schema.build-date: '20200114'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: CentOS Base Image
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vendor: CentOS
-          org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
-          org.opencontainers.image.licenses: GPL-2.0-only
-          org.opencontainers.image.title: CentOS Base Image
-          org.opencontainers.image.vendor: CentOS
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: root
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/tower/SECRET_KEY: { }
-          /etc/tower/conf.d/credentials.py: { }
-          /etc/tower/conf.d/environment.sh: { }
-          /etc/ucmdb.auth: { }
-          /usr/bin/launch_awx_task.sh: { }
-          /var/lib/awx/projects: { }
-          /var/lib/awx/rsyslog/: { }
-          /var/lib/nginx: { }
-          /var/run/awx-rsyslog: { }
-          /var/run/memcached: { }
-          /var/run/redis: { }
-          /var/run/supervisor: { }
-        WorkingDir: /var/lib/awx
-      Created: '2021-10-18T11:44:59.182845248Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro'
-          - '/etc/localtime:/etc/localtime:ro'
-          - '/var/run/awx_memcached:/var/run/memcached:rw'
-          - '/var/run/awx_rsyslog:/var/run/awx-rsyslog:rw'
-          - '/var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw'
-          - >-
-            /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
-          - >-
-            /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
-          - '/var/lib/awx/projects/awx01__runners__1:/var/lib/awx/projects:rw'
-          - >-
-            /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro'
-          - '/var/run/awx_supervisor:/var/run/supervisor:rw'
-          - '/var/run/awx_redis:/var/run/redis:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/hostname
-      HostsPath: /etc/hosts
-      Id: d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
-      Image: 'sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7'
-      LogPath: >-
-        /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/tower/SECRET_KEY
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/SECRET_KEY
-          Type: bind
-        - Destination: /var/lib/nginx
-          Driver: local
-          Mode: ''
-          Name: 7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6/_data
-          Type: volume
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-        - Destination: /etc/ucmdb.auth
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/ucmdb.auth
-          Type: bind
-        - Destination: /var/lib/awx/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/projects/awx01__runners__1
-          Type: bind
-        - Destination: /var/lib/awx/rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/lib/awx/rsyslog
-          Type: bind
-        - Destination: /etc/tower/conf.d/credentials.py
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/credentials.py
-          Type: bind
-        - Destination: /etc/tower/conf.d/environment.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/environment.sh
-          Type: bind
-        - Destination: /var/run/awx-rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_rsyslog
-          Type: bind
-        - Destination: /var/run/supervisor
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_supervisor
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /usr/bin/launch_awx_task.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/launch_awx_task.sh
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-      Name: /awx_awx01_task_1
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          awx:
-            Aliases:
-              - d13b4e9fdb7e
-            DriverOpts: null
-            EndpointID: 85027b2a5efa749aa7c8e87269e8803be0c4f0b5a75520aff51ab68492f91a7d
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:02'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-        Ports:
-          8052/tcp: null
-        SandboxID: b952a5e659a2bad6bef04200378542419a1ab00bffee6fb12ffefdf90ea009eb
-        SandboxKey: /var/run/docker/netns/b952a5e659a2
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.691239226Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8441
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.062811086Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '--'
-        - /bin/sh
-        - '-c'
-        - /usr/bin/launch_awx_task.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - /usr/bin/launch_awx_task.sh
-        Domainname: ''
-        Entrypoint:
-          - tini
-          - '--'
-        Env:
-          - TASK_HOSTNAME=awx_awx01_task_tower_1
-          - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
-          - DATABASE_NAME=awx
-          - AWX_QUEUE_NAME=tower
-          - AWX_ADMIN_USER=datadope
-          - AWX_HOSTNAME=awx01
-          - DATABASE_PORT=5432
-          - AWX_ADMIN_PASSWORD=the_password
-          - DATABASE_PASSWORD=the_password
-          - SECRET_KEY=the_key
-          - DATABASE_HOST=192.168.0.252
-          - DATABASE_USER=awx
-          - >-
-            PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=en_US.UTF-8
-          - 'LANGUAGE=en_US:en'
-          - LC_ALL=en_US.UTF-8
-          - HOME=/home/awx
-        ExposedPorts:
-          8052/tcp: { }
-        Hostname: awx_awx01_task_tower_1
-        Image: 'nexusregistry.opensolutions.cloud/awx_task:11.2.0'
-        Labels:
-          org.label-schema.build-date: '20200114'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: CentOS Base Image
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vendor: CentOS
-          org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
-          org.opencontainers.image.licenses: GPL-2.0-only
-          org.opencontainers.image.title: CentOS Base Image
-          org.opencontainers.image.vendor: CentOS
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: root
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/tower/SECRET_KEY: { }
-          /etc/tower/conf.d/credentials.py: { }
-          /etc/tower/conf.d/environment.sh: { }
-          /etc/tower/iometrics: { }
-          /etc/ucmdb.auth: { }
-          /usr/bin/launch_awx_task.sh: { }
-          /var/lib/awx/projects: { }
-          /var/lib/awx/rsyslog/: { }
-          /var/lib/nginx: { }
-          /var/run/awx-rsyslog: { }
-          /var/run/memcached: { }
-          /var/run/redis: { }
-          /var/run/supervisor: { }
-          /var/tmp/projects: { }
-        WorkingDir: /var/lib/awx
-      Created: '2021-10-18T11:44:40.881348712Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro'
-          - '/var/lib/awx/projects/awx01__tower_task__1:/var/lib/awx/projects:rw'
-          - '/etc/localtime:/etc/localtime:ro'
-          - '/var/run/awx_memcached:/var/run/memcached:rw'
-          - '/var/run/awx_rsyslog:/var/run/awx-rsyslog:rw'
-          - >-
-            /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
-          - >-
-            /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
-          - '/var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw'
-          - >-
-            /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro'
-          - '/var/lib/awx/var/tmp/projects:/var/tmp/projects:rw'
-          - '/var/run/awx_supervisor:/var/run/supervisor:rw'
-          - '/var/run/awx_redis:/var/run/redis:rw'
-          - '/var/lib/awx/etc/awx/iometrics:/etc/tower/iometrics:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/hostname
-      HostsPath: /etc/hosts
-      Id: efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
-      Image: 'sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7'
-      LogPath: >-
-        /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/tower/conf.d/environment.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/environment.sh
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-        - Destination: /usr/bin/launch_awx_task.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/launch_awx_task.sh
-          Type: bind
-        - Destination: /var/lib/nginx
-          Driver: local
-          Mode: ''
-          Name: 8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e/_data
-          Type: volume
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/tower/SECRET_KEY
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/SECRET_KEY
-          Type: bind
-        - Destination: /var/lib/awx/rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/lib/awx/rsyslog
-          Type: bind
-        - Destination: /var/tmp/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/tmp/projects
-          Type: bind
-        - Destination: /var/run/awx-rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_rsyslog
-          Type: bind
-        - Destination: /var/run/supervisor
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_supervisor
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/tower/conf.d/credentials.py
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/credentials.py
-          Type: bind
-        - Destination: /etc/tower/iometrics
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/iometrics
-          Type: bind
-        - Destination: /etc/ucmdb.auth
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/ucmdb.auth
-          Type: bind
-        - Destination: /var/lib/awx/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/projects/awx01__tower_task__1
-          Type: bind
-      Name: /awx_awx01_task_tower_1
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          awx:
-            Aliases:
-              - efdbe7e2ed56
-            DriverOpts: null
-            EndpointID: 793c5d8df433bbb806037f28add3fb99b4b1deb2a738cd38a8b3432dabec6683
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.3
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:03'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-        Ports:
-          8052/tcp: null
-        SandboxID: c8b6987031aa99ac901a2ec3ec5eff6490a8fc6163a78728e1e72c7b07ba5f36
-        SandboxKey: /var/run/docker/netns/c8b6987031aa
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.666814215Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8448
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.066062167Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '--'
-        - /bin/sh
-        - '-c'
-        - /usr/bin/launch_awx.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - /usr/bin/launch_awx.sh
-        Domainname: ''
-        Entrypoint:
-          - tini
-          - '--'
-        Env:
-          - DATABASE_NAME=awx
-          - AWX_QUEUE_NAME=tower
-          - AWX_ADMIN_USER=datadope
-          - DATABASE_PORT=5432
-          - AWX_ADMIN_PASSWORD=the_password
-          - DATABASE_PASSWORD=the_password
-          - SECRET_KEY=the_key
-          - DATABASE_HOST=192.168.0.252
-          - DATABASE_USER=awx
-          - >-
-            PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=en_US.UTF-8
-          - 'LANGUAGE=en_US:en'
-          - LC_ALL=en_US.UTF-8
-          - HOME=/home/awx
-        ExposedPorts:
-          8052/tcp: { }
-          8053/tcp: { }
-        Hostname: awx_web_tower_1
-        Image: 'nexusregistry.opensolutions.cloud/awx_web:11.2.0'
-        Labels:
-          org.label-schema.build-date: '20200114'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: CentOS Base Image
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vendor: CentOS
-          org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
-          org.opencontainers.image.licenses: GPL-2.0-only
-          org.opencontainers.image.title: CentOS Base Image
-          org.opencontainers.image.vendor: CentOS
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: root
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/nginx/awxweb.pem: { }
-          /etc/nginx/nginx.conf: { }
-          /etc/tower/SECRET_KEY: { }
-          /etc/tower/conf.d/credentials.py: { }
-          /etc/tower/conf.d/environment.sh: { }
-          /etc/ucmdb.auth: { }
-          /var/lib/awx/projects: { }
-          /var/lib/awx/rsyslog/: { }
-          /var/lib/nginx: { }
-          /var/run/awx-rsyslog: { }
-          /var/run/memcached: { }
-          /var/run/redis: { }
-          /var/run/supervisor: { }
-        WorkingDir: /var/lib/awx
-      Created: '2021-10-18T10:22:23.792332427Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2-init/diff:/var/lib/docker/overlay2/3c13fb2448c4706f60677e56fabf13eee05734ec5a9766eee43659261dab90a3/diff:/var/lib/docker/overlay2/91b427dfbb443e5fd41e123d6b65806881f1527b05e897537808332da3c65afc/diff:/var/lib/docker/overlay2/37f36c6664c7d70bb927546ad358b46f72fa603c0511aab5625546c4fbaf4224/diff:/var/lib/docker/overlay2/cb747a616cd72b17e0277b27cd036ff79f061d2bf1ec49f6f7576a513ff1f454/diff:/var/lib/docker/overlay2/1f5a7c255f9d87a97f18408553cc5ea8a3e57b803d58d444684e77065992886c/diff:/var/lib/docker/overlay2/701b839302666be2d93bcec208db2b10bfc64f25b9dd3edbb4b6f5beeb0ff215/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro'
-          - '/etc/localtime:/etc/localtime:ro'
-          - '/var/run/awx_memcached:/var/run/memcached:rw'
-          - '/var/run/awx_rsyslog:/var/run/awx-rsyslog:rw'
-          - '/var/run/awx_supervisor:/var/run/supervisor:rw'
-          - >-
-            /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
-          - >-
-            /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
-          - '/var/lib/awx/etc/awx/nginx.conf:/etc/nginx/nginx.conf:ro'
-          - '/var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw'
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro'
-          - '/var/lib/awx/etc/awx/awxweb.pem:/etc/nginx/awxweb.pem:ro'
-          - '/var/lib/awx/projects/awx01__tower_web_1:/var/lib/awx/projects:rw'
-          - '/var/run/awx_redis:/var/run/redis:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths: null
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8052/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '80'
-          8053/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '443'
-        Privileged: true
-        PublishAllPorts: false
-        ReadonlyPaths: null
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt:
-          - label=disable
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/hostname
-      HostsPath: /etc/hosts
-      Id: b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
-      Image: 'sha256:71ea5e1b1b2f382bd0b0560464ea9c77dc30e396e8c6e9b8958b33b94416b708'
-      LogPath: >-
-        /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/nginx/awxweb.pem
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/awxweb.pem
-          Type: bind
-        - Destination: /var/lib/awx/rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/lib/awx/rsyslog
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/tower/conf.d/credentials.py
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/credentials.py
-          Type: bind
-        - Destination: /etc/ucmdb.auth
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/ucmdb.auth
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx/nginx.conf
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/nginx.conf
-          Type: bind
-        - Destination: /var/lib/awx/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/projects/awx01__tower_web_1
-          Type: bind
-        - Destination: /var/lib/nginx
-          Driver: local
-          Mode: ''
-          Name: 9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd/_data
-          Type: volume
-        - Destination: /var/run/awx-rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_rsyslog
-          Type: bind
-        - Destination: /etc/tower/SECRET_KEY
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/SECRET_KEY
-          Type: bind
-        - Destination: /etc/tower/conf.d/environment.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/environment.sh
-          Type: bind
-        - Destination: /var/run/supervisor
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_supervisor
-          Type: bind
-      Name: /awx_web_tower_1
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          awx:
-            Aliases:
-              - awx_web
-              - b7972b752e85
-            DriverOpts: null
-            EndpointID: 68e96dfb1a48497323aabc5ffbad6da682bbd271778ed383ed3c9cbf86ddb732
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.4
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:04'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-        Ports:
-          8052/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '80'
-          8053/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '443'
-        SandboxID: 82cf34c71f29edf07f8bfba5e104fe5715f8195c1c5d6af30843be7315149a93
-        SandboxKey: /var/run/docker/netns/82cf34c71f29
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.713044964Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8455
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.064174569Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-s'
-        - /var/run/memcached/memcached.sock
-        - '-a'
-        - '0666'
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-s'
-          - /var/run/memcached/memcached.sock
-          - '-a'
-          - '0666'
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - MEMCACHED_VERSION=1.6.6
-          - MEMCACHED_SHA1=d8895b12dc9fc82b389f1713e2c09cc6ca3d03e4
-        ExposedPorts:
-          11211/tcp: { }
-        Hostname: 1c624b0d7c73
-        Image: 'nexusregistry.opensolutions.cloud/monitorizacion/memcached:alpine'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: memcache
-        Volumes:
-          /etc/localtime: { }
-          /var/run/memcached: { }
-        WorkingDir: ''
-      Created: '2020-06-03T10:16:16.67286319Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d-init/diff:/var/lib/docker/overlay2/d8877c054116b5ee97ee53c893117c6fb2dfff8ecd5f7de53f12ae1a64c9e063/diff:/var/lib/docker/overlay2/09557cecc7a0ad7866cb864928e034e550f8e97703d629f1f16287ebc96056ca/diff:/var/lib/docker/overlay2/e26535172b18e8ba64dfeb361e9a74d224ba94487968fff19550ae35baa09f1b/diff:/var/lib/docker/overlay2/005ea37c98a59f97323add0a2222945ef78f4af4abc0478bfd68a0de5805ee3a/diff:/var/lib/docker/overlay2/7b303f0c79fd7aa2e61f9f75e0fd0cc48375e353dc577c2ddbc819d1d42e1144/diff:/var/lib/docker/overlay2/5e13e12e87f251e2cf30736940f53a5b2a922d1b8fbab5fdb529c204d56010e3/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/var/run/awx_memcached:/var/run/memcached:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths: null
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          11211/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '11211'
-        Privileged: true
-        PublishAllPorts: false
-        ReadonlyPaths: null
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt:
-          - label=disable
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hosts
-      Id: 1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
-      Image: 'sha256:35acd9837d07e6369afd8683ae08f7da10de93ea5d50e74050abbdeece1e6754'
-      LogPath: >-
-        /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-      Name: /awx_memcached
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: '02:42:ac:11:00:02'
-        Networks:
-          awx:
-            Aliases:
-              - memcached
-              - 1c624b0d7c73
-            DriverOpts: null
-            EndpointID: 1918e2a1786dc68318500c7bb707bd61536735c440afa195359d798150cd924e
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.5
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:05'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:11:00:02'
-            NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
-        Ports:
-          11211/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '11211'
-        SandboxID: 6b1d0adc35d952fa492b943f4104aa574aa23454c9b23be2ff55da2e148d9879
-        SandboxKey: /var/run/docker/netns/6b1d0adc35d9
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.690727633Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8510
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:10.809715881Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - /usr/local/etc/redis/redis.conf
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /usr/local/etc/redis/redis.conf
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.0.4
-          - >-
-            REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.4.tar.gz
-          - >-
-            REDIS_DOWNLOAD_SHA=3337005a1e0c3aa293c87c313467ea8ac11984921fab08807998ba765c9943de
-        ExposedPorts:
-          6379/tcp: { }
-        Hostname: 46897b6fb532
-        Image: 'nexusregistry.opensolutions.cloud/monitorizacion/redis:6.0.4'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: { }
-          /etc/localtime: { }
-          /usr/local/etc/redis/redis.conf: { }
-          /var/run/redis: { }
-        WorkingDir: /data
-      Created: '2020-06-03T10:08:34.836826924Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5-init/diff:/var/lib/docker/overlay2/f195086ba7e5c223584dc55602eabac57e67456493d3adcbaa39c5734cc1aed6/diff:/var/lib/docker/overlay2/69a5b254a5f5034b01f48dfca65e3a9350da9ef3d39afa86378af53f17773bbc/diff:/var/lib/docker/overlay2/e7bc5968d1154c270b86fc6c25dff4cc0cd6445fd93053648cc6f647d108ac5d/diff:/var/lib/docker/overlay2/5acabe980feecd71fcb74ff02e49f3b54ea1274abfcc2901ac6aaf29bc76c00f/diff:/var/lib/docker/overlay2/1943e56b8ae64a1d3392bb93a86e20b8240ee27400cbfbc0f859909ed75d1b1c/diff:/var/lib/docker/overlay2/7c53990c945f93e734234bf43cdb0ba2ecce49b3b66c9abe18f529aef297e1c3/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/var/run/awx_redis:/var/run/redis:rw'
-          - '/usr/local/etc/redis/redis.conf:/usr/local/etc/redis/redis.conf:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          6379/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '6379'
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hosts
-      Id: 46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
-      Image: 'sha256:36304d3b4540c5143673b2cefaba583a0426b57c709b5a35363f96a3510058cd'
-      LogPath: >-
-        /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data
-          Driver: local
-          Mode: ''
-          Name: 6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330/_data
-          Type: volume
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /usr/local/etc/redis/redis.conf
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /usr/local/etc/redis/redis.conf
-          Type: bind
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-      Name: /awx_redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.3
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: '02:42:ac:11:00:03'
-        Networks:
-          awx:
-            Aliases:
-              - redis
-              - 46897b6fb532
-            DriverOpts: null
-            EndpointID: 484b6930ad5e400adc2c0bd5d5c0072f63b82cb3d210d25dbdf2776e30583828
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.6
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:12:00:06'
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.3
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:11:00:03'
-            NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
-        Ports:
-          6379/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '6379'
-        SandboxID: e3c098aa78f830407f21419ab0f92eccc5d1f533c2c37be76db60452521346cd
-        SandboxKey: /var/run/docker/netns/e3c098aa78f8
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.690312533Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8576
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.070796868Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-devel:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-devel
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 2.el7
-      source: rpm
-      version: 0.8.5
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  git:
-    - arch: x86_64
-      epoch: null
-      name: git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  htop:
-    - arch: x86_64
-      epoch: null
-      name: htop
-      release: 3.el7
-      source: rpm
-      version: 2.2.0
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1127.13.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs-devel:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs-devel
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-devel:
-    - arch: x86_64
-      epoch: null
-      name: krb5-devel
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcom_err-devel:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err-devel
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libffi-devel:
-    - arch: x86_64
-      epoch: null
-      name: libffi-devel
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libkadm5:
-    - arch: x86_64
-      epoch: null
-      name: libkadm5
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnet:
-    - arch: x86_64
-      epoch: null
-      name: libnet
-      release: 7.el7
-      source: rpm
-      version: 1.1.6
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-devel:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-devel
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsepol-devel:
-    - arch: x86_64
-      epoch: null
-      name: libsepol-devel
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-devel:
-    - arch: x86_64
-      epoch: null
-      name: libverto-devel
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 7.el7_8.2
-      source: rpm
-      version: 2.02.186
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 2.02.186
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  ngrep:
-    - arch: x86_64
-      epoch: null
-      name: ngrep
-      release: 1.1.20180101git9b59468.el7
-      source: rpm
-      version: '1.47'
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-devel:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-devel
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcre-devel:
-    - arch: x86_64
-      epoch: null
-      name: pcre-devel
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Error:
-    - arch: noarch
-      epoch: 1
-      name: perl-Error
-      release: 2.el7
-      source: rpm
-      version: '0.17020'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-Git:
-    - arch: noarch
-      epoch: null
-      name: perl-Git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-TermReadKey:
-    - arch: x86_64
-      epoch: null
-      name: perl-TermReadKey
-      release: 20.el7
-      source: rpm
-      version: '2.30'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 6.el7
-      source: rpm
-      version: '4.24'
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 65.el7_8
-      source: rpm
-      version: '0.17'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 1.el7
-      source: rpm
-      version: 3.2.11
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 1.el7
-      source: rpm
-      version: 4.0.19
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-  zlib-devel:
-    - arch: x86_64
-      epoch: null
-      name: zlib-devel
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '63'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '130'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '179'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '180'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '281'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '304'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '347'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '426'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '443'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '452'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '560'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '561'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '588'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '617'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '619'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '621'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '624'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '629'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '639'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '646'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H awx01 eth0
-    pid: '872'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '931'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '933'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '941'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '950'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '953'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '954'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '955'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '956'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '957'
-    ppid: '950'
-    user: zabbix
-  - cmdline: ''
-    pid: '1028'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1034'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1036'
-    ppid: '1034'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1096'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/vault server -config=/etc/vault.d/vault_main.hcl
-      -log-level=info
-    pid: '1135'
-    ppid: '1'
-    user: vault
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1136'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1137'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1139'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1140'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1154'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
-    pid: '2678'
-    ppid: '9043'
-    user: root
-  - cmdline: ''
-    pid: '2738'
-    ppid: '2'
-    user: root
-  - cmdline: python3 /usr/bin/config-watcher
-    pid: '2745'
-    ppid: '2678'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '2747'
-    ppid: '2678'
-    user: root
-  - cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
-    pid: '2763'
-    ppid: '9045'
-    user: root
-  - cmdline: python3 /usr/bin/config-watcher
-    pid: '2811'
-    ppid: '2763'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '2814'
-    ppid: '2763'
-    user: root
-  - cmdline: ''
-    pid: '3258'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '5442'
-    ppid: '26058'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '7506'
-    ppid: '19428'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '7647'
-    ppid: '1096'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 443
-      -container-ip 192.168.2.4 -container-port 8053
-    pid: '7659'
-    ppid: '1136'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '7669'
-    ppid: '7647'
-    user: centos
-  - cmdline: '-bash'
-    pid: '7673'
-    ppid: '7669'
-    user: centos
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 80
-      -container-ip 192.168.2.4 -container-port 8052
-    pid: '7676'
-    ppid: '1136'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7706'
-    ppid: '2747'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7811'
-    ppid: '2747'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7814'
-    ppid: '2814'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 11211
-      -container-ip 192.168.2.5 -container-port 11211
-    pid: '7816'
-    ppid: '1136'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7850'
-    ppid: '2814'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7851'
-    ppid: '2747'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '7877'
-    ppid: '941'
-    user: root
-  - cmdline: sudo su -
-    pid: '7904'
-    ppid: '7673'
-    user: root
-  - cmdline: su -
-    pid: '7905'
-    ppid: '7904'
-    user: root
-  - cmdline: '-bash'
-    pid: '7906'
-    ppid: '7905'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '7943'
-    ppid: '941'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7965'
-    ppid: '2814'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '7966'
-    ppid: '2747'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage
-      run_callback_receiver
-    pid: '8027'
-    ppid: '2814'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8384'
-    ppid: '941'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 6379
-      -container-ip 192.168.2.6 -container-port 6379
-    pid: '8401'
-    ppid: '1136'
-    user: root
-  - cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
-    pid: '8441'
-    ppid: '7877'
-    user: root
-  - cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
-    pid: '8448'
-    ppid: '7943'
-    user: root
-  - cmdline: tini -- /bin/sh -c /usr/bin/launch_awx.sh
+  - AppArmorProfile: ''
+    Args:
+    - run
+    - python3
+    - cli.py
+    - -c
+    - /app/etc/awx_cleaner_conf.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/awx_cleaner_conf.yml
+      Domainname: ''
+      Entrypoint:
+      - pipenv
+      - run
+      - python3
+      - cli.py
+      Env:
+      - AWX_CLEANER_PASSWORD=
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=the_gpg_key
+      - PYTHON_VERSION=3.7.9
+      - PYTHON_PIP_VERSION=20.2.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
+      - PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
+      - PYTHONUNBUFFERED=true
+      Hostname: awx01.novalocal
+      Image: nexusregistry.opensolutions.cloud/awx-cleaner:1.2.1
+      Labels:
+        maintainer: oromeu
+        os_contianer_type: awx_cleaner
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2021-10-18T11:45:16.316785262Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976-init/diff:/var/lib/docker/overlay2/22df782a1cbd5e34a3d5776753b2a807f00ba47e6013551e8b95f7e2ed93db35/diff:/var/lib/docker/overlay2/312b95522dd6921da5c2d5289fb7f32e63ceb5e10ba2143adbbc4c99d35023a9/diff:/var/lib/docker/overlay2/6300a0d70ac3252c87a6be17df77e286b97b4db13ba9be1526f70834f50875e1/diff:/var/lib/docker/overlay2/fd460f916e69c1b50a62212515f5b8bc8a8d29472da602c7c4cb37a16eb20137/diff:/var/lib/docker/overlay2/f1d776f54a392e59db855bf36785245f6d6774c0d16951e72d5ef172007b3fb9/diff:/var/lib/docker/overlay2/a68da68959434fd6261752e9e627f939d0d4b2b2ccbac7f32d663f915b67b07d/diff:/var/lib/docker/overlay2/6705a2fe1186389824def98c101d6b9b14b6d32e920c3c874e43208cb067f5f1/diff:/var/lib/docker/overlay2/2fe2d6a4cb1c5d9f55c98910a5ea422b2f8e7d8fefedefc8b1913aed66fe7ed2/diff:/var/lib/docker/overlay2/5fabbebbda1b3e287dc88fa6f41f6e1cb3e63553bb07ce5e0f945eea1bfe255d/diff:/var/lib/docker/overlay2/5d678a8dc7b4f4a16fd7a36e567ea771d528ac34407935769ebfd7e1bac68eb4/diff
+        MergedDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/merged
+        UpperDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/diff
+        WorkDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/hostname
+    HostsPath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/hosts
+    Id: 19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941
+    Image: sha256:9e588379d3c89b34839fda2502e557249b103a4b22fd1b80c37097ad0488fdf6
+    LogPath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics
+      Type: bind
+    Name: /awx_cleaner
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ''
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 9f8b86b22be78ec095186dd5f8afda1a02d9c56c4e2bbb6a334825173f523943
+      Ports: {}
+      SandboxID: b51930dfcc56796bad98dfb651ad63bb5ac26cf16ef4294558378f9bb1466bd8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: pipenv
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 1
+      FinishedAt: '2022-06-08T22:18:50.484288029Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 0
+      Restarting: false
+      Running: false
+      StartedAt: '2022-06-08T22:18:48.743921162Z'
+      Status: exited
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /bin/sh
+    - -c
+    - /usr/bin/launch_awx_task.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - /usr/bin/launch_awx_task.sh
+      Domainname: ''
+      Entrypoint:
+      - tini
+      - --
+      Env:
+      - TASK_HOSTNAME=awx_awx01_task_1
+      - DATABASE_PORT=5432
+      - DATABASE_NAME=awx
+      - AWX_QUEUE_NAME=runners
+      - AWX_ADMIN_USER=datadope
+      - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
+      - AWX_ADMIN_PASSWORD=the_password
+      - DATABASE_PASSWORD=the_password
+      - SECRET_KEY=the_key
+      - DATABASE_HOST=192.168.0.252
+      - DATABASE_USER=awx
+      - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
+      - LC_ALL=en_US.UTF-8
+      - HOME=/home/awx
+      ExposedPorts:
+        8052/tcp: {}
+      Hostname: awx_awx01_task_1
+      Image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
+      Labels:
+        org.label-schema.build-date: '20200114'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: CentOS Base Image
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vendor: CentOS
+        org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
+        org.opencontainers.image.licenses: GPL-2.0-only
+        org.opencontainers.image.title: CentOS Base Image
+        org.opencontainers.image.vendor: CentOS
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: root
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/tower/SECRET_KEY: {}
+        /etc/tower/conf.d/credentials.py: {}
+        /etc/tower/conf.d/environment.sh: {}
+        /etc/ucmdb.auth: {}
+        /usr/bin/launch_awx_task.sh: {}
+        /var/lib/awx/projects: {}
+        /var/lib/awx/rsyslog/: {}
+        /var/lib/nginx: {}
+        /var/run/awx-rsyslog: {}
+        /var/run/memcached: {}
+        /var/run/redis: {}
+        /var/run/supervisor: {}
+      WorkingDir: /var/lib/awx
+    Created: '2021-10-18T11:44:59.182845248Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
+        MergedDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/merged
+        UpperDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/diff
+        WorkDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
+      - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
+      - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
+      - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
+      - /var/lib/awx/projects/awx01__runners__1:/var/lib/awx/projects:rw
+      - /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
+      - /etc/hosts:/etc/hosts:ro
+      - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
+      - /var/run/awx_supervisor:/var/run/supervisor:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/hostname
+    HostsPath: /etc/hosts
+    Id: d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
+    Image: sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7
+    LogPath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/tower/SECRET_KEY
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/SECRET_KEY
+      Type: bind
+    - Destination: /var/lib/nginx
+      Driver: local
+      Mode: ''
+      Name: 7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6/_data
+      Type: volume
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    - Destination: /etc/ucmdb.auth
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/ucmdb.auth
+      Type: bind
+    - Destination: /var/lib/awx/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/projects/awx01__runners__1
+      Type: bind
+    - Destination: /var/lib/awx/rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/lib/awx/rsyslog
+      Type: bind
+    - Destination: /etc/tower/conf.d/credentials.py
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/credentials.py
+      Type: bind
+    - Destination: /etc/tower/conf.d/environment.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/environment.sh
+      Type: bind
+    - Destination: /var/run/awx-rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_rsyslog
+      Type: bind
+    - Destination: /var/run/supervisor
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_supervisor
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /usr/bin/launch_awx_task.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/launch_awx_task.sh
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    Name: /awx_awx01_task_1
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        awx:
+          Aliases:
+          - d13b4e9fdb7e
+          DriverOpts: null
+          EndpointID: 85027b2a5efa749aa7c8e87269e8803be0c4f0b5a75520aff51ab68492f91a7d
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:02
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+      Ports:
+        8052/tcp: null
+      SandboxID: b952a5e659a2bad6bef04200378542419a1ab00bffee6fb12ffefdf90ea009eb
+      SandboxKey: /var/run/docker/netns/b952a5e659a2
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.691239226Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8441
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.062811086Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /bin/sh
+    - -c
+    - /usr/bin/launch_awx_task.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - /usr/bin/launch_awx_task.sh
+      Domainname: ''
+      Entrypoint:
+      - tini
+      - --
+      Env:
+      - TASK_HOSTNAME=awx_awx01_task_tower_1
+      - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
+      - DATABASE_NAME=awx
+      - AWX_QUEUE_NAME=tower
+      - AWX_ADMIN_USER=datadope
+      - AWX_HOSTNAME=awx01
+      - DATABASE_PORT=5432
+      - AWX_ADMIN_PASSWORD=the_password
+      - DATABASE_PASSWORD=the_password
+      - SECRET_KEY=the_key
+      - DATABASE_HOST=192.168.0.252
+      - DATABASE_USER=awx
+      - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
+      - LC_ALL=en_US.UTF-8
+      - HOME=/home/awx
+      ExposedPorts:
+        8052/tcp: {}
+      Hostname: awx_awx01_task_tower_1
+      Image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
+      Labels:
+        org.label-schema.build-date: '20200114'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: CentOS Base Image
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vendor: CentOS
+        org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
+        org.opencontainers.image.licenses: GPL-2.0-only
+        org.opencontainers.image.title: CentOS Base Image
+        org.opencontainers.image.vendor: CentOS
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: root
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/tower/SECRET_KEY: {}
+        /etc/tower/conf.d/credentials.py: {}
+        /etc/tower/conf.d/environment.sh: {}
+        /etc/tower/iometrics: {}
+        /etc/ucmdb.auth: {}
+        /usr/bin/launch_awx_task.sh: {}
+        /var/lib/awx/projects: {}
+        /var/lib/awx/rsyslog/: {}
+        /var/lib/nginx: {}
+        /var/run/awx-rsyslog: {}
+        /var/run/memcached: {}
+        /var/run/redis: {}
+        /var/run/supervisor: {}
+        /var/tmp/projects: {}
+      WorkingDir: /var/lib/awx
+    Created: '2021-10-18T11:44:40.881348712Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
+        MergedDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/merged
+        UpperDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/diff
+        WorkDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
+      - /var/lib/awx/projects/awx01__tower_task__1:/var/lib/awx/projects:rw
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
+      - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
+      - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
+      - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
+      - /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
+      - /etc/hosts:/etc/hosts:ro
+      - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
+      - /var/lib/awx/var/tmp/projects:/var/tmp/projects:rw
+      - /var/run/awx_supervisor:/var/run/supervisor:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      - /var/lib/awx/etc/awx/iometrics:/etc/tower/iometrics:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/hostname
+    HostsPath: /etc/hosts
+    Id: efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
+    Image: sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7
+    LogPath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/tower/conf.d/environment.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/environment.sh
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    - Destination: /usr/bin/launch_awx_task.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/launch_awx_task.sh
+      Type: bind
+    - Destination: /var/lib/nginx
+      Driver: local
+      Mode: ''
+      Name: 8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e/_data
+      Type: volume
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/tower/SECRET_KEY
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/SECRET_KEY
+      Type: bind
+    - Destination: /var/lib/awx/rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/lib/awx/rsyslog
+      Type: bind
+    - Destination: /var/tmp/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/tmp/projects
+      Type: bind
+    - Destination: /var/run/awx-rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_rsyslog
+      Type: bind
+    - Destination: /var/run/supervisor
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_supervisor
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/tower/conf.d/credentials.py
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/credentials.py
+      Type: bind
+    - Destination: /etc/tower/iometrics
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/iometrics
+      Type: bind
+    - Destination: /etc/ucmdb.auth
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/ucmdb.auth
+      Type: bind
+    - Destination: /var/lib/awx/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/projects/awx01__tower_task__1
+      Type: bind
+    Name: /awx_awx01_task_tower_1
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        awx:
+          Aliases:
+          - efdbe7e2ed56
+          DriverOpts: null
+          EndpointID: 793c5d8df433bbb806037f28add3fb99b4b1deb2a738cd38a8b3432dabec6683
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.3
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:03
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+      Ports:
+        8052/tcp: null
+      SandboxID: c8b6987031aa99ac901a2ec3ec5eff6490a8fc6163a78728e1e72c7b07ba5f36
+      SandboxKey: /var/run/docker/netns/c8b6987031aa
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.666814215Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8448
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.066062167Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /bin/sh
+    - -c
+    - /usr/bin/launch_awx.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - /usr/bin/launch_awx.sh
+      Domainname: ''
+      Entrypoint:
+      - tini
+      - --
+      Env:
+      - DATABASE_NAME=awx
+      - AWX_QUEUE_NAME=tower
+      - AWX_ADMIN_USER=datadope
+      - DATABASE_PORT=5432
+      - AWX_ADMIN_PASSWORD=the_password
+      - DATABASE_PASSWORD=the_password
+      - SECRET_KEY=the_key
+      - DATABASE_HOST=192.168.0.252
+      - DATABASE_USER=awx
+      - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
+      - LC_ALL=en_US.UTF-8
+      - HOME=/home/awx
+      ExposedPorts:
+        8052/tcp: {}
+        8053/tcp: {}
+      Hostname: awx_web_tower_1
+      Image: nexusregistry.opensolutions.cloud/awx_web:11.2.0
+      Labels:
+        org.label-schema.build-date: '20200114'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: CentOS Base Image
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vendor: CentOS
+        org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
+        org.opencontainers.image.licenses: GPL-2.0-only
+        org.opencontainers.image.title: CentOS Base Image
+        org.opencontainers.image.vendor: CentOS
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: root
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx/awxweb.pem: {}
+        /etc/nginx/nginx.conf: {}
+        /etc/tower/SECRET_KEY: {}
+        /etc/tower/conf.d/credentials.py: {}
+        /etc/tower/conf.d/environment.sh: {}
+        /etc/ucmdb.auth: {}
+        /var/lib/awx/projects: {}
+        /var/lib/awx/rsyslog/: {}
+        /var/lib/nginx: {}
+        /var/run/awx-rsyslog: {}
+        /var/run/memcached: {}
+        /var/run/redis: {}
+        /var/run/supervisor: {}
+      WorkingDir: /var/lib/awx
+    Created: '2021-10-18T10:22:23.792332427Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2-init/diff:/var/lib/docker/overlay2/3c13fb2448c4706f60677e56fabf13eee05734ec5a9766eee43659261dab90a3/diff:/var/lib/docker/overlay2/91b427dfbb443e5fd41e123d6b65806881f1527b05e897537808332da3c65afc/diff:/var/lib/docker/overlay2/37f36c6664c7d70bb927546ad358b46f72fa603c0511aab5625546c4fbaf4224/diff:/var/lib/docker/overlay2/cb747a616cd72b17e0277b27cd036ff79f061d2bf1ec49f6f7576a513ff1f454/diff:/var/lib/docker/overlay2/1f5a7c255f9d87a97f18408553cc5ea8a3e57b803d58d444684e77065992886c/diff:/var/lib/docker/overlay2/701b839302666be2d93bcec208db2b10bfc64f25b9dd3edbb4b6f5beeb0ff215/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
+        MergedDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/merged
+        UpperDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/diff
+        WorkDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
+      - /var/run/awx_supervisor:/var/run/supervisor:rw
+      - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
+      - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
+      - /var/lib/awx/etc/awx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
+      - /etc/hosts:/etc/hosts:ro
+      - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
+      - /var/lib/awx/etc/awx/awxweb.pem:/etc/nginx/awxweb.pem:ro
+      - /var/lib/awx/projects/awx01__tower_web_1:/var/lib/awx/projects:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths: null
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8052/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '80'
+        8053/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '443'
+      Privileged: true
+      PublishAllPorts: false
+      ReadonlyPaths: null
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt:
+      - label=disable
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/hostname
+    HostsPath: /etc/hosts
+    Id: b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
+    Image: sha256:71ea5e1b1b2f382bd0b0560464ea9c77dc30e396e8c6e9b8958b33b94416b708
+    LogPath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/nginx/awxweb.pem
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/awxweb.pem
+      Type: bind
+    - Destination: /var/lib/awx/rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/lib/awx/rsyslog
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/tower/conf.d/credentials.py
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/credentials.py
+      Type: bind
+    - Destination: /etc/ucmdb.auth
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/ucmdb.auth
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx/nginx.conf
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/nginx.conf
+      Type: bind
+    - Destination: /var/lib/awx/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/projects/awx01__tower_web_1
+      Type: bind
+    - Destination: /var/lib/nginx
+      Driver: local
+      Mode: ''
+      Name: 9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd/_data
+      Type: volume
+    - Destination: /var/run/awx-rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_rsyslog
+      Type: bind
+    - Destination: /etc/tower/SECRET_KEY
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/SECRET_KEY
+      Type: bind
+    - Destination: /etc/tower/conf.d/environment.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/environment.sh
+      Type: bind
+    - Destination: /var/run/supervisor
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_supervisor
+      Type: bind
+    Name: /awx_web_tower_1
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        awx:
+          Aliases:
+          - awx_web
+          - b7972b752e85
+          DriverOpts: null
+          EndpointID: 68e96dfb1a48497323aabc5ffbad6da682bbd271778ed383ed3c9cbf86ddb732
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.4
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:04
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+      Ports:
+        8052/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '80'
+        8053/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '443'
+      SandboxID: 82cf34c71f29edf07f8bfba5e104fe5715f8195c1c5d6af30843be7315149a93
+      SandboxKey: /var/run/docker/netns/82cf34c71f29
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.713044964Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8455
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.064174569Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -s
+    - /var/run/memcached/memcached.sock
+    - -a
+    - '0666'
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -s
+      - /var/run/memcached/memcached.sock
+      - -a
+      - '0666'
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - MEMCACHED_VERSION=1.6.6
+      - MEMCACHED_SHA1=d8895b12dc9fc82b389f1713e2c09cc6ca3d03e4
+      ExposedPorts:
+        11211/tcp: {}
+      Hostname: 1c624b0d7c73
+      Image: nexusregistry.opensolutions.cloud/monitorizacion/memcached:alpine
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: memcache
+      Volumes:
+        /etc/localtime: {}
+        /var/run/memcached: {}
+      WorkingDir: ''
+    Created: '2020-06-03T10:16:16.67286319Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d-init/diff:/var/lib/docker/overlay2/d8877c054116b5ee97ee53c893117c6fb2dfff8ecd5f7de53f12ae1a64c9e063/diff:/var/lib/docker/overlay2/09557cecc7a0ad7866cb864928e034e550f8e97703d629f1f16287ebc96056ca/diff:/var/lib/docker/overlay2/e26535172b18e8ba64dfeb361e9a74d224ba94487968fff19550ae35baa09f1b/diff:/var/lib/docker/overlay2/005ea37c98a59f97323add0a2222945ef78f4af4abc0478bfd68a0de5805ee3a/diff:/var/lib/docker/overlay2/7b303f0c79fd7aa2e61f9f75e0fd0cc48375e353dc577c2ddbc819d1d42e1144/diff:/var/lib/docker/overlay2/5e13e12e87f251e2cf30736940f53a5b2a922d1b8fbab5fdb529c204d56010e3/diff
+        MergedDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/merged
+        UpperDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/diff
+        WorkDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/localtime:/etc/localtime:rw
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths: null
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        11211/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '11211'
+      Privileged: true
+      PublishAllPorts: false
+      ReadonlyPaths: null
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt:
+      - label=disable
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hostname
+    HostsPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hosts
+    Id: 1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
+    Image: sha256:35acd9837d07e6369afd8683ae08f7da10de93ea5d50e74050abbdeece1e6754
+    LogPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    Name: /awx_memcached
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        awx:
+          Aliases:
+          - memcached
+          - 1c624b0d7c73
+          DriverOpts: null
+          EndpointID: 1918e2a1786dc68318500c7bb707bd61536735c440afa195359d798150cd924e
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.5
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:05
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
+      Ports:
+        11211/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '11211'
+      SandboxID: 6b1d0adc35d952fa492b943f4104aa574aa23454c9b23be2ff55da2e148d9879
+      SandboxKey: /var/run/docker/netns/6b1d0adc35d9
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.690727633Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8510
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:10.809715881Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - /usr/local/etc/redis/redis.conf
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /usr/local/etc/redis/redis.conf
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.0.4
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.4.tar.gz
+      - REDIS_DOWNLOAD_SHA=3337005a1e0c3aa293c87c313467ea8ac11984921fab08807998ba765c9943de
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: 46897b6fb532
+      Image: nexusregistry.opensolutions.cloud/monitorizacion/redis:6.0.4
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+        /etc/localtime: {}
+        /usr/local/etc/redis/redis.conf: {}
+        /var/run/redis: {}
+      WorkingDir: /data
+    Created: '2020-06-03T10:08:34.836826924Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5-init/diff:/var/lib/docker/overlay2/f195086ba7e5c223584dc55602eabac57e67456493d3adcbaa39c5734cc1aed6/diff:/var/lib/docker/overlay2/69a5b254a5f5034b01f48dfca65e3a9350da9ef3d39afa86378af53f17773bbc/diff:/var/lib/docker/overlay2/e7bc5968d1154c270b86fc6c25dff4cc0cd6445fd93053648cc6f647d108ac5d/diff:/var/lib/docker/overlay2/5acabe980feecd71fcb74ff02e49f3b54ea1274abfcc2901ac6aaf29bc76c00f/diff:/var/lib/docker/overlay2/1943e56b8ae64a1d3392bb93a86e20b8240ee27400cbfbc0f859909ed75d1b1c/diff:/var/lib/docker/overlay2/7c53990c945f93e734234bf43cdb0ba2ecce49b3b66c9abe18f529aef297e1c3/diff
+        MergedDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/merged
+        UpperDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/diff
+        WorkDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/localtime:/etc/localtime:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      - /usr/local/etc/redis/redis.conf:/usr/local/etc/redis/redis.conf:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        6379/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '6379'
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hostname
+    HostsPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hosts
+    Id: 46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
+    Image: sha256:36304d3b4540c5143673b2cefaba583a0426b57c709b5a35363f96a3510058cd
+    LogPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data
+      Driver: local
+      Mode: ''
+      Name: 6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330/_data
+      Type: volume
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /usr/local/etc/redis/redis.conf
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /usr/local/etc/redis/redis.conf
+      Type: bind
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    Name: /awx_redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.3
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:03
+      Networks:
+        awx:
+          Aliases:
+          - redis
+          - 46897b6fb532
+          DriverOpts: null
+          EndpointID: 484b6930ad5e400adc2c0bd5d5c0072f63b82cb3d210d25dbdf2776e30583828
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.6
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:06
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.3
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:03
+          NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
+      Ports:
+        6379/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '6379'
+      SandboxID: e3c098aa78f830407f21419ab0f92eccc5d1f533c2c37be76db60452521346cd
+      SandboxKey: /var/run/docker/netns/e3c098aa78f8
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.690312533Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8576
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.070796868Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 443
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 80
+    protocol: tcp
+  discovery_time: '2022-06-29T12:38:53+02:00'
+  docker:
+    exposed_ports:
+      8052/tcp: {}
+      8053/tcp: {}
+    id: b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
+    image: nexusregistry.opensolutions.cloud/awx_web:11.2.0
+    name: /awx_web_tower_1
+    network_mode: default
+    port_bindings:
+      8052/tcp:
+      - HostIp: 0.0.0.0
+        HostPort: '80'
+      8053/tcp:
+      - HostIp: 0.0.0.0
+        HostPort: '443'
+  listening_ports:
+  - 80
+  - 443
+  packages: []
+  process:
+    cmdline: tini -- /bin/sh -c /usr/bin/launch_awx.sh
+    cwd: /
+    listening_ports:
+    - 80
+    - 443
     pid: '8455'
     ppid: '8384'
     user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8484'
-    ppid: '941'
-    user: root
-  - cmdline: memcached -s /var/run/memcached/memcached.sock -a 0666
-    pid: '8510'
-    ppid: '8484'
-    user: '11211'
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8531'
-    ppid: '941'
-    user: root
-  - cmdline: 'redis-server 127.0.0.1:0'
-    pid: '8576'
-    ppid: '8531'
-    user: polkitd
-  - cmdline: pickup -l -t unix -u
-    pid: '8888'
-    ppid: '1034'
-    user: postfix
-  - cmdline: bash /usr/bin/launch_awx.sh
-    pid: '9042'
-    ppid: '8455'
-    user: root
-  - cmdline: bash /usr/bin/launch_awx_task.sh
-    pid: '9043'
-    ppid: '8448'
-    user: root
-  - cmdline: bash /usr/bin/launch_awx_task.sh
-    pid: '9045'
-    ppid: '8441'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_awx01_task_tower_1
-    pid: '9274'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_redis
-    pid: '9279'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_awx01_task_1
-    pid: '9285'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_memcached
-    pid: '9287'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_web_tower_1
-    pid: '9288'
-    ppid: '1'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '10723'
-    ppid: '26058'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '10724'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '11040'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '11622'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '11658'
-    ppid: '26058'
-    user: root
-  - cmdline: ''
-    pid: '12560'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13171'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15846'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '17310'
-    ppid: '25981'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '17698'
-    ppid: '1096'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '17739'
-    ppid: '17698'
-    user: centos
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '18195'
-    ppid: '26058'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_cleaner
-    pid: '18217'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '18237'
-    ppid: '941'
-    user: root
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-uhxdoyvehawclpcyxvvjrkvpfzjaexud ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656499110.2965217-19977-164861166551179/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '18251'
-    ppid: '17739'
-    user: centos
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/pipenv run python3 cli.py -c
-      /app/etc/awx_cleaner_conf.yml
-    pid: '18262'
-    ppid: '18237'
-    user: root
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-uhxdoyvehawclpcyxvvjrkvpfzjaexud ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656499110.2965217-19977-164861166551179/AnsiballZ_process_facts.py
-    pid: '18274'
-    ppid: '18251'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-uhxdoyvehawclpcyxvvjrkvpfzjaexud ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656499110.2965217-19977-164861166551179/AnsiballZ_process_facts.py
-    pid: '18275'
-    ppid: '18274'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656499110.2965217-19977-164861166551179/AnsiballZ_process_facts.py
-    pid: '18276'
-    ppid: '18275'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654726714
-    pid: '18284'
-    ppid: '933'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '18557'
-    ppid: '19428'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '19267'
-    ppid: '19428'
-    user: root
-  - cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor.conf
-    pid: '19383'
-    ppid: '9042'
-    user: root
-  - cmdline: python3 /usr/bin/config-watcher
-    pid: '19426'
-    ppid: '19383'
-    user: root
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '19427'
-    ppid: '19383'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '19428'
-    ppid: '19383'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/python3 /var/lib/awx/venv/awx/bin/daphne -b
-      127.0.0.1 -p 8051 --websocket_timeout -1 awx.asgi:channel_layer
-    pid: '19429'
-    ppid: '19383'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '19432'
-    ppid: '19427'
-    user: zabbix
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '19437'
-    ppid: '19428'
-    user: root
-  - cmdline: ''
-    pid: '21726'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24660'
-    ppid: '26058'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_wsbroadcast
-    pid: '25923'
-    ppid: '19383'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '25981'
-    ppid: '2678'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '26058'
-    ppid: '2763'
-    user: root
-  - cmdline: ''
-    pid: '26495'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27221'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '27319'
-    ppid: '26058'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '27324'
-    ppid: '25981'
-    user: root
-  - cmdline: >-
-      rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f
-      /var/lib/awx/rsyslog/rsyslog.conf
-    pid: '27383'
-    ppid: '19383'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '31223'
-    ppid: '25981'
-    user: root
-  - cmdline: >-
-      /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050
-      --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120
-      --no-orphans --master --max-requests=1000
-      --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '31706'
-    ppid: '19428'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1034
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:05 2022'
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 950
-    port: 10050
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:03 2022'
-    user: zabbix
-  - address: 192.168.0.145
-    name: vault
-    pid: 1135
-    port: 8200
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:12 2022'
-    user: vault
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:27 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1096
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:11 2022'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1034
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:05 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 7659
-    port: 443
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:05 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 8401
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:07 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 7816
-    port: 11211
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:06 2022'
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:27 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 7676
-    port: 80
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:05 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1096
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:11 2022'
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: AWX Web
+  version:
+  - number: 11.2.0
+    type: docker
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-devel:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-devel
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-event:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-event-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-persistent-data:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 2.el7
+    source: rpm
+    version: 0.8.5
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 872
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:02 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:27 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 639
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:49 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  git:
+  - arch: x86_64
+    epoch: null
+    name: git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  htop:
+  - arch: x86_64
+    epoch: null
+    name: htop
+    release: 3.el7
+    source: rpm
+    version: 2.2.0
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1127.13.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs-devel:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs-devel
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-devel:
+  - arch: x86_64
+    epoch: null
+    name: krb5-devel
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcom_err-devel:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err-devel
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libffi-devel:
+  - arch: x86_64
+    epoch: null
+    name: libffi-devel
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libkadm5:
+  - arch: x86_64
+    epoch: null
+    name: libkadm5
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnet:
+  - arch: x86_64
+    epoch: null
+    name: libnet
+    release: 7.el7
+    source: rpm
+    version: 1.1.6
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-devel:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-devel
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsepol-devel:
+  - arch: x86_64
+    epoch: null
+    name: libsepol-devel
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-devel:
+  - arch: x86_64
+    epoch: null
+    name: libverto-devel
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 7.el7_8.2
+    source: rpm
+    version: 2.02.186
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 2.02.186
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  ngrep:
+  - arch: x86_64
+    epoch: null
+    name: ngrep
+    release: 1.1.20180101git9b59468.el7
+    source: rpm
+    version: '1.47'
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-devel:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-devel
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcre-devel:
+  - arch: x86_64
+    epoch: null
+    name: pcre-devel
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Error:
+  - arch: noarch
+    epoch: 1
+    name: perl-Error
+    release: 2.el7
+    source: rpm
+    version: '0.17020'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-Git:
+  - arch: noarch
+    epoch: null
+    name: perl-Git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-TermReadKey:
+  - arch: x86_64
+    epoch: null
+    name: perl-TermReadKey
+    release: 20.el7
+    source: rpm
+    version: '2.30'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 619
-    port: 788
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:47 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 6.el7
+    source: rpm
+    version: '4.24'
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:27 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 639
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:49 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 619
-    port: 788
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:47 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 65.el7_8
+    source: rpm
+    version: '0.17'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 1.el7
+    source: rpm
+    version: 3.2.11
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 1.el7
+    source: rpm
+    version: 4.0.19
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  zlib-devel:
+  - arch: x86_64
+    epoch: null
+    name: zlib-devel
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '130'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '179'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '180'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '281'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '304'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '347'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '426'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '443'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '452'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '560'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '561'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '588'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '617'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '619'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '621'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '624'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '629'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '639'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '646'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H awx01 eth0
+  cwd: /sbin/
+  pid: '872'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '931'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '933'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '941'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '950'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '953'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '954'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '955'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '956'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '957'
+  ppid: '950'
+  user: zabbix
+- cmdline: ''
+  cwd: /
+  pid: '1028'
+  ppid: '2'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1034'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1036'
+  ppid: '1034'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1096'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/bin/vault server -config=/etc/vault.d/vault_main.hcl -log-level=info
+  cwd: /usr/local/bin/
+  pid: '1135'
+  ppid: '1'
+  user: vault
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1136'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1137'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1139'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1140'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1154'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
+  cwd: /usr/bin/
+  pid: '2678'
+  ppid: '9043'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2738'
+  ppid: '2'
+  user: root
+- cmdline: python3 /usr/bin/config-watcher
+  cwd: /
+  pid: '2745'
+  ppid: '2678'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '2747'
+  ppid: '2678'
+  user: root
+- cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
+  cwd: /usr/bin/
+  pid: '2763'
+  ppid: '9045'
+  user: root
+- cmdline: python3 /usr/bin/config-watcher
+  cwd: /
+  pid: '2811'
+  ppid: '2763'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '2814'
+  ppid: '2763'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3258'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '5442'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7506'
+  ppid: '19428'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '7647'
+  ppid: '1096'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 443 -container-ip
+    192.168.2.4 -container-port 8053
+  cwd: /usr/bin/
+  pid: '7659'
+  ppid: '1136'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '7669'
+  ppid: '7647'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '7673'
+  ppid: '7669'
+  user: centos
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 80 -container-ip
+    192.168.2.4 -container-port 8052
+  cwd: /usr/bin/
+  pid: '7676'
+  ppid: '1136'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7706'
+  ppid: '2747'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7811'
+  ppid: '2747'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7814'
+  ppid: '2814'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 11211 -container-ip
+    192.168.2.5 -container-port 11211
+  cwd: /usr/bin/
+  pid: '7816'
+  ppid: '1136'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7850'
+  ppid: '2814'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7851'
+  ppid: '2747'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '7877'
+  ppid: '941'
+  user: root
+- cmdline: sudo su -
+  cwd: /
+  pid: '7904'
+  ppid: '7673'
+  user: root
+- cmdline: su -
+  cwd: /
+  pid: '7905'
+  ppid: '7904'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '7906'
+  ppid: '7905'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '7943'
+  ppid: '941'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7965'
+  ppid: '2814'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7966'
+  ppid: '2747'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '8027'
+  ppid: '2814'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8384'
+  ppid: '941'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 6379 -container-ip
+    192.168.2.6 -container-port 6379
+  cwd: /usr/bin/
+  pid: '8401'
+  ppid: '1136'
+  user: root
+- cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '8441'
+  ppid: '7877'
+  user: root
+- cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '8448'
+  ppid: '7943'
+  user: root
+- cmdline: tini -- /bin/sh -c /usr/bin/launch_awx.sh
+  cwd: /
+  pid: '8455'
+  ppid: '8384'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8484'
+  ppid: '941'
+  user: root
+- cmdline: memcached -s /var/run/memcached/memcached.sock -a 0666
+  cwd: /
+  pid: '8510'
+  ppid: '8484'
+  user: '11211'
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8531'
+  ppid: '941'
+  user: root
+- cmdline: redis-server 127.0.0.1:0
+  cwd: /
+  pid: '8576'
+  ppid: '8531'
+  user: polkitd
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '8888'
+  ppid: '1034'
+  user: postfix
+- cmdline: bash /usr/bin/launch_awx.sh
+  cwd: /
+  pid: '9042'
+  ppid: '8455'
+  user: root
+- cmdline: bash /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '9043'
+  ppid: '8448'
+  user: root
+- cmdline: bash /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '9045'
+  ppid: '8441'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_awx01_task_tower_1
+  cwd: /usr/bin/
+  pid: '9274'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_redis
+  cwd: /usr/bin/
+  pid: '9279'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_awx01_task_1
+  cwd: /usr/bin/
+  pid: '9285'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_memcached
+  cwd: /usr/bin/
+  pid: '9287'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_web_tower_1
+  cwd: /usr/bin/
+  pid: '9288'
+  ppid: '1'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '10723'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '10724'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '11040'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '11622'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '11658'
+  ppid: '26058'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12560'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13171'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15846'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '17310'
+  ppid: '25981'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '17698'
+  ppid: '1096'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '17739'
+  ppid: '17698'
+  user: centos
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '18195'
+  ppid: '26058'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_cleaner
+  cwd: /usr/bin/
+  pid: '18217'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '18237'
+  ppid: '941'
+  user: root
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-uhxdoyvehawclpcyxvvjrkvpfzjaexud
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656499110.2965217-19977-164861166551179/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '18251'
+  ppid: '17739'
+  user: centos
+- cmdline: /usr/local/bin/python /usr/local/bin/pipenv run python3 cli.py -c /app/etc/awx_cleaner_conf.yml
+  cwd: /usr/local/bin/
+  pid: '18262'
+  ppid: '18237'
+  user: root
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-uhxdoyvehawclpcyxvvjrkvpfzjaexud
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656499110.2965217-19977-164861166551179/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '18274'
+  ppid: '18251'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-uhxdoyvehawclpcyxvvjrkvpfzjaexud ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656499110.2965217-19977-164861166551179/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '18275'
+  ppid: '18274'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656499110.2965217-19977-164861166551179/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '18276'
+  ppid: '18275'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654726714
+  cwd: /usr/lib64/sa/
+  pid: '18284'
+  ppid: '933'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '18557'
+  ppid: '19428'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19267'
+  ppid: '19428'
+  user: root
+- cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor.conf
+  cwd: /usr/bin/
+  pid: '19383'
+  ppid: '9042'
+  user: root
+- cmdline: python3 /usr/bin/config-watcher
+  cwd: /
+  pid: '19426'
+  ppid: '19383'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '19427'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19428'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /var/lib/awx/venv/awx/bin/daphne -b 127.0.0.1
+    -p 8051 --websocket_timeout -1 awx.asgi:channel_layer
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19429'
+  ppid: '19383'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '19432'
+  ppid: '19427'
+  user: zabbix
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19437'
+  ppid: '19428'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21726'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24660'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_wsbroadcast
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '25923'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '25981'
+  ppid: '2678'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '26058'
+  ppid: '2763'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26495'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27221'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '27319'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '27324'
+  ppid: '25981'
+  user: root
+- cmdline: rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
+  cwd: /
+  pid: '27383'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '31223'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '31706'
+  ppid: '19428'
+  user: root
+software_list:
+- cmd_regexp: launch_awx.sh
+  name: AWX Web
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1034
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:05 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 950
+  port: 10050
+  protocol: tcp
+  stime: Tue Apr 26 15:55:03 2022
+  user: zabbix
+- address: 192.168.0.145
+  name: vault
+  pid: 1135
+  port: 8200
+  protocol: tcp
+  stime: Tue Apr 26 15:55:12 2022
+  user: vault
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1096
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:11 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1034
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:05 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 7659
+  port: 443
+  protocol: tcp
+  stime: Tue Apr 26 15:56:05 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 8401
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 15:56:07 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 7816
+  port: 11211
+  protocol: tcp
+  stime: Tue Apr 26 15:56:06 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 7676
+  port: 80
+  protocol: tcp
+  stime: Tue Apr 26 15:56:05 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1096
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:11 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 872
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:02 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 639
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 619
+  port: 788
+  protocol: udp
+  stime: Tue Apr 26 15:54:47 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 639
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 619
+  port: 788
+  protocol: udp
+  stime: Tue Apr 26 15:54:47 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/chrony_ntp/chrony_ntp_tests.yaml
+++ b/tests/unit/plugins/action/auto/resources/chrony_ntp/chrony_ntp_tests.yaml
@@ -1,1251 +1,1208 @@
-expected_result:
-  - discovery_time: '2022-07-05T11:20:28+02:00'
-    bindings:
-      - address: 0.0.0.0
-        class: service
-        port: 53314
-        protocol: tcp
-    listening_ports:
-      - 53314
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: chronynp
-        release: 18.el7
-        source: rpm
-        version: 1.2.7
-    process:
-      cmdline: /usr/bin/chronyd -b config.yaml
-      listening_ports:
-        - 53314
-      pid: '121'
-      ppid: '0'
-      user: root
-    type: chrony ntp service
-    version:
-      - number: 1.2.7
-        type: package
-software_list:
-  - cmd_regexp: chronyd
-    name: chrony ntp service
-    pkg_regexp: ^chrony
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: {}
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: 'sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25'
-      LogPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: []
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /var/lib/grafana: {}
-          /var/log/grafana: {}
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: {}
-          /var/lib/postgresql/data: {}
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: {}
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ''
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 7595fac666b5ff158136ee9dd001665a3c5d469c74b8f5fbdcbc5fb0af339165
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 1
-        FinishedAt: '2022-07-05T09:20:26.91341435Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 0
-        Restarting: false
-        Running: false
-        StartedAt: '2022-07-05T09:20:25.695023849Z'
-        Status: exited
-packages:
-  chrony-np-package:
-    - arch: x86_64
-      epoch: null
-      name: chronynp
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/bin/chronyd -b config.yaml
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ''
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 7595fac666b5ff158136ee9dd001665a3c5d469c74b8f5fbdcbc5fb0af339165
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 1
+      FinishedAt: '2022-07-05T09:20:26.91341435Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 0
+      Restarting: false
+      Running: false
+      StartedAt: '2022-07-05T09:20:25.695023849Z'
+      Status: exited
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 53314
+    protocol: tcp
+  discovery_time: '2022-07-05T11:20:28+02:00'
+  listening_ports:
+  - 53314
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: chronynp
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  process:
+    cmdline: /usr/bin/chronyd -b config.yaml
+    cwd: /usr/bin/
+    listening_ports:
+    - 53314
     pid: '121'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
+  type: chrony ntp service
+  version:
+  - number: 1.2.7
+    type: package
+packages:
+  chrony-np-package:
+  - arch: x86_64
+    epoch: null
+    name: chronynp
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/bin/chronyd -b config.yaml
+  cwd: /usr/bin/
+  pid: '121'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: chronyd
+  name: chrony ntp service
+  pkg_regexp: ^chrony
+  process_type: parent
+  return_children: false
+  return_packages: true
 tcp_listen:
-  - address: 0.0.0.0
-    name: port1
-    pid: 121
-    port: 53314
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: port2
-    pid: 122
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: port3
-    pid: 123
-    port: 52914
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port4
-    pid: 124
-    port: 53213
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port5
-    pid: 125
-    port: 52614
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
+- address: 0.0.0.0
+  name: port1
+  pid: 121
+  port: 53314
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: port2
+  pid: 122
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: port3
+  pid: 123
+  port: 52914
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port4
+  pid: 124
+  port: 53213
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port5
+  pid: 125
+  port: 52614
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
 udp_listen:
-  - address: 0.0.0.0
-    name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/docker/docker19.03.11_centos.yaml
+++ b/tests/unit/plugins/action/auto/resources/docker/docker19.03.11_centos.yaml
@@ -1,3710 +1,3768 @@
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - /usr/local/bin/docker-entrypoint.sh
+    - catalina.sh
+    - run
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - catalina.sh
+      - run
+      Domainname: ''
+      Entrypoint:
+      - /bin/sh
+      - -c
+      - /usr/local/bin/docker-entrypoint.sh
+      Env:
+      - POSTGRES_HOST=cmdb-db01-integracion-internal.iometrics.io
+      - TZ=Europe/Madrid
+      - POSTGRES_PASS=ta5Puid4et2aemeveeshaeha
+      - JAVA_OPTS=-Xmx4000m -Xms2000m
+      - POSTGRES_APP_USER=datadope
+      - POSTGRES_DB=cmdbuild_r2u2
+      - POSTGRES_APP_PASSWORD=ta5Puid4et2aemeveeshaeha
+      - POSTGRES_USER=datadope
+      - PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - JAVA_HOME=/usr/local/openjdk-11
+      - JAVA_VERSION=11.0.6
+      - JAVA_BASE_URL=https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_
+      - JAVA_URL_VERSION=11.0.6_10
+      - CATALINA_HOME=/usr/local/tomcat
+      - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
+      - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
+      - GPG_KEYS=05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42
+        47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7
+        61B832AC2F1C5A90F0F9B00A1C506407564C17A3 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED
+        9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC
+        A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
+        F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+      - TOMCAT_MAJOR=9
+      - TOMCAT_VERSION=9.0.31
+      - TOMCAT_SHA512=75045ce54ad1b6ea66fd112e8b2ffa32a0740c018ab9392c7217a6dd6b829e8645b6810ab4b28dd186c12ce6045c1eb18ed19743c5d4b22c9e613e76294f22f5
+      - CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
+      - POSTGRES_PORT=5432
+      - CMDBUILD_DUMP=empty.dump.xz
+      ExposedPorts:
+        8080/tcp: {}
+        8443/tcp: {}
+      Hostname: localhost
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.4.1
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: tomcat
+      Volumes:
+        /etc/hosts: {}
+        /usr/local/tomcat/certs: {}
+        /usr/local/tomcat/logs: {}
+      WorkingDir: /usr/local/tomcat
+    Created: '2021-11-11T10:02:57.904221801Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440-init/diff:/var/lib/docker/overlay2/c0100c5fc0888fad72adf7c709d3142ccba8797311803c32b1c6ee9fdc1de50e/diff:/var/lib/docker/overlay2/63d738012f51ff7170406467832e013db70f935f583552a7886aa38962e82982/diff:/var/lib/docker/overlay2/47cd80f7dedb3bc34c2bca3fa92244ea9c185fcf0542caef919e1cc857cfdd3b/diff:/var/lib/docker/overlay2/a2db2a600330275b614855b67ddd415e3a75afa829346adfa0bb03a7333b402e/diff:/var/lib/docker/overlay2/9379979c9dd250c039f4afc2567766061715e709bfc36ee01ae3c3239025986b/diff:/var/lib/docker/overlay2/18f67ad491d73a59df5e91b962f57ef4869ddd92c6ebd3e44102469697624266/diff:/var/lib/docker/overlay2/137a09117ac770c6d5fc56e5112ebc5b08ef3c3d9efff29df177409a565a87b0/diff:/var/lib/docker/overlay2/de594fddde953514eeacfe63c99be98087989c214e4e5de974831664ffbe66a8/diff:/var/lib/docker/overlay2/4e4b98753830b09fce6331e4e11cb57368a29059ef703c11757668499e1a5a6b/diff:/var/lib/docker/overlay2/43329bb8f930dbaf651a0f9ec89f9a81ca1177bcda97d444ef43dffa082d7d30/diff:/var/lib/docker/overlay2/93fb2b626f5a929d0e2aef75b0a4504b487754c638f06ef853846011b1b04f90/diff:/var/lib/docker/overlay2/d7655bb3f45fb79b3810a732adf321480912998b29d65842ce8546dbd67ca402/diff:/var/lib/docker/overlay2/dae7334ac1a1ee12d6b8def3204d21f3c259a623f01098a682d52185f87f53b1/diff:/var/lib/docker/overlay2/bd55b267f3dc2165fe8ae6ca4d7ad01824c9f073f3d9a209b4aabb15f1e3f628/diff:/var/lib/docker/overlay2/7038e40fc28165f150bb277854f7fe37c3b19967a7fe07fe70eb5663343ec96c/diff:/var/lib/docker/overlay2/04ddf62add125112aeeef17f32406bf3e5a42a342ee771e8f4fe30f12794c4b4/diff:/var/lib/docker/overlay2/f38683ed385ddb64de321621e8f8e7b8cb161f8100a64417c64a152429822c63/diff:/var/lib/docker/overlay2/9101a62094b1ab60a4e9477e952bbc50c513103b178d2f07c51449876454d328/diff:/var/lib/docker/overlay2/a61859f12ba2af9c9dc4b9318ddc2efa3636248af9c1c5819afcaa93cdd478a6/diff:/var/lib/docker/overlay2/7bbd2fba82cda8d8110a79811738382f993dfbbcaec424690f81f0f602188578/diff:/var/lib/docker/overlay2/fc177696896be4d18ffb7582249deb2e6bc004fa6c1b59bd2cca3b3165e6240e/diff
+        MergedDir: /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/merged
+        UpperDir: /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/diff
+        WorkDir: /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:ro
+      - /etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw
+      - /var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 4194304000
+      MemoryReservation: 2097152000
+      MemorySwap: 8388608000
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: bridge
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/hostname
+    HostsPath: /etc/hosts
+    Id: 54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
+    Image: sha256:4963cc7d5cdaa74048cc3a833584e1634a8245490d8f6c206a97b163157817ff
+    LogPath: /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /usr/local/tomcat/certs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics-cmdbuild/certs
+      Type: bind
+    - Destination: /usr/local/tomcat/logs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/iometrics-cmdbuild
+      Type: bind
+    Name: /iometrics-cmdbuild
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 22ff115460d2a139cd405d257f4f459e1065cfd74de5843e8c3f95f8217e9617
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 22ff115460d2a139cd405d257f4f459e1065cfd74de5843e8c3f95f8217e9617
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: 91d42730928d475ba307be852a455668b8122288ceb5c15f12d313f2ce0b4255
+      Ports:
+        8080/tcp: null
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      SandboxID: 9b1e826fe1933efbee33d38c3dc53844e07f4ee2d33be8c2c1e3e022d4e3e081
+      SandboxKey: /var/run/docker/netns/9b1e826fe193
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-08-28T17:37:02.812501368Z'
+      OOMKilled: true
+      Paused: false
+      Pid: 13238
+      Restarting: false
+      Running: true
+      StartedAt: '2022-08-28T17:37:05.646301012Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      - GF_RENDERER_PLUGIN_CHROME_BIN=/usr/bin/chromium-browser
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: cmdb01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui-enterprise:6.6.2.3
+      Labels:
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-01-15T12:45:30.765987178Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1-init/diff:/var/lib/docker/overlay2/0d2c44c827bfb7dabdebae887d8683db32d93d4d76b196d7ad89704e0fcb1389/diff:/var/lib/docker/overlay2/f0e1f1f418c2281b381cf1865c8f26dcd6b3d932f40f52d1b1fdca5b51f59403/diff:/var/lib/docker/overlay2/55a6a205817b93c52fb9fd4c2cc8f934d19e4b2ccfbcf3c08b298753a45ae973/diff:/var/lib/docker/overlay2/6eb3c76533ef49d07490c8c83d99533de21abd3109451cf52fc0c67b69ab611b/diff:/var/lib/docker/overlay2/e2815a71b491409711b3d35eea90c0dd86fd08cf49d3cef7a3b8975805873009/diff:/var/lib/docker/overlay2/7a4561e76b8114bef56fd08e6cb03450a148795b234a3d8dc8236b8fe76c8bcd/diff:/var/lib/docker/overlay2/54dd3972aadb529dba440730f58fa712249b38347dd0c302925e87327062d273/diff:/var/lib/docker/overlay2/67b520bda1cd13ae235e8248930218fdf9fb9d3a9677961b748af89d704c3f26/diff:/var/lib/docker/overlay2/39a352a4de1195eb0ea5d56384fcb82143edf4b381d039933cfdfc8437742018/diff:/var/lib/docker/overlay2/8bba506a78e1be76f9df4721f9e1d9b803663b7b7de87f041d8089ef1f641d5a/diff:/var/lib/docker/overlay2/f5ed7d8d022525cf8f03f3be2493851803cd595469b11b32f183255bddca9349/diff:/var/lib/docker/overlay2/14f5fd087aa9d77e5433f13239715857e7bf55e03bf0369c3369e1d0f2fc805e/diff
+        MergedDir: /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/merged
+        UpperDir: /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/diff
+        WorkDir: /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/hostname
+    HostsPath: /etc/hosts
+    Id: 9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60
+    Image: sha256:d3c19e6207531bc75d6e96acb05ba4e07aa8497c67ffb7300c22f09129e7c6ac
+    LogPath: /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 4be9102529bde6561a20aef10b892eaeb6db6ff824a222a50ac373182b510706
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 1ab6c0eaf33ebf3437299022cf3d1481c808eb54b77862bc018876a78726b0f4
+      Ports: {}
+      SandboxID: 20caa57c43e433507a96073c6dc1cf2134b03a9874406acdb6540325c821a29f
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:42.531786634Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 5645
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:55:52.595384652Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 8443
+    protocol: tcp
+  discovery_time: '2022-09-01T17:02:25+02:00'
+  files:
+  - path: /usr/bin/dockerd
+    subtype: generic
+    type: binary
+  listening_ports:
+  - 8443
+  packages:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  process:
+    cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+    cwd: /usr/bin/
+    pid: '1192'
+    ppid: '1'
+    user: root
+  type: Docker
+  version:
+  - number: 19.03.11
+    type: active
+  - number: 19.03.11
+    type: package
+expected_tasks_calls:
+  Run version command: 1
 mocked_plugin_tasks:
   Run version command:
     number_of_calls: 1
     plugin_result:
       failed: false
-      stdout: "Docker version 19.03.11, build 42e35e61f3"
-
-expected_tasks_calls:
-  Run version command: 1
-
-expected_result:
-  - discovery_time: '2022-09-01T17:02:25+02:00'
-    bindings:
-      - address: '::'
-        class: service
-        port: 8443
-        protocol: tcp
-    files:
-      - path: /usr/bin/dockerd
-        subtype: generic
-        type: binary
-    listening_ports:
-      - 8443
-    packages:
-      - arch: x86_64
-        epoch: 3
-        name: docker-ce
-        release: 3.el7
-        source: rpm
-        version: 19.03.11
-      - arch: x86_64
-        epoch: 1
-        name: docker-ce-cli
-        release: 3.el7
-        source: rpm
-        version: 19.03.11
-    process:
-      cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-      pid: '1192'
-      ppid: '1'
-      user: root
-    type: Docker
-    version:
-      - number: 19.03.11
-        type: active
-      - number: 19.03.11
-        type: package
-software_list:
-  - name: Docker
-    cmd_regexp: dockerd
-    pkg_regexp: docker
-    process_type: parent
-    return_children: false
-    return_packages: true
-    custom_tasks:
-      - name: Include Docker specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/docker.yaml"
+      stdout: Docker version 19.03.11, build 42e35e61f3
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 297.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '95'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '178'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '179'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '280'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '303'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '310'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '385'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '401'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '402'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '403'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '404'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '405'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '406'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '407'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '408'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '487'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '527'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '565'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '570'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '573'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '582'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '742'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '743'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '745'
-    ppid: '1'
-    user: polkitd
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '746'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '747'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '750'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '757'
-    ppid: '1'
-    user: chrony
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H cmdb01 eth0
-    pid: '990'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '1049'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1051'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1058'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '1066'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '1067'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '1068'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '1069'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '1070'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '1071'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1151'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1153'
-    ppid: '1151'
-    user: postfix
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1192'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1194'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1197'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1201'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1209'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1210'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '5539'
-    ppid: '1058'
-    user: root
-  - cmdline: >-
-      grafana-server --homepath=/usr/share/grafana
-      --config=/etc/grafana/grafana.ini --packaging=docker
-      cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
-      cfg:default.paths.logs=/var/log/grafana
-      cfg:default.paths.plugins=/usr/share/grafana/plugins
-      cfg:default.paths.provisioning=/etc/grafana/provisioning
-    pid: '5645'
-    ppid: '5539'
-    user: grafana
-  - cmdline: /usr/bin/docker start -a grafana
-    pid: '5846'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '11388'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-cmdbuild
-    pid: '13198'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443
-      -container-ip 192.168.1.2 -container-port 8443
-    pid: '13215'
-    ppid: '1192'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '13221'
-    ppid: '1058'
-    user: root
-  - cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
-    pid: '13238'
-    ppid: '13221'
-    user: centos
-  - cmdline: >-
-      /usr/local/openjdk-11/bin/java
-      -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      -Xmx4000m -Xms2000m -Djdk.tls.ephemeralDHKeySize=2048
-      -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
-      -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
-      -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
-      -Dignore.endorsed.dirs= -classpath
-      /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
-      -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat
-      -Djava.io.tmpdir=/usr/local/tomcat/temp
-      org.apache.catalina.startup.Bootstrap start
-    pid: '13266'
-    ppid: '13238'
-    user: centos
-  - cmdline: pickup -l -t unix -u
-    pid: '15603'
-    ppid: '1151'
-    user: postfix
-  - cmdline: ''
-    pid: '16933'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17112'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17147'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19907'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20140'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20143'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '20145'
-    ppid: '1197'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1662044504
-    pid: '20175'
-    ppid: '1049'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '20178'
-    ppid: '20145'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-vgicqcqrieenhtaftbsiremubnzsqqgv ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1662044521.7672658-78280-44261581920973/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '20371'
-    ppid: '20178'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-vgicqcqrieenhtaftbsiremubnzsqqgv ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1662044521.7672658-78280-44261581920973/AnsiballZ_process_facts.py
-    pid: '20386'
-    ppid: '20371'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-vgicqcqrieenhtaftbsiremubnzsqqgv ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1662044521.7672658-78280-44261581920973/AnsiballZ_process_facts.py
-    pid: '20387'
-    ppid: '20386'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1662044521.7672658-78280-44261581920973/AnsiballZ_process_facts.py
-    pid: '20388'
-    ppid: '20387'
-    user: root
-  - cmdline: ''
-    pid: '30870'
-    ppid: '2'
-    user: root
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - /usr/local/bin/docker-entrypoint.sh
-        - catalina.sh
-        - run
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - catalina.sh
-          - run
-        Domainname: ''
-        Entrypoint:
-          - /bin/sh
-          - '-c'
-          - /usr/local/bin/docker-entrypoint.sh
-        Env:
-          - POSTGRES_HOST=cmdb-db01-integracion-internal.iometrics.io
-          - TZ=Europe/Madrid
-          - POSTGRES_PASS=ta5Puid4et2aemeveeshaeha
-          - JAVA_OPTS=-Xmx4000m -Xms2000m
-          - POSTGRES_APP_USER=datadope
-          - POSTGRES_DB=cmdbuild_r2u2
-          - POSTGRES_APP_PASSWORD=ta5Puid4et2aemeveeshaeha
-          - POSTGRES_USER=datadope
-          - >-
-            PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - JAVA_HOME=/usr/local/openjdk-11
-          - JAVA_VERSION=11.0.6
-          - >-
-            JAVA_BASE_URL=https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_
-          - JAVA_URL_VERSION=11.0.6_10
-          - CATALINA_HOME=/usr/local/tomcat
-          - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
-          - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
-          - >-
-            GPG_KEYS=05AB33110949707C93A279E3D3EFE6B686867BA6
-            07E48665A34DCAFAE522E5E6266191C37C037D42
-            47309207D818FFD8DCD3F83F1931D684307A10A5
-            541FBE7D8F78B25E055DDEE13C370389288584E7
-            61B832AC2F1C5A90F0F9B00A1C506407564C17A3
-            79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED
-            9BA44C2621385CB966EBA586F72C284D731FABEE
-            A27677289986DB50844682F8ACB77FC2E86E29AC
-            A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
-            DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
-            F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE
-            F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
-          - TOMCAT_MAJOR=9
-          - TOMCAT_VERSION=9.0.31
-          - >-
-            TOMCAT_SHA512=75045ce54ad1b6ea66fd112e8b2ffa32a0740c018ab9392c7217a6dd6b829e8645b6810ab4b28dd186c12ce6045c1eb18ed19743c5d4b22c9e613e76294f22f5
-          - >-
-            CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
-          - POSTGRES_PORT=5432
-          - CMDBUILD_DUMP=empty.dump.xz
-        ExposedPorts:
-          8080/tcp: {}
-          8443/tcp: {}
-        Hostname: localhost
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.4.1'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: tomcat
-        Volumes:
-          /etc/hosts: {}
-          /usr/local/tomcat/certs: {}
-          /usr/local/tomcat/logs: {}
-        WorkingDir: /usr/local/tomcat
-      Created: '2021-11-11T10:02:57.904221801Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440-init/diff:/var/lib/docker/overlay2/c0100c5fc0888fad72adf7c709d3142ccba8797311803c32b1c6ee9fdc1de50e/diff:/var/lib/docker/overlay2/63d738012f51ff7170406467832e013db70f935f583552a7886aa38962e82982/diff:/var/lib/docker/overlay2/47cd80f7dedb3bc34c2bca3fa92244ea9c185fcf0542caef919e1cc857cfdd3b/diff:/var/lib/docker/overlay2/a2db2a600330275b614855b67ddd415e3a75afa829346adfa0bb03a7333b402e/diff:/var/lib/docker/overlay2/9379979c9dd250c039f4afc2567766061715e709bfc36ee01ae3c3239025986b/diff:/var/lib/docker/overlay2/18f67ad491d73a59df5e91b962f57ef4869ddd92c6ebd3e44102469697624266/diff:/var/lib/docker/overlay2/137a09117ac770c6d5fc56e5112ebc5b08ef3c3d9efff29df177409a565a87b0/diff:/var/lib/docker/overlay2/de594fddde953514eeacfe63c99be98087989c214e4e5de974831664ffbe66a8/diff:/var/lib/docker/overlay2/4e4b98753830b09fce6331e4e11cb57368a29059ef703c11757668499e1a5a6b/diff:/var/lib/docker/overlay2/43329bb8f930dbaf651a0f9ec89f9a81ca1177bcda97d444ef43dffa082d7d30/diff:/var/lib/docker/overlay2/93fb2b626f5a929d0e2aef75b0a4504b487754c638f06ef853846011b1b04f90/diff:/var/lib/docker/overlay2/d7655bb3f45fb79b3810a732adf321480912998b29d65842ce8546dbd67ca402/diff:/var/lib/docker/overlay2/dae7334ac1a1ee12d6b8def3204d21f3c259a623f01098a682d52185f87f53b1/diff:/var/lib/docker/overlay2/bd55b267f3dc2165fe8ae6ca4d7ad01824c9f073f3d9a209b4aabb15f1e3f628/diff:/var/lib/docker/overlay2/7038e40fc28165f150bb277854f7fe37c3b19967a7fe07fe70eb5663343ec96c/diff:/var/lib/docker/overlay2/04ddf62add125112aeeef17f32406bf3e5a42a342ee771e8f4fe30f12794c4b4/diff:/var/lib/docker/overlay2/f38683ed385ddb64de321621e8f8e7b8cb161f8100a64417c64a152429822c63/diff:/var/lib/docker/overlay2/9101a62094b1ab60a4e9477e952bbc50c513103b178d2f07c51449876454d328/diff:/var/lib/docker/overlay2/a61859f12ba2af9c9dc4b9318ddc2efa3636248af9c1c5819afcaa93cdd478a6/diff:/var/lib/docker/overlay2/7bbd2fba82cda8d8110a79811738382f993dfbbcaec424690f81f0f602188578/diff:/var/lib/docker/overlay2/fc177696896be4d18ffb7582249deb2e6bc004fa6c1b59bd2cca3b3165e6240e/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw'
-          - '/var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 4194304000
-        MemoryReservation: 2097152000
-        MemorySwap: 8388608000
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: bridge
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/hostname
-      HostsPath: /etc/hosts
-      Id: 54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
-      Image: 'sha256:4963cc7d5cdaa74048cc3a833584e1634a8245490d8f6c206a97b163157817ff'
-      LogPath: >-
-        /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /usr/local/tomcat/certs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics-cmdbuild/certs
-          Type: bind
-        - Destination: /usr/local/tomcat/logs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/iometrics-cmdbuild
-          Type: bind
-      Name: /iometrics-cmdbuild
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 22ff115460d2a139cd405d257f4f459e1065cfd74de5843e8c3f95f8217e9617
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: '02:42:ac:11:00:02'
-        Networks:
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 22ff115460d2a139cd405d257f4f459e1065cfd74de5843e8c3f95f8217e9617
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:11:00:02'
-            NetworkID: 91d42730928d475ba307be852a455668b8122288ceb5c15f12d313f2ce0b4255
-        Ports:
-          8080/tcp: null
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        SandboxID: 9b1e826fe1933efbee33d38c3dc53844e07f4ee2d33be8c2c1e3e022d4e3e081
-        SandboxKey: /var/run/docker/netns/9b1e826fe193
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-08-28T17:37:02.812501368Z'
-        OOMKilled: true
-        Paused: false
-        Pid: 13238
-        Restarting: false
-        Running: true
-        StartedAt: '2022-08-28T17:37:05.646301012Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: []
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-          - GF_RENDERER_PLUGIN_CHROME_BIN=/usr/bin/chromium-browser
-        ExposedPorts:
-          3000/tcp: {}
-        Hostname: cmdb01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui-enterprise:6.6.2.3'
-        Labels:
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /var/lib/grafana: {}
-          /var/log/grafana: {}
-        WorkingDir: /usr/share/grafana
-      Created: '2021-01-15T12:45:30.765987178Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1-init/diff:/var/lib/docker/overlay2/0d2c44c827bfb7dabdebae887d8683db32d93d4d76b196d7ad89704e0fcb1389/diff:/var/lib/docker/overlay2/f0e1f1f418c2281b381cf1865c8f26dcd6b3d932f40f52d1b1fdca5b51f59403/diff:/var/lib/docker/overlay2/55a6a205817b93c52fb9fd4c2cc8f934d19e4b2ccfbcf3c08b298753a45ae973/diff:/var/lib/docker/overlay2/6eb3c76533ef49d07490c8c83d99533de21abd3109451cf52fc0c67b69ab611b/diff:/var/lib/docker/overlay2/e2815a71b491409711b3d35eea90c0dd86fd08cf49d3cef7a3b8975805873009/diff:/var/lib/docker/overlay2/7a4561e76b8114bef56fd08e6cb03450a148795b234a3d8dc8236b8fe76c8bcd/diff:/var/lib/docker/overlay2/54dd3972aadb529dba440730f58fa712249b38347dd0c302925e87327062d273/diff:/var/lib/docker/overlay2/67b520bda1cd13ae235e8248930218fdf9fb9d3a9677961b748af89d704c3f26/diff:/var/lib/docker/overlay2/39a352a4de1195eb0ea5d56384fcb82143edf4b381d039933cfdfc8437742018/diff:/var/lib/docker/overlay2/8bba506a78e1be76f9df4721f9e1d9b803663b7b7de87f041d8089ef1f641d5a/diff:/var/lib/docker/overlay2/f5ed7d8d022525cf8f03f3be2493851803cd595469b11b32f183255bddca9349/diff:/var/lib/docker/overlay2/14f5fd087aa9d77e5433f13239715857e7bf55e03bf0369c3369e1d0f2fc805e/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/hostname
-      HostsPath: /etc/hosts
-      Id: 9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60
-      Image: 'sha256:d3c19e6207531bc75d6e96acb05ba4e07aa8497c67ffb7300c22f09129e7c6ac'
-      LogPath: >-
-        /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 4be9102529bde6561a20aef10b892eaeb6db6ff824a222a50ac373182b510706
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 1ab6c0eaf33ebf3437299022cf3d1481c808eb54b77862bc018876a78726b0f4
-        Ports: {}
-        SandboxID: 20caa57c43e433507a96073c6dc1cf2134b03a9874406acdb6540325c821a29f
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:42.531786634Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 5645
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:55:52.595384652Z'
-        Status: running
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1151
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:08 2022'
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 1066
-    port: 10050
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:04 2022'
-    user: zabbix
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1197
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:10 2022'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1151
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:08 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 13215
-    port: 8443
-    protocol: tcp
-    stime: 'Sun Aug 28 17:37:04 2022'
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1197
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:10 2022'
-    user: root
-  - address: '::'
-    name: grafana-server
-    pid: 5645
-    port: 3000
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:51 2022'
-    user: grafana
-udp_listen:
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 990
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:03 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 757
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:50 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 297.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 747
-    port: 905
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:49 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 757
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:50 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 747
-    port: 905
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:49 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '95'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '178'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '179'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '280'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '303'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '310'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '385'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '401'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '402'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '403'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '404'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '405'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '406'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '407'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '408'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '487'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '527'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '565'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '570'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '573'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '582'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '742'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '743'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '745'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '746'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '747'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '750'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '757'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H cmdb01 eth0
+  cwd: /sbin/
+  pid: '990'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1049'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1051'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1058'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '1066'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1067'
+  ppid: '1066'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1068'
+  ppid: '1066'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1069'
+  ppid: '1066'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1070'
+  ppid: '1066'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1071'
+  ppid: '1066'
+  user: zabbix
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1153'
+  ppid: '1151'
+  user: postfix
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1192'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1194'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1197'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1201'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1209'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1210'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '5539'
+  ppid: '1058'
+  user: root
+- cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini
+    --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
+    cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/usr/share/grafana/plugins
+    cfg:default.paths.provisioning=/etc/grafana/provisioning
+  cwd: /
+  pid: '5645'
+  ppid: '5539'
+  user: grafana
+- cmdline: /usr/bin/docker start -a grafana
+  cwd: /usr/bin/
+  pid: '5846'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11388'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-cmdbuild
+  cwd: /usr/bin/
+  pid: '13198'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 -container-ip
+    192.168.1.2 -container-port 8443
+  cwd: /usr/bin/
+  pid: '13215'
+  ppid: '1192'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '13221'
+  ppid: '1058'
+  user: root
+- cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
+  cwd: /bin/
+  pid: '13238'
+  ppid: '13221'
+  user: centos
+- cmdline: /usr/local/openjdk-11/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx4000m -Xms2000m
+    -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+    -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
+    -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
+    -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp
+    org.apache.catalina.startup.Bootstrap start
+  cwd: /usr/local/openjdk-11/bin/
+  pid: '13266'
+  ppid: '13238'
+  user: centos
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '15603'
+  ppid: '1151'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '16933'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17112'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17147'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19907'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20140'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20143'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '20145'
+  ppid: '1197'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1662044504
+  cwd: /usr/lib64/sa/
+  pid: '20175'
+  ppid: '1049'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '20178'
+  ppid: '20145'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-vgicqcqrieenhtaftbsiremubnzsqqgv
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1662044521.7672658-78280-44261581920973/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '20371'
+  ppid: '20178'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-vgicqcqrieenhtaftbsiremubnzsqqgv
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1662044521.7672658-78280-44261581920973/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '20386'
+  ppid: '20371'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-vgicqcqrieenhtaftbsiremubnzsqqgv ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1662044521.7672658-78280-44261581920973/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '20387'
+  ppid: '20386'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1662044521.7672658-78280-44261581920973/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '20388'
+  ppid: '20387'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30870'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: dockerd
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/docker.yaml'
+    name: Include Docker specific plugins
+  name: Docker
+  pkg_regexp: docker
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1151
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:08 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 1066
+  port: 10050
+  protocol: tcp
+  stime: Tue Apr 26 15:55:04 2022
+  user: zabbix
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:29 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1197
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:10 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1151
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:08 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 13215
+  port: 8443
+  protocol: tcp
+  stime: Sun Aug 28 17:37:04 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:29 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1197
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:10 2022
+  user: root
+- address: '::'
+  name: grafana-server
+  pid: 5645
+  port: 3000
+  protocol: tcp
+  stime: Tue Apr 26 15:55:51 2022
+  user: grafana
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 990
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:03 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 757
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:50 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 747
+  port: 905
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 757
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:50 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 747
+  port: 905
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/docker/docker19.03.9_centos.yaml
+++ b/tests/unit/plugins/action/auto/resources/docker/docker19.03.9_centos.yaml
@@ -1,4184 +1,4246 @@
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.10.0-9f12e79
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-14T14:48:50.293726599Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/f03368d7e7d3afd2279ce1d78652e7984aa4518d325842556752a86e4ee011df-init/diff:/var/lib/docker/overlay2/ef5ffbeba33d9b4fdc51636edc9f67856aee17bd3542cafbd11fcdea7f21fcad/diff:/var/lib/docker/overlay2/89ce38e42c37a366b88d2d5aa708991604c2bdde38ef17b1211e548bd5ad15d2/diff:/var/lib/docker/overlay2/5e420b431faae9560c9908ca4d8f90b4e5501e6fe69d8727b357adfd8c693f6b/diff:/var/lib/docker/overlay2/de8abcef462d67213f6eca1acad16efd3c30e55d22b4f849d571758043732442/diff:/var/lib/docker/overlay2/5ff5954ffbfec9b03ce3aa3f26aa0a1712d26b3df80db47967c82f582ff1f066/diff:/var/lib/docker/overlay2/7d3cf994d3764a7d8c8b71b327a547378b96f28fd6db54acf3e7b4776db9a8e9/diff:/var/lib/docker/overlay2/b1e719ca30c05659835bd62b3eea16b0a7c43c6181445c12a62a127e81806a28/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/f03368d7e7d3afd2279ce1d78652e7984aa4518d325842556752a86e4ee011df/merged
+        UpperDir: /var/lib/docker/overlay2/f03368d7e7d3afd2279ce1d78652e7984aa4518d325842556752a86e4ee011df/diff
+        WorkDir: /var/lib/docker/overlay2/f03368d7e7d3afd2279ce1d78652e7984aa4518d325842556752a86e4ee011df/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416/hostname
+    HostsPath: /var/lib/docker/containers/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416/hosts
+    Id: 424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416
+    Image: sha256:8fc77935e01595fff6b7a86817ce019e716de194f65e4449fc9ad3cc23811237
+    LogPath: /var/lib/docker/containers/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 0e08f9b9b47832fa8e0494bce45e27d06fc457adc287c674022ffe9614247a66
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 3c7c381e6aba0f1d754a4b7acc8ac59d1e76eda02fc719b498ec09a8e4b088e9
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1142
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-14T14:48:50.97370942Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: e9fe3e3448594356252b8ab3d075903a0eae022234501d69ec929f8858edb261
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: a4cb1ed2a5a1b91bea8fb78669b20e98f5c3f3698ee3ee76980f0e061ff0fecc
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-15T09:39:40.4217915Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 11511
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-15T09:39:42.151756185Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+expected_result:
+- bindings: []
+  discovery_time: '2022-09-01T17:30:59+02:00'
+  files:
+  - path: /usr/bin/dockerd
+    subtype: generic
+    type: binary
+  listening_ports: []
+  packages:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  process:
+    cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+    cwd: /usr/bin/
+    pid: '1182'
+    ppid: '1'
+    user: root
+  type: Docker
+  version:
+  - number: 19.03.9
+    type: active
+  - number: 19.03.9
+    type: package
+expected_tasks_calls:
+  Run version command: 1
 mocked_plugin_tasks:
   Run version command:
     number_of_calls: 1
     plugin_result:
       failed: false
-      stdout: "Docker version 19.03.9, build 42e35e61f3"
-
-expected_tasks_calls:
-  Run version command: 1
-
-expected_result:
-  - discovery_time: '2022-09-01T17:30:59+02:00'
-    bindings: [ ]
-    files:
-      - path: /usr/bin/dockerd
-        subtype: generic
-        type: binary
-    listening_ports: []
-    packages:
-      - arch: x86_64
-        epoch: 3
-        name: docker-ce
-        release: 3.el7
-        source: rpm
-        version: 19.03.9
-      - arch: x86_64
-        epoch: 1
-        name: docker-ce-cli
-        release: 3.el7
-        source: rpm
-        version: 19.03.9
-    process:
-      cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-      pid: '1182'
-      ppid: '1'
-      user: root
-    type: Docker
-    version:
-      - number: 19.03.9
-        type: active
-      - number: 19.03.9
-        type: package
-software_list:
-  - cmd_regexp: dockerd
-    custom_tasks:
-      - include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/docker.yaml"
-        name: Include Docker specific plugins
-    name: Docker
-    pkg_regexp: docker
-    process_type: parent
-    return_children: false
-    return_packages: true
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.10.0-9f12e79
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: {}
-        WorkingDir: /usr/src/app
-      Created: '2022-07-14T14:48:50.293726599Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/f03368d7e7d3afd2279ce1d78652e7984aa4518d325842556752a86e4ee011df-init/diff:/var/lib/docker/overlay2/ef5ffbeba33d9b4fdc51636edc9f67856aee17bd3542cafbd11fcdea7f21fcad/diff:/var/lib/docker/overlay2/89ce38e42c37a366b88d2d5aa708991604c2bdde38ef17b1211e548bd5ad15d2/diff:/var/lib/docker/overlay2/5e420b431faae9560c9908ca4d8f90b4e5501e6fe69d8727b357adfd8c693f6b/diff:/var/lib/docker/overlay2/de8abcef462d67213f6eca1acad16efd3c30e55d22b4f849d571758043732442/diff:/var/lib/docker/overlay2/5ff5954ffbfec9b03ce3aa3f26aa0a1712d26b3df80db47967c82f582ff1f066/diff:/var/lib/docker/overlay2/7d3cf994d3764a7d8c8b71b327a547378b96f28fd6db54acf3e7b4776db9a8e9/diff:/var/lib/docker/overlay2/b1e719ca30c05659835bd62b3eea16b0a7c43c6181445c12a62a127e81806a28/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/f03368d7e7d3afd2279ce1d78652e7984aa4518d325842556752a86e4ee011df/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/f03368d7e7d3afd2279ce1d78652e7984aa4518d325842556752a86e4ee011df/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/f03368d7e7d3afd2279ce1d78652e7984aa4518d325842556752a86e4ee011df/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416/hosts
-      Id: 424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416
-      Image: 'sha256:8fc77935e01595fff6b7a86817ce019e716de194f65e4449fc9ad3cc23811237'
-      LogPath: >-
-        /var/lib/docker/containers/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 0e08f9b9b47832fa8e0494bce45e27d06fc457adc287c674022ffe9614247a66
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 3c7c381e6aba0f1d754a4b7acc8ac59d1e76eda02fc719b498ec09a8e4b088e9
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1142
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-14T14:48:50.97370942Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: []
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /var/lib/grafana: {}
-          /var/log/grafana: {}
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: e9fe3e3448594356252b8ab3d075903a0eae022234501d69ec929f8858edb261
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: a4cb1ed2a5a1b91bea8fb78669b20e98f5c3f3698ee3ee76980f0e061ff0fecc
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-15T09:39:40.4217915Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 11511
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-15T09:39:42.151756185Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: {}
-          /var/lib/postgresql/data: {}
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
+      stdout: Docker version 19.03.9, build 42e35e61f3
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.3.1p1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 3.el7
-      source: rpm
-      version: '1.217'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 22.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '40'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '100'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '261'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '313'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '377'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '393'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '477'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '543'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '566'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '719'
-    ppid: '1'
-    user: dbus
-  - cmdline: ''
-    pid: '721'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '728'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/rpcbind -w
-    pid: '730'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '734'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '738'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '750'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H grafana01 eth0
-    pid: '978'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1038'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '1041'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1044'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '1054'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '1055'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '1056'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '1057'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '1058'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '1059'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '1126'
-    ppid: '1044'
-    user: root
-  - cmdline: python ./main.py
-    pid: '1142'
-    ppid: '1126'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1143'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1148'
-    ppid: '1143'
-    user: postfix
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1182'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1184'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1187'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1198'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1199'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1208'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-visualizer-api
-    pid: '1241'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: grafana grafana 127.0.0.1(45146) idle'
-    pid: '7131'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: grafana grafana 127.0.0.1(45148) idle'
-    pid: '7132'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10256'
-    ppid: '1044'
-    user: root
-  - cmdline: postgres
-    pid: '10435'
-    ppid: '10256'
-    user: polkitd
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10463'
-    ppid: '1044'
-    user: root
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '10501'
-    ppid: '10463'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '10612'
-    ppid: '10501'
-    user: '101'
-  - cmdline: /usr/bin/docker start -a nginx
-    pid: '10630'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a postgres-grafana
-    pid: '10633'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: checkpointer'
-    pid: '10848'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: background writer'
-    pid: '10849'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: walwriter'
-    pid: '10850'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '10851'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: stats collector'
-    pid: '10852'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '10853'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: /usr/bin/docker start -a grafana
-    pid: '11489'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '11495'
-    ppid: '1044'
-    user: root
-  - cmdline: >-
-      grafana-server --homepath=/usr/share/grafana
-      --config=/etc/grafana/grafana.ini --packaging=docker
-      cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
-      cfg:default.paths.logs=/var/log/grafana
-      cfg:default.paths.plugins=/usr/share/grafana/plugins
-      cfg:default.paths.provisioning=/etc/grafana/provisioning
-    pid: '11511'
-    ppid: '11495'
-    user: grafana
-  - cmdline: pickup -l -t unix -u
-    pid: '12706'
-    ppid: '1143'
-    user: postfix
-  - cmdline: ''
-    pid: '14721'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14850'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14895'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17730'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1662046199
-    pid: '17866'
-    ppid: '1041'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '17873'
-    ppid: '1187'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '17875'
-    ppid: '17873'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-vwnbqpwwcdwlwemxfncbfxupyvlcsace ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1662046235.6407137-71141-14467804172126/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '18060'
-    ppid: '17875'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-vwnbqpwwcdwlwemxfncbfxupyvlcsace ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1662046235.6407137-71141-14467804172126/AnsiballZ_process_facts.py
-    pid: '18075'
-    ppid: '18060'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-vwnbqpwwcdwlwemxfncbfxupyvlcsace ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1662046235.6407137-71141-14467804172126/AnsiballZ_process_facts.py
-    pid: '18076'
-    ppid: '18075'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1662046235.6407137-71141-14467804172126/AnsiballZ_process_facts.py
-    pid: '18077'
-    ppid: '18076'
-    user: root
-  - cmdline: ''
-    pid: '20454'
-    ppid: '2'
-    user: root
-  - cmdline: bash
-    pid: '28255'
-    ppid: '10256'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '31877'
-    ppid: '1187'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '31879'
-    ppid: '31877'
-    user: centos
-  - cmdline: '-bash'
-    pid: '31880'
-    ppid: '31879'
-    user: centos
-  - cmdline: sudo su
-    pid: '31920'
-    ppid: '31880'
-    user: root
-  - cmdline: su
-    pid: '31921'
-    ppid: '31920'
-    user: root
-  - cmdline: bash
-    pid: '31922'
-    ppid: '31921'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1143
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: python
-    pid: 1142
-    port: 3004
-    protocol: tcp
-    stime: 'Thu Jul 14 14:48:49 2022'
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 1054
-    port: 10050
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:27 2022'
-    user: zabbix
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:33 2022'
-    user: root
-  - address: 0.0.0.0
-    name: postgres
-    pid: 10435
-    port: 5432
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:50 2022'
-    user: polkitd
-  - address: '::1'
-    name: master
-    pid: 1143
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:33 2022'
-    user: root
-  - address: '::'
-    name: grafana-serve
-    pid: 11511
-    port: 3000
-    protocol: tcp
-    stime: 'Fri Jul 15 09:39:41 2022'
-    user: grafana
-  - address: '::'
-    name: postgres
-    pid: 10435
-    port: 5432
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:50 2022'
-    user: polkitd
-udp_listen:
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.3.1p1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 3.el7
+    source: rpm
+    version: '1.217'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 22.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '40'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '100'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '261'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '377'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '393'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '477'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '543'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '566'
+  ppid: '2'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '719'
+  ppid: '1'
+  user: dbus
+- cmdline: ''
+  cwd: /
+  pid: '721'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '728'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '730'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '734'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '738'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '750'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H grafana01 eth0
+  cwd: /sbin/
+  pid: '978'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1038'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1041'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1044'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '1054'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1055'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1056'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1057'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1058'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1059'
+  ppid: '1054'
+  user: zabbix
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/424e4197270e30b4617378ce723646130dc96e22ac60b7f7b99c0012827e0416
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '1126'
+  ppid: '1044'
+  user: root
+- cmdline: python ./main.py
+  cwd: /
+  pid: '1142'
+  ppid: '1126'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1143'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1148'
+  ppid: '1143'
+  user: postfix
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1182'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1184'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1187'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1198'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1199'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1208'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-visualizer-api
+  cwd: /usr/bin/
+  pid: '1241'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: grafana grafana 127.0.0.1(45146) idle'
+  cwd: /
+  pid: '7131'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: grafana grafana 127.0.0.1(45148) idle'
+  cwd: /
+  pid: '7132'
+  ppid: '10435'
+  user: polkitd
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10256'
+  ppid: '1044'
+  user: root
+- cmdline: postgres
+  cwd: /
+  pid: '10435'
+  ppid: '10256'
+  user: polkitd
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10463'
+  ppid: '1044'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '10501'
+  ppid: '10463'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '10612'
+  ppid: '10501'
+  user: '101'
+- cmdline: /usr/bin/docker start -a nginx
+  cwd: /usr/bin/
+  pid: '10630'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a postgres-grafana
+  cwd: /usr/bin/
+  pid: '10633'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '10848'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '10849'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '10850'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '10851'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '10852'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '10853'
+  ppid: '10435'
+  user: polkitd
+- cmdline: /usr/bin/docker start -a grafana
+  cwd: /usr/bin/
+  pid: '11489'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '11495'
+  ppid: '1044'
+  user: root
+- cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini
+    --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
+    cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/usr/share/grafana/plugins
+    cfg:default.paths.provisioning=/etc/grafana/provisioning
+  cwd: /
+  pid: '11511'
+  ppid: '11495'
+  user: grafana
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '12706'
+  ppid: '1143'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '14721'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14850'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14895'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17730'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1662046199
+  cwd: /usr/lib64/sa/
+  pid: '17866'
+  ppid: '1041'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '17873'
+  ppid: '1187'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '17875'
+  ppid: '17873'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-vwnbqpwwcdwlwemxfncbfxupyvlcsace
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1662046235.6407137-71141-14467804172126/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '18060'
+  ppid: '17875'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-vwnbqpwwcdwlwemxfncbfxupyvlcsace
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1662046235.6407137-71141-14467804172126/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '18075'
+  ppid: '18060'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-vwnbqpwwcdwlwemxfncbfxupyvlcsace ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1662046235.6407137-71141-14467804172126/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '18076'
+  ppid: '18075'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1662046235.6407137-71141-14467804172126/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '18077'
+  ppid: '18076'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20454'
+  ppid: '2'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '28255'
+  ppid: '10256'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '31877'
+  ppid: '1187'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '31879'
+  ppid: '31877'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '31880'
+  ppid: '31879'
+  user: centos
+- cmdline: sudo su
+  cwd: /
+  pid: '31920'
+  ppid: '31880'
+  user: root
+- cmdline: su
+  cwd: /
+  pid: '31921'
+  ppid: '31920'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '31922'
+  ppid: '31921'
+  user: root
+software_list:
+- cmd_regexp: dockerd
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/docker.yaml'
+    name: Include Docker specific plugins
+  name: Docker
+  pkg_regexp: docker
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1143
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: python
+  pid: 1142
+  port: 3004
+  protocol: tcp
+  stime: Thu Jul 14 14:48:49 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 1054
+  port: 10050
+  protocol: tcp
+  stime: Tue Apr 26 15:55:27 2022
+  user: zabbix
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:33 2022
+  user: root
+- address: 0.0.0.0
+  name: postgres
+  pid: 10435
+  port: 5432
+  protocol: tcp
+  stime: Tue Apr 26 15:56:50 2022
+  user: polkitd
+- address: ::1
+  name: master
+  pid: 1143
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:33 2022
+  user: root
+- address: '::'
+  name: grafana-serve
+  pid: 11511
+  port: 3000
+  protocol: tcp
+  stime: Fri Jul 15 09:39:41 2022
+  user: grafana
+- address: '::'
+  name: postgres
+  pid: 10435
+  port: 5432
+  protocol: tcp
+  stime: Tue Apr 26 15:56:50 2022
+  user: polkitd
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/dynatrace/dynatrace_test.yaml
+++ b/tests/unit/plugins/action/auto/resources/dynatrace/dynatrace_test.yaml
@@ -1,561 +1,615 @@
+dockers: []
 expected_result:
-  - discovery_time: '2022-07-05T13:24:09+02:00'
-    bindings:
-      - address: 0.0.0.0
-        class: service
-        port: 111
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        port: 111
-        protocol: udp
-
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 111
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 111
+    protocol: udp
+  discovery_time: '2022-07-05T13:24:09+02:00'
+  listening_ports:
+  - 111
+  process:
+    cmdline: /usr/lib/systemd/dtserve
+    cwd: /usr/lib/systemd/
     listening_ports:
-      - 111
-    process:
-      cmdline: /usr/lib/systemd/dtserve
-      listening_ports:
-        - 111
-      pid: '1'
-      ppid: '0'
-      user: root
-    type: Dynatrace Server
-    version: []
-software_list:
-  - name: Dynatrace Server
-    cmd_regexp: dtserve
-    process_type: parent
-    return_children: false
-    return_packages: false
-processes:
-  - cmdline: /usr/lib/systemd/dtserve
+    - 111
     pid: '1'
     ppid: '0'
     user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '102'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '179'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '180'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '318'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '319'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-
+  type: Dynatrace Server
+  version: []
 packages:
   freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
   gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
   gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
   gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
   glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
   glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
   glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
   gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
   gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
   gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
   gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
   gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
   gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
   grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
   groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
   grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
   gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
   gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
   hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
   hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
   hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
   info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
   iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
   iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
   iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
   iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+processes:
+- cmdline: /usr/lib/systemd/dtserve
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '102'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '179'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '180'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: dtserve
+  name: Dynatrace Server
+  process_type: parent
+  return_children: false
+  return_packages: false
 tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1055
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:02 2022'
-    user: root
-  - address: 127.0.0.1
-    name: mulesoft
-    pid: 5410
-    port: 12379
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 5410
-    port: 12380
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:53:41 2022'
-    user: root
+- address: 127.0.0.1
+  name: master
+  pid: 1055
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:54:02 2022
+  user: root
+- address: 127.0.0.1
+  name: mulesoft
+  pid: 5410
+  port: 12379
+  protocol: tcp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 5410
+  port: 12380
+  protocol: tcp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:53:41 2022
+  user: root
 udp_listen:
-  - address: 0.0.0.0
-    name: dhclient
-    pid: 865
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:59 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:41 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 626
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:48 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 618
-    port: 781
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:47 2022'
-    user: rpc
-dockers: []
+- address: 0.0.0.0
+  name: dhclient
+  pid: 865
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:53:59 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:53:41 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 626
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:53:48 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 618
+  port: 781
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/elastic/elastic7.10.0_centos7.6_docker.yaml
+++ b/tests/unit/plugins/action/auto/resources/elastic/elastic7.10.0_centos7.6_docker.yaml
@@ -1,3869 +1,4036 @@
-expected_result:
-  - discovery_time: '2022-07-05T09:43:11+02:00'
-    bindings:
-      - address: '::'
-        class: service
-        port: 9200
-        protocol: tcp
-      - address: '::'
-        class: service
-        port: 9300
-        protocol: tcp
-
-    docker:
-      exposed_ports:
-        9200/tcp: { }
-        9300/tcp: { }
-      id: c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487
-      image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
-      name: /elasticsearch
-      network_mode: 'host'
-      port_bindings: { }
-    listening_ports:
-      - 9200
-      - 9300
-    packages: [ ]
-    process:
-      children:
-        - children: [ ]
-          cmdline: /usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller
-          pid: '23242'
-          ppid: '23002'
-          user: centos
-      cmdline: /usr/share/elasticsearch/jdk/bin/java -Xshare:auto -Des.networkaddress.cache.ttl=60 -Des.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -XX:+ShowCodeDetailsInExceptionMessages -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.allocator.numDirectArenas=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Djava.locale.providers=SPI,COMPAT -Xms512m -Xmx512m -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:ErrorFile=logs/hs_err_pid%p.log -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m -Des.allow_insecure_settings=true -Des.cgroups.hierarchy.override=/ -XX:MaxDirectMemorySize=268435456 -Des.path.home=/usr/share/elasticsearch -Des.path.conf=/usr/share/elasticsearch/config -Des.distribution.flavor=default -Des.distribution.type=docker -Des.bundled_jdk=true -cp /usr/share/elasticsearch/lib/* org.elasticsearch.bootstrap.Elasticsearch
-      listening_ports:
-        - 9200
-        - 9300
-      pid: '23002'
-      ppid: '22988'
-      user: centos
-    type: ElasticSearch
-    version:
-      - number: 7.10.0
-        type: docker
-
-software_list:
-  - name: ElasticSearch
-    cmd_regexp: org\.elasticsearch\.bootstrap\.Elasticsearch
-    pkg_regexp: ^elasticsearch
-    process_type: parent
-    return_children: true
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - --
-        - /usr/local/bin/kibana-docker
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /usr/local/bin/kibana-docker
-        Domainname: ''
-        Entrypoint:
-          - /usr/local/bin/dumb-init
-          - --
-        Env:
-          - PATH=/usr/share/kibana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - ELASTIC_CONTAINER=true
-        ExposedPorts:
-          5601/tcp: { }
-        Hostname: esnode01.novalocal
-        Image: docker.elastic.co/kibana/kibana:7.10.0
-        Labels:
-          org.label-schema.build-date: '2020-11-09T22:36:43.117Z'
-          org.label-schema.license: Elastic License
-          org.label-schema.name: Kibana
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.url: https://www.elastic.co/products/kibana
-          org.label-schema.usage: https://www.elastic.co/guide/en/kibana/reference/index.html
-          org.label-schema.vcs-ref: 1796b5ec8fa1e60ccea63f2e5c25ccc665b92fdc
-          org.label-schema.vcs-url: https://github.com/elastic/kibana
-          org.label-schema.vendor: Elastic
-          org.label-schema.version: 7.10.0
-          org.opencontainers.image.created: '2020-11-09T22:36:43.117Z'
-          org.opencontainers.image.documentation: https://www.elastic.co/guide/en/kibana/reference/index.html
-          org.opencontainers.image.licenses: Elastic License
-          org.opencontainers.image.revision: 1796b5ec8fa1e60ccea63f2e5c25ccc665b92fdc
-          org.opencontainers.image.source: https://github.com/elastic/kibana
-          org.opencontainers.image.title: Kibana
-          org.opencontainers.image.url: https://www.elastic.co/products/kibana
-          org.opencontainers.image.vendor: Elastic
-          org.opencontainers.image.version: 7.10.0
-          os_container_type: kibana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: kibana
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /usr/share/kibana/config/kibana.yml: { }
-          /usr/share/kibana/config/ssl: { }
-        WorkingDir: /usr/share/kibana
-      Created: '2021-09-08T07:42:53.064135062Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/32dcb4a4acf1701a79409ea63ff34f945151f7a374a8292555295f4ceea2acd9-init/diff:/var/lib/docker/overlay2/6c06d97a6d0774bd059d123d5a23428b34ee740dc3bdfd84f7fd57af5b855aaa/diff:/var/lib/docker/overlay2/9401d18969a4cc55ef41428621a24cb658d1bd9ab11703d43b5872e4d5f144b6/diff:/var/lib/docker/overlay2/14ee2b6cef3b5b284486204c9eb63c6ed1668eac0fd2d6e5beea62e80f8bd1fb/diff:/var/lib/docker/overlay2/0e4c26bba6ca9a218df3f4e46ce87e1b9d1759cc4e769ebb0c2a693556649ca3/diff:/var/lib/docker/overlay2/12d296c830debe6acfb1f5b06ddb1c2084a8e61b30c6bd9d8377ee378882c5c0/diff:/var/lib/docker/overlay2/594eedd917131de54862bd55190938ca5bfe7a6b2f70f0af449a48795b5b7b79/diff:/var/lib/docker/overlay2/af85385f9c6c791c3bfa495b01d796f1cc0a2d2f1d029a035cdd00155bc17b4e/diff:/var/lib/docker/overlay2/304ae285f87db2119c9d9f32c76f68b97ff5c56bad643eedc562f7a5b75c7449/diff:/var/lib/docker/overlay2/a9000e69f3e9ecaaf05909a821038bbc071ae9f284ef773b31b696c249b23c85/diff:/var/lib/docker/overlay2/f25888f79523c76b41c972ce1795f891c36260efb1c9073b0c915a88a0b5251f/diff:/var/lib/docker/overlay2/e970360bca8544f2c260522e867e2f954f244530e070cb3c737c68b30272a1b1/diff:/var/lib/docker/overlay2/3892b622731f5dcf04dc1479553cdc37bcf1e33564752f6a5bd2268f44117162/diff:/var/lib/docker/overlay2/ba799942135d6104f59478146173b36f8a2dcb8a935ffa10dc8e8e8099fc7454/diff:/var/lib/docker/overlay2/98673c2f07a9ebb4272211874509bce2254e8d68f51c66171247e2bcc98c5e6f/diff
-          MergedDir: /var/lib/docker/overlay2/32dcb4a4acf1701a79409ea63ff34f945151f7a374a8292555295f4ceea2acd9/merged
-          UpperDir: /var/lib/docker/overlay2/32dcb4a4acf1701a79409ea63ff34f945151f7a374a8292555295f4ceea2acd9/diff
-          WorkDir: /var/lib/docker/overlay2/32dcb4a4acf1701a79409ea63ff34f945151f7a374a8292555295f4ceea2acd9/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/localtime:/etc/localtime:rw
-          - /etc/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml:rw
-          - /etc/kibana/ssl:/usr/share/kibana/config/ssl:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632/hostname
-      HostsPath: /etc/hosts
-      Id: d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632
-      Image: sha256:da7fcd5925954eccf1dbc041dd64299b92665922321b83686e43c7914f74272f
-      LogPath: /var/lib/docker/containers/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/share/kibana/config/kibana.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/kibana/kibana.yml
-          Type: bind
-        - Destination: /usr/share/kibana/config/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/kibana/ssl
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-      Name: /kibana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: c20363edb1a7fc926181331f24a04897038d1d2a115657c1405d5023adb44ea9
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: ea9aa9bb98ba48221ef5593ef5fb4a245e02911a3dc9f0f35a3cecdb08078a75
-        Ports: { }
-        SandboxID: b380df99835eaaf1742342e4cb11494c831dd3242c5338716d85447dd3d19064
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/local/bin/dumb-init
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-06-27T13:48:51.581335419Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 24904
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-27T13:48:53.544981109Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - --
-        - /usr/local/bin/docker-entrypoint.sh
-        - eswrapper
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - eswrapper
-        Domainname: ''
-        Entrypoint:
-          - /tini
-          - --
-          - /usr/local/bin/docker-entrypoint.sh
-        Env:
-          - PATH=/usr/share/elasticsearch/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - ELASTIC_CONTAINER=true
-        ExposedPorts:
-          9200/tcp: { }
-          9300/tcp: { }
-        Hostname: esnode01.novalocal
-        Image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
-        Labels:
-          org.label-schema.build-date: '2020-11-09T21:30:33.964949Z'
-          org.label-schema.license: Elastic-License
-          org.label-schema.name: Elasticsearch
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.url: https://www.elastic.co/products/elasticsearch
-          org.label-schema.usage: https://www.elastic.co/guide/en/elasticsearch/reference/index.html
-          org.label-schema.vcs-ref: 51e9d6f22758d0374a0f3f5c6e8f3a7997850f96
-          org.label-schema.vcs-url: https://github.com/elastic/elasticsearch
-          org.label-schema.vendor: Elastic
-          org.label-schema.version: 7.10.0
-          org.opencontainers.image.created: '2020-11-09T21:30:33.964949Z'
-          org.opencontainers.image.documentation: https://www.elastic.co/guide/en/elasticsearch/reference/index.html
-          org.opencontainers.image.licenses: Elastic-License
-          org.opencontainers.image.revision: 51e9d6f22758d0374a0f3f5c6e8f3a7997850f96
-          org.opencontainers.image.source: https://github.com/elastic/elasticsearch
-          org.opencontainers.image.title: Elasticsearch
-          org.opencontainers.image.url: https://www.elastic.co/products/elasticsearch
-          org.opencontainers.image.vendor: Elastic
-          org.opencontainers.image.version: 7.10.0
-          os_container_type: elasticsearch
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/security/limits.conf: { }
-          /usr/share/elasticsearch/config/elasticsearch.keystore: { }
-          /usr/share/elasticsearch/config/elasticsearch.yml: { }
-          /usr/share/elasticsearch/config/jvm.options: { }
-          /usr/share/elasticsearch/config/ssl: { }
-          /usr/share/elasticsearch/config/x-pack: { }
-          /usr/share/elasticsearch/data: { }
-          /usr/share/elasticsearch/data/backup: { }
-          /usr/share/elasticsearch/plugins: { }
-        WorkingDir: /usr/share/elasticsearch
-      Created: '2021-04-07T08:23:54.40885802Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/318cc3ff7d117312704dddc36012f1360bad07976b170078f92c2ba0c7e4a073-init/diff:/var/lib/docker/overlay2/4781d49581e545444a4158786ebee322586bd29aa83e8fea38f92bdb1533bb27/diff:/var/lib/docker/overlay2/7e6ee2f0fe6bf0d8d28454b615aa744db36c3c8cac9716897a5432af6e12a88f/diff:/var/lib/docker/overlay2/a3ae91071d7a34c6279742cff6b7cd3e64931a9146da920ab71d6a9d71155398/diff:/var/lib/docker/overlay2/4667682d672c7420150a5d9e0926099cafab9669072e8619db510fbee1af3ed6/diff:/var/lib/docker/overlay2/fb4700be3bd4afa6121b321104148c687c9a78d34abfd94b4cf3fc5a25a1641c/diff:/var/lib/docker/overlay2/20f7205781134f7ecb9af88f4d031593c6f927dad67e5f2ac6df59f3ab5c90e3/diff:/var/lib/docker/overlay2/ed8472d7b2d6db8be5f88dc26e8f6269c37f04408e07782de82537e9eb110c01/diff:/var/lib/docker/overlay2/652b57fdddb9fde28692617885fe3ae40a27b200550d21d54148d3c1fef4142c/diff:/var/lib/docker/overlay2/98673c2f07a9ebb4272211874509bce2254e8d68f51c66171247e2bcc98c5e6f/diff
-          MergedDir: /var/lib/docker/overlay2/318cc3ff7d117312704dddc36012f1360bad07976b170078f92c2ba0c7e4a073/merged
-          UpperDir: /var/lib/docker/overlay2/318cc3ff7d117312704dddc36012f1360bad07976b170078f92c2ba0c7e4a073/diff
-          WorkDir: /var/lib/docker/overlay2/318cc3ff7d117312704dddc36012f1360bad07976b170078f92c2ba0c7e4a073/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/localtime:/etc/localtime:rw
-          - /etc/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:rw
-          - /etc/elasticsearch/ssl:/usr/share/elasticsearch/config/ssl:rw
-          - /etc/elasticsearch/jvm.options:/usr/share/elasticsearch/config/jvm.options:rw
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/elasticsearch/plugins:/usr/share/elasticsearch/plugins:rw
-          - /etc/elasticsearch/x-pack:/usr/share/elasticsearch/config/x-pack:rw
-          - /var/lib/elasticsearch/backup:/usr/share/elasticsearch/data/backup:rw
-          - /etc/security/limits.conf:/etc/security/limits.conf:rw
-          - /var/lib/elasticsearch:/usr/share/elasticsearch/data:rw
-          - /etc/elasticsearch/elasticsearch.keystore:/usr/share/elasticsearch/config/elasticsearch.keystore:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths: null
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: true
-        PublishAllPorts: false
-        ReadonlyPaths: null
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt:
-          - label=disable
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits:
-          - Hard: 9223372036854775807
-            Name: memlock
-            Soft: 9223372036854775807
-          - Hard: 65536
-            Name: nofile
-            Soft: 65536
-          - Hard: 10240
-            Name: nproc
-            Soft: 10240
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487/hostname
-      HostsPath: /etc/hosts
-      Id: c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487
-      Image: sha256:37190fe5beea0394c3ab4b02578411e9d006dbdfc4a1940220cc1926bc2f691a
-      LogPath: /var/lib/docker/containers/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/share/elasticsearch/config/elasticsearch.keystore
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/elasticsearch/elasticsearch.keystore
-          Type: bind
-        - Destination: /usr/share/elasticsearch/config/elasticsearch.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/elasticsearch/elasticsearch.yml
-          Type: bind
-        - Destination: /usr/share/elasticsearch/config/jvm.options
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/elasticsearch/jvm.options
-          Type: bind
-        - Destination: /usr/share/elasticsearch/config/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/elasticsearch/ssl
-          Type: bind
-        - Destination: /usr/share/elasticsearch/plugins
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/elasticsearch/plugins
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /usr/share/elasticsearch/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/elasticsearch
-          Type: bind
-        - Destination: /usr/share/elasticsearch/data/backup
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/elasticsearch/backup
-          Type: bind
-        - Destination: /etc/security/limits.conf
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/security/limits.conf
-          Type: bind
-        - Destination: /usr/share/elasticsearch/config/x-pack
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/elasticsearch/x-pack
-          Type: bind
-      Name: /elasticsearch
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 102a7e01bec0cc1db63d0ba75ba180ba054134ff6ebc714cfc8de020b6e797b6
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: ea9aa9bb98ba48221ef5593ef5fb4a245e02911a3dc9f0f35a3cecdb08078a75
-        Ports: { }
-        SandboxID: e57120efdb6416134c0aab97f3c1777aeba6be23ae9120c4d33551f7402bf3fd
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-06-27T13:45:30.286041284Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 22988
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-27T13:45:30.881408996Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - server
-        - /data
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - server
-          - /data
-        Domainname: ''
-        Entrypoint:
-          - /usr/bin/docker-entrypoint.sh
-        Env:
-          - MINIO_ACCESS_KEY=admin
-          - MINIO_SECRET_KEY=the_key
-          - AWS_ACCESS_KEY_ID=admin
-          - AWS_SECRET_ACCESS_KEY=the_key
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - MINIO_UPDATE=off
-          - MINIO_ACCESS_KEY_FILE=access_key
-          - MINIO_SECRET_KEY_FILE=secret_key
-          - MINIO_SSE_MASTER_KEY=my-minio-key:the_key
-          - MINIO_USERNAME=minio
-          - MINIO_GROUPNAME=minio
-          - MINIO_UID=9000
-          - MINIO_GID=9000
-          - AWSCLI_VERSION=1.16.198
-        ExposedPorts:
-          9000/tcp: { }
-        Healthcheck:
-          Interval: 60000000000
-          Test:
-            - CMD-SHELL
-            - healthcheck
-        Hostname: esnode01.novalocal
-        Image: nexusregistry.opensolutions.cloud/minio:1.0.0
-        Labels:
-          maintainer: MinIO Inc <dev@min.io>
-          os_contianer_type: minio
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: minio
-        Volumes:
-          /data: { }
-          /etc/localtime: { }
-          /home/minio/.minio: { }
-        WorkingDir: ''
-      Created: '2020-11-19T17:18:28.426043251Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/86103c651797af992bfb423a7f16309033169eb5a02bee540776ba5e61c33a82-init/diff:/var/lib/docker/overlay2/006c48874f8d492ac02e9cc6048c52b226c8a4fff4215d409e9df856cba0bbcf/diff:/var/lib/docker/overlay2/3ed4a827929e1ac9daace5003a6339bb3120814d8b24eaa086e9f5e8ffb130d5/diff:/var/lib/docker/overlay2/cda5811bca984ced0739043771fa4728d4ba3ed8ac3df24690b03eb3b823835b/diff:/var/lib/docker/overlay2/96322090524e04aaee46f4ef471311a0ca9bb8af73ec73bae8dcb9c29b6df8d4/diff:/var/lib/docker/overlay2/143020fd9ba8e42e2a0a493d0d0505ce97d8f48bdae9919cf11f4989e2f082a7/diff:/var/lib/docker/overlay2/c1c0634844e74e4016c48368741a908bd15cbd08a5bc883872486fdd67170a8f/diff:/var/lib/docker/overlay2/c0c0c75cff56c764783132a6149c0f09f39e68787b2d5a86596b9814000d2b2e/diff
-          MergedDir: /var/lib/docker/overlay2/86103c651797af992bfb423a7f16309033169eb5a02bee540776ba5e61c33a82/merged
-          UpperDir: /var/lib/docker/overlay2/86103c651797af992bfb423a7f16309033169eb5a02bee540776ba5e61c33a82/diff
-          WorkDir: /var/lib/docker/overlay2/86103c651797af992bfb423a7f16309033169eb5a02bee540776ba5e61c33a82/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /var/lib/minio/data:/data:rw
-          - /etc/localtime:/etc/localtime:ro
-          - /etc/minio:/home/minio/.minio:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f/hostname
-      HostsPath: /var/lib/docker/containers/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f/hosts
-      Id: 0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f
-      Image: sha256:4257a5b7f71e9f92fdbd81caf9c76bbb49e4ab4a106f9d20e7ce3d481c1d7aa1
-      LogPath: /var/lib/docker/containers/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/minio/data
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /home/minio/.minio
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/minio
-          Type: bind
-      Name: /minio
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 3620aefa73f37b8f3d03b0a0df9c986d7773dffc17f70ef395ad7790baae38f5
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: ea9aa9bb98ba48221ef5593ef5fb4a245e02911a3dc9f0f35a3cecdb08078a75
-        Ports: { }
-        SandboxID: e1d3c46a786c204f99b64ab605760daea0ccbb62e2f69b82c65acc0a64814c0d
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/bin/docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-06-23T15:52:34.34303025Z'
-        Health:
-          FailingStreak: 16710
-          Log:
-            - End: '2022-07-05T07:38:22.799006168Z'
-              ExitCode: 1
-              Output: '2022/07/05 07:38:22 Get http://[::1]:25/minio/health/live: malformed HTTP status code "esnode01.novalocal"
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /usr/local/bin/kibana-docker
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /usr/local/bin/kibana-docker
+      Domainname: ''
+      Entrypoint:
+      - /usr/local/bin/dumb-init
+      - --
+      Env:
+      - PATH=/usr/share/kibana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - ELASTIC_CONTAINER=true
+      ExposedPorts:
+        5601/tcp: {}
+      Hostname: esnode01.novalocal
+      Image: docker.elastic.co/kibana/kibana:7.10.0
+      Labels:
+        org.label-schema.build-date: '2020-11-09T22:36:43.117Z'
+        org.label-schema.license: Elastic License
+        org.label-schema.name: Kibana
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.url: https://www.elastic.co/products/kibana
+        org.label-schema.usage: https://www.elastic.co/guide/en/kibana/reference/index.html
+        org.label-schema.vcs-ref: 1796b5ec8fa1e60ccea63f2e5c25ccc665b92fdc
+        org.label-schema.vcs-url: https://github.com/elastic/kibana
+        org.label-schema.vendor: Elastic
+        org.label-schema.version: 7.10.0
+        org.opencontainers.image.created: '2020-11-09T22:36:43.117Z'
+        org.opencontainers.image.documentation: https://www.elastic.co/guide/en/kibana/reference/index.html
+        org.opencontainers.image.licenses: Elastic License
+        org.opencontainers.image.revision: 1796b5ec8fa1e60ccea63f2e5c25ccc665b92fdc
+        org.opencontainers.image.source: https://github.com/elastic/kibana
+        org.opencontainers.image.title: Kibana
+        org.opencontainers.image.url: https://www.elastic.co/products/kibana
+        org.opencontainers.image.vendor: Elastic
+        org.opencontainers.image.version: 7.10.0
+        os_container_type: kibana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: kibana
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /usr/share/kibana/config/kibana.yml: {}
+        /usr/share/kibana/config/ssl: {}
+      WorkingDir: /usr/share/kibana
+    Created: '2021-09-08T07:42:53.064135062Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/32dcb4a4acf1701a79409ea63ff34f945151f7a374a8292555295f4ceea2acd9-init/diff:/var/lib/docker/overlay2/6c06d97a6d0774bd059d123d5a23428b34ee740dc3bdfd84f7fd57af5b855aaa/diff:/var/lib/docker/overlay2/9401d18969a4cc55ef41428621a24cb658d1bd9ab11703d43b5872e4d5f144b6/diff:/var/lib/docker/overlay2/14ee2b6cef3b5b284486204c9eb63c6ed1668eac0fd2d6e5beea62e80f8bd1fb/diff:/var/lib/docker/overlay2/0e4c26bba6ca9a218df3f4e46ce87e1b9d1759cc4e769ebb0c2a693556649ca3/diff:/var/lib/docker/overlay2/12d296c830debe6acfb1f5b06ddb1c2084a8e61b30c6bd9d8377ee378882c5c0/diff:/var/lib/docker/overlay2/594eedd917131de54862bd55190938ca5bfe7a6b2f70f0af449a48795b5b7b79/diff:/var/lib/docker/overlay2/af85385f9c6c791c3bfa495b01d796f1cc0a2d2f1d029a035cdd00155bc17b4e/diff:/var/lib/docker/overlay2/304ae285f87db2119c9d9f32c76f68b97ff5c56bad643eedc562f7a5b75c7449/diff:/var/lib/docker/overlay2/a9000e69f3e9ecaaf05909a821038bbc071ae9f284ef773b31b696c249b23c85/diff:/var/lib/docker/overlay2/f25888f79523c76b41c972ce1795f891c36260efb1c9073b0c915a88a0b5251f/diff:/var/lib/docker/overlay2/e970360bca8544f2c260522e867e2f954f244530e070cb3c737c68b30272a1b1/diff:/var/lib/docker/overlay2/3892b622731f5dcf04dc1479553cdc37bcf1e33564752f6a5bd2268f44117162/diff:/var/lib/docker/overlay2/ba799942135d6104f59478146173b36f8a2dcb8a935ffa10dc8e8e8099fc7454/diff:/var/lib/docker/overlay2/98673c2f07a9ebb4272211874509bce2254e8d68f51c66171247e2bcc98c5e6f/diff
+        MergedDir: /var/lib/docker/overlay2/32dcb4a4acf1701a79409ea63ff34f945151f7a374a8292555295f4ceea2acd9/merged
+        UpperDir: /var/lib/docker/overlay2/32dcb4a4acf1701a79409ea63ff34f945151f7a374a8292555295f4ceea2acd9/diff
+        WorkDir: /var/lib/docker/overlay2/32dcb4a4acf1701a79409ea63ff34f945151f7a374a8292555295f4ceea2acd9/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml:rw
+      - /etc/kibana/ssl:/usr/share/kibana/config/ssl:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632/hostname
+    HostsPath: /etc/hosts
+    Id: d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632
+    Image: sha256:da7fcd5925954eccf1dbc041dd64299b92665922321b83686e43c7914f74272f
+    LogPath: /var/lib/docker/containers/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/share/kibana/config/kibana.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/kibana/kibana.yml
+      Type: bind
+    - Destination: /usr/share/kibana/config/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/kibana/ssl
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    Name: /kibana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: c20363edb1a7fc926181331f24a04897038d1d2a115657c1405d5023adb44ea9
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: ea9aa9bb98ba48221ef5593ef5fb4a245e02911a3dc9f0f35a3cecdb08078a75
+      Ports: {}
+      SandboxID: b380df99835eaaf1742342e4cb11494c831dd3242c5338716d85447dd3d19064
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/local/bin/dumb-init
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-06-27T13:48:51.581335419Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 24904
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-27T13:48:53.544981109Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /usr/local/bin/docker-entrypoint.sh
+    - eswrapper
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - eswrapper
+      Domainname: ''
+      Entrypoint:
+      - /tini
+      - --
+      - /usr/local/bin/docker-entrypoint.sh
+      Env:
+      - PATH=/usr/share/elasticsearch/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - ELASTIC_CONTAINER=true
+      ExposedPorts:
+        9200/tcp: {}
+        9300/tcp: {}
+      Hostname: esnode01.novalocal
+      Image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+      Labels:
+        org.label-schema.build-date: '2020-11-09T21:30:33.964949Z'
+        org.label-schema.license: Elastic-License
+        org.label-schema.name: Elasticsearch
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.url: https://www.elastic.co/products/elasticsearch
+        org.label-schema.usage: https://www.elastic.co/guide/en/elasticsearch/reference/index.html
+        org.label-schema.vcs-ref: 51e9d6f22758d0374a0f3f5c6e8f3a7997850f96
+        org.label-schema.vcs-url: https://github.com/elastic/elasticsearch
+        org.label-schema.vendor: Elastic
+        org.label-schema.version: 7.10.0
+        org.opencontainers.image.created: '2020-11-09T21:30:33.964949Z'
+        org.opencontainers.image.documentation: https://www.elastic.co/guide/en/elasticsearch/reference/index.html
+        org.opencontainers.image.licenses: Elastic-License
+        org.opencontainers.image.revision: 51e9d6f22758d0374a0f3f5c6e8f3a7997850f96
+        org.opencontainers.image.source: https://github.com/elastic/elasticsearch
+        org.opencontainers.image.title: Elasticsearch
+        org.opencontainers.image.url: https://www.elastic.co/products/elasticsearch
+        org.opencontainers.image.vendor: Elastic
+        org.opencontainers.image.version: 7.10.0
+        os_container_type: elasticsearch
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/security/limits.conf: {}
+        /usr/share/elasticsearch/config/elasticsearch.keystore: {}
+        /usr/share/elasticsearch/config/elasticsearch.yml: {}
+        /usr/share/elasticsearch/config/jvm.options: {}
+        /usr/share/elasticsearch/config/ssl: {}
+        /usr/share/elasticsearch/config/x-pack: {}
+        /usr/share/elasticsearch/data: {}
+        /usr/share/elasticsearch/data/backup: {}
+        /usr/share/elasticsearch/plugins: {}
+      WorkingDir: /usr/share/elasticsearch
+    Created: '2021-04-07T08:23:54.40885802Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/318cc3ff7d117312704dddc36012f1360bad07976b170078f92c2ba0c7e4a073-init/diff:/var/lib/docker/overlay2/4781d49581e545444a4158786ebee322586bd29aa83e8fea38f92bdb1533bb27/diff:/var/lib/docker/overlay2/7e6ee2f0fe6bf0d8d28454b615aa744db36c3c8cac9716897a5432af6e12a88f/diff:/var/lib/docker/overlay2/a3ae91071d7a34c6279742cff6b7cd3e64931a9146da920ab71d6a9d71155398/diff:/var/lib/docker/overlay2/4667682d672c7420150a5d9e0926099cafab9669072e8619db510fbee1af3ed6/diff:/var/lib/docker/overlay2/fb4700be3bd4afa6121b321104148c687c9a78d34abfd94b4cf3fc5a25a1641c/diff:/var/lib/docker/overlay2/20f7205781134f7ecb9af88f4d031593c6f927dad67e5f2ac6df59f3ab5c90e3/diff:/var/lib/docker/overlay2/ed8472d7b2d6db8be5f88dc26e8f6269c37f04408e07782de82537e9eb110c01/diff:/var/lib/docker/overlay2/652b57fdddb9fde28692617885fe3ae40a27b200550d21d54148d3c1fef4142c/diff:/var/lib/docker/overlay2/98673c2f07a9ebb4272211874509bce2254e8d68f51c66171247e2bcc98c5e6f/diff
+        MergedDir: /var/lib/docker/overlay2/318cc3ff7d117312704dddc36012f1360bad07976b170078f92c2ba0c7e4a073/merged
+        UpperDir: /var/lib/docker/overlay2/318cc3ff7d117312704dddc36012f1360bad07976b170078f92c2ba0c7e4a073/diff
+        WorkDir: /var/lib/docker/overlay2/318cc3ff7d117312704dddc36012f1360bad07976b170078f92c2ba0c7e4a073/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/elasticsearch/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml:rw
+      - /etc/elasticsearch/ssl:/usr/share/elasticsearch/config/ssl:rw
+      - /etc/elasticsearch/jvm.options:/usr/share/elasticsearch/config/jvm.options:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/elasticsearch/plugins:/usr/share/elasticsearch/plugins:rw
+      - /etc/elasticsearch/x-pack:/usr/share/elasticsearch/config/x-pack:rw
+      - /var/lib/elasticsearch/backup:/usr/share/elasticsearch/data/backup:rw
+      - /etc/security/limits.conf:/etc/security/limits.conf:rw
+      - /var/lib/elasticsearch:/usr/share/elasticsearch/data:rw
+      - /etc/elasticsearch/elasticsearch.keystore:/usr/share/elasticsearch/config/elasticsearch.keystore:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths: null
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: true
+      PublishAllPorts: false
+      ReadonlyPaths: null
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt:
+      - label=disable
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits:
+      - Hard: 9223372036854775807
+        Name: memlock
+        Soft: 9223372036854775807
+      - Hard: 65536
+        Name: nofile
+        Soft: 65536
+      - Hard: 10240
+        Name: nproc
+        Soft: 10240
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487/hostname
+    HostsPath: /etc/hosts
+    Id: c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487
+    Image: sha256:37190fe5beea0394c3ab4b02578411e9d006dbdfc4a1940220cc1926bc2f691a
+    LogPath: /var/lib/docker/containers/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/share/elasticsearch/config/elasticsearch.keystore
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/elasticsearch/elasticsearch.keystore
+      Type: bind
+    - Destination: /usr/share/elasticsearch/config/elasticsearch.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/elasticsearch/elasticsearch.yml
+      Type: bind
+    - Destination: /usr/share/elasticsearch/config/jvm.options
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/elasticsearch/jvm.options
+      Type: bind
+    - Destination: /usr/share/elasticsearch/config/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/elasticsearch/ssl
+      Type: bind
+    - Destination: /usr/share/elasticsearch/plugins
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/elasticsearch/plugins
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /usr/share/elasticsearch/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/elasticsearch
+      Type: bind
+    - Destination: /usr/share/elasticsearch/data/backup
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/elasticsearch/backup
+      Type: bind
+    - Destination: /etc/security/limits.conf
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/security/limits.conf
+      Type: bind
+    - Destination: /usr/share/elasticsearch/config/x-pack
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/elasticsearch/x-pack
+      Type: bind
+    Name: /elasticsearch
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 102a7e01bec0cc1db63d0ba75ba180ba054134ff6ebc714cfc8de020b6e797b6
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: ea9aa9bb98ba48221ef5593ef5fb4a245e02911a3dc9f0f35a3cecdb08078a75
+      Ports: {}
+      SandboxID: e57120efdb6416134c0aab97f3c1777aeba6be23ae9120c4d33551f7402bf3fd
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-06-27T13:45:30.286041284Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 22988
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-27T13:45:30.881408996Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - server
+    - /data
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - server
+      - /data
+      Domainname: ''
+      Entrypoint:
+      - /usr/bin/docker-entrypoint.sh
+      Env:
+      - MINIO_ACCESS_KEY=admin
+      - MINIO_SECRET_KEY=the_key
+      - AWS_ACCESS_KEY_ID=admin
+      - AWS_SECRET_ACCESS_KEY=the_key
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - MINIO_UPDATE=off
+      - MINIO_ACCESS_KEY_FILE=access_key
+      - MINIO_SECRET_KEY_FILE=secret_key
+      - MINIO_SSE_MASTER_KEY=my-minio-key:the_key
+      - MINIO_USERNAME=minio
+      - MINIO_GROUPNAME=minio
+      - MINIO_UID=9000
+      - MINIO_GID=9000
+      - AWSCLI_VERSION=1.16.198
+      ExposedPorts:
+        9000/tcp: {}
+      Healthcheck:
+        Interval: 60000000000
+        Test:
+        - CMD-SHELL
+        - healthcheck
+      Hostname: esnode01.novalocal
+      Image: nexusregistry.opensolutions.cloud/minio:1.0.0
+      Labels:
+        maintainer: MinIO Inc <dev@min.io>
+        os_contianer_type: minio
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: minio
+      Volumes:
+        /data: {}
+        /etc/localtime: {}
+        /home/minio/.minio: {}
+      WorkingDir: ''
+    Created: '2020-11-19T17:18:28.426043251Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/86103c651797af992bfb423a7f16309033169eb5a02bee540776ba5e61c33a82-init/diff:/var/lib/docker/overlay2/006c48874f8d492ac02e9cc6048c52b226c8a4fff4215d409e9df856cba0bbcf/diff:/var/lib/docker/overlay2/3ed4a827929e1ac9daace5003a6339bb3120814d8b24eaa086e9f5e8ffb130d5/diff:/var/lib/docker/overlay2/cda5811bca984ced0739043771fa4728d4ba3ed8ac3df24690b03eb3b823835b/diff:/var/lib/docker/overlay2/96322090524e04aaee46f4ef471311a0ca9bb8af73ec73bae8dcb9c29b6df8d4/diff:/var/lib/docker/overlay2/143020fd9ba8e42e2a0a493d0d0505ce97d8f48bdae9919cf11f4989e2f082a7/diff:/var/lib/docker/overlay2/c1c0634844e74e4016c48368741a908bd15cbd08a5bc883872486fdd67170a8f/diff:/var/lib/docker/overlay2/c0c0c75cff56c764783132a6149c0f09f39e68787b2d5a86596b9814000d2b2e/diff
+        MergedDir: /var/lib/docker/overlay2/86103c651797af992bfb423a7f16309033169eb5a02bee540776ba5e61c33a82/merged
+        UpperDir: /var/lib/docker/overlay2/86103c651797af992bfb423a7f16309033169eb5a02bee540776ba5e61c33a82/diff
+        WorkDir: /var/lib/docker/overlay2/86103c651797af992bfb423a7f16309033169eb5a02bee540776ba5e61c33a82/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/minio/data:/data:rw
+      - /etc/localtime:/etc/localtime:ro
+      - /etc/minio:/home/minio/.minio:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f/hostname
+    HostsPath: /var/lib/docker/containers/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f/hosts
+    Id: 0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f
+    Image: sha256:4257a5b7f71e9f92fdbd81caf9c76bbb49e4ab4a106f9d20e7ce3d481c1d7aa1
+    LogPath: /var/lib/docker/containers/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/minio/data
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /home/minio/.minio
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/minio
+      Type: bind
+    Name: /minio
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 3620aefa73f37b8f3d03b0a0df9c986d7773dffc17f70ef395ad7790baae38f5
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: ea9aa9bb98ba48221ef5593ef5fb4a245e02911a3dc9f0f35a3cecdb08078a75
+      Ports: {}
+      SandboxID: e1d3c46a786c204f99b64ab605760daea0ccbb62e2f69b82c65acc0a64814c0d
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/bin/docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-06-23T15:52:34.34303025Z'
+      Health:
+        FailingStreak: 16710
+        Log:
+        - End: '2022-07-05T07:38:22.799006168Z'
+          ExitCode: 1
+          Output: '2022/07/05 07:38:22 Get http://[::1]:25/minio/health/live: malformed
+            HTTP status code "esnode01.novalocal"
 
             '
-              Start: '2022-07-05T07:38:22.555365505Z'
-            - End: '2022-07-05T07:39:23.083766849Z'
-              ExitCode: 1
-              Output: '2022/07/05 07:39:22 Get http://[::1]:25/minio/health/live: net/http: HTTP/1.x transport connection broken: malformed HTTP status code "esnode01.novalocal"
+          Start: '2022-07-05T07:38:22.555365505Z'
+        - End: '2022-07-05T07:39:23.083766849Z'
+          ExitCode: 1
+          Output: '2022/07/05 07:39:22 Get http://[::1]:25/minio/health/live: net/http:
+            HTTP/1.x transport connection broken: malformed HTTP status code "esnode01.novalocal"
 
             '
-              Start: '2022-07-05T07:39:22.826055915Z'
-            - End: '2022-07-05T07:40:23.343135578Z'
-              ExitCode: 1
-              Output: '2022/07/05 07:40:23 Get http://[::1]:25/minio/health/live: malformed HTTP status code "esnode01.novalocal"
+          Start: '2022-07-05T07:39:22.826055915Z'
+        - End: '2022-07-05T07:40:23.343135578Z'
+          ExitCode: 1
+          Output: '2022/07/05 07:40:23 Get http://[::1]:25/minio/health/live: malformed
+            HTTP status code "esnode01.novalocal"
 
             '
-              Start: '2022-07-05T07:40:23.102990266Z'
-            - End: '2022-07-05T07:41:23.631862528Z'
-              ExitCode: 1
-              Output: '2022/07/05 07:41:23 Get http://[::1]:25/minio/health/live: net/http: HTTP/1.x transport connection broken: malformed HTTP status code "esnode01.novalocal"
+          Start: '2022-07-05T07:40:23.102990266Z'
+        - End: '2022-07-05T07:41:23.631862528Z'
+          ExitCode: 1
+          Output: '2022/07/05 07:41:23 Get http://[::1]:25/minio/health/live: net/http:
+            HTTP/1.x transport connection broken: malformed HTTP status code "esnode01.novalocal"
 
             '
-              Start: '2022-07-05T07:41:23.362656653Z'
-            - End: '2022-07-05T07:42:23.936534337Z'
-              ExitCode: 1
-              Output: '2022/07/05 07:42:23 Get http://[::1]:25/minio/health/live: malformed HTTP status code "esnode01.novalocal"
+          Start: '2022-07-05T07:41:23.362656653Z'
+        - End: '2022-07-05T07:42:23.936534337Z'
+          ExitCode: 1
+          Output: '2022/07/05 07:42:23 Get http://[::1]:25/minio/health/live: malformed
+            HTTP status code "esnode01.novalocal"
 
             '
-              Start: '2022-07-05T07:42:23.652489339Z'
-          Status: unhealthy
-        OOMKilled: false
-        Paused: false
-        Pid: 2750
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-23T15:52:37.092109951Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.3.7
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7
-      source: rpm
-      version: 1.02.170
-  device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 6.el7
-      source: rpm
-      version: 1.02.170
-  device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 6.el7
-      source: rpm
-      version: 1.02.170
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7
-      source: rpm
-      version: 1.02.170
-  device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 3.el7_9.2
-      source: rpm
-      version: 0.8.5
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.13
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.13
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.3.1p1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 6.el7
-      source: rpm
-      version: 2.02.187
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 6.el7
-      source: rpm
-      version: 2.02.187
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 3.el7
-      source: rpm
-      version: '1.217'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 2.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '63'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '106'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '179'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '180'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '274'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '324'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '335'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '425'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '448'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '463'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '555'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '556'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '557'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '558'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '559'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '560'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '561'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '562'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '566'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '573'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '582'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '583'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '589'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '590'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '591'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '592'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '593'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '594'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '595'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '597'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '615'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '644'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /sbin/rpcbind -w
-    pid: '645'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '649'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '652'
-    ppid: '1'
-    user: chrony
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '653'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '667'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '677'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H esnode01 eth0
-    pid: '912'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '973'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
-    pid: '975'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '980'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1134'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1138'
-    ppid: '1134'
-    user: postfix
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1144'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
-    pid: '1146'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1148'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1174'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1175'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1176'
-    ppid: '1'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '2590'
-    ppid: '980'
-    user: root
-  - cmdline: minio server /data
-    pid: '2750'
-    ppid: '2590'
-    user: minio
-  - cmdline: /usr/bin/docker start -a minio
-    pid: '3006'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '6711'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '12053'
-    ppid: '1134'
-    user: postfix
-  - cmdline: ''
-    pid: '15852'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16134'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16467'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16501'
-    ppid: '2'
-    user: root
-  - cmdline: smtpd -n smtp -t inet -u -s 2
-    pid: '17454'
-    ppid: '1134'
-    user: postfix
-  - cmdline: ''
-    pid: '17543'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17808'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1657006961
-    pid: '18043'
-    ppid: '975'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '18044'
-    ppid: '1148'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '18046'
-    ppid: '18044'
-    user: centos
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-pokaugfpuyeoncvvjqxckjscsjfgazwu ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657006970.7584682-40830-147218497204/AnsiballZ_process_facts.py' && sleep 0
-    pid: '18235'
-    ppid: '18046'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-pokaugfpuyeoncvvjqxckjscsjfgazwu ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657006970.7584682-40830-147218497204/AnsiballZ_process_facts.py
-    pid: '18248'
-    ppid: '18235'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-pokaugfpuyeoncvvjqxckjscsjfgazwu ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657006970.7584682-40830-147218497204/AnsiballZ_process_facts.py
-    pid: '18249'
-    ppid: '18248'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657006970.7584682-40830-147218497204/AnsiballZ_process_facts.py
-    pid: '18250'
-    ppid: '18249'
-    user: root
-  - cmdline: ''
-    pid: '20617'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/bin/docker start -a elasticsearch
-    pid: '22947'
-    ppid: '1'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '22965'
-    ppid: '980'
-    user: root
-  - cmdline: /tini -- /usr/local/bin/docker-entrypoint.sh eswrapper
-    pid: '22988'
-    ppid: '22965'
-    user: root
-  - cmdline: /usr/share/elasticsearch/jdk/bin/java -Xshare:auto -Des.networkaddress.cache.ttl=60 -Des.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -XX:+ShowCodeDetailsInExceptionMessages -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.allocator.numDirectArenas=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Djava.locale.providers=SPI,COMPAT -Xms512m -Xmx512m -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -XX:ErrorFile=logs/hs_err_pid%p.log -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m -Des.allow_insecure_settings=true -Des.cgroups.hierarchy.override=/ -XX:MaxDirectMemorySize=268435456 -Des.path.home=/usr/share/elasticsearch -Des.path.conf=/usr/share/elasticsearch/config -Des.distribution.flavor=default -Des.distribution.type=docker -Des.bundled_jdk=true -cp /usr/share/elasticsearch/lib/* org.elasticsearch.bootstrap.Elasticsearch
+          Start: '2022-07-05T07:42:23.652489339Z'
+        Status: unhealthy
+      OOMKilled: false
+      Paused: false
+      Pid: 2750
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-23T15:52:37.092109951Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 9200
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 9300
+    protocol: tcp
+  discovery_time: '2022-07-05T09:43:11+02:00'
+  docker:
+    exposed_ports:
+      9200/tcp: {}
+      9300/tcp: {}
+    id: c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+    name: /elasticsearch
+    network_mode: host
+    port_bindings: {}
+  listening_ports:
+  - 9200
+  - 9300
+  packages: []
+  process:
+    children:
+    - children: []
+      cmdline: /usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller
+      cwd: /usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/
+      pid: '23242'
+      ppid: '23002'
+      user: centos
+    cmdline: /usr/share/elasticsearch/jdk/bin/java -Xshare:auto -Des.networkaddress.cache.ttl=60
+      -Des.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true
+      -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -XX:+ShowCodeDetailsInExceptionMessages
+      -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0
+      -Dio.netty.allocator.numDirectArenas=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true
+      -Djava.locale.providers=SPI,COMPAT -Xms512m -Xmx512m -XX:+UseG1GC -XX:G1ReservePercent=25
+      -XX:InitiatingHeapOccupancyPercent=30 -XX:ErrorFile=logs/hs_err_pid%p.log -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+      -Des.allow_insecure_settings=true -Des.cgroups.hierarchy.override=/ -XX:MaxDirectMemorySize=268435456
+      -Des.path.home=/usr/share/elasticsearch -Des.path.conf=/usr/share/elasticsearch/config
+      -Des.distribution.flavor=default -Des.distribution.type=docker -Des.bundled_jdk=true
+      -cp /usr/share/elasticsearch/lib/* org.elasticsearch.bootstrap.Elasticsearch
+    cwd: /usr/share/elasticsearch/jdk/bin/
+    listening_ports:
+    - 9200
+    - 9300
     pid: '23002'
     ppid: '22988'
     user: centos
-  - cmdline: /usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller
-    pid: '23242'
-    ppid: '23002'
-    user: centos
-  - cmdline: /usr/bin/docker start -a kibana
-    pid: '24878'
-    ppid: '1'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '24887'
-    ppid: '980'
-    user: root
-  - cmdline: /usr/local/bin/dumb-init -- /usr/local/bin/kibana-docker
-    pid: '24904'
-    ppid: '24887'
-    user: centos
-  - cmdline: /usr/share/kibana/bin/../node/bin/node /usr/share/kibana/bin/../src/cli/dist --ops.cGroupOverrides.cpuPath=/ --ops.cGroupOverrides.cpuAcctPath=/
-    pid: '24917'
-    ppid: '24904'
-    user: centos
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1134
-    port: 25
-    protocol: tcp
-    stime: Thu Jun 23 15:52:28 2022
-    user: root
-  - address: 0.0.0.0
-    name: node
-    pid: 24917
-    port: 5601
-    protocol: tcp
-    stime: Mon Jun 27 13:48:52 2022
-    user: centos
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Thu Jun 23 15:52:15 2022
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1148
-    port: 22
-    protocol: tcp
-    stime: Thu Jun 23 15:52:28 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1134
-    port: 25
-    protocol: tcp
-    stime: Thu Jun 23 15:52:28 2022
-    user: root
-  - address: '::'
-    name: minio
-    pid: 2750
-    port: 9000
-    protocol: tcp
-    stime: Thu Jun 23 15:52:35 2022
-    user: minio
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Thu Jun 23 15:52:15 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 23002
-    port: 9200
-    protocol: tcp
-    stime: Mon Jun 27 13:45:29 2022
-    user: centos
-  - address: '::'
-    name: java
-    pid: 23002
-    port: 9300
-    protocol: tcp
-    stime: Mon Jun 27 13:45:29 2022
-    user: centos
-  - address: '::'
-    name: sshd
-    pid: 1148
-    port: 22
-    protocol: tcp
-    stime: Thu Jun 23 15:52:28 2022
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: ElasticSearch
+  version:
+  - number: 7.10.0
+    type: docker
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.3.7
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7
+    source: rpm
+    version: 1.02.170
+  device-mapper-event:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 6.el7
+    source: rpm
+    version: 1.02.170
+  device-mapper-event-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 6.el7
+    source: rpm
+    version: 1.02.170
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7
+    source: rpm
+    version: 1.02.170
+  device-mapper-persistent-data:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 3.el7_9.2
+    source: rpm
+    version: 0.8.5
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 912
-    port: 68
-    protocol: udp
-    stime: Thu Jun 23 15:52:27 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Thu Jun 23 15:52:15 2022
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 652
-    port: 323
-    protocol: udp
-    stime: Thu Jun 23 15:52:22 2022
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.13
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.13
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.3.1p1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 6.el7
+    source: rpm
+    version: 2.02.187
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 6.el7
+    source: rpm
+    version: 2.02.187
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 3.el7
+    source: rpm
+    version: '1.217'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 2.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 645
-    port: 816
-    protocol: udp
-    stime: Thu Jun 23 15:52:22 2022
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Thu Jun 23 15:52:15 2022
-    user: root
-  - address: ::1
-    name: chronyd
-    pid: 652
-    port: 323
-    protocol: udp
-    stime: Thu Jun 23 15:52:22 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 645
-    port: 816
-    protocol: udp
-    stime: Thu Jun 23 15:52:22 2022
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '106'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '179'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '180'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '324'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '335'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '425'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '448'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '463'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '555'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '556'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '557'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '558'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '559'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '560'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '561'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '562'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '566'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '573'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '582'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '583'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '589'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '590'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '591'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '592'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '593'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '594'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '595'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '597'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '615'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '644'
+  ppid: '1'
+  user: polkitd
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '645'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '649'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '652'
+  ppid: '1'
+  user: chrony
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '653'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '667'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '677'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H esnode01 eth0
+  cwd: /sbin/
+  pid: '912'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '973'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '975'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '980'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1134'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1138'
+  ppid: '1134'
+  user: postfix
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1144'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1146'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1148'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1174'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1175'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1176'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/0c87f3b683a61a4ab8cd94605920a6c4f8a1cea4be3b147852042573386d5a7f
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '2590'
+  ppid: '980'
+  user: root
+- cmdline: minio server /data
+  cwd: /
+  pid: '2750'
+  ppid: '2590'
+  user: minio
+- cmdline: /usr/bin/docker start -a minio
+  cwd: /usr/bin/
+  pid: '3006'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6711'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '12053'
+  ppid: '1134'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '15852'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16134'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16467'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16501'
+  ppid: '2'
+  user: root
+- cmdline: smtpd -n smtp -t inet -u -s 2
+  cwd: /
+  pid: '17454'
+  ppid: '1134'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '17543'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17808'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1657006961
+  cwd: /usr/lib64/sa/
+  pid: '18043'
+  ppid: '975'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '18044'
+  ppid: '1148'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '18046'
+  ppid: '18044'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-pokaugfpuyeoncvvjqxckjscsjfgazwu
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657006970.7584682-40830-147218497204/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '18235'
+  ppid: '18046'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-pokaugfpuyeoncvvjqxckjscsjfgazwu
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657006970.7584682-40830-147218497204/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '18248'
+  ppid: '18235'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-pokaugfpuyeoncvvjqxckjscsjfgazwu ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1657006970.7584682-40830-147218497204/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '18249'
+  ppid: '18248'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657006970.7584682-40830-147218497204/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '18250'
+  ppid: '18249'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20617'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/docker start -a elasticsearch
+  cwd: /usr/bin/
+  pid: '22947'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/c01b7dd29adfbd9bf8b9ee5eb5f927ff6f309749401d66c8f40b6a5231d3e487
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '22965'
+  ppid: '980'
+  user: root
+- cmdline: /tini -- /usr/local/bin/docker-entrypoint.sh eswrapper
+  cwd: /
+  pid: '22988'
+  ppid: '22965'
+  user: root
+- cmdline: /usr/share/elasticsearch/jdk/bin/java -Xshare:auto -Des.networkaddress.cache.ttl=60
+    -Des.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true
+    -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -XX:+ShowCodeDetailsInExceptionMessages
+    -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0
+    -Dio.netty.allocator.numDirectArenas=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true
+    -Djava.locale.providers=SPI,COMPAT -Xms512m -Xmx512m -XX:+UseG1GC -XX:G1ReservePercent=25
+    -XX:InitiatingHeapOccupancyPercent=30 -XX:ErrorFile=logs/hs_err_pid%p.log -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+    -Des.allow_insecure_settings=true -Des.cgroups.hierarchy.override=/ -XX:MaxDirectMemorySize=268435456
+    -Des.path.home=/usr/share/elasticsearch -Des.path.conf=/usr/share/elasticsearch/config
+    -Des.distribution.flavor=default -Des.distribution.type=docker -Des.bundled_jdk=true
+    -cp /usr/share/elasticsearch/lib/* org.elasticsearch.bootstrap.Elasticsearch
+  cwd: /usr/share/elasticsearch/jdk/bin/
+  pid: '23002'
+  ppid: '22988'
+  user: centos
+- cmdline: /usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller
+  cwd: /usr/share/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/
+  pid: '23242'
+  ppid: '23002'
+  user: centos
+- cmdline: /usr/bin/docker start -a kibana
+  cwd: /usr/bin/
+  pid: '24878'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d41dd22de7604f5b149d81eab5d75c8a715429b357bb0fcb37711e398e59f632
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '24887'
+  ppid: '980'
+  user: root
+- cmdline: /usr/local/bin/dumb-init -- /usr/local/bin/kibana-docker
+  cwd: /usr/local/bin/
+  pid: '24904'
+  ppid: '24887'
+  user: centos
+- cmdline: /usr/share/kibana/bin/../node/bin/node /usr/share/kibana/bin/../src/cli/dist
+    --ops.cGroupOverrides.cpuPath=/ --ops.cGroupOverrides.cpuAcctPath=/
+  cwd: /usr/share/kibana/bin/../node/bin/
+  pid: '24917'
+  ppid: '24904'
+  user: centos
+software_list:
+- cmd_regexp: org\.elasticsearch\.bootstrap\.Elasticsearch
+  name: ElasticSearch
+  pkg_regexp: ^elasticsearch
+  process_type: parent
+  return_children: true
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1134
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 23 15:52:28 2022
+  user: root
+- address: 0.0.0.0
+  name: node
+  pid: 24917
+  port: 5601
+  protocol: tcp
+  stime: Mon Jun 27 13:48:52 2022
+  user: centos
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 23 15:52:15 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1148
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 23 15:52:28 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1134
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 23 15:52:28 2022
+  user: root
+- address: '::'
+  name: minio
+  pid: 2750
+  port: 9000
+  protocol: tcp
+  stime: Thu Jun 23 15:52:35 2022
+  user: minio
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 23 15:52:15 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 23002
+  port: 9200
+  protocol: tcp
+  stime: Mon Jun 27 13:45:29 2022
+  user: centos
+- address: '::'
+  name: java
+  pid: 23002
+  port: 9300
+  protocol: tcp
+  stime: Mon Jun 27 13:45:29 2022
+  user: centos
+- address: '::'
+  name: sshd
+  pid: 1148
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 23 15:52:28 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 912
+  port: 68
+  protocol: udp
+  stime: Thu Jun 23 15:52:27 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Thu Jun 23 15:52:15 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 652
+  port: 323
+  protocol: udp
+  stime: Thu Jun 23 15:52:22 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 645
+  port: 816
+  protocol: udp
+  stime: Thu Jun 23 15:52:22 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Thu Jun 23 15:52:15 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 652
+  port: 323
+  protocol: udp
+  stime: Thu Jun 23 15:52:22 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 645
+  port: 816
+  protocol: udp
+  stime: Thu Jun 23 15:52:22 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/grafana/grafana6.6.2_centos7.yaml
+++ b/tests/unit/plugins/action/auto/resources/grafana/grafana6.6.2_centos7.yaml
@@ -1,4493 +1,4652 @@
----
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=the_gpg_key
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.8.2-d9b0d2f
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-05-26T07:49:05.896112055Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86-init/diff:/var/lib/docker/overlay2/395a0a098af3a906d0b43de3a008385a50d078a5c9c9be9ad290d1ba93fc9d54/diff:/var/lib/docker/overlay2/ef530f145d37479125854996544e943962d75b907389895e832a53f5bf1be0b4/diff:/var/lib/docker/overlay2/aacd9f48b7c7d9206a74c249bc83b6afec331f8973755cc84b91520222113c6a/diff:/var/lib/docker/overlay2/a653e007a808f014a3cdf2a62cf8867245a62cc468322211674f6eb7075edc2d/diff:/var/lib/docker/overlay2/1df1b451d3b0c7cd3356a603610b5f2b30b61bfe47d8b9c3311abac0715bc2c9/diff:/var/lib/docker/overlay2/41f757a985196fb2658fe9b64ee03906a9ef3273caa4cf533f46815ca685387e/diff:/var/lib/docker/overlay2/9d09467ed70aad7f2334135a687a8531961e6224b24d4162233f2e7385da8cac/diff:/var/lib/docker/overlay2/5fb73472da8826e8cd0d3142ce1eb014d2a8168164a20b0c39bee7718165927e/diff:/var/lib/docker/overlay2/e95c88109a4dfa0d00c885520d4c0e9891bd674f28a2074d4ab71bc6aea3ccbf/diff:/var/lib/docker/overlay2/00e551e532ee647bfbfd6d50ed3c40c11afaad3cb2e4c30509423cc14066f9de/diff:/var/lib/docker/overlay2/dffc514cc11477c207690cc5bc501f8c70136a8783ce74836ccbb5db910b3bcb/diff:/var/lib/docker/overlay2/4f6545d825e9673d1a62dbcf4449ed28ce76b02513b8094f2b3f60a0b806160e/diff
+        MergedDir: /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/merged
+        UpperDir: /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/diff
+        WorkDir: /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/hostname
+    HostsPath: /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/hosts
+    Id: 6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775
+    Image: sha256:8e094d91d6749ce8d3ce1b45436a5b500647b9c0e52a7ee00e97f7a21f4cc878
+    LogPath: /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: f6cf94112a5fe8c1be26b086499ae97180987e487b317299594f8c58b9435ae2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: a6c1d1d1c4a924d01c263853345912f759d51fdfff59de9a26988318585a01ca
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-05-26T07:49:09.083806407Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 24640
+      Restarting: false
+      Running: true
+      StartedAt: '2022-05-26T07:49:11.400392642Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=the_password
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=the_gpg_key
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ''
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 3a25e45db6cd680825463e263b963466b9f9781ed8e3f92f991f71568e22642d
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 1
+      FinishedAt: '2022-06-26T23:30:50.884876362Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 0
+      Restarting: false
+      Running: false
+      StartedAt: '2022-06-26T23:30:49.475537222Z'
+      Status: exited
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 3000
+    protocol: tcp
+  discovery_time: '2022-06-27T01:30:56+02:00'
+  docker:
+    exposed_ports:
+      3000/tcp: {}
+    id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+    name: /grafana
+    network_mode: host
+    port_bindings: {}
+  files:
+  - name: grafana.ini
+    path: /etc/grafana
+    subtype: generic
+    type: config
+  - path: /usr/share/grafana
+    subtype: generic
+    type: home
+  - path: /var/lib/grafana
+    subtype: generic
+    type: data
+  - path: /var/log/grafana
+    subtype: generic
+    type: log
+  listening_ports:
+  - 3000
+  packages: []
+  process:
+    cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini
+      --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
+      cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/usr/share/grafana/plugins
+      cfg:default.paths.provisioning=/etc/grafana/provisioning
+    cwd: /
+    listening_ports:
+    - 3000
+    pid: '10876'
+    ppid: '10860'
+    user: grafana
+  type: Grafana
+  version:
+  - number: 6.6.2
+    type: command
+  - number: 6.6.2_iometrics-9
+    type: docker
 mocked_plugin_tasks:
   Check config file:
     expected_args:
-      path: "/etc/grafana/grafana.ini"
-      follow: False
-      get_attributes: True
-      get_mime: True
-      in_docker: True
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /etc/grafana/grafana.ini
     plugin_result:
       failed: false
       stat:
         exists: true
         readable: true
-  Read config file:
-    expected_args:
-      delegate_reading: False
-      file_path: "/etc/grafana/grafana.ini"
-      in_docker: True
-      parser: key_value
-      parser_params:
-        comment_delimiters:
-          - "#"
-          - "["
-    plugin_result: {
-      "failed": false,
-      "skipped": false,
-      "msg": "",
-      "invocation": {
-        "module_args": {
-          "src": "/proc/10876/root/etc/grafana/grafana.ini"
-        }
-      },
-      "task": "Read config file",
-      "content": "# Config file for grafana server.\n#\n# Ansible managed\n############################# Grafana Configuration #############################\n\n\n#################################### Paths #####################################\n[paths]\ndata=/var/lib/grafana\nlogs=/var/log/grafana\nplugins=/usr/share/grafana/plugins\n\n#################################### Server ####################################\n[server]\nhttp_port=3000\nprotocol=http\n\n################################### Database ###################################\n[database]\nhost=127.0.0.1:5432\nname=grafana\npassword=the_password\npath=grafana.db\ntype=postgres\nuser=grafana\n\n################################## Analytics ###################################\n[analytics]\ncheck_for_updates=false\nreporting_enabled=false\n\n#################################### Users #####################################\n[users]\nallow_sign_up=false\n\n################################ Auth.anonymous ################################\n[auth.anonymous]\nenabled=false\n\n################################# Auth.github ##################################\n[auth.github]\nenabled=false\n\n################################# Auth.google ##################################\n[auth.google]\nenabled=false\n\n################################## Auth.proxy ##################################\n[auth.proxy]\nenabled=false\n\n################################## Auth.basic ##################################\n[auth.basic]\nenabled=true\n\n################################## Auth.ldap ###################################\n[auth.ldap]\nconfig_file=/etc/grafana/ldap.toml\nenabled=false\n\n##################################### Log ######################################\n[log]\nlevel=info\nmode=console\n\n################################# Log.console ##################################\n[log.console]\nformat=json\n",
-      "source": "/proc/10876/root/etc/grafana/grafana.ini",
-      "_ansible_parsed": true,
-      "parsed": {
-        "data": "/var/lib/grafana",
-        "logs": "/var/log/grafana",
-        "plugins": "/usr/share/grafana/plugins",
-        "http_port": "3000",
-        "protocol": "http",
-        "host": "127.0.0.1:5432",
-        "name": "grafana",
-        "password": "the_password",
-        "path": "grafana.db",
-        "type": "postgres",
-        "user": "grafana",
-        "check_for_updates": "false",
-        "reporting_enabled": "false",
-        "allow_sign_up": "false",
-        "enabled": "false",
-        "config_file": "/etc/grafana/ldap.toml",
-        "level": "info",
-        "mode": "console",
-        "format": "json"
-      }
-    }
   Check with bin:
     expected_args:
-      path: "/usr/share/grafana/bin/grafana-server"
-      follow: False
-      get_attributes: True
-      get_mime: True
-      in_docker: True
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /usr/share/grafana/bin/grafana-server
     plugin_result:
       failed: false
       stat:
-        exists: true
         executable: true
-        path: "/usr/share/grafana/bin/grafana-server"
+        exists: true
+        path: /usr/share/grafana/bin/grafana-server
   Get grafana version:
     expected_args:
       argv:
-        - "/usr/share/grafana/bin/grafana-server"
-        - "-v"
+      - /usr/share/grafana/bin/grafana-server
+      - -v
       cmd: null
-      in_docker: True
+      in_docker: true
     plugin_result:
-      stdout: "Version 6.6.2 (commit: unknown-dev, branch: master)"
+      stdout: 'Version 6.6.2 (commit: unknown-dev, branch: master)'
+  Read config file:
+    expected_args:
+      delegate_reading: false
+      file_path: /etc/grafana/grafana.ini
+      in_docker: true
+      parser: key_value
+      parser_params:
+        comment_delimiters:
+        - '#'
+        - '['
+    plugin_result:
+      _ansible_parsed: true
+      content: '# Config file for grafana server.
 
-expected_result:
-  - discovery_time: '2022-06-27T01:30:56+02:00'
-    bindings:
-      - address: '::'
-        class: service
-        port: 3000
-        protocol: tcp
+        #
 
-    docker:
-      exposed_ports:
-        3000/tcp: { }
-      id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-      name: /grafana
-      network_mode: 'host'
-      port_bindings: { }
-    files:
-      - name: grafana.ini
-        path: /etc/grafana
-        subtype: generic
-        type: config
-      - path: /usr/share/grafana
-        subtype: generic
-        type: home
-      - path: /var/lib/grafana
-        subtype: generic
-        type: data
-      - path: /var/log/grafana
-        subtype: generic
-        type: log
-    listening_ports:
-      - 3000
-    packages: [ ]
-    process:
-      cmdline: >-
-        grafana-server --homepath=/usr/share/grafana
-        --config=/etc/grafana/grafana.ini --packaging=docker
-        cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
-        cfg:default.paths.logs=/var/log/grafana
-        cfg:default.paths.plugins=/usr/share/grafana/plugins
-        cfg:default.paths.provisioning=/etc/grafana/provisioning
-      listening_ports:
-        - 3000
-      pid: '10876'
-      ppid: '10860'
-      user: grafana
-    type: Grafana
-    version:
-      - number: 6.6.2
-        type: command
-      - number: 6.6.2_iometrics-9
-        type: docker
-software_list:
-  - cmd_regexp: grafana-server
-    name: Grafana
-    pkg_regexp: ^grafana
-    custom_tasks:
-      - include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/grafana.yaml"
-        name: Include Grafana specific plugins
-    process_type: parent
-    return_children: false
-    return_packages: true
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=the_gpg_key
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
-        ExposedPorts:
-          3003/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.8.2-d9b0d2f
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: { }
-        WorkingDir: /usr/src/app
-      Created: '2022-05-26T07:49:05.896112055Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86-init/diff:/var/lib/docker/overlay2/395a0a098af3a906d0b43de3a008385a50d078a5c9c9be9ad290d1ba93fc9d54/diff:/var/lib/docker/overlay2/ef530f145d37479125854996544e943962d75b907389895e832a53f5bf1be0b4/diff:/var/lib/docker/overlay2/aacd9f48b7c7d9206a74c249bc83b6afec331f8973755cc84b91520222113c6a/diff:/var/lib/docker/overlay2/a653e007a808f014a3cdf2a62cf8867245a62cc468322211674f6eb7075edc2d/diff:/var/lib/docker/overlay2/1df1b451d3b0c7cd3356a603610b5f2b30b61bfe47d8b9c3311abac0715bc2c9/diff:/var/lib/docker/overlay2/41f757a985196fb2658fe9b64ee03906a9ef3273caa4cf533f46815ca685387e/diff:/var/lib/docker/overlay2/9d09467ed70aad7f2334135a687a8531961e6224b24d4162233f2e7385da8cac/diff:/var/lib/docker/overlay2/5fb73472da8826e8cd0d3142ce1eb014d2a8168164a20b0c39bee7718165927e/diff:/var/lib/docker/overlay2/e95c88109a4dfa0d00c885520d4c0e9891bd674f28a2074d4ab71bc6aea3ccbf/diff:/var/lib/docker/overlay2/00e551e532ee647bfbfd6d50ed3c40c11afaad3cb2e4c30509423cc14066f9de/diff:/var/lib/docker/overlay2/dffc514cc11477c207690cc5bc501f8c70136a8783ce74836ccbb5db910b3bcb/diff:/var/lib/docker/overlay2/4f6545d825e9673d1a62dbcf4449ed28ce76b02513b8094f2b3f60a0b806160e/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/hosts
-      Id: 6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775
-      Image: 'sha256:8e094d91d6749ce8d3ce1b45436a5b500647b9c0e52a7ee00e97f7a21f4cc878'
-      LogPath: >-
-        /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: f6cf94112a5fe8c1be26b086499ae97180987e487b317299594f8c58b9435ae2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: a6c1d1d1c4a924d01c263853345912f759d51fdfff59de9a26988318585a01ca
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-05-26T07:49:09.083806407Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 24640
-        Restarting: false
-        Running: true
-        StartedAt: '2022-05-26T07:49:11.400392642Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /var/lib/grafana: { }
-          /var/log/grafana: { }
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=the_password
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: { }
-          /var/lib/postgresql/data: { }
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/nginx: { }
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=the_gpg_key
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: { }
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ''
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 3a25e45db6cd680825463e263b963466b9f9781ed8e3f92f991f71568e22642d
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 1
-        FinishedAt: '2022-06-26T23:30:50.884876362Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 0
-        Restarting: false
-        Running: false
-        StartedAt: '2022-06-26T23:30:49.475537222Z'
-        Status: exited
+        # Ansible managed
+
+        ############################# Grafana Configuration #############################
+
+
+
+        #################################### Paths #####################################
+
+        [paths]
+
+        data=/var/lib/grafana
+
+        logs=/var/log/grafana
+
+        plugins=/usr/share/grafana/plugins
+
+
+        #################################### Server ####################################
+
+        [server]
+
+        http_port=3000
+
+        protocol=http
+
+
+        ################################### Database ###################################
+
+        [database]
+
+        host=127.0.0.1:5432
+
+        name=grafana
+
+        password=the_password
+
+        path=grafana.db
+
+        type=postgres
+
+        user=grafana
+
+
+        ################################## Analytics ###################################
+
+        [analytics]
+
+        check_for_updates=false
+
+        reporting_enabled=false
+
+
+        #################################### Users #####################################
+
+        [users]
+
+        allow_sign_up=false
+
+
+        ################################ Auth.anonymous ################################
+
+        [auth.anonymous]
+
+        enabled=false
+
+
+        ################################# Auth.github ##################################
+
+        [auth.github]
+
+        enabled=false
+
+
+        ################################# Auth.google ##################################
+
+        [auth.google]
+
+        enabled=false
+
+
+        ################################## Auth.proxy ##################################
+
+        [auth.proxy]
+
+        enabled=false
+
+
+        ################################## Auth.basic ##################################
+
+        [auth.basic]
+
+        enabled=true
+
+
+        ################################## Auth.ldap ###################################
+
+        [auth.ldap]
+
+        config_file=/etc/grafana/ldap.toml
+
+        enabled=false
+
+
+        ##################################### Log ######################################
+
+        [log]
+
+        level=info
+
+        mode=console
+
+
+        ################################# Log.console ##################################
+
+        [log.console]
+
+        format=json
+
+        '
+      failed: false
+      invocation:
+        module_args:
+          src: /proc/10876/root/etc/grafana/grafana.ini
+      msg: ''
+      parsed:
+        allow_sign_up: 'false'
+        check_for_updates: 'false'
+        config_file: /etc/grafana/ldap.toml
+        data: /var/lib/grafana
+        enabled: 'false'
+        format: json
+        host: 127.0.0.1:5432
+        http_port: '3000'
+        level: info
+        logs: /var/log/grafana
+        mode: console
+        name: grafana
+        password: the_password
+        path: grafana.db
+        plugins: /usr/share/grafana/plugins
+        protocol: http
+        reporting_enabled: 'false'
+        type: postgres
+        user: grafana
+      skipped: false
+      source: /proc/10876/root/etc/grafana/grafana.ini
+      task: Read config file
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.3.1p1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 3.el7
-      source: rpm
-      version: '1.217'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 22.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '40'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '100'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '261'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '313'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '377'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '393'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '477'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '543'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '566'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '719'
-    ppid: '1'
-    user: dbus
-  - cmdline: ''
-    pid: '721'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '728'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/rpcbind -w
-    pid: '730'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '734'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '738'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '750'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H grafana01 eth0
-    pid: '978'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1038'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '1041'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1044'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '1054'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '1055'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '1056'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '1057'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '1058'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '1059'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1143'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1148'
-    ppid: '1143'
-    user: postfix
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1182'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1184'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1187'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1198'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1199'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1208'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '5192'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6209'
-    ppid: '2'
-    user: root
-  - cmdline: bash
-    pid: '8035'
-    ppid: '10860'
-    user: grafana
-  - cmdline: pickup -l -t unix -u
-    pid: '9723'
-    ppid: '1143'
-    user: postfix
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10256'
-    ppid: '1044'
-    user: root
-  - cmdline: ''
-    pid: '10278'
-    ppid: '2'
-    user: root
-  - cmdline: 'postgres: grafana grafana 127.0.0.1(51456) idle'
-    pid: '10337'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: postgres
-    pid: '10435'
-    ppid: '10256'
-    user: polkitd
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10463'
-    ppid: '1044'
-    user: root
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '10501'
-    ppid: '10463'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '10612'
-    ppid: '10501'
-    user: '101'
-  - cmdline: /usr/bin/docker start -a nginx
-    pid: '10630'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a postgres-grafana
-    pid: '10633'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: checkpointer'
-    pid: '10848'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: background writer'
-    pid: '10849'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: walwriter'
-    pid: '10850'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '10851'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: stats collector'
-    pid: '10852'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '10853'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: /usr/bin/docker start -a grafana
-    pid: '10854'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10860'
-    ppid: '1044'
-    user: root
-  - cmdline: >-
-      grafana-server --homepath=/usr/share/grafana
-      --config=/etc/grafana/grafana.ini --packaging=docker
-      cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
-      cfg:default.paths.logs=/var/log/grafana
-      cfg:default.paths.plugins=/usr/share/grafana/plugins
-      cfg:default.paths.provisioning=/etc/grafana/provisioning
-    pid: '10876'
-    ppid: '10860'
-    user: grafana
-  - cmdline: 'postgres: grafana grafana 127.0.0.1(53010) idle'
-    pid: '18046'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: ''
-    pid: '18107'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1656286197
-    pid: '18162'
-    ppid: '1041'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '18827'
-    ppid: '1187'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '18838'
-    ppid: '18827'
-    user: centos
-  - cmdline: /usr/bin/docker start -a es_kg_sync
-    pid: '19081'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '19100'
-    ppid: '1044'
-    user: root
-  - cmdline: python3 es-kg-sync.py -c /app/etc/config.yml
-    pid: '19116'
-    ppid: '19100'
-    user: root
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-djfboqepprkrrttuvmschbcvhxjboiwa ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656286228.8530865-17347-57189507538309/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '19177'
-    ppid: '18838'
-    user: centos
-  - cmdline: ''
-    pid: '19190'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-djfboqepprkrrttuvmschbcvhxjboiwa ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656286228.8530865-17347-57189507538309/AnsiballZ_process_facts.py
-    pid: '19193'
-    ppid: '19177'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-djfboqepprkrrttuvmschbcvhxjboiwa ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656286228.8530865-17347-57189507538309/AnsiballZ_process_facts.py
-    pid: '19194'
-    ppid: '19193'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656286228.8530865-17347-57189507538309/AnsiballZ_process_facts.py
-    pid: '19195'
-    ppid: '19194'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-visualizer-api
-    pid: '24573'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '24624'
-    ppid: '1044'
-    user: root
-  - cmdline: python ./main.py
-    pid: '24640'
-    ppid: '24624'
-    user: root
-  - cmdline: ''
-    pid: '26061'
-    ppid: '2'
-    user: root
-  - cmdline: bash
-    pid: '28255'
-    ppid: '10256'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1143
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: python
-    pid: 24640
-    port: 3004
-    protocol: tcp
-    stime: 'Thu May 26 07:49:10 2022'
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 1054
-    port: 10050
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:27 2022'
-    user: zabbix
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:33 2022'
-    user: root
-  - address: 0.0.0.0
-    name: postgres
-    pid: 10435
-    port: 5432
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:50 2022'
-    user: polkitd
-  - address: '::1'
-    name: master
-    pid: 1143
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:33 2022'
-    user: root
-  - address: '::'
-    name: grafana-serve
-    pid: 10876
-    port: 3000
-    protocol: tcp
-    stime: 'Tue Apr 26 15:57:06 2022'
-    user: grafana
-  - address: '::'
-    name: postgres
-    pid: 10435
-    port: 5432
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:50 2022'
-    user: polkitd
-udp_listen:
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.3.1p1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 3.el7
+    source: rpm
+    version: '1.217'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-
-
-...
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 22.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '40'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '100'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '261'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '377'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '393'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '477'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '543'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '566'
+  ppid: '2'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '719'
+  ppid: '1'
+  user: dbus
+- cmdline: ''
+  cwd: /
+  pid: '721'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '728'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '730'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '734'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '738'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '750'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H grafana01 eth0
+  cwd: /sbin/
+  pid: '978'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1038'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1041'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1044'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '1054'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1055'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1056'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1057'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1058'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1059'
+  ppid: '1054'
+  user: zabbix
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1143'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1148'
+  ppid: '1143'
+  user: postfix
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1182'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1184'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1187'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1198'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1199'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1208'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5192'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6209'
+  ppid: '2'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '8035'
+  ppid: '10860'
+  user: grafana
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '9723'
+  ppid: '1143'
+  user: postfix
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10256'
+  ppid: '1044'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10278'
+  ppid: '2'
+  user: root
+- cmdline: 'postgres: grafana grafana 127.0.0.1(51456) idle'
+  cwd: /
+  pid: '10337'
+  ppid: '10435'
+  user: polkitd
+- cmdline: postgres
+  cwd: /
+  pid: '10435'
+  ppid: '10256'
+  user: polkitd
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10463'
+  ppid: '1044'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '10501'
+  ppid: '10463'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '10612'
+  ppid: '10501'
+  user: '101'
+- cmdline: /usr/bin/docker start -a nginx
+  cwd: /usr/bin/
+  pid: '10630'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a postgres-grafana
+  cwd: /usr/bin/
+  pid: '10633'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '10848'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '10849'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '10850'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '10851'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '10852'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '10853'
+  ppid: '10435'
+  user: polkitd
+- cmdline: /usr/bin/docker start -a grafana
+  cwd: /usr/bin/
+  pid: '10854'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10860'
+  ppid: '1044'
+  user: root
+- cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini
+    --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
+    cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/usr/share/grafana/plugins
+    cfg:default.paths.provisioning=/etc/grafana/provisioning
+  cwd: /
+  pid: '10876'
+  ppid: '10860'
+  user: grafana
+- cmdline: 'postgres: grafana grafana 127.0.0.1(53010) idle'
+  cwd: /
+  pid: '18046'
+  ppid: '10435'
+  user: polkitd
+- cmdline: ''
+  cwd: /
+  pid: '18107'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1656286197
+  cwd: /usr/lib64/sa/
+  pid: '18162'
+  ppid: '1041'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '18827'
+  ppid: '1187'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '18838'
+  ppid: '18827'
+  user: centos
+- cmdline: /usr/bin/docker start -a es_kg_sync
+  cwd: /usr/bin/
+  pid: '19081'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '19100'
+  ppid: '1044'
+  user: root
+- cmdline: python3 es-kg-sync.py -c /app/etc/config.yml
+  cwd: /
+  pid: '19116'
+  ppid: '19100'
+  user: root
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-djfboqepprkrrttuvmschbcvhxjboiwa
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656286228.8530865-17347-57189507538309/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '19177'
+  ppid: '18838'
+  user: centos
+- cmdline: ''
+  cwd: /
+  pid: '19190'
+  ppid: '2'
+  user: root
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-djfboqepprkrrttuvmschbcvhxjboiwa
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656286228.8530865-17347-57189507538309/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '19193'
+  ppid: '19177'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-djfboqepprkrrttuvmschbcvhxjboiwa ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656286228.8530865-17347-57189507538309/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '19194'
+  ppid: '19193'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656286228.8530865-17347-57189507538309/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '19195'
+  ppid: '19194'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-visualizer-api
+  cwd: /usr/bin/
+  pid: '24573'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '24624'
+  ppid: '1044'
+  user: root
+- cmdline: python ./main.py
+  cwd: /
+  pid: '24640'
+  ppid: '24624'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26061'
+  ppid: '2'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '28255'
+  ppid: '10256'
+  user: root
+software_list:
+- cmd_regexp: grafana-server
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/grafana.yaml'
+    name: Include Grafana specific plugins
+  name: Grafana
+  pkg_regexp: ^grafana
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1143
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: python
+  pid: 24640
+  port: 3004
+  protocol: tcp
+  stime: Thu May 26 07:49:10 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 1054
+  port: 10050
+  protocol: tcp
+  stime: Tue Apr 26 15:55:27 2022
+  user: zabbix
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:33 2022
+  user: root
+- address: 0.0.0.0
+  name: postgres
+  pid: 10435
+  port: 5432
+  protocol: tcp
+  stime: Tue Apr 26 15:56:50 2022
+  user: polkitd
+- address: ::1
+  name: master
+  pid: 1143
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:33 2022
+  user: root
+- address: '::'
+  name: grafana-serve
+  pid: 10876
+  port: 3000
+  protocol: tcp
+  stime: Tue Apr 26 15:57:06 2022
+  user: grafana
+- address: '::'
+  name: postgres
+  pid: 10435
+  port: 5432
+  protocol: tcp
+  stime: Tue Apr 26 15:56:50 2022
+  user: polkitd
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/haproxy/haproxy1.5.18_centos7.6.yaml
+++ b/tests/unit/plugins/action/auto/resources/haproxy/haproxy1.5.18_centos7.6.yaml
@@ -1,140 +1,170 @@
-mocked_plugin_tasks:
-  "Read process environment":
-    plugin_result:
-      failed: false
-      parsed: {
-        "LANG": "en_US.UTF-8",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
-        "OPTIONS": ""
-      }
-  "Check if config file is accesible":
-    expected_args:
-      path: "/etc/haproxy/haproxy.cfg"
-      follow: False
-      get_attributes: True
-      get_mime: True
-      in_docker: True
-    plugin_result:
-      failed: false
-  "Parse config file":
-    plugin_result:
-      failed: false
-      parsed: {
-        "backend static": {
-          "balance": "roundrobin",
-          "server": "static 127.0.0.1:4331 check"
-        },
-        "backend app": {
-          "balance": "roundrobin",
-          "server": [
-            "app1 127.0.0.1:5001 check",
-            "app2 127.0.0.1:5002 check",
-            "app3 127.0.0.1:5003 check",
-            "app4 127.0.0.1:5004 check"
-          ]
-        },
-        "global": {
-          "daemon": null,
-          "chroot": "/var/lib/haproxy",
-          "stats": "socket /var/lib/haproxy/stats",
-          "log": "127.0.0.1 local2",
-          "user": "haproxy",
-          "group": "haproxy",
-          "maxconn": "4000",
-          "pidfile": "/var/run/haproxy.pid"
-        },
-        "frontend micro-http-02": {
-          "bind": "*:83",
-          "default_backend": "micro02",
-          "reqadd": "X-Forwarded-Proto:\\ http"
-        },
-        "backend micro02": {
-          "server": [
-            "loadbalancer-1 192.168.0.142:8080 check",
-            "loadbalancer-2 192.168.0.223:8080 check"
-          ],
-          "balance": "leastconn",
-          "option": [
-            "http-server-close",
-            "forwardfor"
-          ],
-          "timeout": [
-            "http-keep-alive 300",
-            "connect 10s",
-            "server 1m"
-          ],
-          "mode": "http"
-        },
-        "frontend main": {
-          "default_backend": "app",
-          "use_backend": "static          if url_static",
-          "*:5000": null,
-          "acl": [
-            "url_static       path_beg       -i /static /images /javascript /stylesheets",
-            "url_static       path_end       -i .jpg .gif .png .css .js"
-          ]
-        },
-        "defaults": {
-          "retries": "3",
-          "log": "global",
-          "mode": "http",
-          "timeout": [
-            "http-request    10s",
-            "queue           1m",
-            "connect         10s",
-            "client          1m",
-            "server          1m",
-            "http-keep-alive 10s",
-            "check           10s"
-          ],
-          "maxconn": "3000",
-          "option": [
-            "httplog",
-            "dontlognull",
-            "http-server-close",
-            "forwardfor       except 127.0.0.0/8",
-            "redispatch"
-          ]
-        }
-      }
-
+dockers:
+  containers: []
 expected_result:
-  - configuration:
-      backend app:
-        balance: roundrobin
-        server:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 49899
+    protocol: udp
+  - address: 0.0.0.0
+    class: service
+    port: 83
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 5000
+    protocol: tcp
+  configuration:
+    backend app:
+      balance: roundrobin
+      server:
+      - app1 127.0.0.1:5001 check
+      - app2 127.0.0.1:5002 check
+      - app3 127.0.0.1:5003 check
+      - app4 127.0.0.1:5004 check
+    backend micro02:
+      balance: leastconn
+      mode: http
+      option:
+      - http-server-close
+      - forwardfor
+      server:
+      - loadbalancer-1 192.168.0.142:8080 check
+      - loadbalancer-2 192.168.0.223:8080 check
+      timeout:
+      - http-keep-alive 300
+      - connect 10s
+      - server 1m
+    backend static:
+      balance: roundrobin
+      server: static 127.0.0.1:4331 check
+    defaults:
+      log: global
+      maxconn: '3000'
+      mode: http
+      option:
+      - httplog
+      - dontlognull
+      - http-server-close
+      - forwardfor       except 127.0.0.0/8
+      - redispatch
+      retries: '3'
+      timeout:
+      - http-request    10s
+      - queue           1m
+      - connect         10s
+      - client          1m
+      - server          1m
+      - http-keep-alive 10s
+      - check           10s
+    frontend main:
+      '*:5000': null
+      acl:
+      - url_static       path_beg       -i /static /images /javascript /stylesheets
+      - url_static       path_end       -i .jpg .gif .png .css .js
+      default_backend: app
+      use_backend: static          if url_static
+    frontend micro-http-02:
+      bind: '*:83'
+      default_backend: micro02
+      reqadd: X-Forwarded-Proto:\ http
+    global:
+      chroot: /var/lib/haproxy
+      daemon: null
+      group: haproxy
+      log: 127.0.0.1 local2
+      maxconn: '4000'
+      pidfile: /var/run/haproxy.pid
+      stats: socket /var/lib/haproxy/stats
+      user: haproxy
+  discovery_time: '2022-06-16T23:16:05+02:00'
+  files:
+  - name: haproxy.cfg
+    path: /etc/haproxy
+    subtype: generic
+    type: config
+  listening_ports:
+  - 83
+  - 5000
+  - 49899
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: haproxy
+    release: 9.el7_9.1
+    source: rpm
+    version: 1.5.18
+  process:
+    children:
+    - children: []
+      cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+      cwd: /usr/sbin/
+      listening_ports:
+      - 83
+      - 5000
+      pid: '905'
+      ppid: '896'
+      user: haproxy
+    cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+    cwd: /usr/sbin/
+    listening_ports:
+    - 49899
+    pid: '896'
+    ppid: '891'
+    user: haproxy
+  type: HAProxy
+  version:
+  - number: 1.5.18
+    type: package
+mocked_plugin_tasks:
+  Check if config file is accesible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /etc/haproxy/haproxy.cfg
+    plugin_result:
+      failed: false
+  Parse config file:
+    plugin_result:
+      failed: false
+      parsed:
+        backend app:
+          balance: roundrobin
+          server:
           - app1 127.0.0.1:5001 check
           - app2 127.0.0.1:5002 check
           - app3 127.0.0.1:5003 check
           - app4 127.0.0.1:5004 check
-      backend micro02:
-        balance: leastconn
-        mode: http
-        option:
+        backend micro02:
+          balance: leastconn
+          mode: http
+          option:
           - http-server-close
           - forwardfor
-        server:
+          server:
           - loadbalancer-1 192.168.0.142:8080 check
           - loadbalancer-2 192.168.0.223:8080 check
-        timeout:
+          timeout:
           - http-keep-alive 300
           - connect 10s
           - server 1m
-      backend static:
-        balance: roundrobin
-        server: static 127.0.0.1:4331 check
-      defaults:
-        log: global
-        maxconn: '3000'
-        mode: http
-        option:
+        backend static:
+          balance: roundrobin
+          server: static 127.0.0.1:4331 check
+        defaults:
+          log: global
+          maxconn: '3000'
+          mode: http
+          option:
           - httplog
           - dontlognull
           - http-server-close
           - forwardfor       except 127.0.0.0/8
           - redispatch
-        retries: '3'
-        timeout:
+          retries: '3'
+          timeout:
           - http-request    10s
           - queue           1m
           - connect         10s
@@ -142,4321 +172,4405 @@ expected_result:
           - server          1m
           - http-keep-alive 10s
           - check           10s
-      frontend main:
-        '*:5000': null
-        acl:
+        frontend main:
+          '*:5000': null
+          acl:
           - url_static       path_beg       -i /static /images /javascript /stylesheets
           - url_static       path_end       -i .jpg .gif .png .css .js
-        default_backend: app
-        use_backend: static          if url_static
-      frontend micro-http-02:
-        bind: '*:83'
-        default_backend: micro02
-        reqadd: X-Forwarded-Proto:\ http
-      global:
-        chroot: /var/lib/haproxy
-        daemon: null
-        group: haproxy
-        log: 127.0.0.1 local2
-        maxconn: '4000'
-        pidfile: /var/run/haproxy.pid
-        stats: socket /var/lib/haproxy/stats
-        user: haproxy
-    bindings:
-      - address: 0.0.0.0
-        class: service
-        port: 49899
-        protocol: udp
-      - address: 0.0.0.0
-        class: service
-        port: 83
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        port: 5000
-        protocol: tcp
-    discovery_time: '2022-06-16T23:16:05+02:00'
-    files:
-      - name: haproxy.cfg
-        path: /etc/haproxy
-        subtype: generic
-        type: config
-    listening_ports:
-      - 83
-      - 5000
-      - 49899
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: haproxy
-        release: 9.el7_9.1
-        source: rpm
-        version: 1.5.18
-    process:
-      children:
-        - children: [ ]
-          cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-          listening_ports:
-            - 83
-            - 5000
-          pid: '905'
-          ppid: '896'
+          default_backend: app
+          use_backend: static          if url_static
+        frontend micro-http-02:
+          bind: '*:83'
+          default_backend: micro02
+          reqadd: X-Forwarded-Proto:\ http
+        global:
+          chroot: /var/lib/haproxy
+          daemon: null
+          group: haproxy
+          log: 127.0.0.1 local2
+          maxconn: '4000'
+          pidfile: /var/run/haproxy.pid
+          stats: socket /var/lib/haproxy/stats
           user: haproxy
-      cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-      listening_ports:
-        - 49899
-      pid: '896'
-      ppid: '891'
-      user: haproxy
-    type: HAProxy
-    version:
-      - number: 1.5.18
-        type: package
-
-software_list:
-  - cmd_regexp: haproxy .*
-    name: HAProxy
-    pkg_regexp: haproxy
-    custom_tasks:
-      - name: Include HAProxy specific plugins
-        include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/haproxy.yaml"
-    process_type: parent
-    return_children: true
-    return_packages: true
-
-dockers:
-  containers: [ ]
+  Read process environment:
+    plugin_result:
+      failed: false
+      parsed:
+        LANG: en_US.UTF-8
+        OPTIONS: ''
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 packages:
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   apache-commons-collections:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-collections
-      release: 22.el7_2
-      source: rpm
-      version: 3.2.1
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
   apache-commons-daemon:
-    - arch: x86_64
-      epoch: null
-      name: apache-commons-daemon
-      release: 7.el7
-      source: rpm
-      version: 1.0.13
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
   apache-commons-dbcp:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-dbcp
-      release: 17.el7
-      source: rpm
-      version: '1.4'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
   apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
   apache-commons-pool:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-pool
-      release: 9.el7
-      source: rpm
-      version: '1.6'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
   apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-devel
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr-devel
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   apr-util-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-util-devel
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util-devel
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autoconf:
-    - arch: noarch
-      epoch: null
-      name: autoconf
-      release: 11.el7
-      source: rpm
-      version: '2.69'
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
   automake:
-    - arch: noarch
-      epoch: null
-      name: automake
-      release: 3.el7
-      source: rpm
-      version: 1.13.4
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
   avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 16.P2.el7_8.2
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 16.P2.el7_8.2
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 43.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 43.base.el7
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 76.el7_7
-      source: rpm
-      version: 2019.2.32
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 76.el7_7
+    source: rpm
+    version: 2019.2.32
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   centos-indexhtml:
-    - arch: noarch
-      epoch: null
-      name: centos-indexhtml
-      release: 9.el7.centos
-      source: rpm
-      version: '7'
+  - arch: noarch
+    epoch: null
+    name: centos-indexhtml
+    release: 9.el7.centos
+    source: rpm
+    version: '7'
   centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 8.2003.0.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 8.2003.0.el7.centos
+    source: rpm
+    version: '7'
   centos-release-scl-rh:
-    - arch: noarch
-      epoch: null
-      name: centos-release-scl-rh
-      release: 3.el7.centos
-      source: rpm
-      version: '2'
+  - arch: noarch
+    epoch: null
+    name: centos-release-scl-rh
+    release: 3.el7.centos
+    source: rpm
+    version: '2'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 6.el7.centos
-      source: rpm
-      version: '18.5'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 6.el7.centos
+    source: rpm
+    version: '18.5'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
   cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
   cyrus-sasl:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-devel:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-devel
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-devel
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
   devtoolset-7-binutils:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-binutils
-      release: 11.el7
-      source: rpm
-      version: '2.28'
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-binutils
+    release: 11.el7
+    source: rpm
+    version: '2.28'
   devtoolset-7-gcc:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
   devtoolset-7-gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc-c++
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc-c++
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
   devtoolset-7-libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-libstdc++-devel
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-libstdc++-devel
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
   devtoolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: '7.1'
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: '7.1'
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 3.el7
-      source: rpm
-      version: '3.2'
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dwz:
-    - arch: x86_64
-      epoch: null
-      name: dwz
-      release: 3.el7
-      source: rpm
-      version: '0.11'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  ecj:
-    - arch: x86_64
-      epoch: 1
-      name: ecj
-      release: 3.el7
-      source: rpm
-      version: 4.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  expat-devel:
-    - arch: x86_64
-      epoch: null
-      name: expat-devel
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  geronimo-jta:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jta
-      release: 17.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 5.el7
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gperftools-libs:
-    - arch: x86_64
-      epoch: null
-      name: gperftools-libs
-      release: 1.el7
-      source: rpm
-      version: 2.6.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 608c8351
-      source: rpm
-      version: 442df0f8
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 560cfc0a
-      source: rpm
-      version: f2ee9d55
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 28.el7
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  haproxy:
-    - arch: x86_64
-      epoch: null
-      name: haproxy
-      release: 9.el7_9.1
-      source: rpm
-      version: 1.5.18
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  httpd:
-    - arch: x86_64
-      epoch: null
-      name: httpd
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-devel:
-    - arch: x86_64
-      epoch: null
-      name: httpd-devel
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-tools:
-    - arch: x86_64
-      epoch: null
-      name: httpd-tools
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.5.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.49
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 25.el7_7.2
-      source: rpm
-      version: 4.11.0
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 34.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-taglibs-standard:
-    - arch: noarch
-      epoch: 0
-      name: jakarta-taglibs-standard
-      release: 14.el7_1
-      source: rpm
-      version: 1.1.2
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  keepalived:
-    - arch: x86_64
-      epoch: null
-      name: keepalived
-      release: 19.el7
-      source: rpm
-      version: 1.3.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.42.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 43.el7
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 131.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-devel:
-    - arch: x86_64
-      epoch: null
-      name: libdb-devel
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libedit-devel:
-    - arch: x86_64
-      epoch: null
-      name: libedit-devel
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libicu-devel:
-    - arch: x86_64
-      epoch: null
-      name: libicu-devel
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 3.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libtool:
-    - arch: x86_64
-      epoch: null
-      name: libtool
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  llvm-toolset-7-clang:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-clang-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang-libs
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-compiler-rt:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-compiler-rt
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-libomp:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-libomp
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-llvm-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-llvm-libs
-      release: 8.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-devel:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-devel
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-libs
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 16.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 14.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.65
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 61.el7
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-devel:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-devel
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.66.el7
-      source: rpm
-      version: 1.3.0
-  nginx:
-    - arch: x86_64
-      epoch: 1
-      name: nginx
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: nginx-filesystem
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-mod-stream:
-    - arch: x86_64
-      epoch: 1
-      name: nginx-mod-stream
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7
-      source: rpm
-      version: 4.21.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 4.el7_7
-      source: rpm
-      version: 3.44.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openldap-devel:
-    - arch: x86_64
-      epoch: null
-      name: openldap-devel
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Thread-Queue:
-    - arch: noarch
-      epoch: null
-      name: perl-Thread-Queue
-      release: 2.el7
-      source: rpm
-      version: '3.02'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: perl-srpm-macros
-      release: 8.el7
-      source: rpm
-      version: '1'
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pgdg-redhat-repo:
-    - arch: noarch
-      epoch: null
-      name: pgdg-redhat-repo
-      release: '24'
-      source: rpm
-      version: '42.0'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql11:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-contrib
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-devel:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-devel
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-libs
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-server
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 27.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-devel:
-    - arch: x86_64
-      epoch: null
-      name: python-devel
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 9.el7_8
-      source: rpm
-      version: 2.6.0
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python2-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python2-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-devel:
-    - arch: x86_64
-      epoch: null
-      name: python3-devel
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-rpm-generators:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-generators
-      release: 2.el7
-      source: rpm
-      version: '6'
-  python3-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redhat-rpm-config:
-    - arch: noarch
-      epoch: null
-      name: redhat-rpm-config
-      release: 88.el7.centos
-      source: rpm
-      version: 9.1.0
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 52.el7
-      source: rpm
-      version: 8.24.0
-  scl-utils:
-    - arch: x86_64
-      epoch: null
-      name: scl-utils
-      release: 19.el7
-      source: rpm
-      version: '20130529'
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 6.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 9.el7
-      source: rpm
-      version: 1.8.23
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  tomcat:
-    - arch: noarch
-      epoch: 0
-      name: tomcat
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-admin-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-admin-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-el-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-el-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-jsp-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-jsp-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-lib:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-lib
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 8.el7
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019c
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021a
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 20.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 167.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  zip:
-    - arch: x86_64
-      epoch: null
-      name: zip
-      release: 11.el7
-      source: rpm
-      version: '3.0'
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '50'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '65'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '197'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '198'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '274'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '275'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '276'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '277'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '279'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '294'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '295'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '297'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '298'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '299'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '412'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '444'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '466'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '469'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '511'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '513'
-    ppid: '1'
-    user: dbus
-  - cmdline: ''
-    pid: '514'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '556'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '559'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '564'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '566'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '567'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '581'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/rpcbind -w
-    pid: '582'
-    ppid: '1'
-    user: rpc
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H loadbalancer-2 eth0
-    pid: '830'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap start
-    pid: '887'
-    ppid: '1'
-    user: tomcat
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '888'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '889'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
-    pid: '891'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-    pid: '896'
-    ppid: '891'
-    user: haproxy
-  - cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-    pid: '905'
-    ppid: '896'
-    user: haproxy
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1074'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1077'
-    ppid: '1074'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1079'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1083'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1089'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1090'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1092'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: master process /usr/sbin/nginx'
-    pid: '1151'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '1156'
-    ppid: '1151'
-    user: nginx
-  - cmdline: 'nginx: worker process'
-    pid: '1157'
-    ppid: '1151'
-    user: nginx
-  - cmdline: ''
-    pid: '2129'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '2661'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '4117'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '4171'
-    ppid: '1074'
-    user: postfix
-  - cmdline: ''
-    pid: '4175'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '4188'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '4973'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '5659'
-    ppid: '1079'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '5661'
-    ppid: '5659'
-    user: centos
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-rgltwuazpjfexbnaxnpeyhpbxdhxxwob ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py' && sleep 0
-    pid: '5810'
-    ppid: '5661'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-rgltwuazpjfexbnaxnpeyhpbxdhxxwob ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py
-    pid: '5823'
-    ppid: '5810'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-rgltwuazpjfexbnaxnpeyhpbxdhxxwob ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py
-    pid: '5824'
-    ppid: '5823'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py
-    pid: '5825'
-    ppid: '5824'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '15591'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '15593'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '15594'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '15595'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '15596'
-    ppid: '889'
-    user: apache
-  - cmdline: ''
-    pid: '16751'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '19692'
-    ppid: '1079'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '19694'
-    ppid: '19692'
-    user: centos
-  - cmdline: -bash
-    pid: '19695'
-    ppid: '19694'
-    user: centos
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20808'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20809'
-    ppid: '20808'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20810'
-    ppid: '20808'
-    user: root
-  - cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
-    pid: '21221'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: logger'
-    pid: '21223'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: checkpointer'
-    pid: '21225'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: background writer'
-    pid: '21226'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: walwriter'
-    pid: '21227'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '21228'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: stats collector'
-    pid: '21229'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '21230'
-    ppid: '21221'
-    user: postgres
-  - cmdline: ''
-    pid: '27662'
-    ppid: '2'
-    user: root
-tcp_listen:
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: tcp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 1151
-    port: 81
-    protocol: tcp
-    stime: Wed Apr 27 08:37:54 2022
-    user: root
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 1151
-    port: 82
-    protocol: tcp
-    stime: Wed Apr 27 08:37:54 2022
-    user: root
-  - address: 0.0.0.0
-    name: haproxy
-    pid: 905
-    port: 83
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: haproxy
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1079
-    port: 22
-    protocol: tcp
-    stime: Wed Apr 27 08:37:53 2022
-    user: root
-  - address: 127.0.0.1
-    name: postmaster
-    pid: 21221
-    port: 5432
-    protocol: tcp
-    stime: Thu Apr 28 13:53:52 2022
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1074
-    port: 25
-    protocol: tcp
-    stime: Wed Apr 27 08:37:53 2022
-    user: root
-  - address: 0.0.0.0
-    name: haproxy
-    pid: 905
-    port: 5000
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: haproxy
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: tcp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: '::'
-    name: java
-    pid: 887
-    port: 8080
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: tomcat
-  - address: '::'
-    name: httpd
-    pid: 889
-    port: 80
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: root
-  - address: '::'
-    name: 'nginx:'
-    pid: 1151
-    port: 81
-    protocol: tcp
-    stime: Wed Apr 27 08:37:54 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1079
-    port: 22
-    protocol: tcp
-    stime: Wed Apr 27 08:37:53 2022
-    user: root
-  - address: ::1
-    name: postmaster
-    pid: 21221
-    port: 5432
-    protocol: tcp
-    stime: Thu Apr 28 13:53:52 2022
-    user: postgres
-  - address: ::1
-    name: master
-    pid: 1074
-    port: 25
-    protocol: tcp
-    stime: Wed Apr 27 08:37:53 2022
-    user: root
-  - address: 127.0.0.1
-    name: java
-    pid: 887
-    port: 8005
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 887
-    port: 8009
-    protocol: tcp
-    stime: Wed Apr 27 08:37:52 2022
-    user: tomcat
-udp_listen:
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 830
-    port: 68
-    protocol: udp
-    stime: Wed Apr 27 08:37:52 2022
-    user: root
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 581
-    port: 323
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: chrony
-  - address: 0.0.0.0
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 3.el7
+    source: rpm
+    version: '3.2'
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dwz:
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  expat-devel:
+  - arch: x86_64
+    epoch: null
+    name: expat-devel
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 5.el7
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gperftools-libs:
+  - arch: x86_64
+    epoch: null
+    name: gperftools-libs
+    release: 1.el7
+    source: rpm
+    version: 2.6.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 560cfc0a
+    source: rpm
+    version: f2ee9d55
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 28.el7
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  haproxy:
+  - arch: x86_64
+    epoch: null
     name: haproxy
-    pid: 896
-    port: 49899
-    protocol: udp
-    stime: Wed Apr 27 08:37:52 2022
-    user: haproxy
-  - address: 0.0.0.0
+    release: 9.el7_9.1
+    source: rpm
+    version: 1.5.18
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  httpd:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-devel:
+  - arch: x86_64
+    epoch: null
+    name: httpd-devel
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-tools:
+  - arch: x86_64
+    epoch: null
+    name: httpd-tools
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.5.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.49
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 25.el7_7.2
+    source: rpm
+    version: 4.11.0
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 34.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  keepalived:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 19.el7
+    source: rpm
+    version: 1.3.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.42.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 43.el7
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 131.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-devel:
+  - arch: x86_64
+    epoch: null
+    name: libdb-devel
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libedit-devel:
+  - arch: x86_64
+    epoch: null
+    name: libedit-devel
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libicu-devel:
+  - arch: x86_64
+    epoch: null
+    name: libicu-devel
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 3.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libtool:
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  llvm-toolset-7-clang:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-clang-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang-libs
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-compiler-rt:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-compiler-rt
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-libomp:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-libomp
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-llvm-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-llvm-libs
+    release: 8.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-runtime:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-devel:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-devel
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-libs
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 16.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 14.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.65
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 61.el7
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-devel:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-devel
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.66.el7
+    source: rpm
+    version: 1.3.0
+  nginx:
+  - arch: x86_64
+    epoch: 1
+    name: nginx
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: nginx-filesystem
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-mod-stream:
+  - arch: x86_64
+    epoch: 1
+    name: nginx-mod-stream
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7
+    source: rpm
+    version: 4.21.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 4.el7_7
+    source: rpm
+    version: 3.44.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openldap-devel:
+  - arch: x86_64
+    epoch: null
+    name: openldap-devel
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Thread-Queue:
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pgdg-redhat-repo:
+  - arch: noarch
+    epoch: null
+    name: pgdg-redhat-repo
+    release: '24'
+    source: rpm
+    version: '42.0'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql11:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-devel:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-devel
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 27.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-devel:
+  - arch: x86_64
+    epoch: null
+    name: python-devel
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 9.el7_8
+    source: rpm
+    version: 2.6.0
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python2-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python2-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 582
-    port: 750
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
-  - address: ::1
-    name: chronyd
-    pid: 581
-    port: 323
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 750
-    protocol: udp
-    stime: Wed Apr 27 08:37:48 2022
-    user: rpc
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 52.el7
+    source: rpm
+    version: 8.24.0
+  scl-utils:
+  - arch: x86_64
+    epoch: null
+    name: scl-utils
+    release: 19.el7
+    source: rpm
+    version: '20130529'
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 6.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 9.el7
+    source: rpm
+    version: 1.8.23
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 8.el7
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019c
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 20.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 167.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '197'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '198'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '275'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '276'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '277'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '279'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '295'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '297'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '412'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '444'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '466'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '469'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '511'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '513'
+  ppid: '1'
+  user: dbus
+- cmdline: ''
+  cwd: /
+  pid: '514'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '556'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '559'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '564'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '566'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '567'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '581'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '582'
+  ppid: '1'
+  user: rpc
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H loadbalancer-2 eth0
+  cwd: /sbin/
+  pid: '830'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+    -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+    -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+    -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+    start
+  cwd: /usr/lib/jvm/jre/bin/
+  pid: '887'
+  ppid: '1'
+  user: tomcat
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '888'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '889'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
+  cwd: /usr/sbin/
+  pid: '891'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '896'
+  ppid: '891'
+  user: haproxy
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '905'
+  ppid: '896'
+  user: haproxy
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1074'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1077'
+  ppid: '1074'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1079'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1083'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1089'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1090'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1092'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: master process /usr/sbin/nginx'
+  cwd: /
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1156'
+  ppid: '1151'
+  user: nginx
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1157'
+  ppid: '1151'
+  user: nginx
+- cmdline: ''
+  cwd: /
+  pid: '2129'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2661'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4117'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '4171'
+  ppid: '1074'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '4175'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4188'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4973'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '5659'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '5661'
+  ppid: '5659'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-rgltwuazpjfexbnaxnpeyhpbxdhxxwob
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '5810'
+  ppid: '5661'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-rgltwuazpjfexbnaxnpeyhpbxdhxxwob
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '5823'
+  ppid: '5810'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-rgltwuazpjfexbnaxnpeyhpbxdhxxwob ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '5824'
+  ppid: '5823'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '5825'
+  ppid: '5824'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15591'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15593'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15594'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15595'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15596'
+  ppid: '889'
+  user: apache
+- cmdline: ''
+  cwd: /
+  pid: '16751'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '19692'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '19694'
+  ppid: '19692'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '19695'
+  ppid: '19694'
+  user: centos
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20808'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20809'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20810'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
+  cwd: /usr/pgsql-11/bin/
+  pid: '21221'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: logger'
+  cwd: /
+  pid: '21223'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '21225'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '21226'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '21227'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '21228'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '21229'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '21230'
+  ppid: '21221'
+  user: postgres
+- cmdline: ''
+  cwd: /
+  pid: '27662'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: haproxy .*
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/haproxy.yaml
+    name: Include HAProxy specific plugins
+  name: HAProxy
+  pkg_regexp: haproxy
+  process_type: parent
+  return_children: true
+  return_packages: true
+tcp_listen:
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 82
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 83
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 5000
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: java
+  pid: 887
+  port: 8080
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: httpd
+  pid: 889
+  port: 80
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: '::'
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: ::1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: ::1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: 887
+  port: 8005
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 887
+  port: 8009
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 830
+  port: 68
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: 0.0.0.0
+  name: haproxy
+  pid: 896
+  port: 49899
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/hobbit/hobbit_tests.yaml
+++ b/tests/unit/plugins/action/auto/resources/hobbit/hobbit_tests.yaml
@@ -1,1251 +1,1208 @@
-expected_result:
-  - discovery_time: '2022-07-04T19:06:24+02:00'
-    bindings:
-      - address: 0.0.0.0
-        class: service
-        port: 53314
-        protocol: tcp
-    listening_ports:
-      - 53314
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: hobbit package
-        release: 18.el7
-        source: rpm
-        version: 1.2.7
-    process:
-      cmdline: /usr/bin/hobbitlaunch -b config.yaml
-      listening_ports:
-        - 53314
-      pid: '121'
-      ppid: '0'
-      user: root
-    type: Hobbit
-    version:
-      - number: 1.2.7
-        type: package
-software_list:
-  - cmd_regexp: hobbitlaunch
-    name: Hobbit
-    pkg_regexp: hobbit
-    process_type: parent
-    return_children: false
-    return_packages: true
-packages:
-  hobbit package:
-    - arch: x86_64
-      epoch: null
-      name: hobbit package
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: {}
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: 'sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25'
-      LogPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: []
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /var/lib/grafana: {}
-          /var/log/grafana: {}
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: {}
-          /var/lib/postgresql/data: {}
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: {}
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: b24594442304d945f9c35e4b642ccba765c5365057dc16ae005f6fc8daeb3acb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 6f351ba6edbac3d1cae20899298786d7f0b28903eb478891cef8994ca9e5499c
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-04T17:06:22.637620047Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 489
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-04T17:06:23.457026632Z'
-        Status: running
-processes:
-  - cmdline: /usr/bin/hobbitlaunch -b config.yaml
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: b24594442304d945f9c35e4b642ccba765c5365057dc16ae005f6fc8daeb3acb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 6f351ba6edbac3d1cae20899298786d7f0b28903eb478891cef8994ca9e5499c
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-04T17:06:22.637620047Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 489
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-04T17:06:23.457026632Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 53314
+    protocol: tcp
+  discovery_time: '2022-07-04T19:06:24+02:00'
+  listening_ports:
+  - 53314
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: hobbit package
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  process:
+    cmdline: /usr/bin/hobbitlaunch -b config.yaml
+    cwd: /usr/bin/
+    listening_ports:
+    - 53314
     pid: '121'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
+  type: Hobbit
+  version:
+  - number: 1.2.7
+    type: package
+packages:
+  hobbit package:
+  - arch: x86_64
+    epoch: null
+    name: hobbit package
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/bin/hobbitlaunch -b config.yaml
+  cwd: /usr/bin/
+  pid: '121'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: hobbitlaunch
+  name: Hobbit
+  pkg_regexp: hobbit
+  process_type: parent
+  return_children: false
+  return_packages: true
 tcp_listen:
-  - address: 0.0.0.0
-    name: port1
-    pid: 121
-    port: 53314
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: port2
-    pid: 122
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: port3
-    pid: 123
-    port: 52914
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port4
-    pid: 124
-    port: 53213
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port5
-    pid: 125
-    port: 52614
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
+- address: 0.0.0.0
+  name: port1
+  pid: 121
+  port: 53314
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: port2
+  pid: 122
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: port3
+  pid: 123
+  port: 52914
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port4
+  pid: 124
+  port: 53213
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port5
+  pid: 125
+  port: 52614
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
 udp_listen:
-  - address: 0.0.0.0
-    name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/hpe_data_protector/HPE_tests.yaml
+++ b/tests/unit/plugins/action/auto/resources/hpe_data_protector/HPE_tests.yaml
@@ -1,3834 +1,3789 @@
-expected_result:
-  - discovery_time: '2022-07-04T10:29:05+02:00'
-    bindings:
-      - address: 0.0.0.0
-        class: service
-        port: 53314
-        protocol: tcp
-    listening_ports:
-      - 53314
-    packages:
-      - arch: 'x86_64'
-        epoch: null
-        name: 'OpenView Storage Data Protector'
-        release: '18.el7'
-        source: 'rpm'
-        version: '1.2.7'
-    process:
-      cmdline: /usr/bin/bomni -b config.yaml
-      listening_ports:
-        - 53314
-      pid: '121'
-      ppid: '0'
-      user: root
-    type: hpe_data_protector
-    version:
-      - number: '1.2.7'
-        type: 'package'
-software_list:
-  - cmd_regexp: bomni
-    name: hpe_data_protector
-    pkg_regexp: >-
-      DATA-PROTECTOR|HP Data Protector|OmniBack|OpenView Storage Data
-      Protector|OB2-CORE|OB2-DAP
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: {}
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: 'sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25'
-      LogPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: []
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /var/lib/grafana: {}
-          /var/log/grafana: {}
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: {}
-          /var/lib/postgresql/data: {}
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: {}
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: c14df23839be53583458cfdee85f491022f548f1c9402b7ecc3cd1b99d9b0f8b
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 6501a993e8a27002a9a855652876d82525b003bb7ecc9b9b3ef5f6420a6aac6a
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-04T08:29:03.046796277Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 26377
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-04T08:29:03.905156773Z'
-        Status: running
-packages:
-  OpenView Storage Data Protector:
-    - arch: x86_64
-      epoch: null
-      name: OpenView Storage Data Protector
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.3.1p1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 3.el7
-      source: rpm
-      version: '1.217'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 22.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/bin/bomni -b config.yaml
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: c14df23839be53583458cfdee85f491022f548f1c9402b7ecc3cd1b99d9b0f8b
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 6501a993e8a27002a9a855652876d82525b003bb7ecc9b9b3ef5f6420a6aac6a
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-04T08:29:03.046796277Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 26377
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-04T08:29:03.905156773Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 53314
+    protocol: tcp
+  discovery_time: '2022-07-04T10:29:05+02:00'
+  listening_ports:
+  - 53314
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: OpenView Storage Data Protector
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  process:
+    cmdline: /usr/bin/bomni -b config.yaml
+    cwd: /usr/bin/
+    listening_ports:
+    - 53314
     pid: '121'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
-tcp_listen:
-  - address: 0.0.0.0
-    name: port1
-    pid: 121
-    port: 53314
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: port2
-    pid: 122
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: port3
-    pid: 123
-    port: 52914
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port4
-    pid: 124
-    port: 53213
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port5
-    pid: 125
-    port: 52614
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: hpe_data_protector
+  version:
+  - number: 1.2.7
+    type: package
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  OpenView Storage Data Protector:
+  - arch: x86_64
+    epoch: null
+    name: OpenView Storage Data Protector
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.3.1p1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 3.el7
+    source: rpm
+    version: '1.217'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 22.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/bin/bomni -b config.yaml
+  cwd: /usr/bin/
+  pid: '121'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: bomni
+  name: hpe_data_protector
+  pkg_regexp: DATA-PROTECTOR|HP Data Protector|OmniBack|OpenView Storage Data Protector|OB2-CORE|OB2-DAP
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 0.0.0.0
+  name: port1
+  pid: 121
+  port: 53314
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: port2
+  pid: 122
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: port3
+  pid: 123
+  port: 52914
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port4
+  pid: 124
+  port: 53213
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port5
+  pid: 125
+  port: 52614
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/iis/windows_server_2012_r2_iis_8.5.yaml
+++ b/tests/unit/plugins/action/auto/resources/iis/windows_server_2012_r2_iis_8.5.yaml
@@ -1,2359 +1,2400 @@
-mocked_plugin_tasks:
-  "Run command to gather version":
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      stdout_lines:
-        - 8.5.9600.16384
-  "Run command to gather sites":
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      stdout_lines:
-        - "{\"name\":\"Default Web Site\",\"protocol\":\"http\",\"bindings\":\"*:80:\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
-        - "{\"name\":\"Default Web Site\",\"protocol\":\"net.tcp\",\"bindings\":\"808:*\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
-        - "{\"name\":\"Default Web Site\",\"protocol\":\"net.msmq\",\"bindings\":\"localhost\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
-        - "{\"name\":\"Default Web Site\",\"protocol\":\"msmq.formatname\",\"bindings\":\"localhost\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
-        - "{\"name\":\"Default Web Site\",\"protocol\":\"net.pipe\",\"bindings\":\"*\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
-        - "{\"name\":\"Default Web Site\",\"protocol\":\"https\",\"bindings\":\"*:443:\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
-        - "{\"name\":\"Extra Web Site\",\"protocol\":\"http\",\"bindings\":\"*:800:demo.iometrics.io\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
-
-expected_tasks_calls_mode_strict: false
-expected_tasks_calls:
-  Run command to gather version: 1
-  Run command to gather sites: 1
-
-software_list:
-  - cmd_regexp: w3wp.exe
-    custom_tasks:
-      - name: Include IIS specific plugins
-        include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/iis.yaml"
-    name: IIS
-    process_type: single
-    return_children: false
-    return_packages: false
-
+dockers: {}
 expected_result:
-  - discovery_time: '2022-09-10T14:29:21+02:00'
-    endpoints:
-      - extra_data:
-          name: Default Web Site
-          path: "%SystemDrive%\\inetpub\\wwwroot"
-        type: generic
-        uri: http://0.0.0.0:80
-      - extra_data:
-          name: Default Web Site
-          path: "%SystemDrive%\\inetpub\\wwwroot"
-        type: generic
-        uri: net.tcp://0.0.0.0:808
-      - extra_data:
-          name: Default Web Site
-          path: "%SystemDrive%\\inetpub\\wwwroot"
-        type: generic
-        uri: net.msmq://localhost
-      - extra_data:
-          name: Default Web Site
-          path: "%SystemDrive%\\inetpub\\wwwroot"
-        type: generic
-        uri: https://0.0.0.0:443
-      - extra_data:
-          name: Extra Web Site
-          path: "%SystemDrive%\\inetpub\\wwwroot"
-        type: generic
-        uri: http://demo.iometrics.io:800
-    bindings:
-      - address: 0.0.0.0
-        class: service
-        port: 80
-        protocol: http
-      - class: service
-        port: 808
-        protocol: net.tcp
-      - class: service
-        port: 1801
-        protocol: net.msmq
-      - address: 0.0.0.0
-        class: service
-        port: 443
-        protocol: https
-      - address: 0.0.0.0
-        class: service
-        port: 800
-        protocol: http
-    listening_ports:
-      - 80
-      - 808
-      - 1801
-      - 443
-      - 800
-    process:
-      cmdline: c:\windows\system32\inetsrv\w3wp.exe -ap "DefaultAppPool" -v "v4.0" -l "webengine4.dll" -a .\pipe\iisipm4bbd81c3-b78e-4b0c-9df3-5be8fdd12d40 -h "C:\inetpub\temp\apppools\DefaultAppPool\DefaultAppPool.config" -w "\" -m 0 -t 20 -ta 0"
-      pid: "1964"
-      ppid: "4972"
-      user: IIS APPPOOL\DefaultAppPool
-    type: IIS
-    version:
-      - number: 8.5.9600.16384
-        type: file
-
-dockers: { }
-packages:
-  Azure Data Studio:
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 543259
-      help_link: https://github.com/Microsoft/azuredatastudio
-      help_telephone: null
-      install_date: '20220530'
-      install_location: C:\Program Files\Azure Data Studio\
-      install_source: null
-      language: null
-      modify_path: null
-      name: Azure Data Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\Azure Data Studio\unins000.exe"'
-      url_info_about: https://github.com/Microsoft/azuredatastudio
-      url_update_info: https://github.com/Microsoft/azuredatastudio
-      vendor: null
-      version: 1.35.0
-      version_major: 1
-      version_minor: 35
-      windows_installer: null
-  Browser for SQL Server 2017:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11312
-      help_link: https://go.microsoft.com/fwlink/?LinkId=90959
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
-      name: Browser for SQL Server 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Cloudbase-Init 0.9.11:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 121670
-      help_link: ''
-      help_telephone: ''
-      install_date: '20170320'
-      install_location: ''
-      install_source: C:\UnattendResources\
-      language: 1033
-      modify_path: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
-      name: Cloudbase-Init 0.9.11
-      no_repair: null
-      publisher: Cloudbase Solutions Srl
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 0.9.11.0
-      version_major: 0
-      version_minor: 9
-      windows_installer: 1
-  Integration Services:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 91264
-      help_link: https://support.microsoft.com
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{4938A647-7EA4-4496-A843-5E338B91C07E}v15.0.2000.168\x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
-      name: Integration Services
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.168
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Analysis Services OLE DB Provider:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 243952
-      help_link: https://go.microsoft.com/fwlink/?LinkId=52159
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}v15.0.2000.832\x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
-      name: Microsoft Analysis Services OLE DB Provider
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.832
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 499504
-      help_link: https://go.microsoft.com/fwlink/?LinkId=52159
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}v15.0.2000.832\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
-      name: Microsoft Analysis Services OLE DB Provider
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.832
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Help Viewer 2.3:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 12438
-      help_link: https://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: null
-      install_date: null
-      install_location: C:\Program Files (x86)\Microsoft Help Viewer\v2.3\
-      install_source: null
-      language: null
-      modify_path: msiexec.exe /I{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      name: Microsoft Help Viewer 2.3
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: msiexec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      url_info_about: null
-      url_update_info: https://go.microsoft.com/fwlink/?LinkId=133408
-      vendor: null
-      version: 2.3.28307
-      version_major: '2'
-      version_minor: '0'
-      windows_installer: null
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 13260
-      help_link: https://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}v2.3.28307\redist\
-      language: 1033
-      modify_path: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      name: Microsoft Help Viewer 2.3
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 2.3.28307
-      version_major: 2
-      version_minor: 3
-      windows_installer: 1
-  Microsoft ODBC Driver 13 for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 5124
-      help_link: https://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
-      name: Microsoft ODBC Driver 13 for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft ODBC Driver 17 for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 7184
-      help_link: https://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{853997DA-6FCB-4FB9-918E-E0FF881FAF65}v17.7.2.1\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
-      name: Microsoft ODBC Driver 17 for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 17.7.2.1
-      version_major: 17
-      version_minor: 7
-      windows_installer: 1
-  Microsoft OLE DB Driver for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8480
-      help_link: https://go.microsoft.com/fwlink/?linkid=870127
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{9D6F8754-28E9-4940-B319-3FC8588CF18F}v18.5.0.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
-      name: Microsoft OLE DB Driver for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 18.5.0.0
-      version_major: 18
-      version_minor: 5
-      windows_installer: 1
-  'Microsoft SQL Server 2012 Native Client ':
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8160
-      help_link: http://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{9D93D367-A2CC-4378-BD63-79EF3FE76C78}v11.4.7462.6\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
-      name: 'Microsoft SQL Server 2012 Native Client '
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 11.4.7462.6
-      version_major: 11
-      version_minor: 4
-      windows_installer: 1
-  Microsoft SQL Server 2017 (64-bit):
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: null
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server 2017 (64-bit)
-      no_repair: null
-      publisher: null
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: 1
-      uninstall_string: null
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: null
-      version_major: null
-      version_minor: null
-      windows_installer: null
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: null
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server 2017 (64-bit)
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\Microsoft SQL Server\140\Setup Bootstrap\SQL2017\x64\SetupARP.exe"'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: null
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft SQL Server 2017 RsFx Driver:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 344
-      help_link: https://go.microsoft.com/fwlink/?LinkId=101173
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
-      name: Microsoft SQL Server 2017 RsFx Driver
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft SQL Server 2017 Setup (English):
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 39588
-      help_link: https://go.microsoft.com/fwlink/?LinkId=101173
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
-      name: Microsoft SQL Server 2017 Setup (English)
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  'Microsoft SQL Server 2017 T-SQL Language Service ':
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8116
-      help_link: https://go.microsoft.com/fwlink/?LinkID=150605
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
-      name: 'Microsoft SQL Server 2017 T-SQL Language Service '
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft SQL Server Management Studio - 18.11.1:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 2881605
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server Management Studio - 18.11.1
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{88f77b67-7f88-4b59-b93b-c9f2546b649c}\SSMS-Setup-ENU.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 15.0.18410.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft VSS Writer for SQL Server 2017:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 3256
-      help_link: https://go.microsoft.com/fwlink/?LinkId=90958
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
-      name: Microsoft VSS Writer for SQL Server 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 21062
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe" /modify'
-      name: Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 12.0.40664.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 17602
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe" /modify'
-      name: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 12.0.40664.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 11784
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{010792BA-551A-3AC0-A7EF-0FAB4156C382}v12.0.40664\packages\vcRuntimeAdditional_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
-      name: Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 2524
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{53CF6934-A98D-3D84-9146-FC4EDF3D5641}v12.0.40664\packages\vcRuntimeMinimum_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
-      name: Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 9456
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{D401961D-3A20-3AC7-943B-6139D5BD490A}v12.0.40664\packages\vcRuntimeAdditional_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
-      name: Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 2076
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{8122DAB1-ED4D-3676-BB0A-CA368196543E}v12.0.40664\packages\vcRuntimeMinimum_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
-      name: Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 22598
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe" /modify'
-      name: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.30.30704.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 19969
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe" /modify'
-      name: Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.30.30704.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11724
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}v14.30.30704\packages\vcRuntimeAdditional_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
-      name: Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 2168
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{662A0088-6FCD-45DD-9EA7-68674058AED5}v14.30.30704\packages\vcRuntimeMinimum_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
-      name: Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 10164
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{BF08E976-B92E-4336-B56F-2171179476C4}v14.30.30704\packages\vcRuntimeAdditional_x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
-      name: Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 1744
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}v14.30.30704\packages\vcRuntimeMinimum_x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
-      name: Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual Studio Tools for Applications 2017:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 19606
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe" /modify'
-      name: Microsoft Visual Studio Tools for Applications 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 15.0.26717
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 2844
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{10AB056B-1B8C-3E9E-95CC-43C33EB88513}v15.0.26717\packages\vsta_hostingcore_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
-      name: Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.26717
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 3828
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}v15.0.26717\packages\vsta_hostingcore_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
-      name: Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.26717
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  PgBouncer 1.16.1:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: 'PgBouncer: Connection pooler for PostgreSQL, packaged by EnterpriseDB'
-      contact: ''
-      estimated_size: 25101
-      help_link: ''
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files (x86)\PgBouncer
-      install_source: null
-      language: null
-      modify_path: null
-      name: PgBouncer 1.16.1
-      no_repair: '1'
-      publisher: EnterpriseDB
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files (x86)\PgBouncer\uninstall-pgbouncer.exe"'
-      url_info_about: ''
-      url_update_info: null
-      vendor: null
-      version: 1.16.1-1
-      version_major: 1
-      version_minor: 16
-      windows_installer: null
-  'PostgreSQL 14 ':
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: The PostgreSQL RDBMS, version 14, packaged by EnterpriseDB
-      contact: ''
-      estimated_size: 829400
-      help_link: http://www.postgresql.org/docs
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files\PostgreSQL\14
-      install_source: null
-      language: null
-      modify_path: null
-      name: 'PostgreSQL 14 '
-      no_repair: '1'
-      publisher: PostgreSQL Global Development Group
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\PostgreSQL\14\uninstall-postgresql.exe"'
-      url_info_about: http://www.postgresql.org/
-      url_update_info: null
-      vendor: null
-      version: '14'
-      version_major: 14
-      version_minor: 0
-      windows_installer: null
-  SQL Server 2017 Batch Parser:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 744
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
-      name: SQL Server 2017 Batch Parser
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Common Files:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 21464
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
-      name: SQL Server 2017 Common Files
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 760
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
-      name: SQL Server 2017 Common Files
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Connection Info:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 264
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
-      name: SQL Server 2017 Connection Info
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 884
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
-      name: SQL Server 2017 Connection Info
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 DMF:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 1376
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
-      name: SQL Server 2017 DMF
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 408
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
-      name: SQL Server 2017 DMF
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Database Engine Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 72372
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
-      name: SQL Server 2017 Database Engine Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 285556
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
-      name: SQL Server 2017 Database Engine Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Database Engine Shared:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 87436
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
-      name: SQL Server 2017 Database Engine Shared
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11884
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
-      name: SQL Server 2017 Database Engine Shared
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 SQL Diagnostics:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 516
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
-      name: SQL Server 2017 SQL Diagnostics
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Shared Management Objects:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 5908
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
-      name: SQL Server 2017 Shared Management Objects
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 12528
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
-      name: SQL Server 2017 Shared Management Objects
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Shared Management Objects Extensions:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 4952
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
-      name: SQL Server 2017 Shared Management Objects Extensions
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 532
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
-      name: SQL Server 2017 Shared Management Objects Extensions
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 XEvent:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 84
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
-      name: SQL Server 2017 XEvent
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 732
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
-      name: SQL Server 2017 XEvent
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server Management Studio:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 4796
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{3A6E604C-766B-46F2-8E2D-4371B4CDF858}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
-      name: SQL Server Management Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 215640
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
-      name: SQL Server Management Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  SQL Server Management Studio for Analysis Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 358312
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
-      name: SQL Server Management Studio for Analysis Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  SQL Server Management Studio for Reporting Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 26840
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{D91AA5D8-1080-487B-83B6-622061902012}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
-      name: SQL Server Management Studio for Reporting Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  SSMS Post Install Tasks:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 296
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{7AEA9B43-10CD-4D33-B116-621B81A45490}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
-      name: SSMS Post Install Tasks
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Visual Studio 2017 Isolated Shell for SSMS:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 412588
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{AAA9F15B-AF45-4562-9991-93A848D3A902}v15.0.28307.421\redist\
-      language: 1033
-      modify_path: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
-      name: Visual Studio 2017 Isolated Shell for SSMS
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.28307.421
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  psqlODBC 13.00.0000:
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: ODBC drivers for PostgreSQL, packaged by EnterpriseDB
-      contact: ''
-      estimated_size: 13676
-      help_link: ''
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files\PostgreSQL\psqlODBC
-      install_source: null
-      language: null
-      modify_path: null
-      name: psqlODBC 13.00.0000
-      no_repair: '1'
-      publisher: EnterpriseDB
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\PostgreSQL\psqlODBC\uninstall-psqlodbc.exe"'
-      url_info_about: ''
-      url_update_info: null
-      vendor: null
-      version: 13.00.0000-2
-      version_major: 13
-      version_minor: 0
-      windows_installer: null
-processes:
-  - cmdline: null
-    pid: '0'
-    ppid: '0'
-    user: null
-  - cmdline: null
-    pid: '4'
-    ppid: '0'
-    user: null
-  - cmdline: null
-    pid: '192'
-    ppid: '4'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '284'
-    ppid: '276'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '336'
-    ppid: '328'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: wininit.exe
-    pid: '344'
-    ppid: '276'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: winlogon.exe
-    pid: '372'
-    ppid: '328'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '432'
-    ppid: '344'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\lsass.exe'
-    pid: '440'
-    ppid: '344'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\svchost.exe -k DcomLaunch'
-    pid: '496'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\svchost.exe -k RPCSS'
-    pid: '524'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"LogonUI.exe" /flags:0x0'
-    pid: '624'
-    ppid: '372'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"dwm.exe"'
-    pid: '632'
-    ppid: '372'
-    user: Window Manager\DWM-1
-  - cmdline: 'C:\windows\System32\svchost.exe -k LocalServiceNetworkRestricted'
-    pid: '652'
-    ppid: '432'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: 'C:\windows\system32\svchost.exe -k netsvcs'
-    pid: '708'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\svchost.exe -k LocalService'
-    pid: '800'
-    ppid: '432'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: 'C:\windows\system32\svchost.exe -k NetworkService'
-    pid: '888'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: 'C:\windows\system32\svchost.exe -k LocalServiceNoNetwork'
-    pid: '292'
-    ppid: '432'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: 'C:\windows\System32\spoolsv.exe'
-    pid: '444'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\System32\svchost.exe -k utcsvc'
-    pid: '1040'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: >-
-      "C:\Program Files (x86)\PgBouncer\bin\pgbouncer.exe" --service "C:\Program
-      Files (x86)\PgBouncer\share\pgbouncer.ini"
-    pid: '1076'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: >-
-      "C:\Program Files\PostgreSQL\14\bin\pg_ctl.exe" runservice -N
-      "postgresql-x64-14" -D "C:\Program Files\PostgreSQL\14\data" -w
-    pid: '1176'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:\Program Files\Microsoft SQL
-      Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlceip.exe" -Service SQLEXPRESS
-    pid: '1240'
-    ppid: '432'
-    user: NT SERVICE\SQLTELEMETRY$SQLEXPRESS
-  - cmdline: >-
-      "C:\Program Files\PostgreSQL\14\bin\postgres.exe" -D "C:\Program
-      Files\PostgreSQL\14\data"
-    pid: '1248'
-    ppid: '1176'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '\??\C:\windows\system32\conhost.exe 0x4'
-    pid: '1256'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forklog" "5308"
-      "5312" "0"
-    pid: '1304'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5212"
-      "-x5"
-    pid: '1336'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5224"
-      "-x3"
-    pid: '1344'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5204"
-      "-x6"
-    pid: '1352'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkavlauncher"
-      "5196"
-    pid: '1360'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkcol" "5188"'
-    pid: '1368'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkbgworker=0"
-      "5180"
-    pid: '1376'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe"'
-    pid: '1420'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\System32\svchost.exe -k LocalSystemNetworkRestricted'
-    pid: '1444'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\System32\svchost.exe -k termsvcs'
-    pid: '2028'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: 'C:\windows\system32\svchost.exe -k NetworkServiceNetworkRestricted'
-    pid: '1052'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: null
-    pid: '2772'
-    ppid: '2764'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: winlogon.exe
-    pid: '2800'
-    ppid: '2764'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"dwm.exe"'
-    pid: '2856'
-    ppid: '2800'
-    user: Window Manager\DWM-2
-  - cmdline: 'taskhostex.exe '
-    pid: '3008'
-    ppid: '708'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: rdpclip
-    pid: '880'
-    ppid: '2028'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: 'C:\windows\Explorer.EXE'
-    pid: '2144'
-    ppid: '2176'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: 'C:\windows\System32\msdtc.exe'
-    pid: '1836'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:\Program Files\Microsoft SQL
-      Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe" -sSQLEXPRESS
-    pid: '1904'
-    ppid: '432'
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - cmdline: >-
-      C:/telegraf/telegraf.exe -config C:/telegraf/telegraf.conf
-      -config-directory C:/telegraf/telegraf.d/
-    pid: '6120'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: >-
-      "C:\winlogbeat\winlogbeat.exe" -c "C:\winlogbeat\winlogbeat.yml"
-      -path.home "C:\winlogbeat" -path.data "C:\ProgramData\winlogbeat"
-      -path.logs "C:\ProgramData\winlogbeat\logs"
-    pid: '772'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\wbem\wmiprvse.exe'
-    pid: '1292'
-    ppid: '496'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: 'C:\windows\system32\svchost.exe -k apphost'
-    pid: '2560'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\svchost.exe -k iissvcs'
-    pid: '4972'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: >-
-      c:\windows\system32\inetsrv\w3wp.exe -ap "DefaultAppPool" -v "v4.0" -l
-      "webengine4.dll" -a .\pipe\iisipm4bbd81c3-b78e-4b0c-9df3-5be8fdd12d40 -h
-      "C:\inetpub\temp\apppools\DefaultAppPool\DefaultAppPool.config" -w "\" -m
-      0 -t 20 -ta 0"
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 80
+    protocol: http
+  - class: service
+    port: 808
+    protocol: net.tcp
+  - class: service
+    port: 1801
+    protocol: net.msmq
+  - address: 0.0.0.0
+    class: service
+    port: 443
+    protocol: https
+  - address: 0.0.0.0
+    class: service
+    port: 800
+    protocol: http
+  discovery_time: '2022-09-10T14:29:21+02:00'
+  endpoints:
+  - extra_data:
+      name: Default Web Site
+      path: '%SystemDrive%\inetpub\wwwroot'
+    type: generic
+    uri: http://0.0.0.0:80
+  - extra_data:
+      name: Default Web Site
+      path: '%SystemDrive%\inetpub\wwwroot'
+    type: generic
+    uri: net.tcp://0.0.0.0:808
+  - extra_data:
+      name: Default Web Site
+      path: '%SystemDrive%\inetpub\wwwroot'
+    type: generic
+    uri: net.msmq://localhost
+  - extra_data:
+      name: Default Web Site
+      path: '%SystemDrive%\inetpub\wwwroot'
+    type: generic
+    uri: https://0.0.0.0:443
+  - extra_data:
+      name: Extra Web Site
+      path: '%SystemDrive%\inetpub\wwwroot'
+    type: generic
+    uri: http://demo.iometrics.io:800
+  listening_ports:
+  - 80
+  - 808
+  - 1801
+  - 443
+  - 800
+  process:
+    cmdline: c:\windows\system32\inetsrv\w3wp.exe -ap "DefaultAppPool" -v "v4.0" -l
+      "webengine4.dll" -a .\pipe\iisipm4bbd81c3-b78e-4b0c-9df3-5be8fdd12d40 -h "C:\inetpub\temp\apppools\DefaultAppPool\DefaultAppPool.config"
+      -w "\" -m 0 -t 20 -ta 0"
+    cwd: /
     pid: '1964'
     ppid: '4972'
     user: IIS APPPOOL\DefaultAppPool
-  - cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
-    pid: '2496'
-    ppid: '2144'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '\??\C:\windows\system32\conhost.exe 0x4'
-    pid: '5788'
-    ppid: '2496'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\windows\system32\ServerManager.exe" '
-    pid: '1604'
-    ppid: '2144'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: 'C:\windows\system32\WinrsHost.exe -Embedding'
-    pid: '5200'
-    ppid: '496'
-    user: TEST-NORM-WIN01\iometrics
-  - cmdline: '\??\C:\windows\system32\conhost.exe 0x4'
-    pid: '588'
-    ppid: '5200'
-    user: TEST-NORM-WIN01\iometrics
-  - cmdline: >-
-      C:\windows\system32\cmd.exe /C PowerShell -NoProfile -NonInteractive
-      -ExecutionPolicy Unrestricted -EncodedCommand
-      UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
-    pid: '5344'
-    ppid: '5200'
-    user: TEST-NORM-WIN01\iometrics
-  - cmdline: >-
-      PowerShell  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted
-      -EncodedCommand
-      UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
-    pid: '3212'
-    ppid: '5344'
-    user: TEST-NORM-WIN01\iometrics
-  - cmdline: >-
-      "C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe"  -NoProfile
-      -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand
-      JgBjAGgAYwBwAC4AYwBvAG0AIAA2ADUAMAAwADEAIAA+ACAAJABuAHUAbABsAAoAaQBmACAAKAAkAFAAUwBWAGUAcgBzAGkAbwBuAFQAYQBiAGwAZQAuAFAAUwBWAGUAcgBzAGkAbwBuACAALQBsAHQAIABbAFYAZQByAHMAaQBvAG4AXQAiADMALgAwACIAKQAgAHsACgAnAHsAIgBmAGEAaQBsAGUAZAAiADoAdAByAHUAZQAsACIAbQBzAGcAIgA6ACIAQQBuAHMAaQBiAGwAZQAgAHIAZQBxAHUAaQByAGUAcwAgAFAAbwB3AGUAcgBTAGgAZQBsAGwAIAB2ADMALgAwACAAbwByACAAbgBlAHcAZQByACIAfQAnAAoAZQB4AGkAdAAgADEACgB9AAoAJABlAHgAZQBjAF8AdwByAGEAcABwAGUAcgBfAHMAdAByACAAPQAgACQAaQBuAHAAdQB0ACAAfAAgAE8AdQB0AC0AUwB0AHIAaQBuAGcACgAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAgAD0AIAAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAF8AcwB0AHIALgBTAHAAbABpAHQAKABAACgAIgBgADAAYAAwAGAAMABgADAAIgApACwAIAAyACwAIABbAFMAdAByAGkAbgBnAFMAcABsAGkAdABPAHAAdABpAG8AbgBzAF0AOgA6AFIAZQBtAG8AdgBlAEUAbQBwAHQAeQBFAG4AdAByAGkAZQBzACkACgBJAGYAIAAoAC0AbgBvAHQAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAuAEwAZQBuAGcAdABoACAALQBlAHEAIAAyACkAIAB7ACAAdABoAHIAbwB3ACAAIgBpAG4AdgBhAGwAaQBkACAAcABhAHkAbABvAGEAZAAiACAAfQAKAFMAZQB0AC0AVgBhAHIAaQBhAGIAbABlACAALQBOAGEAbQBlACAAagBzAG8AbgBfAHIAYQB3ACAALQBWAGEAbAB1AGUAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADEAXQAKACQAZQB4AGUAYwBfAHcAcgBhAHAAcABlAHIAIAA9ACAAWwBTAGMAcgBpAHAAdABCAGwAbwBjAGsAXQA6ADoAQwByAGUAYQB0AGUAKAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADAAXQApAAoAJgAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAA==
-    pid: '3156'
-    ppid: '3212'
-    user: TEST-NORM-WIN01\iometrics
+  type: IIS
+  version:
+  - number: 8.5.9600.16384
+    type: file
+expected_tasks_calls:
+  Run command to gather sites: 1
+  Run command to gather version: 1
+expected_tasks_calls_mode_strict: false
+mocked_plugin_tasks:
+  Run command to gather sites:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      stdout_lines:
+      - '{"name":"Default Web Site","protocol":"http","bindings":"*:80:","physical_path":"%SystemDrive%\\inetpub\\wwwroot"}'
+      - '{"name":"Default Web Site","protocol":"net.tcp","bindings":"808:*","physical_path":"%SystemDrive%\\inetpub\\wwwroot"}'
+      - '{"name":"Default Web Site","protocol":"net.msmq","bindings":"localhost","physical_path":"%SystemDrive%\\inetpub\\wwwroot"}'
+      - '{"name":"Default Web Site","protocol":"msmq.formatname","bindings":"localhost","physical_path":"%SystemDrive%\\inetpub\\wwwroot"}'
+      - '{"name":"Default Web Site","protocol":"net.pipe","bindings":"*","physical_path":"%SystemDrive%\\inetpub\\wwwroot"}'
+      - '{"name":"Default Web Site","protocol":"https","bindings":"*:443:","physical_path":"%SystemDrive%\\inetpub\\wwwroot"}'
+      - '{"name":"Extra Web Site","protocol":"http","bindings":"*:800:demo.iometrics.io","physical_path":"%SystemDrive%\\inetpub\\wwwroot"}'
+  Run command to gather version:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      stdout_lines:
+      - 8.5.9600.16384
+packages:
+  Azure Data Studio:
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 543259
+    help_link: https://github.com/Microsoft/azuredatastudio
+    help_telephone: null
+    install_date: '20220530'
+    install_location: C:\Program Files\Azure Data Studio\
+    install_source: null
+    language: null
+    modify_path: null
+    name: Azure Data Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\Azure Data Studio\unins000.exe"'
+    url_info_about: https://github.com/Microsoft/azuredatastudio
+    url_update_info: https://github.com/Microsoft/azuredatastudio
+    vendor: null
+    version: 1.35.0
+    version_major: 1
+    version_minor: 35
+    windows_installer: null
+  Browser for SQL Server 2017:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11312
+    help_link: https://go.microsoft.com/fwlink/?LinkId=90959
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
+    name: Browser for SQL Server 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Cloudbase-Init 0.9.11:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 121670
+    help_link: ''
+    help_telephone: ''
+    install_date: '20170320'
+    install_location: ''
+    install_source: C:\UnattendResources\
+    language: 1033
+    modify_path: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
+    name: Cloudbase-Init 0.9.11
+    no_repair: null
+    publisher: Cloudbase Solutions Srl
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 0.9.11.0
+    version_major: 0
+    version_minor: 9
+    windows_installer: 1
+  Integration Services:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 91264
+    help_link: https://support.microsoft.com
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{4938A647-7EA4-4496-A843-5E338B91C07E}v15.0.2000.168\x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
+    name: Integration Services
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.168
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Analysis Services OLE DB Provider:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 243952
+    help_link: https://go.microsoft.com/fwlink/?LinkId=52159
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}v15.0.2000.832\x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
+    name: Microsoft Analysis Services OLE DB Provider
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.832
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 499504
+    help_link: https://go.microsoft.com/fwlink/?LinkId=52159
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}v15.0.2000.832\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
+    name: Microsoft Analysis Services OLE DB Provider
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.832
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Help Viewer 2.3:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 12438
+    help_link: https://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: null
+    install_date: null
+    install_location: C:\Program Files (x86)\Microsoft Help Viewer\v2.3\
+    install_source: null
+    language: null
+    modify_path: msiexec.exe /I{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    name: Microsoft Help Viewer 2.3
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: msiexec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    url_info_about: null
+    url_update_info: https://go.microsoft.com/fwlink/?LinkId=133408
+    vendor: null
+    version: 2.3.28307
+    version_major: '2'
+    version_minor: '0'
+    windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 13260
+    help_link: https://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}v2.3.28307\redist\
+    language: 1033
+    modify_path: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    name: Microsoft Help Viewer 2.3
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 2.3.28307
+    version_major: 2
+    version_minor: 3
+    windows_installer: 1
+  Microsoft ODBC Driver 13 for SQL Server:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 5124
+    help_link: https://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
+    name: Microsoft ODBC Driver 13 for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft ODBC Driver 17 for SQL Server:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 7184
+    help_link: https://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{853997DA-6FCB-4FB9-918E-E0FF881FAF65}v17.7.2.1\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
+    name: Microsoft ODBC Driver 17 for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 17.7.2.1
+    version_major: 17
+    version_minor: 7
+    windows_installer: 1
+  Microsoft OLE DB Driver for SQL Server:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8480
+    help_link: https://go.microsoft.com/fwlink/?linkid=870127
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{9D6F8754-28E9-4940-B319-3FC8588CF18F}v18.5.0.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
+    name: Microsoft OLE DB Driver for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 18.5.0.0
+    version_major: 18
+    version_minor: 5
+    windows_installer: 1
+  'Microsoft SQL Server 2012 Native Client ':
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8160
+    help_link: http://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{9D93D367-A2CC-4378-BD63-79EF3FE76C78}v11.4.7462.6\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
+    name: 'Microsoft SQL Server 2012 Native Client '
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 11.4.7462.6
+    version_major: 11
+    version_minor: 4
+    windows_installer: 1
+  Microsoft SQL Server 2017 (64-bit):
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: null
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server 2017 (64-bit)
+    no_repair: null
+    publisher: null
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: 1
+    uninstall_string: null
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: null
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: null
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server 2017 (64-bit)
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\Microsoft SQL Server\140\Setup Bootstrap\SQL2017\x64\SetupARP.exe"'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: null
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft SQL Server 2017 RsFx Driver:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 344
+    help_link: https://go.microsoft.com/fwlink/?LinkId=101173
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
+    name: Microsoft SQL Server 2017 RsFx Driver
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft SQL Server 2017 Setup (English):
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 39588
+    help_link: https://go.microsoft.com/fwlink/?LinkId=101173
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
+    name: Microsoft SQL Server 2017 Setup (English)
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  'Microsoft SQL Server 2017 T-SQL Language Service ':
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8116
+    help_link: https://go.microsoft.com/fwlink/?LinkID=150605
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
+    name: 'Microsoft SQL Server 2017 T-SQL Language Service '
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft SQL Server Management Studio - 18.11.1:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 2881605
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server Management Studio - 18.11.1
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{88f77b67-7f88-4b59-b93b-c9f2546b649c}\SSMS-Setup-ENU.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 15.0.18410.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft VSS Writer for SQL Server 2017:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 3256
+    help_link: https://go.microsoft.com/fwlink/?LinkId=90958
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
+    name: Microsoft VSS Writer for SQL Server 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 21062
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"
+      /modify'
+    name: Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 12.0.40664.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 17602
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"
+      /modify'
+    name: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 12.0.40664.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 11784
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{010792BA-551A-3AC0-A7EF-0FAB4156C382}v12.0.40664\packages\vcRuntimeAdditional_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
+    name: Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 2524
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{53CF6934-A98D-3D84-9146-FC4EDF3D5641}v12.0.40664\packages\vcRuntimeMinimum_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
+    name: Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 9456
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{D401961D-3A20-3AC7-943B-6139D5BD490A}v12.0.40664\packages\vcRuntimeAdditional_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
+    name: Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 2076
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{8122DAB1-ED4D-3676-BB0A-CA368196543E}v12.0.40664\packages\vcRuntimeMinimum_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
+    name: Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 22598
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"
+      /modify'
+    name: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.30.30704.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 19969
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"
+      /modify'
+    name: Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.30.30704.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11724
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}v14.30.30704\packages\vcRuntimeAdditional_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
+    name: Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 2168
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{662A0088-6FCD-45DD-9EA7-68674058AED5}v14.30.30704\packages\vcRuntimeMinimum_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
+    name: Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 10164
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{BF08E976-B92E-4336-B56F-2171179476C4}v14.30.30704\packages\vcRuntimeAdditional_x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
+    name: Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 1744
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}v14.30.30704\packages\vcRuntimeMinimum_x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
+    name: Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual Studio Tools for Applications 2017:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 19606
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"
+      /modify'
+    name: Microsoft Visual Studio Tools for Applications 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 15.0.26717
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 2844
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{10AB056B-1B8C-3E9E-95CC-43C33EB88513}v15.0.26717\packages\vsta_hostingcore_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
+    name: Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.26717
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 3828
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}v15.0.26717\packages\vsta_hostingcore_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
+    name: Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.26717
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  PgBouncer 1.16.1:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: 'PgBouncer: Connection pooler for PostgreSQL, packaged by EnterpriseDB'
+    contact: ''
+    estimated_size: 25101
+    help_link: ''
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files (x86)\PgBouncer
+    install_source: null
+    language: null
+    modify_path: null
+    name: PgBouncer 1.16.1
+    no_repair: '1'
+    publisher: EnterpriseDB
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files (x86)\PgBouncer\uninstall-pgbouncer.exe"'
+    url_info_about: ''
+    url_update_info: null
+    vendor: null
+    version: 1.16.1-1
+    version_major: 1
+    version_minor: 16
+    windows_installer: null
+  'PostgreSQL 14 ':
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: The PostgreSQL RDBMS, version 14, packaged by EnterpriseDB
+    contact: ''
+    estimated_size: 829400
+    help_link: http://www.postgresql.org/docs
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files\PostgreSQL\14
+    install_source: null
+    language: null
+    modify_path: null
+    name: 'PostgreSQL 14 '
+    no_repair: '1'
+    publisher: PostgreSQL Global Development Group
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\PostgreSQL\14\uninstall-postgresql.exe"'
+    url_info_about: http://www.postgresql.org/
+    url_update_info: null
+    vendor: null
+    version: '14'
+    version_major: 14
+    version_minor: 0
+    windows_installer: null
+  SQL Server 2017 Batch Parser:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 744
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
+    name: SQL Server 2017 Batch Parser
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Common Files:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 21464
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
+    name: SQL Server 2017 Common Files
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 760
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
+    name: SQL Server 2017 Common Files
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Connection Info:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 264
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
+    name: SQL Server 2017 Connection Info
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 884
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
+    name: SQL Server 2017 Connection Info
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 DMF:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 1376
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
+    name: SQL Server 2017 DMF
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 408
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
+    name: SQL Server 2017 DMF
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Database Engine Services:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 72372
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
+    name: SQL Server 2017 Database Engine Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 285556
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
+    name: SQL Server 2017 Database Engine Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Database Engine Shared:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 87436
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
+    name: SQL Server 2017 Database Engine Shared
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11884
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
+    name: SQL Server 2017 Database Engine Shared
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 SQL Diagnostics:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 516
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
+    name: SQL Server 2017 SQL Diagnostics
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Shared Management Objects:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 5908
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
+    name: SQL Server 2017 Shared Management Objects
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 12528
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
+    name: SQL Server 2017 Shared Management Objects
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Shared Management Objects Extensions:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 4952
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
+    name: SQL Server 2017 Shared Management Objects Extensions
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 532
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
+    name: SQL Server 2017 Shared Management Objects Extensions
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 XEvent:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 84
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
+    name: SQL Server 2017 XEvent
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 732
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
+    name: SQL Server 2017 XEvent
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server Management Studio:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 4796
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{3A6E604C-766B-46F2-8E2D-4371B4CDF858}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
+    name: SQL Server Management Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 215640
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
+    name: SQL Server Management Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  SQL Server Management Studio for Analysis Services:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 358312
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
+    name: SQL Server Management Studio for Analysis Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  SQL Server Management Studio for Reporting Services:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 26840
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{D91AA5D8-1080-487B-83B6-622061902012}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
+    name: SQL Server Management Studio for Reporting Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  SSMS Post Install Tasks:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 296
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{7AEA9B43-10CD-4D33-B116-621B81A45490}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
+    name: SSMS Post Install Tasks
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Visual Studio 2017 Isolated Shell for SSMS:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 412588
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{AAA9F15B-AF45-4562-9991-93A848D3A902}v15.0.28307.421\redist\
+    language: 1033
+    modify_path: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
+    name: Visual Studio 2017 Isolated Shell for SSMS
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.28307.421
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  psqlODBC 13.00.0000:
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: ODBC drivers for PostgreSQL, packaged by EnterpriseDB
+    contact: ''
+    estimated_size: 13676
+    help_link: ''
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files\PostgreSQL\psqlODBC
+    install_source: null
+    language: null
+    modify_path: null
+    name: psqlODBC 13.00.0000
+    no_repair: '1'
+    publisher: EnterpriseDB
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\PostgreSQL\psqlODBC\uninstall-psqlodbc.exe"'
+    url_info_about: ''
+    url_update_info: null
+    vendor: null
+    version: 13.00.0000-2
+    version_major: 13
+    version_minor: 0
+    windows_installer: null
+processes:
+- cmdline: null
+  cwd: /
+  pid: '0'
+  ppid: '0'
+  user: null
+- cmdline: null
+  cwd: /
+  pid: '4'
+  ppid: '0'
+  user: null
+- cmdline: null
+  cwd: /
+  pid: '192'
+  ppid: '4'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: null
+  cwd: /
+  pid: '284'
+  ppid: '276'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: null
+  cwd: /
+  pid: '336'
+  ppid: '328'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: wininit.exe
+  cwd: /
+  pid: '344'
+  ppid: '276'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: winlogon.exe
+  cwd: /
+  pid: '372'
+  ppid: '328'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: null
+  cwd: /
+  pid: '432'
+  ppid: '344'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\lsass.exe
+  cwd: /
+  pid: '440'
+  ppid: '344'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k DcomLaunch
+  cwd: /
+  pid: '496'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k RPCSS
+  cwd: /
+  pid: '524'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"LogonUI.exe" /flags:0x0'
+  cwd: /
+  pid: '624'
+  ppid: '372'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"dwm.exe"'
+  cwd: /
+  pid: '632'
+  ppid: '372'
+  user: Window Manager\DWM-1
+- cmdline: C:\windows\System32\svchost.exe -k LocalServiceNetworkRestricted
+  cwd: /
+  pid: '652'
+  ppid: '432'
+  user: NT AUTHORITY\LOCAL SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k netsvcs
+  cwd: /
+  pid: '708'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k LocalService
+  cwd: /
+  pid: '800'
+  ppid: '432'
+  user: NT AUTHORITY\LOCAL SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k NetworkService
+  cwd: /
+  pid: '888'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k LocalServiceNoNetwork
+  cwd: /
+  pid: '292'
+  ppid: '432'
+  user: NT AUTHORITY\LOCAL SERVICE
+- cmdline: C:\windows\System32\spoolsv.exe
+  cwd: /
+  pid: '444'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\System32\svchost.exe -k utcsvc
+  cwd: /
+  pid: '1040'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\Program Files (x86)\PgBouncer\bin\pgbouncer.exe" --service "C:\Program
+    Files (x86)\PgBouncer\share\pgbouncer.ini"'
+  cwd: /
+  pid: '1076'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\Program Files\PostgreSQL\14\bin\pg_ctl.exe" runservice -N "postgresql-x64-14"
+    -D "C:\Program Files\PostgreSQL\14\data" -w'
+  cwd: /
+  pid: '1176'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlceip.exe"
+    -Service SQLEXPRESS'
+  cwd: /
+  pid: '1240'
+  ppid: '432'
+  user: NT SERVICE\SQLTELEMETRY$SQLEXPRESS
+- cmdline: '"C:\Program Files\PostgreSQL\14\bin\postgres.exe" -D "C:\Program Files\PostgreSQL\14\data"'
+  cwd: /
+  pid: '1248'
+  ppid: '1176'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: '1256'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forklog" "5308" "5312"
+    "0"'
+  cwd: '"C:/'
+  pid: '1304'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5212"
+    "-x5"'
+  cwd: '"C:/'
+  pid: '1336'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5224"
+    "-x3"'
+  cwd: '"C:/'
+  pid: '1344'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5204"
+    "-x6"'
+  cwd: '"C:/'
+  pid: '1352'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkavlauncher" "5196"'
+  cwd: '"C:/'
+  pid: '1360'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkcol" "5188"'
+  cwd: '"C:/'
+  pid: '1368'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkbgworker=0" "5180"'
+  cwd: '"C:/'
+  pid: '1376'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe"'
+  cwd: /
+  pid: '1420'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+  cwd: /
+  pid: '1444'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\System32\svchost.exe -k termsvcs
+  cwd: /
+  pid: '2028'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k NetworkServiceNetworkRestricted
+  cwd: /
+  pid: '1052'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: null
+  cwd: /
+  pid: '2772'
+  ppid: '2764'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: winlogon.exe
+  cwd: /
+  pid: '2800'
+  ppid: '2764'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"dwm.exe"'
+  cwd: /
+  pid: '2856'
+  ppid: '2800'
+  user: Window Manager\DWM-2
+- cmdline: 'taskhostex.exe '
+  cwd: /
+  pid: '3008'
+  ppid: '708'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: rdpclip
+  cwd: /
+  pid: '880'
+  ppid: '2028'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\Explorer.EXE
+  cwd: /
+  pid: '2144'
+  ppid: '2176'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\System32\msdtc.exe
+  cwd: /
+  pid: '1836'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe"
+    -sSQLEXPRESS'
+  cwd: /
+  pid: '1904'
+  ppid: '432'
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- cmdline: C:/telegraf/telegraf.exe -config C:/telegraf/telegraf.conf -config-directory
+    C:/telegraf/telegraf.d/
+  cwd: C:/telegraf/
+  pid: '6120'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\winlogbeat\winlogbeat.exe" -c "C:\winlogbeat\winlogbeat.yml" -path.home
+    "C:\winlogbeat" -path.data "C:\ProgramData\winlogbeat" -path.logs "C:\ProgramData\winlogbeat\logs"'
+  cwd: /
+  pid: '772'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\wbem\wmiprvse.exe
+  cwd: /
+  pid: '1292'
+  ppid: '496'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k apphost
+  cwd: /
+  pid: '2560'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k iissvcs
+  cwd: /
+  pid: '4972'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: c:\windows\system32\inetsrv\w3wp.exe -ap "DefaultAppPool" -v "v4.0" -l
+    "webengine4.dll" -a .\pipe\iisipm4bbd81c3-b78e-4b0c-9df3-5be8fdd12d40 -h "C:\inetpub\temp\apppools\DefaultAppPool\DefaultAppPool.config"
+    -w "\" -m 0 -t 20 -ta 0"
+  cwd: /
+  pid: '1964'
+  ppid: '4972'
+  user: IIS APPPOOL\DefaultAppPool
+- cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
+  cwd: /
+  pid: '2496'
+  ppid: '2144'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: '5788'
+  ppid: '2496'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: '"C:\windows\system32\ServerManager.exe" '
+  cwd: /
+  pid: '1604'
+  ppid: '2144'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\system32\WinrsHost.exe -Embedding
+  cwd: /
+  pid: '5200'
+  ppid: '496'
+  user: TEST-NORM-WIN01\iometrics
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: '588'
+  ppid: '5200'
+  user: TEST-NORM-WIN01\iometrics
+- cmdline: C:\windows\system32\cmd.exe /C PowerShell -NoProfile -NonInteractive -ExecutionPolicy
+    Unrestricted -EncodedCommand UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
+  cwd: /
+  pid: '5344'
+  ppid: '5200'
+  user: TEST-NORM-WIN01\iometrics
+- cmdline: PowerShell  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand
+    UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
+  cwd: /
+  pid: '3212'
+  ppid: '5344'
+  user: TEST-NORM-WIN01\iometrics
+- cmdline: '"C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe"  -NoProfile
+    -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand JgBjAGgAYwBwAC4AYwBvAG0AIAA2ADUAMAAwADEAIAA+ACAAJABuAHUAbABsAAoAaQBmACAAKAAkAFAAUwBWAGUAcgBzAGkAbwBuAFQAYQBiAGwAZQAuAFAAUwBWAGUAcgBzAGkAbwBuACAALQBsAHQAIABbAFYAZQByAHMAaQBvAG4AXQAiADMALgAwACIAKQAgAHsACgAnAHsAIgBmAGEAaQBsAGUAZAAiADoAdAByAHUAZQAsACIAbQBzAGcAIgA6ACIAQQBuAHMAaQBiAGwAZQAgAHIAZQBxAHUAaQByAGUAcwAgAFAAbwB3AGUAcgBTAGgAZQBsAGwAIAB2ADMALgAwACAAbwByACAAbgBlAHcAZQByACIAfQAnAAoAZQB4AGkAdAAgADEACgB9AAoAJABlAHgAZQBjAF8AdwByAGEAcABwAGUAcgBfAHMAdAByACAAPQAgACQAaQBuAHAAdQB0ACAAfAAgAE8AdQB0AC0AUwB0AHIAaQBuAGcACgAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAgAD0AIAAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAF8AcwB0AHIALgBTAHAAbABpAHQAKABAACgAIgBgADAAYAAwAGAAMABgADAAIgApACwAIAAyACwAIABbAFMAdAByAGkAbgBnAFMAcABsAGkAdABPAHAAdABpAG8AbgBzAF0AOgA6AFIAZQBtAG8AdgBlAEUAbQBwAHQAeQBFAG4AdAByAGkAZQBzACkACgBJAGYAIAAoAC0AbgBvAHQAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAuAEwAZQBuAGcAdABoACAALQBlAHEAIAAyACkAIAB7ACAAdABoAHIAbwB3ACAAIgBpAG4AdgBhAGwAaQBkACAAcABhAHkAbABvAGEAZAAiACAAfQAKAFMAZQB0AC0AVgBhAHIAaQBhAGIAbABlACAALQBOAGEAbQBlACAAagBzAG8AbgBfAHIAYQB3ACAALQBWAGEAbAB1AGUAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADEAXQAKACQAZQB4AGUAYwBfAHcAcgBhAHAAcABlAHIAIAA9ACAAWwBTAGMAcgBpAHAAdABCAGwAbwBjAGsAXQA6ADoAQwByAGUAYQB0AGUAKAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADAAXQApAAoAJgAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAA=='
+  cwd: /
+  pid: '3156'
+  ppid: '3212'
+  user: TEST-NORM-WIN01\iometrics
+software_list:
+- cmd_regexp: w3wp.exe
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/iis.yaml
+    name: Include IIS specific plugins
+  name: IIS
+  process_type: single
+  return_children: false
+  return_packages: false
 tcp_listen:
-  - address: '::'
-    name: sqlservr.exe
-    pid: 1904
-    port: 49350
-    protocol: tcp
-    stime: Mon May 30 17:47:16 2022
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - address: '::'
-    name: services.exe
-    pid: 432
-    port: 49169
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: lsass.exe
-    pid: 440
-    port: 49167
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: spoolsv.exe
-    pid: 444
-    port: 49155
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: svchost.exe
-    pid: 708
-    port: 49154
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: svchost.exe
-    pid: 652
-    port: 49153
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: '::'
-    name: wininit.exe
-    pid: 344
-    port: 49152
-    protocol: tcp
-    stime: Mon May 30 17:21:40 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: System
-    pid: 4
-    port: 47001
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: ::1
-    name: pgbouncer.exe
-    pid: 1076
-    port: 6432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: System
-    pid: 4
-    port: 5986
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System
-    pid: 4
-    port: 5985
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: postgres.exe
-    pid: 1248
-    port: 5432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: svchost.exe
-    pid: 2028
-    port: 3389
-    protocol: tcp
-    stime: Mon May 30 17:21:53 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: System
-    pid: 4
-    port: 445
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: svchost.exe
-    pid: 524
-    port: 135
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: System
-    pid: 4
-    port: 80
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: sqlservr.exe
-    pid: 1904
-    port: 49350
-    protocol: tcp
-    stime: Mon May 30 17:47:16 2022
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - address: 0.0.0.0
-    name: services.exe
-    pid: 432
-    port: 49169
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: lsass.exe
-    pid: 440
-    port: 49167
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: spoolsv.exe
-    pid: 444
-    port: 49155
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 708
-    port: 49154
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 652
-    port: 49153
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: 0.0.0.0
-    name: wininit.exe
-    pid: 344
-    port: 49152
-    protocol: tcp
-    stime: Mon May 30 17:21:40 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 127.0.0.1
-    name: pgbouncer.exe
-    pid: 1076
-    port: 6432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: postgres.exe
-    pid: 1248
-    port: 5432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 2028
-    port: 3389
-    protocol: tcp
-    stime: Mon May 30 17:21:53 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 192.168.0.94
-    name: System
-    pid: 4
-    port: 139
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 524
-    port: 135
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: sqlservr.exe
+  pid: 1904
+  port: 49350
+  protocol: tcp
+  stime: Mon May 30 17:47:16 2022
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- address: '::'
+  name: services.exe
+  pid: 432
+  port: 49169
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: lsass.exe
+  pid: 440
+  port: 49167
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: spoolsv.exe
+  pid: 444
+  port: 49155
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: svchost.exe
+  pid: 708
+  port: 49154
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: svchost.exe
+  pid: 652
+  port: 49153
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: '::'
+  name: wininit.exe
+  pid: 344
+  port: 49152
+  protocol: tcp
+  stime: Mon May 30 17:21:40 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: System
+  pid: 4
+  port: 47001
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: ::1
+  name: pgbouncer.exe
+  pid: 1076
+  port: 6432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: System
+  pid: 4
+  port: 5986
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System
+  pid: 4
+  port: 5985
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: postgres.exe
+  pid: 1248
+  port: 5432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: svchost.exe
+  pid: 2028
+  port: 3389
+  protocol: tcp
+  stime: Mon May 30 17:21:53 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: System
+  pid: 4
+  port: 445
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: svchost.exe
+  pid: 524
+  port: 135
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: System
+  pid: 4
+  port: 80
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: sqlservr.exe
+  pid: 1904
+  port: 49350
+  protocol: tcp
+  stime: Mon May 30 17:47:16 2022
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- address: 0.0.0.0
+  name: services.exe
+  pid: 432
+  port: 49169
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: lsass.exe
+  pid: 440
+  port: 49167
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: spoolsv.exe
+  pid: 444
+  port: 49155
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 708
+  port: 49154
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 652
+  port: 49153
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: 0.0.0.0
+  name: wininit.exe
+  pid: 344
+  port: 49152
+  protocol: tcp
+  stime: Mon May 30 17:21:40 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 127.0.0.1
+  name: pgbouncer.exe
+  pid: 1076
+  port: 6432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: postgres.exe
+  pid: 1248
+  port: 5432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 2028
+  port: 3389
+  protocol: tcp
+  stime: Mon May 30 17:21:53 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 192.168.0.94
+  name: System
+  pid: 4
+  port: 139
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 524
+  port: 135
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\NETWORK SERVICE
 udp_listen:
-  - address: ::1
-    name: System Idle Process
-    pid: null
-    port: 59132
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 5355
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 4500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 3389
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 123
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 5355
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 4500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 3389
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 192.168.0.94
-    name: System Idle Process
-    pid: null
-    port: 138
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 192.168.0.94
-    name: System Idle Process
-    pid: null
-    port: 137
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 123
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
+- address: ::1
+  name: System Idle Process
+  pid: null
+  port: 59132
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 5355
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 4500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 3389
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 123
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 5355
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 4500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 3389
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 192.168.0.94
+  name: System Idle Process
+  pid: null
+  port: 138
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 192.168.0.94
+  name: System Idle Process
+  pid: null
+  port: 137
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 123
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null

--- a/tests/unit/plugins/action/auto/resources/influxdb/influxdb1.8.1_centos7.6_docker.yaml
+++ b/tests/unit/plugins/action/auto/resources/influxdb/influxdb1.8.1_centos7.6_docker.yaml
@@ -1,3619 +1,3734 @@
-expected_result:
-  - discovery_time: '2022-07-05T09:43:49+02:00'
-    bindings:
-      - address: '::'
-        class: service
-        port: 8086
-        protocol: tcp
-    docker:
-      exposed_ports:
-        8086/tcp: { }
-      id: 6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23
-      image: influxdb:1.8.1
-      name: /influxdb
-      network_mode: 'bridge'
-      port_bindings:
-        '8086/tcp':
-          - 'HostIp': '0.0.0.0'
-            'HostPort': '8086'
-    listening_ports:
-      - 8086
-    packages: [ ]
-    process:
-      cmdline: influxd
-      listening_ports:
-        - 8086
-      pid: '2817'
-      ppid: '2746'
-      user: root
-    type: InfluxDB
-    version:
-      - number: 1.8.1
-        type: docker
-
-software_list:
-  - name: InfluxDB
-    cmd_regexp: ^influxd
-    pkg_regexp: ^influxdb
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - ./bin/iometrics-slator
-        Env:
-          - SLATOR_INFLUX_PASS=the_password
-          - SLATOR_INFLUX_SSLCA=/etc/iometrics/slator/ssl/slator_ca.crt
-          - SLATOR_INFLUX_SSLCERT=/etc/iometrics/slator/ssl/slator.crt
-          - SLATOR_INFLUX_PORT=8086
-          - SLATOR_DATABASE_PASSWORD=the_password
-          - SLATOR_INFLUX_HOST=127.0.0.1
-          - SLATOR_GENERAL_INSTANCE_ID=instance_integracion
-          - SLATOR_CMDB_GATEWAY_API_KEY=the_api_key
-          - TZ=Europe/Madrid
-          - SLATOR_DATABASE_DRIVER_TYPE=postgres
-          - SLATOR_INFLUX_ENABLESSL=true
-          - SLATOR_HTTP_CERT_FILE=
-          - SLATOR_HTTP_CERT_KEY=
-          - SLATOR_DATABASE_USERNAME=slator
-          - SLATOR_INFLUX_DB=slator
-          - SLATOR_HTTP_COOKIE_ID=the_cookie_id
-          - SLATOR_GENERAL_LOGLEVEL=debug
-          - SLATOR_DATABASE_SERVER_HOST=zabbix_db01-integracion-internal.iometrics.io
-          - SLATOR_HTTP_LISTEN=:5090
-          - SLATOR_GENERAL_CRON_HOURLY_EXPR=5 * * * *
-          - SLATOR_HTTP_PROTOCOL=http
-          - SLATOR_INFLUX_ID=influx_integracion
-          - SLATOR_INFLUX_USER=slator_writer
-          - SLATOR_HTTP_ADMIN_USER=admin
-          - SLATOR_HTTP_ADMIN_PASSWORD=the_password
-          - SLATOR_GENERAL_TRIGGER_WORKERS=50
-          - SLATOR_INFLUX_SSLKEY=/etc/iometrics/slator/ssl/slator.key
-          - SLATOR_INFLUX_USERAGENT=iometrics-slator
-          - SLATOR_CMDB_GATEWAY_INSECURE_SKIP_VERIFY=true
-          - SLATOR_CMDB_GATEWAY_ENDPOINT_URL=https://api-gateway01-integracion-internal.iometrics.io:8444
-          - SLATOR_INFLUX_PRECISION=s
-          - SLATOR_DATABASE_NAME=zabbix
-          - SLATOR_INFLUX_TIMEOUT=30
-          - SLATOR_INFLUX_SSL_SKIP_VERIFY=true
-          - SLATOR_GENERAL_LOGDIR=/var/log/iometrics/slator
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - PATHS_HOME=/opt/iometrics-slator/
-          - SLATOR_GENERAL_DATADIR=/opt/iometrics-slator//data/
-        Hostname: influx01.novalocal
-        Image: nexusregistry.opensolutions.cloud/iometrics-slator:0.10.0
-        Labels:
-          maintainer: Datadope team <hello@datadope.io>
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ioslator
-        Volumes:
-          /etc/hosts: { }
-          /etc/iometrics/slator: { }
-          /etc/localtime: { }
-          /etc/security/limits.conf: { }
-          /var/log/iometrics/slator: { }
-        WorkingDir: /opt/iometrics-slator
-      Created: '2022-02-21T13:03:16.535500187Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014-init/diff:/var/lib/docker/overlay2/3eb45e8d17b6caf064f852a3b1255f5926a4139c8b0c472b89b6a8af3368fba0/diff:/var/lib/docker/overlay2/299ea389326d6e4b0a9af4b11b3e96bd1ec4d1d37614d465fda0f93d043ef0b6/diff:/var/lib/docker/overlay2/7c34345270f7a46f95bff2c2aee4648991933d566a8b0cad3340f8c8a1d443b5/diff:/var/lib/docker/overlay2/1273b96e688b37e0b3146fdfa36d43feecd27ffa4071ea2c484a3b67cfd1cd0e/diff:/var/lib/docker/overlay2/ab052fa24cf28927c331dc09ff243ecd820514f73998a962f4026f4682117381/diff:/var/lib/docker/overlay2/42984760f1fac710d4df8c30676293e4a4f9644cca0a6e8d5eac10ee227e13b2/diff:/var/lib/docker/overlay2/dd743e32747f5ba0b1da8e94dfefaca40149e207df8da70b12327720cb744428/diff
-          MergedDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/merged
-          UpperDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/diff
-          WorkDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/security/limits.conf:/etc/security/limits.conf:rw
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/localtime:/etc/localtime:rw
-          - /etc/iometrics/slator:/etc/iometrics/slator:rw
-          - /var/log/iometrics/slator:/var/log/iometrics/slator:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/hostname
-      HostsPath: /etc/hosts
-      Id: 78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2
-      Image: sha256:f9f3eacc59989487f1b3a6230601926e49787e5de0397d1f0e00575b5d3c3e90
-      LogPath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/security/limits.conf
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/security/limits.conf
-          Type: bind
-        - Destination: /var/log/iometrics/slator
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/iometrics/slator
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/iometrics/slator
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics/slator
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-      Name: /iometrics-slator
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: dedbe9a4823a67145dc8726ee84212c61f5f918d6bb0b019df35a69e12b240b7
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 22ea41f046099e66be3b48637867802728f449d19d626feaf7c19960b8b4d066
-        Ports: { }
-        SandboxID: bdc3ebb62c54844f1918cf05ed1609bd82d8150573dc3caa079a2d4e4ce100bc
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: ./bin/iometrics-slator
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:53:56.375095737Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 2845
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:53:58.119828417Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - influxd
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - influxd
-        Domainname: ''
-        Entrypoint:
-          - /entrypoint.sh
-        Env:
-          - INFLUXDB_ADMIN_PASSWORD=the_password
-          - INFLUXDB_HTTP_AUTH_ENABLED=true
-          - INFLUXDB_ADMIN_USER=datadope
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - INFLUXDB_VERSION=1.8.1
-        ExposedPorts:
-          8086/tcp: { }
-        Hostname: influx01
-        Image: influxdb:1.8.1
-        Labels:
-          os_container_type: influxdb
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: { }
-          /etc/influxdb: { }
-          /etc/influxdb/ssl: { }
-          /etc/localtime: { }
-          /etc/security/limits.conf: { }
-          /var/lib/influxdb: { }
-          /var/log/influxdb: { }
-        WorkingDir: ''
-      Created: '2020-08-07T21:06:47.158240789Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237-init/diff:/var/lib/docker/overlay2/ab6c271d74b14be40567b2c5ca5a73809c9ac5ada545f367000d28960a986d59/diff:/var/lib/docker/overlay2/55c23a908f2bab1da10ec1fa8ffbb12cbe3aeb152f9ddc298a32bf7ea0aef6c2/diff:/var/lib/docker/overlay2/0019175c77d3735fb2bb3a6c210b0c4d8e75d5bac343e0e2054225f9296e36f4/diff:/var/lib/docker/overlay2/cba146eb323f84649ca51f51eaa7825766be06fedfc02b5615bfeb67ad561f3d/diff:/var/lib/docker/overlay2/ea11433136426e45d50aaa3a0f041123c09e7684096665e595f0df2b812c06f2/diff:/var/lib/docker/overlay2/dae3e09be85845c11eed020ea17957e29463de2e952e18983efe620d88c421f0/diff:/var/lib/docker/overlay2/92b70e9476d3d4d4320167281a9a1053bf649ac68c0d8f6d1c491d86c880e661/diff:/var/lib/docker/overlay2/f3b251e4145b6b7360c84717b0f241e8f4d88dabb05ed0664a1fde97aaa9ad39/diff
-          MergedDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/merged
-          UpperDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/diff
-          WorkDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/localtime:/etc/localtime:rw
-          - /var/lib/influxdb:/var/lib/influxdb:rw
-          - /etc/hosts:/etc/hosts:rw
-          - /var/log/influxdb:/var/log/influxdb:rw
-          - /etc/security/limits.conf:/etc/security/limits.conf:rw
-          - /etc/influxdb:/etc/influxdb:rw
-          - /etc/influxdb/ssl:/etc/influxdb/ssl:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths: null
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: bridge
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8086/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8086'
-        Privileged: true
-        PublishAllPorts: false
-        ReadonlyPaths: null
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt:
-          - label=disable
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits:
-          - Hard: 9223372036854775807
-            Name: memlock
-            Soft: 9223372036854775807
-          - Hard: 65536
-            Name: nofile
-            Soft: 65536
-          - Hard: 10240
-            Name: nproc
-            Soft: 10240
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/hostname
-      HostsPath: /etc/hosts
-      Id: 6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23
-      Image: sha256:376a04c5c7e5fc478b8751338ce3253db605b076610e728ea86c691191917f08
-      LogPath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/influxdb/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/influxdb/ssl
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/security/limits.conf
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/security/limits.conf
-          Type: bind
-        - Destination: /var/lib/influxdb
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/influxdb
-          Type: bind
-        - Destination: /var/log/influxdb
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/influxdb
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/influxdb
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/influxdb
-          Type: bind
-      Name: /influxdb
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 9ae83e650dc981da8f102cfa52062a8e4a143012848b8e9ff8cd1f1146f24db4
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: 02:42:ac:11:00:02
-        Networks:
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 9ae83e650dc981da8f102cfa52062a8e4a143012848b8e9ff8cd1f1146f24db4
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:11:00:02
-            NetworkID: 464f09cfa25107da9da5cb755ac0605528a42e2f1961e32882035ff1eef4df6d
-        Ports:
-          8086/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8086'
-        SandboxID: 49fd6b0dba89b1da1c4e472e6d5b5f4e976840c4e993a4759cd8cb5dd9d7fc6c
-        SandboxKey: /var/run/docker/netns/49fd6b0dba89
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:53:56.380909076Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 2817
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:53:58.315771334Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  htop:
-    - arch: x86_64
-      epoch: null
-      name: htop
-      release: 3.el7
-      source: rpm
-      version: 2.2.0
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 297.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 7.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 7.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 7.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '108'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '180'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '181'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '318'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '319'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '424'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '460'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '493'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '496'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/rpcbind -w
-    pid: '590'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '591'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '596'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '599'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/sbin/chronyd
-    pid: '603'
-    ppid: '1'
-    user: chrony
-  - cmdline: ''
-    pid: '610'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '612'
-    ppid: '1'
-    user: polkitd
-  - cmdline: ''
-    pid: '622'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '623'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H influx01 eth0
-    pid: '863'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
-    pid: '924'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '925'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '930'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1076'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1085'
-    ppid: '1076'
-    user: postfix
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1094'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
-    pid: '1096'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1099'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1101'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1102'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1103'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8086 -container-ip 192.168.1.2 -container-port 8086
-    pid: '2734'
-    ppid: '1096'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '2746'
-    ppid: '930'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '2799'
-    ppid: '930'
-    user: root
-  - cmdline: influxd
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - ./bin/iometrics-slator
+      Env:
+      - SLATOR_INFLUX_PASS=the_password
+      - SLATOR_INFLUX_SSLCA=/etc/iometrics/slator/ssl/slator_ca.crt
+      - SLATOR_INFLUX_SSLCERT=/etc/iometrics/slator/ssl/slator.crt
+      - SLATOR_INFLUX_PORT=8086
+      - SLATOR_DATABASE_PASSWORD=the_password
+      - SLATOR_INFLUX_HOST=127.0.0.1
+      - SLATOR_GENERAL_INSTANCE_ID=instance_integracion
+      - SLATOR_CMDB_GATEWAY_API_KEY=the_api_key
+      - TZ=Europe/Madrid
+      - SLATOR_DATABASE_DRIVER_TYPE=postgres
+      - SLATOR_INFLUX_ENABLESSL=true
+      - SLATOR_HTTP_CERT_FILE=
+      - SLATOR_HTTP_CERT_KEY=
+      - SLATOR_DATABASE_USERNAME=slator
+      - SLATOR_INFLUX_DB=slator
+      - SLATOR_HTTP_COOKIE_ID=the_cookie_id
+      - SLATOR_GENERAL_LOGLEVEL=debug
+      - SLATOR_DATABASE_SERVER_HOST=zabbix_db01-integracion-internal.iometrics.io
+      - SLATOR_HTTP_LISTEN=:5090
+      - SLATOR_GENERAL_CRON_HOURLY_EXPR=5 * * * *
+      - SLATOR_HTTP_PROTOCOL=http
+      - SLATOR_INFLUX_ID=influx_integracion
+      - SLATOR_INFLUX_USER=slator_writer
+      - SLATOR_HTTP_ADMIN_USER=admin
+      - SLATOR_HTTP_ADMIN_PASSWORD=the_password
+      - SLATOR_GENERAL_TRIGGER_WORKERS=50
+      - SLATOR_INFLUX_SSLKEY=/etc/iometrics/slator/ssl/slator.key
+      - SLATOR_INFLUX_USERAGENT=iometrics-slator
+      - SLATOR_CMDB_GATEWAY_INSECURE_SKIP_VERIFY=true
+      - SLATOR_CMDB_GATEWAY_ENDPOINT_URL=https://api-gateway01-integracion-internal.iometrics.io:8444
+      - SLATOR_INFLUX_PRECISION=s
+      - SLATOR_DATABASE_NAME=zabbix
+      - SLATOR_INFLUX_TIMEOUT=30
+      - SLATOR_INFLUX_SSL_SKIP_VERIFY=true
+      - SLATOR_GENERAL_LOGDIR=/var/log/iometrics/slator
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - PATHS_HOME=/opt/iometrics-slator/
+      - SLATOR_GENERAL_DATADIR=/opt/iometrics-slator//data/
+      Hostname: influx01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-slator:0.10.0
+      Labels:
+        maintainer: Datadope team <hello@datadope.io>
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ioslator
+      Volumes:
+        /etc/hosts: {}
+        /etc/iometrics/slator: {}
+        /etc/localtime: {}
+        /etc/security/limits.conf: {}
+        /var/log/iometrics/slator: {}
+      WorkingDir: /opt/iometrics-slator
+    Created: '2022-02-21T13:03:16.535500187Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014-init/diff:/var/lib/docker/overlay2/3eb45e8d17b6caf064f852a3b1255f5926a4139c8b0c472b89b6a8af3368fba0/diff:/var/lib/docker/overlay2/299ea389326d6e4b0a9af4b11b3e96bd1ec4d1d37614d465fda0f93d043ef0b6/diff:/var/lib/docker/overlay2/7c34345270f7a46f95bff2c2aee4648991933d566a8b0cad3340f8c8a1d443b5/diff:/var/lib/docker/overlay2/1273b96e688b37e0b3146fdfa36d43feecd27ffa4071ea2c484a3b67cfd1cd0e/diff:/var/lib/docker/overlay2/ab052fa24cf28927c331dc09ff243ecd820514f73998a962f4026f4682117381/diff:/var/lib/docker/overlay2/42984760f1fac710d4df8c30676293e4a4f9644cca0a6e8d5eac10ee227e13b2/diff:/var/lib/docker/overlay2/dd743e32747f5ba0b1da8e94dfefaca40149e207df8da70b12327720cb744428/diff
+        MergedDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/merged
+        UpperDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/diff
+        WorkDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/security/limits.conf:/etc/security/limits.conf:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/iometrics/slator:/etc/iometrics/slator:rw
+      - /var/log/iometrics/slator:/var/log/iometrics/slator:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/hostname
+    HostsPath: /etc/hosts
+    Id: 78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2
+    Image: sha256:f9f3eacc59989487f1b3a6230601926e49787e5de0397d1f0e00575b5d3c3e90
+    LogPath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/security/limits.conf
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/security/limits.conf
+      Type: bind
+    - Destination: /var/log/iometrics/slator
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/iometrics/slator
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/iometrics/slator
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics/slator
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    Name: /iometrics-slator
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: dedbe9a4823a67145dc8726ee84212c61f5f918d6bb0b019df35a69e12b240b7
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 22ea41f046099e66be3b48637867802728f449d19d626feaf7c19960b8b4d066
+      Ports: {}
+      SandboxID: bdc3ebb62c54844f1918cf05ed1609bd82d8150573dc3caa079a2d4e4ce100bc
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: ./bin/iometrics-slator
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:53:56.375095737Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 2845
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:53:58.119828417Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - influxd
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - influxd
+      Domainname: ''
+      Entrypoint:
+      - /entrypoint.sh
+      Env:
+      - INFLUXDB_ADMIN_PASSWORD=the_password
+      - INFLUXDB_HTTP_AUTH_ENABLED=true
+      - INFLUXDB_ADMIN_USER=datadope
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - INFLUXDB_VERSION=1.8.1
+      ExposedPorts:
+        8086/tcp: {}
+      Hostname: influx01
+      Image: influxdb:1.8.1
+      Labels:
+        os_container_type: influxdb
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/influxdb: {}
+        /etc/influxdb/ssl: {}
+        /etc/localtime: {}
+        /etc/security/limits.conf: {}
+        /var/lib/influxdb: {}
+        /var/log/influxdb: {}
+      WorkingDir: ''
+    Created: '2020-08-07T21:06:47.158240789Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237-init/diff:/var/lib/docker/overlay2/ab6c271d74b14be40567b2c5ca5a73809c9ac5ada545f367000d28960a986d59/diff:/var/lib/docker/overlay2/55c23a908f2bab1da10ec1fa8ffbb12cbe3aeb152f9ddc298a32bf7ea0aef6c2/diff:/var/lib/docker/overlay2/0019175c77d3735fb2bb3a6c210b0c4d8e75d5bac343e0e2054225f9296e36f4/diff:/var/lib/docker/overlay2/cba146eb323f84649ca51f51eaa7825766be06fedfc02b5615bfeb67ad561f3d/diff:/var/lib/docker/overlay2/ea11433136426e45d50aaa3a0f041123c09e7684096665e595f0df2b812c06f2/diff:/var/lib/docker/overlay2/dae3e09be85845c11eed020ea17957e29463de2e952e18983efe620d88c421f0/diff:/var/lib/docker/overlay2/92b70e9476d3d4d4320167281a9a1053bf649ac68c0d8f6d1c491d86c880e661/diff:/var/lib/docker/overlay2/f3b251e4145b6b7360c84717b0f241e8f4d88dabb05ed0664a1fde97aaa9ad39/diff
+        MergedDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/merged
+        UpperDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/diff
+        WorkDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/localtime:/etc/localtime:rw
+      - /var/lib/influxdb:/var/lib/influxdb:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /var/log/influxdb:/var/log/influxdb:rw
+      - /etc/security/limits.conf:/etc/security/limits.conf:rw
+      - /etc/influxdb:/etc/influxdb:rw
+      - /etc/influxdb/ssl:/etc/influxdb/ssl:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths: null
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: bridge
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8086/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8086'
+      Privileged: true
+      PublishAllPorts: false
+      ReadonlyPaths: null
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt:
+      - label=disable
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits:
+      - Hard: 9223372036854775807
+        Name: memlock
+        Soft: 9223372036854775807
+      - Hard: 65536
+        Name: nofile
+        Soft: 65536
+      - Hard: 10240
+        Name: nproc
+        Soft: 10240
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/hostname
+    HostsPath: /etc/hosts
+    Id: 6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23
+    Image: sha256:376a04c5c7e5fc478b8751338ce3253db605b076610e728ea86c691191917f08
+    LogPath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/influxdb/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/influxdb/ssl
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/security/limits.conf
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/security/limits.conf
+      Type: bind
+    - Destination: /var/lib/influxdb
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/influxdb
+      Type: bind
+    - Destination: /var/log/influxdb
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/influxdb
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/influxdb
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/influxdb
+      Type: bind
+    Name: /influxdb
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 9ae83e650dc981da8f102cfa52062a8e4a143012848b8e9ff8cd1f1146f24db4
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 9ae83e650dc981da8f102cfa52062a8e4a143012848b8e9ff8cd1f1146f24db4
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: 464f09cfa25107da9da5cb755ac0605528a42e2f1961e32882035ff1eef4df6d
+      Ports:
+        8086/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8086'
+      SandboxID: 49fd6b0dba89b1da1c4e472e6d5b5f4e976840c4e993a4759cd8cb5dd9d7fc6c
+      SandboxKey: /var/run/docker/netns/49fd6b0dba89
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:53:56.380909076Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 2817
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:53:58.315771334Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 8086
+    protocol: tcp
+  discovery_time: '2022-07-05T09:43:49+02:00'
+  docker:
+    exposed_ports:
+      8086/tcp: {}
+    id: 6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23
+    image: influxdb:1.8.1
+    name: /influxdb
+    network_mode: bridge
+    port_bindings:
+      8086/tcp:
+      - HostIp: 0.0.0.0
+        HostPort: '8086'
+  listening_ports:
+  - 8086
+  packages: []
+  process:
+    cmdline: influxd
+    cwd: /
+    listening_ports:
+    - 8086
     pid: '2817'
     ppid: '2746'
     user: root
-  - cmdline: ./bin/iometrics-slator
-    pid: '2845'
-    ppid: '2799'
-    user: '472'
-  - cmdline: /usr/bin/docker start -a influxdb
-    pid: '3085'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-slator
-    pid: '3086'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '7641'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15055'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18560'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '19611'
-    ppid: '1076'
-    user: postfix
-  - cmdline: ''
-    pid: '19958'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20792'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20823'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21037'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21040'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1657006981
-    pid: '21112'
-    ppid: '924'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '21143'
-    ppid: '1099'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '21145'
-    ppid: '21143'
-    user: centos
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-nslfqojzddygcxwpegiztybqmbevrhsn ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007012.996911-41121-176857011542369/AnsiballZ_process_facts.py' && sleep 0
-    pid: '21337'
-    ppid: '21145'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-nslfqojzddygcxwpegiztybqmbevrhsn ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007012.996911-41121-176857011542369/AnsiballZ_process_facts.py
-    pid: '21352'
-    ppid: '21337'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-nslfqojzddygcxwpegiztybqmbevrhsn ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007012.996911-41121-176857011542369/AnsiballZ_process_facts.py
-    pid: '21353'
-    ppid: '21352'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007012.996911-41121-176857011542369/AnsiballZ_process_facts.py
-    pid: '21354'
-    ppid: '21353'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1076
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:53:53 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:53:43 2022
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1099
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:53:54 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1076
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:53:53 2022
-    user: root
-  - address: '::'
-    name: ./bin/iometric
-    pid: 2845
-    port: 5090
-    protocol: tcp
-    stime: Tue Apr 26 15:53:58 2022
-    user: '472'
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:53:43 2022
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 2734
-    port: 8086
-    protocol: tcp
-    stime: Tue Apr 26 15:53:58 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1099
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:53:54 2022
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: InfluxDB
+  version:
+  - number: 1.8.1
+    type: docker
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 863
-    port: 68
-    protocol: udp
-    stime: Tue Apr 26 15:53:52 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:53:43 2022
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 603
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:53:47 2022
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  htop:
+  - arch: x86_64
+    epoch: null
+    name: htop
+    release: 3.el7
+    source: rpm
+    version: 2.2.0
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 297.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 590
-    port: 759
-    protocol: udp
-    stime: Tue Apr 26 15:53:47 2022
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:53:43 2022
-    user: root
-  - address: ::1
-    name: chronyd
-    pid: 603
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:53:47 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 590
-    port: 759
-    protocol: udp
-    stime: Tue Apr 26 15:53:47 2022
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 7.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 7.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 7.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '108'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '180'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '181'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '424'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '460'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '493'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '496'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '590'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '591'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '596'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '599'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '603'
+  ppid: '1'
+  user: chrony
+- cmdline: ''
+  cwd: /
+  pid: '610'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '612'
+  ppid: '1'
+  user: polkitd
+- cmdline: ''
+  cwd: /
+  pid: '622'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '623'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H influx01 eth0
+  cwd: /sbin/
+  pid: '863'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '924'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '925'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '930'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1076'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1085'
+  ppid: '1076'
+  user: postfix
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1094'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1096'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1099'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1101'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1102'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1103'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8086 -container-ip
+    192.168.1.2 -container-port 8086
+  cwd: /usr/bin/
+  pid: '2734'
+  ppid: '1096'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '2746'
+  ppid: '930'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '2799'
+  ppid: '930'
+  user: root
+- cmdline: influxd
+  cwd: /
+  pid: '2817'
+  ppid: '2746'
+  user: root
+- cmdline: ./bin/iometrics-slator
+  cwd: ./bin/
+  pid: '2845'
+  ppid: '2799'
+  user: '472'
+- cmdline: /usr/bin/docker start -a influxdb
+  cwd: /usr/bin/
+  pid: '3085'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-slator
+  cwd: /usr/bin/
+  pid: '3086'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7641'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15055'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18560'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '19611'
+  ppid: '1076'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '19958'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20792'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20823'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21037'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21040'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1657006981
+  cwd: /usr/lib64/sa/
+  pid: '21112'
+  ppid: '924'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '21143'
+  ppid: '1099'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '21145'
+  ppid: '21143'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-nslfqojzddygcxwpegiztybqmbevrhsn
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007012.996911-41121-176857011542369/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '21337'
+  ppid: '21145'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-nslfqojzddygcxwpegiztybqmbevrhsn
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007012.996911-41121-176857011542369/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '21352'
+  ppid: '21337'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-nslfqojzddygcxwpegiztybqmbevrhsn ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1657007012.996911-41121-176857011542369/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '21353'
+  ppid: '21352'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007012.996911-41121-176857011542369/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '21354'
+  ppid: '21353'
+  user: root
+software_list:
+- cmd_regexp: ^influxd
+  name: InfluxDB
+  pkg_regexp: ^influxdb
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1076
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:53:53 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:53:43 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1099
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:53:54 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1076
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:53:53 2022
+  user: root
+- address: '::'
+  name: ./bin/iometric
+  pid: 2845
+  port: 5090
+  protocol: tcp
+  stime: Tue Apr 26 15:53:58 2022
+  user: '472'
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:53:43 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 2734
+  port: 8086
+  protocol: tcp
+  stime: Tue Apr 26 15:53:58 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1099
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:53:54 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 863
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:53:52 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:53:43 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 603
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 590
+  port: 759
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:53:43 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 603
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 590
+  port: 759
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/iometrics_slator/slator0.10.0_centos7.6_docker.yaml
+++ b/tests/unit/plugins/action/auto/resources/iometrics_slator/slator0.10.0_centos7.6_docker.yaml
@@ -1,3610 +1,3724 @@
-expected_result:
-  - discovery_time: '2022-07-04T15:11:01+02:00'
-    bindings:
-      - address: '::'
-        class: service
-        port: 5090
-        protocol: tcp
-    docker:
-      exposed_ports: { }
-      id: 78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2
-      image: nexusregistry.opensolutions.cloud/iometrics-slator:0.10.0
-      name: /iometrics-slator
-      network_mode: 'host'
-      port_bindings: { }
-    listening_ports:
-      - 5090
-    process:
-      children: [ ]
-      cmdline: ./bin/iometrics-slator
-      listening_ports:
-        - 5090
-      pid: '2845'
-      ppid: '2799'
-      user: '472'
-    type: IOMetrics SLAtor
-    version:
-      - number: 0.10.0
-        type: docker
-
-software_list:
-  - name: IOMetrics SLAtor
-    cmd_regexp: /iometrics-slator
-    process_type: parent
-    return_children: true
-    return_packages: false
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - ./bin/iometrics-slator
-        Env:
-          - SLATOR_INFLUX_PASS=the_password
-          - SLATOR_INFLUX_SSLCA=/etc/iometrics/slator/ssl/slator_ca.crt
-          - SLATOR_INFLUX_SSLCERT=/etc/iometrics/slator/ssl/slator.crt
-          - SLATOR_INFLUX_PORT=8086
-          - SLATOR_DATABASE_PASSWORD=the_password
-          - SLATOR_INFLUX_HOST=127.0.0.1
-          - SLATOR_GENERAL_INSTANCE_ID=instance_integracion
-          - SLATOR_CMDB_GATEWAY_API_KEY=the_api_key
-          - TZ=Europe/Madrid
-          - SLATOR_DATABASE_DRIVER_TYPE=postgres
-          - SLATOR_INFLUX_ENABLESSL=true
-          - SLATOR_HTTP_CERT_FILE=
-          - SLATOR_HTTP_CERT_KEY=
-          - SLATOR_DATABASE_USERNAME=slator
-          - SLATOR_INFLUX_DB=slator
-          - SLATOR_HTTP_COOKIE_ID=so0oop7OjohFati
-          - SLATOR_GENERAL_LOGLEVEL=debug
-          - SLATOR_DATABASE_SERVER_HOST=zabbix_db01-integracion-internal.iometrics.io
-          - SLATOR_HTTP_LISTEN=:5090
-          - SLATOR_GENERAL_CRON_HOURLY_EXPR=5 * * * *
-          - SLATOR_HTTP_PROTOCOL=http
-          - SLATOR_INFLUX_ID=influx_integracion
-          - SLATOR_INFLUX_USER=slator_writer
-          - SLATOR_HTTP_ADMIN_USER=admin
-          - SLATOR_HTTP_ADMIN_PASSWORD=the_password
-          - SLATOR_GENERAL_TRIGGER_WORKERS=50
-          - SLATOR_INFLUX_SSLKEY=/etc/iometrics/slator/ssl/slator.key
-          - SLATOR_INFLUX_USERAGENT=iometrics-slator
-          - SLATOR_CMDB_GATEWAY_INSECURE_SKIP_VERIFY=true
-          - SLATOR_CMDB_GATEWAY_ENDPOINT_URL=https://api-gateway01-integracion-internal.iometrics.io:8444
-          - SLATOR_INFLUX_PRECISION=s
-          - SLATOR_DATABASE_NAME=zabbix
-          - SLATOR_INFLUX_TIMEOUT=30
-          - SLATOR_INFLUX_SSL_SKIP_VERIFY=true
-          - SLATOR_GENERAL_LOGDIR=/var/log/iometrics/slator
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - PATHS_HOME=/opt/iometrics-slator/
-          - SLATOR_GENERAL_DATADIR=/opt/iometrics-slator//data/
-        Hostname: influx01.novalocal
-        Image: nexusregistry.opensolutions.cloud/iometrics-slator:0.10.0
-        Labels:
-          maintainer: Datadope team <hello@datadope.io>
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ioslator
-        Volumes:
-          /etc/hosts: { }
-          /etc/iometrics/slator: { }
-          /etc/localtime: { }
-          /etc/security/limits.conf: { }
-          /var/log/iometrics/slator: { }
-        WorkingDir: /opt/iometrics-slator
-      Created: '2022-02-21T13:03:16.535500187Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014-init/diff:/var/lib/docker/overlay2/3eb45e8d17b6caf064f852a3b1255f5926a4139c8b0c472b89b6a8af3368fba0/diff:/var/lib/docker/overlay2/299ea389326d6e4b0a9af4b11b3e96bd1ec4d1d37614d465fda0f93d043ef0b6/diff:/var/lib/docker/overlay2/7c34345270f7a46f95bff2c2aee4648991933d566a8b0cad3340f8c8a1d443b5/diff:/var/lib/docker/overlay2/1273b96e688b37e0b3146fdfa36d43feecd27ffa4071ea2c484a3b67cfd1cd0e/diff:/var/lib/docker/overlay2/ab052fa24cf28927c331dc09ff243ecd820514f73998a962f4026f4682117381/diff:/var/lib/docker/overlay2/42984760f1fac710d4df8c30676293e4a4f9644cca0a6e8d5eac10ee227e13b2/diff:/var/lib/docker/overlay2/dd743e32747f5ba0b1da8e94dfefaca40149e207df8da70b12327720cb744428/diff
-          MergedDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/merged
-          UpperDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/diff
-          WorkDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/security/limits.conf:/etc/security/limits.conf:rw
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/localtime:/etc/localtime:rw
-          - /etc/iometrics/slator:/etc/iometrics/slator:rw
-          - /var/log/iometrics/slator:/var/log/iometrics/slator:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/hostname
-      HostsPath: /etc/hosts
-      Id: 78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2
-      Image: sha256:f9f3eacc59989487f1b3a6230601926e49787e5de0397d1f0e00575b5d3c3e90
-      LogPath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/log/iometrics/slator
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/iometrics/slator
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/iometrics/slator
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics/slator
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/security/limits.conf
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/security/limits.conf
-          Type: bind
-      Name: /iometrics-slator
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: dedbe9a4823a67145dc8726ee84212c61f5f918d6bb0b019df35a69e12b240b7
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 22ea41f046099e66be3b48637867802728f449d19d626feaf7c19960b8b4d066
-        Ports: { }
-        SandboxID: bdc3ebb62c54844f1918cf05ed1609bd82d8150573dc3caa079a2d4e4ce100bc
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: ./bin/iometrics-slator
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:53:56.375095737Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 2845
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:53:58.119828417Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - influxd
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - influxd
-        Domainname: ''
-        Entrypoint:
-          - /entrypoint.sh
-        Env:
-          - INFLUXDB_ADMIN_PASSWORD=the_password
-          - INFLUXDB_HTTP_AUTH_ENABLED=true
-          - INFLUXDB_ADMIN_USER=datadope
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - INFLUXDB_VERSION=1.8.1
-        ExposedPorts:
-          8086/tcp: { }
-        Hostname: influx01
-        Image: influxdb:1.8.1
-        Labels:
-          os_container_type: influxdb
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: { }
-          /etc/influxdb: { }
-          /etc/influxdb/ssl: { }
-          /etc/localtime: { }
-          /etc/security/limits.conf: { }
-          /var/lib/influxdb: { }
-          /var/log/influxdb: { }
-        WorkingDir: ''
-      Created: '2020-08-07T21:06:47.158240789Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237-init/diff:/var/lib/docker/overlay2/ab6c271d74b14be40567b2c5ca5a73809c9ac5ada545f367000d28960a986d59/diff:/var/lib/docker/overlay2/55c23a908f2bab1da10ec1fa8ffbb12cbe3aeb152f9ddc298a32bf7ea0aef6c2/diff:/var/lib/docker/overlay2/0019175c77d3735fb2bb3a6c210b0c4d8e75d5bac343e0e2054225f9296e36f4/diff:/var/lib/docker/overlay2/cba146eb323f84649ca51f51eaa7825766be06fedfc02b5615bfeb67ad561f3d/diff:/var/lib/docker/overlay2/ea11433136426e45d50aaa3a0f041123c09e7684096665e595f0df2b812c06f2/diff:/var/lib/docker/overlay2/dae3e09be85845c11eed020ea17957e29463de2e952e18983efe620d88c421f0/diff:/var/lib/docker/overlay2/92b70e9476d3d4d4320167281a9a1053bf649ac68c0d8f6d1c491d86c880e661/diff:/var/lib/docker/overlay2/f3b251e4145b6b7360c84717b0f241e8f4d88dabb05ed0664a1fde97aaa9ad39/diff
-          MergedDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/merged
-          UpperDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/diff
-          WorkDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/localtime:/etc/localtime:rw
-          - /var/lib/influxdb:/var/lib/influxdb:rw
-          - /etc/hosts:/etc/hosts:rw
-          - /var/log/influxdb:/var/log/influxdb:rw
-          - /etc/security/limits.conf:/etc/security/limits.conf:rw
-          - /etc/influxdb:/etc/influxdb:rw
-          - /etc/influxdb/ssl:/etc/influxdb/ssl:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths: null
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: bridge
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8086/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8086'
-        Privileged: true
-        PublishAllPorts: false
-        ReadonlyPaths: null
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt:
-          - label=disable
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits:
-          - Hard: 9223372036854775807
-            Name: memlock
-            Soft: 9223372036854775807
-          - Hard: 65536
-            Name: nofile
-            Soft: 65536
-          - Hard: 10240
-            Name: nproc
-            Soft: 10240
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/hostname
-      HostsPath: /etc/hosts
-      Id: 6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23
-      Image: sha256:376a04c5c7e5fc478b8751338ce3253db605b076610e728ea86c691191917f08
-      LogPath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/influxdb
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/influxdb
-          Type: bind
-        - Destination: /var/log/influxdb
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/influxdb
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/influxdb
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/influxdb
-          Type: bind
-        - Destination: /etc/influxdb/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/influxdb/ssl
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/security/limits.conf
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/security/limits.conf
-          Type: bind
-      Name: /influxdb
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 9ae83e650dc981da8f102cfa52062a8e4a143012848b8e9ff8cd1f1146f24db4
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: 02:42:ac:11:00:02
-        Networks:
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 9ae83e650dc981da8f102cfa52062a8e4a143012848b8e9ff8cd1f1146f24db4
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:11:00:02
-            NetworkID: 464f09cfa25107da9da5cb755ac0605528a42e2f1961e32882035ff1eef4df6d
-        Ports:
-          8086/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8086'
-        SandboxID: 49fd6b0dba89b1da1c4e472e6d5b5f4e976840c4e993a4759cd8cb5dd9d7fc6c
-        SandboxKey: /var/run/docker/netns/49fd6b0dba89
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:53:56.380909076Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 2817
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:53:58.315771334Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  htop:
-    - arch: x86_64
-      epoch: null
-      name: htop
-      release: 3.el7
-      source: rpm
-      version: 2.2.0
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 297.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 7.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 7.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 7.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '108'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '180'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '181'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '318'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '319'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '424'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '460'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '493'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '496'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/rpcbind -w
-    pid: '590'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '591'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '596'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '599'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/sbin/chronyd
-    pid: '603'
-    ppid: '1'
-    user: chrony
-  - cmdline: ''
-    pid: '610'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '612'
-    ppid: '1'
-    user: polkitd
-  - cmdline: ''
-    pid: '622'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '623'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H influx01 eth0
-    pid: '863'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
-    pid: '924'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '925'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '930'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1076'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1085'
-    ppid: '1076'
-    user: postfix
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1094'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
-    pid: '1096'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1099'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1101'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1102'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1103'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8086 -container-ip 192.168.1.2 -container-port 8086
-    pid: '2734'
-    ppid: '1096'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '2746'
-    ppid: '930'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '2799'
-    ppid: '930'
-    user: root
-  - cmdline: influxd
-    pid: '2817'
-    ppid: '2746'
-    user: root
-  - cmdline: ./bin/iometrics-slator
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - ./bin/iometrics-slator
+      Env:
+      - SLATOR_INFLUX_PASS=the_password
+      - SLATOR_INFLUX_SSLCA=/etc/iometrics/slator/ssl/slator_ca.crt
+      - SLATOR_INFLUX_SSLCERT=/etc/iometrics/slator/ssl/slator.crt
+      - SLATOR_INFLUX_PORT=8086
+      - SLATOR_DATABASE_PASSWORD=the_password
+      - SLATOR_INFLUX_HOST=127.0.0.1
+      - SLATOR_GENERAL_INSTANCE_ID=instance_integracion
+      - SLATOR_CMDB_GATEWAY_API_KEY=the_api_key
+      - TZ=Europe/Madrid
+      - SLATOR_DATABASE_DRIVER_TYPE=postgres
+      - SLATOR_INFLUX_ENABLESSL=true
+      - SLATOR_HTTP_CERT_FILE=
+      - SLATOR_HTTP_CERT_KEY=
+      - SLATOR_DATABASE_USERNAME=slator
+      - SLATOR_INFLUX_DB=slator
+      - SLATOR_HTTP_COOKIE_ID=so0oop7OjohFati
+      - SLATOR_GENERAL_LOGLEVEL=debug
+      - SLATOR_DATABASE_SERVER_HOST=zabbix_db01-integracion-internal.iometrics.io
+      - SLATOR_HTTP_LISTEN=:5090
+      - SLATOR_GENERAL_CRON_HOURLY_EXPR=5 * * * *
+      - SLATOR_HTTP_PROTOCOL=http
+      - SLATOR_INFLUX_ID=influx_integracion
+      - SLATOR_INFLUX_USER=slator_writer
+      - SLATOR_HTTP_ADMIN_USER=admin
+      - SLATOR_HTTP_ADMIN_PASSWORD=the_password
+      - SLATOR_GENERAL_TRIGGER_WORKERS=50
+      - SLATOR_INFLUX_SSLKEY=/etc/iometrics/slator/ssl/slator.key
+      - SLATOR_INFLUX_USERAGENT=iometrics-slator
+      - SLATOR_CMDB_GATEWAY_INSECURE_SKIP_VERIFY=true
+      - SLATOR_CMDB_GATEWAY_ENDPOINT_URL=https://api-gateway01-integracion-internal.iometrics.io:8444
+      - SLATOR_INFLUX_PRECISION=s
+      - SLATOR_DATABASE_NAME=zabbix
+      - SLATOR_INFLUX_TIMEOUT=30
+      - SLATOR_INFLUX_SSL_SKIP_VERIFY=true
+      - SLATOR_GENERAL_LOGDIR=/var/log/iometrics/slator
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - PATHS_HOME=/opt/iometrics-slator/
+      - SLATOR_GENERAL_DATADIR=/opt/iometrics-slator//data/
+      Hostname: influx01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-slator:0.10.0
+      Labels:
+        maintainer: Datadope team <hello@datadope.io>
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ioslator
+      Volumes:
+        /etc/hosts: {}
+        /etc/iometrics/slator: {}
+        /etc/localtime: {}
+        /etc/security/limits.conf: {}
+        /var/log/iometrics/slator: {}
+      WorkingDir: /opt/iometrics-slator
+    Created: '2022-02-21T13:03:16.535500187Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014-init/diff:/var/lib/docker/overlay2/3eb45e8d17b6caf064f852a3b1255f5926a4139c8b0c472b89b6a8af3368fba0/diff:/var/lib/docker/overlay2/299ea389326d6e4b0a9af4b11b3e96bd1ec4d1d37614d465fda0f93d043ef0b6/diff:/var/lib/docker/overlay2/7c34345270f7a46f95bff2c2aee4648991933d566a8b0cad3340f8c8a1d443b5/diff:/var/lib/docker/overlay2/1273b96e688b37e0b3146fdfa36d43feecd27ffa4071ea2c484a3b67cfd1cd0e/diff:/var/lib/docker/overlay2/ab052fa24cf28927c331dc09ff243ecd820514f73998a962f4026f4682117381/diff:/var/lib/docker/overlay2/42984760f1fac710d4df8c30676293e4a4f9644cca0a6e8d5eac10ee227e13b2/diff:/var/lib/docker/overlay2/dd743e32747f5ba0b1da8e94dfefaca40149e207df8da70b12327720cb744428/diff
+        MergedDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/merged
+        UpperDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/diff
+        WorkDir: /var/lib/docker/overlay2/21117254ff60dbea11f8e72b83314397f747fb9d0d8c8ac43d744bec0b106014/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/security/limits.conf:/etc/security/limits.conf:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/iometrics/slator:/etc/iometrics/slator:rw
+      - /var/log/iometrics/slator:/var/log/iometrics/slator:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/hostname
+    HostsPath: /etc/hosts
+    Id: 78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2
+    Image: sha256:f9f3eacc59989487f1b3a6230601926e49787e5de0397d1f0e00575b5d3c3e90
+    LogPath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/log/iometrics/slator
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/iometrics/slator
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/iometrics/slator
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics/slator
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/security/limits.conf
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/security/limits.conf
+      Type: bind
+    Name: /iometrics-slator
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: dedbe9a4823a67145dc8726ee84212c61f5f918d6bb0b019df35a69e12b240b7
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 22ea41f046099e66be3b48637867802728f449d19d626feaf7c19960b8b4d066
+      Ports: {}
+      SandboxID: bdc3ebb62c54844f1918cf05ed1609bd82d8150573dc3caa079a2d4e4ce100bc
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: ./bin/iometrics-slator
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:53:56.375095737Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 2845
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:53:58.119828417Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - influxd
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - influxd
+      Domainname: ''
+      Entrypoint:
+      - /entrypoint.sh
+      Env:
+      - INFLUXDB_ADMIN_PASSWORD=the_password
+      - INFLUXDB_HTTP_AUTH_ENABLED=true
+      - INFLUXDB_ADMIN_USER=datadope
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - INFLUXDB_VERSION=1.8.1
+      ExposedPorts:
+        8086/tcp: {}
+      Hostname: influx01
+      Image: influxdb:1.8.1
+      Labels:
+        os_container_type: influxdb
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/influxdb: {}
+        /etc/influxdb/ssl: {}
+        /etc/localtime: {}
+        /etc/security/limits.conf: {}
+        /var/lib/influxdb: {}
+        /var/log/influxdb: {}
+      WorkingDir: ''
+    Created: '2020-08-07T21:06:47.158240789Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237-init/diff:/var/lib/docker/overlay2/ab6c271d74b14be40567b2c5ca5a73809c9ac5ada545f367000d28960a986d59/diff:/var/lib/docker/overlay2/55c23a908f2bab1da10ec1fa8ffbb12cbe3aeb152f9ddc298a32bf7ea0aef6c2/diff:/var/lib/docker/overlay2/0019175c77d3735fb2bb3a6c210b0c4d8e75d5bac343e0e2054225f9296e36f4/diff:/var/lib/docker/overlay2/cba146eb323f84649ca51f51eaa7825766be06fedfc02b5615bfeb67ad561f3d/diff:/var/lib/docker/overlay2/ea11433136426e45d50aaa3a0f041123c09e7684096665e595f0df2b812c06f2/diff:/var/lib/docker/overlay2/dae3e09be85845c11eed020ea17957e29463de2e952e18983efe620d88c421f0/diff:/var/lib/docker/overlay2/92b70e9476d3d4d4320167281a9a1053bf649ac68c0d8f6d1c491d86c880e661/diff:/var/lib/docker/overlay2/f3b251e4145b6b7360c84717b0f241e8f4d88dabb05ed0664a1fde97aaa9ad39/diff
+        MergedDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/merged
+        UpperDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/diff
+        WorkDir: /var/lib/docker/overlay2/fbe6f7bfc23a2b79f9bd9cd7684b5dc5ae67ca878aa9be3806073078fbcc0237/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/localtime:/etc/localtime:rw
+      - /var/lib/influxdb:/var/lib/influxdb:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /var/log/influxdb:/var/log/influxdb:rw
+      - /etc/security/limits.conf:/etc/security/limits.conf:rw
+      - /etc/influxdb:/etc/influxdb:rw
+      - /etc/influxdb/ssl:/etc/influxdb/ssl:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths: null
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: bridge
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8086/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8086'
+      Privileged: true
+      PublishAllPorts: false
+      ReadonlyPaths: null
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt:
+      - label=disable
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits:
+      - Hard: 9223372036854775807
+        Name: memlock
+        Soft: 9223372036854775807
+      - Hard: 65536
+        Name: nofile
+        Soft: 65536
+      - Hard: 10240
+        Name: nproc
+        Soft: 10240
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/hostname
+    HostsPath: /etc/hosts
+    Id: 6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23
+    Image: sha256:376a04c5c7e5fc478b8751338ce3253db605b076610e728ea86c691191917f08
+    LogPath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/influxdb
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/influxdb
+      Type: bind
+    - Destination: /var/log/influxdb
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/influxdb
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/influxdb
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/influxdb
+      Type: bind
+    - Destination: /etc/influxdb/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/influxdb/ssl
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/security/limits.conf
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/security/limits.conf
+      Type: bind
+    Name: /influxdb
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 9ae83e650dc981da8f102cfa52062a8e4a143012848b8e9ff8cd1f1146f24db4
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 9ae83e650dc981da8f102cfa52062a8e4a143012848b8e9ff8cd1f1146f24db4
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: 464f09cfa25107da9da5cb755ac0605528a42e2f1961e32882035ff1eef4df6d
+      Ports:
+        8086/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8086'
+      SandboxID: 49fd6b0dba89b1da1c4e472e6d5b5f4e976840c4e993a4759cd8cb5dd9d7fc6c
+      SandboxKey: /var/run/docker/netns/49fd6b0dba89
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:53:56.380909076Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 2817
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:53:58.315771334Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 5090
+    protocol: tcp
+  discovery_time: '2022-07-04T15:11:01+02:00'
+  docker:
+    exposed_ports: {}
+    id: 78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2
+    image: nexusregistry.opensolutions.cloud/iometrics-slator:0.10.0
+    name: /iometrics-slator
+    network_mode: host
+    port_bindings: {}
+  listening_ports:
+  - 5090
+  process:
+    children: []
+    cmdline: ./bin/iometrics-slator
+    cwd: ./bin/
+    listening_ports:
+    - 5090
     pid: '2845'
     ppid: '2799'
     user: '472'
-  - cmdline: /usr/bin/docker start -a influxdb
-    pid: '3085'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-slator
-    pid: '3086'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '7641'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8010'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11987'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12167'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '12197'
-    ppid: '1076'
-    user: postfix
-  - cmdline: ''
-    pid: '12200'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12545'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12565'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '12566'
-    ppid: '1099'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '12568'
-    ppid: '12566'
-    user: centos
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-owugowrthgauxrjpdskjgspjfjabwzwz ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656940247.361475-32053-265005486554504/AnsiballZ_process_facts.py' && sleep 0
-    pid: '12759'
-    ppid: '12568'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-owugowrthgauxrjpdskjgspjfjabwzwz ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656940247.361475-32053-265005486554504/AnsiballZ_process_facts.py
-    pid: '12774'
-    ppid: '12759'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-owugowrthgauxrjpdskjgspjfjabwzwz ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656940247.361475-32053-265005486554504/AnsiballZ_process_facts.py
-    pid: '12775'
-    ppid: '12774'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656940247.361475-32053-265005486554504/AnsiballZ_process_facts.py
-    pid: '12776'
-    ppid: '12775'
-    user: root
-  - cmdline: ''
-    pid: '15055'
-    ppid: '2'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1076
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:53:53 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:53:43 2022
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1099
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:53:54 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1076
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:53:53 2022
-    user: root
-  - address: '::'
-    name: ./bin/iometric
-    pid: 2845
-    port: 5090
-    protocol: tcp
-    stime: Tue Apr 26 15:53:58 2022
-    user: '472'
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:53:43 2022
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 2734
-    port: 8086
-    protocol: tcp
-    stime: Tue Apr 26 15:53:58 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1099
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:53:54 2022
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: IOMetrics SLAtor
+  version:
+  - number: 0.10.0
+    type: docker
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 863
-    port: 68
-    protocol: udp
-    stime: Tue Apr 26 15:53:52 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:53:43 2022
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 603
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:53:47 2022
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  htop:
+  - arch: x86_64
+    epoch: null
+    name: htop
+    release: 3.el7
+    source: rpm
+    version: 2.2.0
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 297.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 590
-    port: 759
-    protocol: udp
-    stime: Tue Apr 26 15:53:47 2022
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:53:43 2022
-    user: root
-  - address: ::1
-    name: chronyd
-    pid: 603
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:53:47 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 590
-    port: 759
-    protocol: udp
-    stime: Tue Apr 26 15:53:47 2022
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 7.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 7.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 7.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '108'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '180'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '181'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '424'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '460'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '493'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '496'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '590'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '591'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '596'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '599'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '603'
+  ppid: '1'
+  user: chrony
+- cmdline: ''
+  cwd: /
+  pid: '610'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '612'
+  ppid: '1'
+  user: polkitd
+- cmdline: ''
+  cwd: /
+  pid: '622'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '623'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H influx01 eth0
+  cwd: /sbin/
+  pid: '863'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '924'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '925'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '930'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1076'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1085'
+  ppid: '1076'
+  user: postfix
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1094'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1096'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1099'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1101'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1102'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1103'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8086 -container-ip
+    192.168.1.2 -container-port 8086
+  cwd: /usr/bin/
+  pid: '2734'
+  ppid: '1096'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/6eecabac77d1c6bd60aa93f52acf32655bf127abc318cf03bf12abbeb32afe23
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '2746'
+  ppid: '930'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/78db2dbe393963fc0ec5384115793aba19d493385029efdf969bf30e439edda2
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '2799'
+  ppid: '930'
+  user: root
+- cmdline: influxd
+  cwd: /
+  pid: '2817'
+  ppid: '2746'
+  user: root
+- cmdline: ./bin/iometrics-slator
+  cwd: ./bin/
+  pid: '2845'
+  ppid: '2799'
+  user: '472'
+- cmdline: /usr/bin/docker start -a influxdb
+  cwd: /usr/bin/
+  pid: '3085'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-slator
+  cwd: /usr/bin/
+  pid: '3086'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7641'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8010'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11987'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12167'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '12197'
+  ppid: '1076'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '12200'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12545'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12565'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '12566'
+  ppid: '1099'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '12568'
+  ppid: '12566'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-owugowrthgauxrjpdskjgspjfjabwzwz
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656940247.361475-32053-265005486554504/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '12759'
+  ppid: '12568'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-owugowrthgauxrjpdskjgspjfjabwzwz
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656940247.361475-32053-265005486554504/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '12774'
+  ppid: '12759'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-owugowrthgauxrjpdskjgspjfjabwzwz ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656940247.361475-32053-265005486554504/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '12775'
+  ppid: '12774'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656940247.361475-32053-265005486554504/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '12776'
+  ppid: '12775'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15055'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: /iometrics-slator
+  name: IOMetrics SLAtor
+  process_type: parent
+  return_children: true
+  return_packages: false
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1076
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:53:53 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:53:43 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1099
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:53:54 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1076
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:53:53 2022
+  user: root
+- address: '::'
+  name: ./bin/iometric
+  pid: 2845
+  port: 5090
+  protocol: tcp
+  stime: Tue Apr 26 15:53:58 2022
+  user: '472'
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:53:43 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 2734
+  port: 8086
+  protocol: tcp
+  stime: Tue Apr 26 15:53:58 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1099
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:53:54 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 863
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:53:52 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:53:43 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 603
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 590
+  port: 759
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:53:43 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 603
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 590
+  port: 759
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/iometrics_visualizer_api/visualizer2.9.0_centos7.6_docker.yaml
+++ b/tests/unit/plugins/action/auto/resources/iometrics_visualizer_api/visualizer2.9.0_centos7.6_docker.yaml
@@ -1,4273 +1,4406 @@
-expected_result:
-  - discovery_time: '2022-07-04T14:57:08+02:00'
-    bindings:
-      - address: 0.0.0.0
-        class: service
-        port: 3004
-        protocol: tcp
-    docker:
-      exposed_ports:
-        3003/tcp: { }
-      id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-      name: /iometrics-visualizer-api
-      network_mode: 'host'
-      port_bindings: { }
-    listening_ports:
-      - 3004
-    process:
-      cmdline: python ./main.py
-      listening_ports:
-        - 3004
-      pid: '1464'
-      ppid: '1430'
-      user: root
-    type: IOMetrics Visualizer API
-    version:
-      - number: 2.9.0-117ca93
-        type: docker
-
-software_list:
-  - name: IOMetrics Visualizer API
-    cmd_regexp: python ./main.py
-    process_type: parent
-    return_children: false
-    return_packages: false
-    custom_tasks:
-      - name: Include IOMetrics Visualizer API specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/iometrics_visualizer_api.yaml"
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=the_key
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: { }
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
-      LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - NO_PROXY=localhost,127.0.0.1
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /var/lib/grafana: { }
-          /var/log/grafana: { }
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/grafana:/etc/grafana:rw
-          - /var/lib/grafana:/var/lib/grafana:rw
-          - /var/log/grafana:/var/log/grafana:rw
-          - /etc/localtime:/etc/localtime:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
-      LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=the_password
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: nexusregistry.opensolutions.cloud/postgres:12
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: { }
-          /var/lib/postgresql/data: { }
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
-          - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
-      LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - -g
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - -g
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/nginx: { }
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/localtime:/etc/localtime:rw
-          - /etc/nginx:/etc/nginx:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
-      LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - -c
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - -c
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=the_key
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: { }
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/datadope/es_kg_sync:/app/etc:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
-      LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 0a613a212395fab2c29339e1fcf76c52fbb00e9b5d550d5328f631fb1733b5de
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: d503b969263f46c92323cce61b1225f853464d36b84aec2aa20e3cfca0379afc
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-04T12:57:05.568036196Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 15410
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-04T12:57:07.634119417Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.3.1p1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 3.el7
-      source: rpm
-      version: '1.217'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 22.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '40'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '100'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '261'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '313'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '333'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '377'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '393'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '477'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '543'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '566'
-    ppid: '2'
-    user: root
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '719'
-    ppid: '1'
-    user: dbus
-  - cmdline: ''
-    pid: '721'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '728'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/rpcbind -w
-    pid: '730'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '734'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '738'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '750'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H grafana01 eth0
-    pid: '978'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1038'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
-    pid: '1041'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1044'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '1054'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '1055'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '1056'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '1057'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '1058'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '1059'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1143'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1148'
-    ppid: '1143'
-    user: postfix
-  - cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
-    pid: '1182'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1184'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1187'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1198'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1199'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1208'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-visualizer-api
-    pid: '1397'
-    ppid: '1'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '1430'
-    ppid: '1044'
-    user: root
-  - cmdline: python ./main.py
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=the_key
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=the_password
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=the_key
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 0a613a212395fab2c29339e1fcf76c52fbb00e9b5d550d5328f631fb1733b5de
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: d503b969263f46c92323cce61b1225f853464d36b84aec2aa20e3cfca0379afc
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-04T12:57:05.568036196Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 15410
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-04T12:57:07.634119417Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 3004
+    protocol: tcp
+  discovery_time: '2022-07-04T14:57:08+02:00'
+  docker:
+    exposed_ports:
+      3003/tcp: {}
+    id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+    name: /iometrics-visualizer-api
+    network_mode: host
+    port_bindings: {}
+  listening_ports:
+  - 3004
+  process:
+    cmdline: python ./main.py
+    cwd: /
+    listening_ports:
+    - 3004
     pid: '1464'
     ppid: '1430'
     user: root
-  - cmdline: ''
-    pid: '4951'
-    ppid: '2'
-    user: root
-  - cmdline: bash
-    pid: '8035'
-    ppid: '10860'
-    user: grafana
-  - cmdline: ''
-    pid: '8482'
-    ppid: '2'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10256'
-    ppid: '1044'
-    user: root
-  - cmdline: postgres
-    pid: '10435'
-    ppid: '10256'
-    user: polkitd
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10463'
-    ppid: '1044'
-    user: root
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '10501'
-    ppid: '10463'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '10612'
-    ppid: '10501'
-    user: '101'
-  - cmdline: /usr/bin/docker start -a nginx
-    pid: '10630'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a postgres-grafana
-    pid: '10633'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: checkpointer'
-    pid: '10848'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: background writer'
-    pid: '10849'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: walwriter'
-    pid: '10850'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '10851'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: stats collector'
-    pid: '10852'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '10853'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: /usr/bin/docker start -a grafana
-    pid: '10854'
-    ppid: '1'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10860'
-    ppid: '1044'
-    user: root
-  - cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/usr/share/grafana/plugins cfg:default.paths.provisioning=/etc/grafana/provisioning
-    pid: '10876'
-    ppid: '10860'
-    user: grafana
-  - cmdline: pickup -l -t unix -u
-    pid: '11206'
-    ppid: '1143'
-    user: postfix
-  - cmdline: ''
-    pid: '11228'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '11582'
-    ppid: '1187'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '11584'
-    ppid: '11582'
-    user: centos
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-arynnxtcgdzslnbrgpmpsfbzjrishytc ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939402.685329-30335-195046279532857/AnsiballZ_process_facts.py' && sleep 0
-    pid: '14196'
-    ppid: '11584'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-arynnxtcgdzslnbrgpmpsfbzjrishytc ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939402.685329-30335-195046279532857/AnsiballZ_process_facts.py
-    pid: '14211'
-    ppid: '14196'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-arynnxtcgdzslnbrgpmpsfbzjrishytc ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939402.685329-30335-195046279532857/AnsiballZ_process_facts.py
-    pid: '14212'
-    ppid: '14211'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939402.685329-30335-195046279532857/AnsiballZ_process_facts.py
-    pid: '14213'
-    ppid: '14212'
-    user: root
-  - cmdline: 'postgres: grafana grafana 127.0.0.1(57788) idle'
-    pid: '20430'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: grafana grafana 127.0.0.1(57792) idle'
-    pid: '20432'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: ''
-    pid: '27396'
-    ppid: '2'
-    user: root
-  - cmdline: bash
-    pid: '28255'
-    ppid: '10256'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1143
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:55:30 2022
-    user: root
-  - address: 0.0.0.0
-    name: python
-    pid: 1464
-    port: 3004
-    protocol: tcp
-    stime: Fri Jul  1 10:19:20 2022
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 1054
-    port: 10050
-    protocol: tcp
-    stime: Tue Apr 26 15:55:27 2022
-    user: zabbix
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:54:45 2022
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:55:33 2022
-    user: root
-  - address: 0.0.0.0
-    name: postgres
-    pid: 10435
-    port: 5432
-    protocol: tcp
-    stime: Tue Apr 26 15:56:50 2022
-    user: polkitd
-  - address: ::1
-    name: master
-    pid: 1143
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:55:30 2022
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:54:45 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:55:33 2022
-    user: root
-  - address: '::'
-    name: grafana-serve
-    pid: 10876
-    port: 3000
-    protocol: tcp
-    stime: Tue Apr 26 15:57:06 2022
-    user: grafana
-  - address: '::'
-    name: postgres
-    pid: 10435
-    port: 5432
-    protocol: tcp
-    stime: Tue Apr 26 15:56:50 2022
-    user: polkitd
-udp_listen:
-  - address: 0.0.0.0
+  type: IOMetrics Visualizer API
+  version:
+  - number: 2.9.0-117ca93
+    type: docker
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: Tue Apr 26 15:55:26 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:54:45 2022
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:55:13 2022
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.3.1p1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 3.el7
+    source: rpm
+    version: '1.217'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: Tue Apr 26 15:55:13 2022
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:54:45 2022
-    user: root
-  - address: ::1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:55:13 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: Tue Apr 26 15:55:13 2022
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 22.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '40'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '100'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '261'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '333'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '377'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '393'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '477'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '543'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '566'
+  ppid: '2'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '719'
+  ppid: '1'
+  user: dbus
+- cmdline: ''
+  cwd: /
+  pid: '721'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '728'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '730'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '734'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '738'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '750'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H grafana01 eth0
+  cwd: /sbin/
+  pid: '978'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1038'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1041'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1044'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '1054'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1055'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1056'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1057'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1058'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1059'
+  ppid: '1054'
+  user: zabbix
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1143'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1148'
+  ppid: '1143'
+  user: postfix
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1182'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1184'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1187'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1198'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1199'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1208'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-visualizer-api
+  cwd: /usr/bin/
+  pid: '1397'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '1430'
+  ppid: '1044'
+  user: root
+- cmdline: python ./main.py
+  cwd: /
+  pid: '1464'
+  ppid: '1430'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4951'
+  ppid: '2'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '8035'
+  ppid: '10860'
+  user: grafana
+- cmdline: ''
+  cwd: /
+  pid: '8482'
+  ppid: '2'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10256'
+  ppid: '1044'
+  user: root
+- cmdline: postgres
+  cwd: /
+  pid: '10435'
+  ppid: '10256'
+  user: polkitd
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10463'
+  ppid: '1044'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '10501'
+  ppid: '10463'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '10612'
+  ppid: '10501'
+  user: '101'
+- cmdline: /usr/bin/docker start -a nginx
+  cwd: /usr/bin/
+  pid: '10630'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a postgres-grafana
+  cwd: /usr/bin/
+  pid: '10633'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '10848'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '10849'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '10850'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '10851'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '10852'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '10853'
+  ppid: '10435'
+  user: polkitd
+- cmdline: /usr/bin/docker start -a grafana
+  cwd: /usr/bin/
+  pid: '10854'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10860'
+  ppid: '1044'
+  user: root
+- cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini
+    --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
+    cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/usr/share/grafana/plugins
+    cfg:default.paths.provisioning=/etc/grafana/provisioning
+  cwd: /
+  pid: '10876'
+  ppid: '10860'
+  user: grafana
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '11206'
+  ppid: '1143'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '11228'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '11582'
+  ppid: '1187'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '11584'
+  ppid: '11582'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-arynnxtcgdzslnbrgpmpsfbzjrishytc
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939402.685329-30335-195046279532857/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '14196'
+  ppid: '11584'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-arynnxtcgdzslnbrgpmpsfbzjrishytc
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939402.685329-30335-195046279532857/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '14211'
+  ppid: '14196'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-arynnxtcgdzslnbrgpmpsfbzjrishytc ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656939402.685329-30335-195046279532857/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '14212'
+  ppid: '14211'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939402.685329-30335-195046279532857/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '14213'
+  ppid: '14212'
+  user: root
+- cmdline: 'postgres: grafana grafana 127.0.0.1(57788) idle'
+  cwd: /
+  pid: '20430'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: grafana grafana 127.0.0.1(57792) idle'
+  cwd: /
+  pid: '20432'
+  ppid: '10435'
+  user: polkitd
+- cmdline: ''
+  cwd: /
+  pid: '27396'
+  ppid: '2'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '28255'
+  ppid: '10256'
+  user: root
+software_list:
+- cmd_regexp: python ./main.py
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/iometrics_visualizer_api.yaml'
+    name: Include IOMetrics Visualizer API specific plugins
+  name: IOMetrics Visualizer API
+  process_type: parent
+  return_children: false
+  return_packages: false
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1143
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: python
+  pid: 1464
+  port: 3004
+  protocol: tcp
+  stime: Fri Jul  1 10:19:20 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 1054
+  port: 10050
+  protocol: tcp
+  stime: Tue Apr 26 15:55:27 2022
+  user: zabbix
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:33 2022
+  user: root
+- address: 0.0.0.0
+  name: postgres
+  pid: 10435
+  port: 5432
+  protocol: tcp
+  stime: Tue Apr 26 15:56:50 2022
+  user: polkitd
+- address: ::1
+  name: master
+  pid: 1143
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:33 2022
+  user: root
+- address: '::'
+  name: grafana-serve
+  pid: 10876
+  port: 3000
+  protocol: tcp
+  stime: Tue Apr 26 15:57:06 2022
+  user: grafana
+- address: '::'
+  name: postgres
+  pid: 10435
+  port: 5432
+  protocol: tcp
+  stime: Tue Apr 26 15:56:50 2022
+  user: polkitd
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/jboss/jboss7.4_domain-master_centos7.6.yaml
+++ b/tests/unit/plugins/action/auto/resources/jboss/jboss7.4_domain-master_centos7.6.yaml
@@ -1,11223 +1,11402 @@
-mocked_plugin_tasks:
-  "Run entry regex":
-    calls:
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - run
-      - run
-      - run
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - run
-      - run
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-  "Check if controller information is available":
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-  "Check if version file is accessible":
-    expected_args:
-      path: "/opt/jboss/version.txt"
-      follow: False
-      get_attributes: True
-      get_mime: True
-      in_docker: True
-    plugin_result:
-      failed: false
-  "Read version file":
-    expected_args:
-      delegate_reading: False
-      file_path: "/opt/jboss/version.txt"
-      in_docker: True
-      parser: null
-      parser_params: null
-    plugin_result:
-      failed: false
-      content: "Red Hat JBoss Enterprise Application Platform - Version 7.4.0.GA"
-  "Check if logging_conf_file is accessible":
-    expected_args:
-      path: "/opt/jboss/domain/servers/nodo1-server1/data/logging.properties"
-      follow: False
-      get_attributes: True
-      get_mime: True
-      in_docker: True
-    plugin_result:
-      failed: false
-  "Read logging_conf_file if accessible":
-    expected_args:
-      delegate_reading: False
-      file_path: "/opt/jboss/domain/servers/nodo1-server1/data/logging.properties"
-      in_docker: True
-      parser: null
-      parser_params: null
-    plugin_result:
-      failed: false
-      content: |-
-        # Note this file has been generated and will be overwritten if a
-        # logging subsystem has been defined in the XML configuration.
-        
-        
-        # Additional loggers to configure (the root logger is always configured)
-        loggers=sun.rmi,org.jboss.as.config,io.jaegertracing.Configuration,com.arjuna
-        
-        logger.level=INFO
-        logger.handlers=FILE
-        
-        logger.sun.rmi.level=WARN
-        logger.sun.rmi.useParentHandlers=true
-        
-        logger.org.jboss.as.config.level=DEBUG
-        logger.org.jboss.as.config.useParentHandlers=true
-        
-        logger.io.jaegertracing.Configuration.level=WARN
-        logger.io.jaegertracing.Configuration.useParentHandlers=true
-        
-        logger.com.arjuna.level=WARN
-        logger.com.arjuna.useParentHandlers=true
-        
-        handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
-        handler.FILE.level=ALL
-        handler.FILE.formatter=PATTERN
-        handler.FILE.properties=autoFlush,append,fileName,suffix
-        handler.FILE.constructorProperties=fileName,append
-        handler.FILE.autoFlush=true
-        handler.FILE.append=true
-        handler.FILE.fileName=/opt/jboss/domain/servers/nodo1-server1/log/server.log
-        handler.FILE.suffix=.yyyy-MM-dd
-        
-        # Additional formatters to configure
-        formatters=COLOR-PATTERN
-        
-        
-        formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
-        formatter.PATTERN.properties=pattern
-        formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
-        
-        formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
-        formatter.COLOR-PATTERN.properties=pattern
-        formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
-  
-  
-
-  "Check if host_xml_file is accessible":
-    expected_args:
-      path: "/opt/jboss/domain/configuration/host.xml"
-      follow: False
-      get_attributes: True
-      get_mime: True
-      in_docker: True
-    plugin_result:
-      failed: false
-  "Read host_xml_file":
-    expected_args:
-      delegate_reading: False
-      file_path: "/opt/jboss/domain/configuration/host.xml"
-      in_docker: True
-      parser: "xml"
-      parser_params: null
-    plugin_result:
-      failed: false
-      parsed:
-        host:
-          attr-name: nodo1-master
-          attr-xmlns: urn:jboss:domain:16.0
-          domain-controller:
-            local: null
-          extensions:
-            extension:
-              - attr-module: org.jboss.as.jmx
-              - attr-module: org.wildfly.extension.core-management
-              - attr-module: org.wildfly.extension.elytron
-          interfaces:
-            interface:
-              - attr-name: management
-                inet-address:
-                  attr-value: ${jboss.bind.address.management:0.0.0.0}
-              - attr-name: public
-                inet-address:
-                  attr-value: ${jboss.bind.address:0.0.0.0}
-          jvms:
-            jvm:
-              attr-name: default
-              heap:
-                attr-max-size: 256m
-                attr-size: 64m
-              jvm-options:
-                option:
-                  - attr-value: -server
-                  - attr-value: -XX:MetaspaceSize=96m
-                  - attr-value: -XX:MaxMetaspaceSize=256m
-          management:
-            audit-log:
-              formatters:
-                json-formatter:
-                  attr-name: json-formatter
-              handlers:
-                file-handler:
-                  - attr-formatter: json-formatter
-                    attr-name: host-file
-                    attr-path: audit-log.log
-                    attr-relative-to: jboss.domain.data.dir
-                  - attr-formatter: json-formatter
-                    attr-name: server-file
-                    attr-path: audit-log.log
-                    attr-relative-to: jboss.server.data.dir
-              logger:
-                attr-enabled: 'false'
-                attr-log-boot: 'true'
-                attr-log-read-only: 'false'
-                handlers:
-                  handler:
-                    attr-name: host-file
-              server-logger:
-                attr-enabled: 'false'
-                attr-log-boot: 'true'
-                attr-log-read-only: 'false'
-                handlers:
-                  handler:
-                    attr-name: server-file
-            management-interfaces:
-              http-interface:
-                attr-security-realm: ManagementRealm
-                http-upgrade:
-                  attr-enabled: 'true'
-                socket:
-                  attr-interface: management
-                  attr-port: ${jboss.management.http.port:9990}
-              native-interface:
-                socket:
-                  attr-interface: management
-                  attr-port: ${jboss.management.native.port:9999}
-            security-realms:
-              security-realm:
-                - attr-name: ManagementRealm
-                  authentication:
-                    local:
-                      attr-default-user: $local
-                      attr-skip-group-loading: 'true'
-                    properties:
-                      attr-path: mgmt-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  authorization:
-                    attr-map-groups-to-roles: 'false'
-                    properties:
-                      attr-path: mgmt-groups.properties
-                      attr-relative-to: jboss.domain.config.dir
-                - attr-name: ApplicationRealm
-                  authentication:
-                    local:
-                      attr-allowed-users: '*'
-                      attr-default-user: $local
-                      attr-skip-group-loading: 'true'
-                    properties:
-                      attr-path: application-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  authorization:
-                    properties:
-                      attr-path: application-roles.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  server-identities:
-                    ssl:
-                      keystore:
-                        attr-alias: server
-                        attr-generate-self-signed-certificate-host: localhost
-                        attr-key-password: password
-                        attr-keystore-password: password
-                        attr-path: application.keystore
-                        attr-relative-to: jboss.domain.config.dir
-          profile:
-            subsystem:
-              - attr-xmlns: urn:jboss:domain:core-management:1.0
-              - attr-disallowed-providers: OracleUcrypto
-                attr-final-providers: combined-providers
-                attr-xmlns: urn:wildfly:elytron:13.0
-                audit-logging:
-                  file-audit-log:
-                    attr-format: JSON
-                    attr-name: local-audit
-                    attr-path: audit.log
-                    attr-relative-to: jboss.domain.log.dir
-                http:
-                  http-authentication-factory:
-                    attr-http-server-mechanism-factory: global
-                    attr-name: management-http-authentication
-                    attr-security-domain: ManagementDomain
-                    mechanism-configuration:
-                      mechanism:
-                        attr-mechanism-name: BASIC
-                        mechanism-realm:
-                          attr-realm-name: Management Realm
-                  provider-http-server-mechanism-factory:
-                    attr-name: global
-                mappers:
-                  constant-realm-mapper:
-                    attr-name: local
-                    attr-realm-name: local
-                  constant-role-mapper:
-                    attr-name: super-user-mapper
-                    role:
-                      attr-name: SuperUser
-                  simple-permission-mapper:
-                    attr-mapping-mode: first
-                    attr-name: default-permission-mapper
-                    permission-mapping:
-                      - permission-set:
-                          attr-name: default-permissions
-                        principal:
-                          attr-name: anonymous
-                      - attr-match-all: 'true'
-                        permission-set:
-                          - attr-name: login-permission
-                          - attr-name: default-permissions
-                  simple-role-decoder:
-                    attr-attribute: groups
-                    attr-name: groups-to-roles
-                permission-sets:
-                  permission-set:
-                    - attr-name: login-permission
-                      permission:
-                        attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                    - attr-name: default-permissions
-                providers:
-                  aggregate-providers:
-                    attr-name: combined-providers
-                    providers:
-                      - attr-name: elytron
-                      - attr-name: openssl
-                  provider-loader:
-                    - attr-module: org.wildfly.security.elytron
-                      attr-name: elytron
-                    - attr-module: org.wildfly.openssl
-                      attr-name: openssl
-                sasl:
-                  configurable-sasl-server-factory:
-                    attr-name: configured
-                    attr-sasl-server-factory: elytron
-                    properties:
-                      property:
-                        attr-name: wildfly.sasl.local-user.default-user
-                        attr-value: $local
-                  mechanism-provider-filtering-sasl-server-factory:
-                    attr-name: elytron
-                    attr-sasl-server-factory: global
-                    filters:
-                      filter:
-                        attr-provider-name: WildFlyElytron
-                  provider-sasl-server-factory:
-                    attr-name: global
-                  sasl-authentication-factory:
-                    attr-name: management-sasl-authentication
-                    attr-sasl-server-factory: configured
-                    attr-security-domain: ManagementDomain
-                    mechanism-configuration:
-                      mechanism:
-                        - attr-mechanism-name: JBOSS-LOCAL-USER
-                          attr-realm-mapper: local
-                        - attr-mechanism-name: DIGEST-MD5
-                          mechanism-realm:
-                            attr-realm-name: ManagementRealm
-                security-domains:
-                  security-domain:
-                    attr-default-realm: ManagementRealm
-                    attr-name: ManagementDomain
-                    attr-permission-mapper: default-permission-mapper
-                    realm:
-                      - attr-name: ManagementRealm
-                        attr-role-decoder: groups-to-roles
-                      - attr-name: local
-                        attr-role-mapper: super-user-mapper
-                security-realms:
-                  identity-realm:
-                    attr-identity: $local
-                    attr-name: local
-                  properties-realm:
-                    attr-name: ManagementRealm
-                    groups-properties:
-                      attr-path: mgmt-groups.properties
-                      attr-relative-to: jboss.domain.config.dir
-                    users-properties:
-                      attr-digest-realm-name: ManagementRealm
-                      attr-path: mgmt-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-              - attr-xmlns: urn:jboss:domain:jmx:1.3
-                expose-expression-model: null
-                expose-resolved-model: null
-                remoting-connector: null
-          servers:
-            server:
-              - attr-auto-start: 'true'
-                attr-group: main-server-group
-                attr-name: nodo1-server1
-              - attr-auto-start: 'true'
-                attr-group: second-server-group
-                attr-name: nodo1-server2
-                jvm:
-                  attr-name: default
-                socket-bindings:
-                  attr-port-offset: '150'
-  "Check if domain_xml_file is accessible":
-    expected_args:
-      path: "/opt/jboss/domain/configuration/domain.xml"
-      follow: False
-      get_attributes: True
-      get_mime: True
-      in_docker: True
-    plugin_result:
-      failed: false
-  "Read domain_xml_file":
-    expected_args:
-      delegate_reading: False
-      file_path: "/opt/jboss/domain/configuration/domain.xml"
-      in_docker: True
-      parser: "xml"
-      parser_params: null
-    plugin_result:
-      failed: false
-      parsed:
-        domain:
-          attr-xmlns: urn:jboss:domain:16.0
-          extensions:
-            extension:
-              - attr-module: org.jboss.as.clustering.infinispan
-              - attr-module: org.jboss.as.clustering.jgroups
-              - attr-module: org.jboss.as.connector
-              - attr-module: org.jboss.as.ee
-              - attr-module: org.jboss.as.ejb3
-              - attr-module: org.jboss.as.jaxrs
-              - attr-module: org.jboss.as.jdr
-              - attr-module: org.jboss.as.jmx
-              - attr-module: org.jboss.as.jpa
-              - attr-module: org.jboss.as.jsf
-              - attr-module: org.jboss.as.jsr77
-              - attr-module: org.jboss.as.logging
-              - attr-module: org.jboss.as.mail
-              - attr-module: org.jboss.as.modcluster
-              - attr-module: org.jboss.as.naming
-              - attr-module: org.jboss.as.pojo
-              - attr-module: org.jboss.as.remoting
-              - attr-module: org.jboss.as.sar
-              - attr-module: org.jboss.as.security
-              - attr-module: org.jboss.as.transactions
-              - attr-module: org.jboss.as.webservices
-              - attr-module: org.jboss.as.weld
-              - attr-module: org.wildfly.extension.batch.jberet
-              - attr-module: org.wildfly.extension.bean-validation
-              - attr-module: org.wildfly.extension.clustering.singleton
-              - attr-module: org.wildfly.extension.clustering.web
-              - attr-module: org.wildfly.extension.core-management
-              - attr-module: org.wildfly.extension.discovery
-              - attr-module: org.wildfly.extension.ee-security
-              - attr-module: org.wildfly.extension.elytron
-              - attr-module: org.wildfly.extension.io
-              - attr-module: org.wildfly.extension.messaging-activemq
-              - attr-module: org.wildfly.extension.request-controller
-              - attr-module: org.wildfly.extension.security.manager
-              - attr-module: org.wildfly.extension.undertow
-              - attr-module: org.wildfly.iiop-openjdk
-          host-excludes:
-            host-exclude:
-              - attr-name: EAP62
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.batch.jberet
-                    - attr-module: org.wildfly.extension.bean-validation
-                    - attr-module: org.wildfly.extension.clustering.singleton
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.io
-                    - attr-module: org.wildfly.extension.messaging-activemq
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.picketlink
-                    - attr-module: org.wildfly.extension.request-controller
-                    - attr-module: org.wildfly.extension.rts
-                    - attr-module: org.wildfly.extension.security.manager
-                    - attr-module: org.wildfly.extension.undertow
-                    - attr-module: org.wildfly.iiop-openjdk
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP6.2
-              - attr-name: EAP63
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.batch.jberet
-                    - attr-module: org.wildfly.extension.bean-validation
-                    - attr-module: org.wildfly.extension.clustering.singleton
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.io
-                    - attr-module: org.wildfly.extension.messaging-activemq
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.request-controller
-                    - attr-module: org.wildfly.extension.rts
-                    - attr-module: org.wildfly.extension.security.manager
-                    - attr-module: org.wildfly.extension.undertow
-                    - attr-module: org.wildfly.iiop-openjdk
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP6.3
-              - attr-name: EAP64
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.batch.jberet
-                    - attr-module: org.wildfly.extension.bean-validation
-                    - attr-module: org.wildfly.extension.clustering.singleton
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.io
-                    - attr-module: org.wildfly.extension.messaging-activemq
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.request-controller
-                    - attr-module: org.wildfly.extension.rts
-                    - attr-module: org.wildfly.extension.security.manager
-                    - attr-module: org.wildfly.extension.undertow
-                    - attr-module: org.wildfly.iiop-openjdk
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP6.4
-              - attr-name: EAP64z
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.batch.jberet
-                    - attr-module: org.wildfly.extension.bean-validation
-                    - attr-module: org.wildfly.extension.clustering.singleton
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.io
-                    - attr-module: org.wildfly.extension.messaging-activemq
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.request-controller
-                    - attr-module: org.wildfly.extension.rts
-                    - attr-module: org.wildfly.extension.security.manager
-                    - attr-module: org.wildfly.extension.undertow
-                    - attr-module: org.wildfly.iiop-openjdk
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-api-version:
-                  attr-major-version: '1'
-                  attr-minor-version: '8'
-              - attr-name: EAP70
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP7.0
-              - attr-name: EAP71
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP7.1
-              - attr-name: EAP72
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP7.2
-              - attr-name: EAP73
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP7.3
-          interfaces:
-            interface:
-              - attr-name: management
-              - attr-name: private
-                inet-address:
-                  attr-value: ${jboss.bind.address.private:127.0.0.1}
-              - any-address: null
-                attr-name: public
-              - attr-name: unsecure
-                inet-address:
-                  attr-value: ${jboss.bind.address.unsecure:127.0.0.1}
-          management:
-            access-control:
-              attr-provider: simple
-              role-mapping:
-                role:
-                  attr-name: SuperUser
-                  include:
-                    user:
-                      attr-name: $local
-          profiles:
-            profile:
-              - attr-name: default
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
-                    default-job-repository:
-                      attr-name: in-memory
-                    default-thread-pool:
-                      attr-name: batch
-                    job-repository:
-                      attr-name: in-memory
-                      in-memory: null
-                    thread-pool:
-                      attr-name: batch
-                      keepalive-time:
-                        attr-time: '30'
-                        attr-unit: seconds
-                      max-threads:
-                        attr-count: '10'
-                  - attr-xmlns: urn:jboss:domain:bean-validation:1.0
-                  - attr-xmlns: urn:jboss:domain:core-management:1.0
-                  - attr-xmlns: urn:jboss:domain:datasources:6.0
-                    datasources:
-                      datasource:
-                        attr-enabled: 'true'
-                        attr-jndi-name: java:jboss/datasources/ExampleDS
-                        attr-pool-name: ExampleDS
-                        attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
-                        attr-use-java-context: 'true'
-                        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-                        driver: h2
-                        security:
-                          password: sa
-                          user-name: sa
-                      drivers:
-                        driver:
-                          attr-module: com.h2database.h2
-                          attr-name: h2
-                          xa-datasource-class: org.h2.jdbcx.JdbcDataSource
-                  - attr-xmlns: urn:jboss:domain:discovery:1.0
-                  - attr-default-session-management: default
-                    attr-default-single-sign-on-management: default
-                    attr-xmlns: urn:jboss:domain:distributable-web:2.0
-                    infinispan-session-management:
-                      attr-cache-container: web
-                      attr-granularity: SESSION
-                      attr-name: default
-                      local-affinity: null
-                    infinispan-single-sign-on-management:
-                      attr-cache: sso
-                      attr-cache-container: web
-                      attr-name: default
-                    local-routing: null
-                  - attr-xmlns: urn:jboss:domain:ee:6.0
-                    concurrent:
-                      context-services:
-                        context-service:
-                          attr-jndi-name: java:jboss/ee/concurrency/context/default
-                          attr-name: default
-                          attr-use-transaction-setup-provider: 'true'
-                      managed-executor-services:
-                        managed-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/executor/default
-                          attr-keepalive-time: '5000'
-                          attr-name: default
-                      managed-scheduled-executor-services:
-                        managed-scheduled-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
-                          attr-keepalive-time: '3000'
-                          attr-name: default
-                      managed-thread-factories:
-                        managed-thread-factory:
-                          attr-context-service: default
-                          attr-jndi-name: java:jboss/ee/concurrency/factory/default
-                          attr-name: default
-                    default-bindings:
-                      attr-context-service: java:jboss/ee/concurrency/context/default
-                      attr-datasource: java:jboss/datasources/ExampleDS
-                      attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
-                      attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
-                      attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
-                    spec-descriptor-property-replacement: 'false'
-                  - attr-xmlns: urn:jboss:domain:ee-security:1.0
-                  - async:
-                      attr-thread-pool-name: default
-                    attr-xmlns: urn:jboss:domain:ejb3:9.0
-                    caches:
-                      cache:
-                        - attr-name: simple
-                        - attr-aliases: passivating clustered
-                          attr-name: distributable
-                          attr-passivation-store-ref: infinispan
-                    default-missing-method-permissions-deny-access:
-                      attr-value: 'true'
-                    default-security-domain:
-                      attr-value: other
-                    log-system-exceptions:
-                      attr-value: 'true'
-                    passivation-stores:
-                      passivation-store:
-                        attr-cache-container: ejb
-                        attr-max-size: '10000'
-                        attr-name: infinispan
-                    pools:
-                      bean-instance-pools:
-                        strict-max-pool:
-                          - attr-derive-size: from-cpu-count
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: mdb-strict-max-pool
-                          - attr-derive-size: from-worker-pools
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: slsb-strict-max-pool
-                    remote:
-                      attr-cluster: ejb
-                      attr-connectors: http-remoting-connector
-                      attr-thread-pool-name: default
-                      channel-creation-options:
-                        option:
-                          attr-name: MAX_OUTBOUND_MESSAGES
-                          attr-type: remoting
-                          attr-value: '1234'
-                    session-bean:
-                      singleton:
-                        attr-default-access-timeout: '5000'
-                      stateful:
-                        attr-cache-ref: simple
-                        attr-default-access-timeout: '5000'
-                        attr-passivation-disabled-cache-ref: simple
-                      stateless:
-                        bean-instance-pool-ref:
-                          attr-pool-name: slsb-strict-max-pool
-                    statistics:
-                      attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    thread-pools:
-                      thread-pool:
-                        attr-name: default
-                        keepalive-time:
-                          attr-time: '60'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '10'
-                    timer-service:
-                      attr-default-data-store: default-file-store
-                      attr-thread-pool-name: default
-                      data-stores:
-                        file-data-store:
-                          attr-name: default-file-store
-                          attr-path: timer-service-data
-                          attr-relative-to: jboss.server.data.dir
-                  - attr-disallowed-providers: OracleUcrypto
-                    attr-final-providers: combined-providers
-                    attr-xmlns: urn:wildfly:elytron:13.0
-                    audit-logging:
-                      file-audit-log:
-                        attr-format: JSON
-                        attr-name: local-audit
-                        attr-path: audit.log
-                        attr-relative-to: jboss.server.log.dir
-                    http:
-                      provider-http-server-mechanism-factory:
-                        attr-name: global
-                    mappers:
-                      constant-realm-mapper:
-                        attr-name: local
-                        attr-realm-name: local
-                      constant-role-mapper:
-                        attr-name: super-user-mapper
-                        role:
-                          attr-name: SuperUser
-                      simple-permission-mapper:
-                        attr-mapping-mode: first
-                        attr-name: default-permission-mapper
-                        permission-mapping:
-                          - permission-set:
-                              attr-name: default-permissions
-                            principal:
-                              attr-name: anonymous
-                          - attr-match-all: 'true'
-                            permission-set:
-                              - attr-name: login-permission
-                              - attr-name: default-permissions
-                      simple-role-decoder:
-                        attr-attribute: groups
-                        attr-name: groups-to-roles
-                    permission-sets:
-                      permission-set:
-                        - attr-name: login-permission
-                          permission:
-                            attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                        - attr-name: default-permissions
-                          permission:
-                            - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
-                              attr-module: org.wildfly.extension.batch.jberet
-                              attr-target-name: '*'
-                            - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
-                              attr-module: org.wildfly.transaction.client
-                            - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
-                              attr-module: org.jboss.ejb-client
-                    providers:
-                      aggregate-providers:
-                        attr-name: combined-providers
-                        providers:
-                          - attr-name: elytron
-                          - attr-name: openssl
-                      provider-loader:
-                        - attr-module: org.wildfly.security.elytron
-                          attr-name: elytron
-                        - attr-module: org.wildfly.openssl
-                          attr-name: openssl
-                    sasl:
-                      configurable-sasl-server-factory:
-                        attr-name: configured
-                        attr-sasl-server-factory: elytron
-                        properties:
-                          property:
-                            attr-name: wildfly.sasl.local-user.default-user
-                            attr-value: $local
-                      mechanism-provider-filtering-sasl-server-factory:
-                        attr-name: elytron
-                        attr-sasl-server-factory: global
-                        filters:
-                          filter:
-                            attr-provider-name: WildFlyElytron
-                      provider-sasl-server-factory:
-                        attr-name: global
-                      sasl-authentication-factory:
-                        attr-name: application-sasl-authentication
-                        attr-sasl-server-factory: configured
-                        attr-security-domain: ApplicationDomain
-                        mechanism-configuration:
-                          mechanism:
-                            - attr-mechanism-name: JBOSS-LOCAL-USER
-                              attr-realm-mapper: local
-                            - attr-mechanism-name: DIGEST-MD5
-                              mechanism-realm:
-                                attr-realm-name: ApplicationRealm
-                    security-domains:
-                      security-domain:
-                        attr-default-realm: ApplicationRealm
-                        attr-name: ApplicationDomain
-                        attr-permission-mapper: default-permission-mapper
-                        realm:
-                          attr-name: ApplicationRealm
-                          attr-role-decoder: groups-to-roles
-                    security-realms:
-                      identity-realm:
-                        attr-identity: $local
-                        attr-name: local
-                      properties-realm:
-                        attr-name: ApplicationRealm
-                        groups-properties:
-                          attr-path: application-roles.properties
-                          attr-relative-to: jboss.domain.config.dir
-                        users-properties:
-                          attr-digest-realm-name: ApplicationRealm
-                          attr-path: application-users.properties
-                          attr-relative-to: jboss.domain.config.dir
-                    tls:
-                      key-managers:
-                        key-manager:
-                          attr-generate-self-signed-certificate-host: localhost
-                          attr-key-store: applicationKS
-                          attr-name: applicationKM
-                          credential-reference:
-                            attr-clear-text: password
-                      key-stores:
-                        key-store:
-                          attr-name: applicationKS
-                          credential-reference:
-                            attr-clear-text: password
-                          file:
-                            attr-path: application.keystore
-                            attr-relative-to: jboss.domain.config.dir
-                          implementation:
-                            attr-type: JKS
-                      server-ssl-contexts:
-                        server-ssl-context:
-                          attr-key-manager: applicationKM
-                          attr-name: applicationSSC
-                  - attr-xmlns: urn:jboss:domain:infinispan:12.0
-                    cache-container:
-                      - attr-aliases: sfsb
-                        attr-default-cache: passivation
-                        attr-modules: org.wildfly.clustering.ejb.infinispan
-                        attr-name: ejb
-                        local-cache:
-                          attr-name: passivation
-                          file-store:
-                            attr-passivation: 'true'
-                            attr-purge: 'false'
-                      - attr-default-cache: passivation
-                        attr-modules: org.wildfly.clustering.web.infinispan
-                        attr-name: web
-                        local-cache:
-                          - attr-name: passivation
-                            file-store:
-                              attr-passivation: 'true'
-                              attr-purge: 'false'
-                          - attr-name: sso
-                      - attr-default-cache: default
-                        attr-modules: org.wildfly.clustering.server
-                        attr-name: server
-                        local-cache:
-                          attr-name: default
-                      - attr-modules: org.infinispan.hibernate-cache
-                        attr-name: hibernate
-                        local-cache:
-                          - attr-name: entity
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: local-query
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: timestamps
-                          - attr-name: pending-puts
-                            expiration:
-                              attr-max-idle: '60000'
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:jaxrs:2.0
-                  - archive-validation:
-                      attr-enabled: 'true'
-                      attr-fail-on-error: 'true'
-                      attr-fail-on-warn: 'false'
-                    attr-xmlns: urn:jboss:domain:jca:5.0
-                    bean-validation:
-                      attr-enabled: 'true'
-                    cached-connection-manager: null
-                    default-workmanager:
-                      long-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                      short-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                  - attr-xmlns: urn:jboss:domain:jdr:1.0
-                  - attr-xmlns: urn:jboss:domain:jmx:1.3
-                    expose-expression-model: null
-                    expose-resolved-model: null
-                  - attr-xmlns: urn:jboss:domain:jpa:1.1
-                    jpa:
-                      attr-default-extended-persistence-inheritance: DEEP
-                  - attr-xmlns: urn:jboss:domain:jsf:1.1
-                  - attr-xmlns: urn:jboss:domain:mail:4.0
-                    mail-session:
-                      attr-jndi-name: java:jboss/mail/Default
-                      attr-name: default
-                      smtp-server:
-                        attr-outbound-socket-binding-ref: mail-smtp
-                  - attr-xmlns: urn:jboss:domain:naming:2.0
-                    remote-naming: null
-                  - attr-xmlns: urn:jboss:domain:pojo:1.0
-                  - attr-xmlns: urn:jboss:domain:remoting:4.0
-                    http-connector:
-                      attr-connector-ref: default
-                      attr-name: http-remoting-connector
-                      attr-security-realm: ApplicationRealm
-                  - attr-xmlns: urn:jboss:domain:request-controller:1.0
-                  - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
-                  - attr-xmlns: urn:jboss:domain:sar:1.0
-                  - attr-xmlns: urn:jboss:domain:security:2.0
-                    security-domains:
-                      security-domain:
-                        - attr-cache-type: default
-                          attr-name: other
-                          authentication:
-                            login-module:
-                              - attr-code: Remoting
-                                attr-flag: optional
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                              - attr-code: RealmDirect
-                                attr-flag: required
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                        - attr-cache-type: default
-                          attr-name: jboss-web-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                        - attr-cache-type: default
-                          attr-name: jaspitest
-                          authentication-jaspi:
-                            auth-module:
-                              attr-code: Dummy
-                            login-module-stack:
-                              attr-name: dummy
-                              login-module:
-                                attr-code: Dummy
-                                attr-flag: optional
-                        - attr-cache-type: default
-                          attr-name: jboss-ejb-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                  - attr-xmlns: urn:jboss:domain:security-manager:1.0
-                    deployment-permissions:
-                      maximum-set:
-                        permission:
-                          attr-class: java.security.AllPermission
-                  - attr-xmlns: urn:jboss:domain:transactions:6.0
-                    coordinator-environment:
-                      attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    core-environment:
-                      attr-node-identifier: ${jboss.tx.node.id:1}
-                      process-id:
-                        uuid: null
-                    object-store:
-                      attr-path: tx-object-store
-                      attr-relative-to: jboss.server.data.dir
-                    recovery-environment:
-                      attr-socket-binding: txn-recovery-environment
-                      attr-status-socket-binding: txn-status-manager
-                  - attr-default-security-domain: other
-                    attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    handlers:
-                      file:
-                        attr-name: welcome-content
-                        attr-path: ${jboss.home.dir}/welcome-content
-                    server:
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        http-invoker:
-                          attr-security-realm: ApplicationRealm
-                        location:
-                          attr-handler: welcome-content
-                          attr-name: /
-                      http-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: default
-                        attr-redirect-socket: https
-                        attr-socket-binding: http
-                      https-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: https
-                        attr-security-realm: ApplicationRealm
-                        attr-socket-binding: https
-                    servlet-container:
-                      attr-name: default
-                      jsp-config: null
-                      websockets: null
-                  - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:webservices:2.0
-                    client-config:
-                      attr-name: Standard-Client-Config
-                    endpoint-config:
-                      - attr-name: Standard-Endpoint-Config
-                      - attr-name: Recording-Endpoint-Config
-                        pre-handler-chain:
-                          attr-name: recording-handlers
-                          attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM'
-                          handler:
-                            attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
-                            attr-name: RecordingHandler
-                    wsdl-host: ${jboss.bind.address:127.0.0.1}
-                  - attr-xmlns: urn:jboss:domain:weld:4.0
-              - attr-name: ha
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
-                    default-job-repository:
-                      attr-name: in-memory
-                    default-thread-pool:
-                      attr-name: batch
-                    job-repository:
-                      attr-name: in-memory
-                      in-memory: null
-                    thread-pool:
-                      attr-name: batch
-                      keepalive-time:
-                        attr-time: '30'
-                        attr-unit: seconds
-                      max-threads:
-                        attr-count: '10'
-                  - attr-xmlns: urn:jboss:domain:bean-validation:1.0
-                  - attr-xmlns: urn:jboss:domain:core-management:1.0
-                  - attr-xmlns: urn:jboss:domain:datasources:6.0
-                    datasources:
-                      datasource:
-                        attr-enabled: 'true'
-                        attr-jndi-name: java:jboss/datasources/ExampleDS
-                        attr-pool-name: ExampleDS
-                        attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
-                        attr-use-java-context: 'true'
-                        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-                        driver: h2
-                        security:
-                          password: sa
-                          user-name: sa
-                      drivers:
-                        driver:
-                          attr-module: com.h2database.h2
-                          attr-name: h2
-                          xa-datasource-class: org.h2.jdbcx.JdbcDataSource
-                  - attr-xmlns: urn:jboss:domain:discovery:1.0
-                  - attr-default-session-management: default
-                    attr-default-single-sign-on-management: default
-                    attr-xmlns: urn:jboss:domain:distributable-web:2.0
-                    infinispan-routing:
-                      attr-cache: routing
-                      attr-cache-container: web
-                    infinispan-session-management:
-                      attr-cache-container: web
-                      attr-granularity: SESSION
-                      attr-name: default
-                      primary-owner-affinity: null
-                    infinispan-single-sign-on-management:
-                      attr-cache: sso
-                      attr-cache-container: web
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:ee:6.0
-                    concurrent:
-                      context-services:
-                        context-service:
-                          attr-jndi-name: java:jboss/ee/concurrency/context/default
-                          attr-name: default
-                          attr-use-transaction-setup-provider: 'true'
-                      managed-executor-services:
-                        managed-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/executor/default
-                          attr-keepalive-time: '5000'
-                          attr-name: default
-                      managed-scheduled-executor-services:
-                        managed-scheduled-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
-                          attr-keepalive-time: '3000'
-                          attr-name: default
-                      managed-thread-factories:
-                        managed-thread-factory:
-                          attr-context-service: default
-                          attr-jndi-name: java:jboss/ee/concurrency/factory/default
-                          attr-name: default
-                    default-bindings:
-                      attr-context-service: java:jboss/ee/concurrency/context/default
-                      attr-datasource: java:jboss/datasources/ExampleDS
-                      attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
-                      attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
-                      attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
-                    spec-descriptor-property-replacement: 'false'
-                  - attr-xmlns: urn:jboss:domain:ee-security:1.0
-                  - async:
-                      attr-thread-pool-name: default
-                    attr-xmlns: urn:jboss:domain:ejb3:9.0
-                    caches:
-                      cache:
-                        - attr-name: simple
-                        - attr-aliases: passivating clustered
-                          attr-name: distributable
-                          attr-passivation-store-ref: infinispan
-                    default-missing-method-permissions-deny-access:
-                      attr-value: 'true'
-                    default-security-domain:
-                      attr-value: other
-                    log-system-exceptions:
-                      attr-value: 'true'
-                    passivation-stores:
-                      passivation-store:
-                        attr-cache-container: ejb
-                        attr-max-size: '10000'
-                        attr-name: infinispan
-                    pools:
-                      bean-instance-pools:
-                        strict-max-pool:
-                          - attr-derive-size: from-cpu-count
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: mdb-strict-max-pool
-                          - attr-derive-size: from-worker-pools
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: slsb-strict-max-pool
-                    remote:
-                      attr-cluster: ejb
-                      attr-connectors: http-remoting-connector
-                      attr-thread-pool-name: default
-                      channel-creation-options:
-                        option:
-                          attr-name: MAX_OUTBOUND_MESSAGES
-                          attr-type: remoting
-                          attr-value: '1234'
-                    session-bean:
-                      singleton:
-                        attr-default-access-timeout: '5000'
-                      stateful:
-                        attr-cache-ref: distributable
-                        attr-default-access-timeout: '5000'
-                        attr-passivation-disabled-cache-ref: simple
-                      stateless:
-                        bean-instance-pool-ref:
-                          attr-pool-name: slsb-strict-max-pool
-                    statistics:
-                      attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    thread-pools:
-                      thread-pool:
-                        attr-name: default
-                        keepalive-time:
-                          attr-time: '60'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '10'
-                    timer-service:
-                      attr-default-data-store: default-file-store
-                      attr-thread-pool-name: default
-                      data-stores:
-                        file-data-store:
-                          attr-name: default-file-store
-                          attr-path: timer-service-data
-                          attr-relative-to: jboss.server.data.dir
-                  - attr-disallowed-providers: OracleUcrypto
-                    attr-final-providers: combined-providers
-                    attr-xmlns: urn:wildfly:elytron:13.0
-                    audit-logging:
-                      file-audit-log:
-                        attr-format: JSON
-                        attr-name: local-audit
-                        attr-path: audit.log
-                        attr-relative-to: jboss.server.log.dir
-                    http:
-                      provider-http-server-mechanism-factory:
-                        attr-name: global
-                    mappers:
-                      constant-realm-mapper:
-                        attr-name: local
-                        attr-realm-name: local
-                      constant-role-mapper:
-                        attr-name: super-user-mapper
-                        role:
-                          attr-name: SuperUser
-                      simple-permission-mapper:
-                        attr-mapping-mode: first
-                        attr-name: default-permission-mapper
-                        permission-mapping:
-                          - permission-set:
-                              attr-name: default-permissions
-                            principal:
-                              attr-name: anonymous
-                          - attr-match-all: 'true'
-                            permission-set:
-                              - attr-name: login-permission
-                              - attr-name: default-permissions
-                      simple-role-decoder:
-                        attr-attribute: groups
-                        attr-name: groups-to-roles
-                    permission-sets:
-                      permission-set:
-                        - attr-name: login-permission
-                          permission:
-                            attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                        - attr-name: default-permissions
-                          permission:
-                            - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
-                              attr-module: org.wildfly.extension.batch.jberet
-                              attr-target-name: '*'
-                            - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
-                              attr-module: org.wildfly.transaction.client
-                            - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
-                              attr-module: org.jboss.ejb-client
-                    providers:
-                      aggregate-providers:
-                        attr-name: combined-providers
-                        providers:
-                          - attr-name: elytron
-                          - attr-name: openssl
-                      provider-loader:
-                        - attr-module: org.wildfly.security.elytron
-                          attr-name: elytron
-                        - attr-module: org.wildfly.openssl
-                          attr-name: openssl
-                    sasl:
-                      configurable-sasl-server-factory:
-                        attr-name: configured
-                        attr-sasl-server-factory: elytron
-                        properties:
-                          property:
-                            attr-name: wildfly.sasl.local-user.default-user
-                            attr-value: $local
-                      mechanism-provider-filtering-sasl-server-factory:
-                        attr-name: elytron
-                        attr-sasl-server-factory: global
-                        filters:
-                          filter:
-                            attr-provider-name: WildFlyElytron
-                      provider-sasl-server-factory:
-                        attr-name: global
-                      sasl-authentication-factory:
-                        attr-name: application-sasl-authentication
-                        attr-sasl-server-factory: configured
-                        attr-security-domain: ApplicationDomain
-                        mechanism-configuration:
-                          mechanism:
-                            - attr-mechanism-name: JBOSS-LOCAL-USER
-                              attr-realm-mapper: local
-                            - attr-mechanism-name: DIGEST-MD5
-                              mechanism-realm:
-                                attr-realm-name: ApplicationRealm
-                    security-domains:
-                      security-domain:
-                        attr-default-realm: ApplicationRealm
-                        attr-name: ApplicationDomain
-                        attr-permission-mapper: default-permission-mapper
-                        realm:
-                          attr-name: ApplicationRealm
-                          attr-role-decoder: groups-to-roles
-                    security-realms:
-                      identity-realm:
-                        attr-identity: $local
-                        attr-name: local
-                      properties-realm:
-                        attr-name: ApplicationRealm
-                        groups-properties:
-                          attr-path: application-roles.properties
-                          attr-relative-to: jboss.domain.config.dir
-                        users-properties:
-                          attr-digest-realm-name: ApplicationRealm
-                          attr-path: application-users.properties
-                          attr-relative-to: jboss.domain.config.dir
-                    tls:
-                      key-managers:
-                        key-manager:
-                          attr-generate-self-signed-certificate-host: localhost
-                          attr-key-store: applicationKS
-                          attr-name: applicationKM
-                          credential-reference:
-                            attr-clear-text: password
-                      key-stores:
-                        key-store:
-                          attr-name: applicationKS
-                          credential-reference:
-                            attr-clear-text: password
-                          file:
-                            attr-path: application.keystore
-                            attr-relative-to: jboss.domain.config.dir
-                          implementation:
-                            attr-type: JKS
-                      server-ssl-contexts:
-                        server-ssl-context:
-                          attr-key-manager: applicationKM
-                          attr-name: applicationSSC
-                  - attr-xmlns: urn:jboss:domain:infinispan:12.0
-                    cache-container:
-                      - attr-aliases: sfsb
-                        attr-default-cache: dist
-                        attr-modules: org.wildfly.clustering.ejb.infinispan
-                        attr-name: ejb
-                        distributed-cache:
-                          attr-name: dist
-                          file-store: null
-                          locking:
-                            attr-isolation: REPEATABLE_READ
-                          transaction:
-                            attr-mode: BATCH
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-aliases: singleton cluster
-                        attr-default-cache: default
-                        attr-modules: org.wildfly.clustering.server
-                        attr-name: server
-                        replicated-cache:
-                          attr-name: default
-                          transaction:
-                            attr-mode: BATCH
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-default-cache: dist
-                        attr-modules: org.wildfly.clustering.web.infinispan
-                        attr-name: web
-                        distributed-cache:
-                          attr-name: dist
-                          file-store: null
-                          locking:
-                            attr-isolation: REPEATABLE_READ
-                          transaction:
-                            attr-mode: BATCH
-                        replicated-cache:
-                          - attr-name: sso
-                            locking:
-                              attr-isolation: REPEATABLE_READ
-                            transaction:
-                              attr-mode: BATCH
-                          - attr-name: routing
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-modules: org.infinispan.hibernate-cache
-                        attr-name: hibernate
-                        invalidation-cache:
-                          attr-name: entity
-                          expiration:
-                            attr-max-idle: '100000'
-                          heap-memory:
-                            attr-size: '10000'
-                        local-cache:
-                          - attr-name: local-query
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: pending-puts
-                            expiration:
-                              attr-max-idle: '60000'
-                        replicated-cache:
-                          attr-name: timestamps
-                        transport:
-                          attr-lock-timeout: '60000'
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:jaxrs:2.0
-                  - archive-validation:
-                      attr-enabled: 'true'
-                      attr-fail-on-error: 'true'
-                      attr-fail-on-warn: 'false'
-                    attr-xmlns: urn:jboss:domain:jca:5.0
-                    bean-validation:
-                      attr-enabled: 'true'
-                    cached-connection-manager: null
-                    default-workmanager:
-                      long-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                      short-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                  - attr-xmlns: urn:jboss:domain:jdr:1.0
-                  - attr-xmlns: urn:jboss:domain:jgroups:8.0
-                    channels:
-                      attr-default: ee
-                      channel:
-                        attr-cluster: ejb
-                        attr-name: ee
-                        attr-stack: udp
-                    stacks:
-                      stack:
-                        - attr-name: udp
-                          protocol:
-                            - attr-type: PING
-                            - attr-type: MERGE3
-                            - attr-type: FD_ALL
-                            - attr-type: VERIFY_SUSPECT
-                            - attr-type: pbcast.NAKACK2
-                            - attr-type: UNICAST3
-                            - attr-type: pbcast.STABLE
-                            - attr-type: pbcast.GMS
-                            - attr-type: UFC
-                            - attr-type: MFC
-                            - attr-type: FRAG3
-                          socket-protocol:
-                            attr-socket-binding: jgroups-udp-fd
-                            attr-type: FD_SOCK
-                          transport:
-                            attr-socket-binding: jgroups-udp
-                            attr-type: UDP
-                        - attr-name: tcp
-                          protocol:
-                            - attr-type: MERGE3
-                            - attr-type: FD_ALL
-                            - attr-type: VERIFY_SUSPECT
-                            - attr-type: pbcast.NAKACK2
-                            - attr-type: UNICAST3
-                            - attr-type: pbcast.STABLE
-                            - attr-type: pbcast.GMS
-                            - attr-type: MFC
-                            - attr-type: FRAG3
-                          socket-protocol:
-                            - attr-socket-binding: jgroups-mping
-                              attr-type: MPING
-                            - attr-socket-binding: jgroups-tcp-fd
-                              attr-type: FD_SOCK
-                          transport:
-                            attr-socket-binding: jgroups-tcp
-                            attr-type: TCP
-                  - attr-xmlns: urn:jboss:domain:jmx:1.3
-                    expose-expression-model: null
-                    expose-resolved-model: null
-                  - attr-xmlns: urn:jboss:domain:jpa:1.1
-                    jpa:
-                      attr-default-extended-persistence-inheritance: DEEP
-                  - attr-xmlns: urn:jboss:domain:jsf:1.1
-                  - attr-xmlns: urn:jboss:domain:mail:4.0
-                    mail-session:
-                      attr-jndi-name: java:jboss/mail/Default
-                      attr-name: default
-                      smtp-server:
-                        attr-outbound-socket-binding-ref: mail-smtp
-                  - attr-xmlns: urn:jboss:domain:modcluster:5.0
-                    proxy:
-                      attr-advertise-socket: modcluster
-                      attr-listener: ajp
-                      attr-name: default
-                      dynamic-load-provider:
-                        load-metric:
-                          attr-type: cpu
-                  - attr-xmlns: urn:jboss:domain:naming:2.0
-                    remote-naming: null
-                  - attr-xmlns: urn:jboss:domain:pojo:1.0
-                  - attr-xmlns: urn:jboss:domain:remoting:4.0
-                    http-connector:
-                      attr-connector-ref: default
-                      attr-name: http-remoting-connector
-                      attr-security-realm: ApplicationRealm
-                  - attr-xmlns: urn:jboss:domain:request-controller:1.0
-                  - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
-                  - attr-xmlns: urn:jboss:domain:sar:1.0
-                  - attr-xmlns: urn:jboss:domain:security:2.0
-                    security-domains:
-                      security-domain:
-                        - attr-cache-type: default
-                          attr-name: other
-                          authentication:
-                            login-module:
-                              - attr-code: Remoting
-                                attr-flag: optional
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                              - attr-code: RealmDirect
-                                attr-flag: required
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                        - attr-cache-type: default
-                          attr-name: jboss-web-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                        - attr-cache-type: default
-                          attr-name: jaspitest
-                          authentication-jaspi:
-                            auth-module:
-                              attr-code: Dummy
-                            login-module-stack:
-                              attr-name: dummy
-                              login-module:
-                                attr-code: Dummy
-                                attr-flag: optional
-                        - attr-cache-type: default
-                          attr-name: jboss-ejb-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                  - attr-xmlns: urn:jboss:domain:security-manager:1.0
-                    deployment-permissions:
-                      maximum-set:
-                        permission:
-                          attr-class: java.security.AllPermission
-                  - attr-xmlns: urn:jboss:domain:singleton:1.0
-                    singleton-policies:
-                      attr-default: default
-                      singleton-policy:
-                        attr-cache-container: server
-                        attr-name: default
-                        simple-election-policy: null
-                  - attr-xmlns: urn:jboss:domain:transactions:6.0
-                    coordinator-environment:
-                      attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    core-environment:
-                      attr-node-identifier: ${jboss.tx.node.id:1}
-                      process-id:
-                        uuid: null
-                    object-store:
-                      attr-path: tx-object-store
-                      attr-relative-to: jboss.server.data.dir
-                    recovery-environment:
-                      attr-socket-binding: txn-recovery-environment
-                      attr-status-socket-binding: txn-status-manager
-                  - attr-default-security-domain: other
-                    attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    handlers:
-                      file:
-                        attr-name: welcome-content
-                        attr-path: ${jboss.home.dir}/welcome-content
-                    server:
-                      ajp-listener:
-                        attr-name: ajp
-                        attr-socket-binding: ajp
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        http-invoker:
-                          attr-security-realm: ApplicationRealm
-                        location:
-                          attr-handler: welcome-content
-                          attr-name: /
-                      http-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: default
-                        attr-redirect-socket: https
-                        attr-socket-binding: http
-                      https-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: https
-                        attr-security-realm: ApplicationRealm
-                        attr-socket-binding: https
-                    servlet-container:
-                      attr-name: default
-                      jsp-config: null
-                      websockets: null
-                  - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:webservices:2.0
-                    client-config:
-                      attr-name: Standard-Client-Config
-                    endpoint-config:
-                      - attr-name: Standard-Endpoint-Config
-                      - attr-name: Recording-Endpoint-Config
-                        pre-handler-chain:
-                          attr-name: recording-handlers
-                          attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM'
-                          handler:
-                            attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
-                            attr-name: RecordingHandler
-                    wsdl-host: ${jboss.bind.address:127.0.0.1}
-                  - attr-xmlns: urn:jboss:domain:weld:4.0
-              - attr-name: full
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
-                    default-job-repository:
-                      attr-name: in-memory
-                    default-thread-pool:
-                      attr-name: batch
-                    job-repository:
-                      attr-name: in-memory
-                      in-memory: null
-                    thread-pool:
-                      attr-name: batch
-                      keepalive-time:
-                        attr-time: '30'
-                        attr-unit: seconds
-                      max-threads:
-                        attr-count: '10'
-                  - attr-xmlns: urn:jboss:domain:bean-validation:1.0
-                  - attr-xmlns: urn:jboss:domain:core-management:1.0
-                  - attr-xmlns: urn:jboss:domain:datasources:6.0
-                    datasources:
-                      datasource:
-                        attr-enabled: 'true'
-                        attr-jndi-name: java:jboss/datasources/ExampleDS
-                        attr-pool-name: ExampleDS
-                        attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
-                        attr-use-java-context: 'true'
-                        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-                        driver: h2
-                        security:
-                          password: sa
-                          user-name: sa
-                      drivers:
-                        driver:
-                          attr-module: com.h2database.h2
-                          attr-name: h2
-                          xa-datasource-class: org.h2.jdbcx.JdbcDataSource
-                  - attr-xmlns: urn:jboss:domain:discovery:1.0
-                  - attr-default-session-management: default
-                    attr-default-single-sign-on-management: default
-                    attr-xmlns: urn:jboss:domain:distributable-web:2.0
-                    infinispan-session-management:
-                      attr-cache-container: web
-                      attr-granularity: SESSION
-                      attr-name: default
-                      local-affinity: null
-                    infinispan-single-sign-on-management:
-                      attr-cache: sso
-                      attr-cache-container: web
-                      attr-name: default
-                    local-routing: null
-                  - attr-xmlns: urn:jboss:domain:ee:6.0
-                    concurrent:
-                      context-services:
-                        context-service:
-                          attr-jndi-name: java:jboss/ee/concurrency/context/default
-                          attr-name: default
-                          attr-use-transaction-setup-provider: 'true'
-                      managed-executor-services:
-                        managed-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/executor/default
-                          attr-keepalive-time: '5000'
-                          attr-name: default
-                      managed-scheduled-executor-services:
-                        managed-scheduled-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
-                          attr-keepalive-time: '3000'
-                          attr-name: default
-                      managed-thread-factories:
-                        managed-thread-factory:
-                          attr-context-service: default
-                          attr-jndi-name: java:jboss/ee/concurrency/factory/default
-                          attr-name: default
-                    default-bindings:
-                      attr-context-service: java:jboss/ee/concurrency/context/default
-                      attr-datasource: java:jboss/datasources/ExampleDS
-                      attr-jms-connection-factory: java:jboss/DefaultJMSConnectionFactory
-                      attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
-                      attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
-                      attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
-                    spec-descriptor-property-replacement: 'false'
-                  - attr-xmlns: urn:jboss:domain:ee-security:1.0
-                  - async:
-                      attr-thread-pool-name: default
-                    attr-xmlns: urn:jboss:domain:ejb3:9.0
-                    caches:
-                      cache:
-                        - attr-name: simple
-                        - attr-aliases: passivating clustered
-                          attr-name: distributable
-                          attr-passivation-store-ref: infinispan
-                    default-missing-method-permissions-deny-access:
-                      attr-value: 'true'
-                    default-security-domain:
-                      attr-value: other
-                    iiop:
-                      attr-enable-by-default: 'false'
-                      attr-use-qualified-name: 'false'
-                    log-system-exceptions:
-                      attr-value: 'true'
-                    mdb:
-                      bean-instance-pool-ref:
-                        attr-pool-name: mdb-strict-max-pool
-                      resource-adapter-ref:
-                        attr-resource-adapter-name: ${ejb.resource-adapter-name:activemq-ra.rar}
-                    passivation-stores:
-                      passivation-store:
-                        attr-cache-container: ejb
-                        attr-max-size: '10000'
-                        attr-name: infinispan
-                    pools:
-                      bean-instance-pools:
-                        strict-max-pool:
-                          - attr-derive-size: from-cpu-count
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: mdb-strict-max-pool
-                          - attr-derive-size: from-worker-pools
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: slsb-strict-max-pool
-                    remote:
-                      attr-cluster: ejb
-                      attr-connectors: http-remoting-connector
-                      attr-thread-pool-name: default
-                      channel-creation-options:
-                        option:
-                          attr-name: MAX_OUTBOUND_MESSAGES
-                          attr-type: remoting
-                          attr-value: '1234'
-                    session-bean:
-                      singleton:
-                        attr-default-access-timeout: '5000'
-                      stateful:
-                        attr-cache-ref: simple
-                        attr-default-access-timeout: '5000'
-                        attr-passivation-disabled-cache-ref: simple
-                      stateless:
-                        bean-instance-pool-ref:
-                          attr-pool-name: slsb-strict-max-pool
-                    statistics:
-                      attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    thread-pools:
-                      thread-pool:
-                        attr-name: default
-                        keepalive-time:
-                          attr-time: '60'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '10'
-                    timer-service:
-                      attr-default-data-store: default-file-store
-                      attr-thread-pool-name: default
-                      data-stores:
-                        file-data-store:
-                          attr-name: default-file-store
-                          attr-path: timer-service-data
-                          attr-relative-to: jboss.server.data.dir
-                  - attr-disallowed-providers: OracleUcrypto
-                    attr-final-providers: combined-providers
-                    attr-xmlns: urn:wildfly:elytron:13.0
-                    audit-logging:
-                      file-audit-log:
-                        attr-format: JSON
-                        attr-name: local-audit
-                        attr-path: audit.log
-                        attr-relative-to: jboss.server.log.dir
-                    http:
-                      provider-http-server-mechanism-factory:
-                        attr-name: global
-                    mappers:
-                      constant-realm-mapper:
-                        attr-name: local
-                        attr-realm-name: local
-                      constant-role-mapper:
-                        attr-name: super-user-mapper
-                        role:
-                          attr-name: SuperUser
-                      simple-permission-mapper:
-                        attr-mapping-mode: first
-                        attr-name: default-permission-mapper
-                        permission-mapping:
-                          - permission-set:
-                              attr-name: default-permissions
-                            principal:
-                              attr-name: anonymous
-                          - attr-match-all: 'true'
-                            permission-set:
-                              - attr-name: login-permission
-                              - attr-name: default-permissions
-                      simple-role-decoder:
-                        attr-attribute: groups
-                        attr-name: groups-to-roles
-                    permission-sets:
-                      permission-set:
-                        - attr-name: login-permission
-                          permission:
-                            attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                        - attr-name: default-permissions
-                          permission:
-                            - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
-                              attr-module: org.wildfly.extension.batch.jberet
-                              attr-target-name: '*'
-                            - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
-                              attr-module: org.wildfly.transaction.client
-                            - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
-                              attr-module: org.jboss.ejb-client
-                    providers:
-                      aggregate-providers:
-                        attr-name: combined-providers
-                        providers:
-                          - attr-name: elytron
-                          - attr-name: openssl
-                      provider-loader:
-                        - attr-module: org.wildfly.security.elytron
-                          attr-name: elytron
-                        - attr-module: org.wildfly.openssl
-                          attr-name: openssl
-                    sasl:
-                      configurable-sasl-server-factory:
-                        attr-name: configured
-                        attr-sasl-server-factory: elytron
-                        properties:
-                          property:
-                            attr-name: wildfly.sasl.local-user.default-user
-                            attr-value: $local
-                      mechanism-provider-filtering-sasl-server-factory:
-                        attr-name: elytron
-                        attr-sasl-server-factory: global
-                        filters:
-                          filter:
-                            attr-provider-name: WildFlyElytron
-                      provider-sasl-server-factory:
-                        attr-name: global
-                      sasl-authentication-factory:
-                        attr-name: application-sasl-authentication
-                        attr-sasl-server-factory: configured
-                        attr-security-domain: ApplicationDomain
-                        mechanism-configuration:
-                          mechanism:
-                            - attr-mechanism-name: JBOSS-LOCAL-USER
-                              attr-realm-mapper: local
-                            - attr-mechanism-name: DIGEST-MD5
-                              mechanism-realm:
-                                attr-realm-name: ApplicationRealm
-                    security-domains:
-                      security-domain:
-                        attr-default-realm: ApplicationRealm
-                        attr-name: ApplicationDomain
-                        attr-permission-mapper: default-permission-mapper
-                        realm:
-                          attr-name: ApplicationRealm
-                          attr-role-decoder: groups-to-roles
-                    security-realms:
-                      identity-realm:
-                        attr-identity: $local
-                        attr-name: local
-                      properties-realm:
-                        attr-name: ApplicationRealm
-                        groups-properties:
-                          attr-path: application-roles.properties
-                          attr-relative-to: jboss.domain.config.dir
-                        users-properties:
-                          attr-digest-realm-name: ApplicationRealm
-                          attr-path: application-users.properties
-                          attr-relative-to: jboss.domain.config.dir
-                    tls:
-                      key-managers:
-                        key-manager:
-                          attr-generate-self-signed-certificate-host: localhost
-                          attr-key-store: applicationKS
-                          attr-name: applicationKM
-                          credential-reference:
-                            attr-clear-text: password
-                      key-stores:
-                        key-store:
-                          attr-name: applicationKS
-                          credential-reference:
-                            attr-clear-text: password
-                          file:
-                            attr-path: application.keystore
-                            attr-relative-to: jboss.domain.config.dir
-                          implementation:
-                            attr-type: JKS
-                      server-ssl-contexts:
-                        server-ssl-context:
-                          attr-key-manager: applicationKM
-                          attr-name: applicationSSC
-                  - attr-xmlns: urn:jboss:domain:iiop-openjdk:2.1
-                    initializers:
-                      attr-security: identity
-                      attr-transactions: spec
-                    orb:
-                      attr-socket-binding: iiop
-                    security:
-                      attr-client-requires-ssl: 'false'
-                      attr-server-requires-ssl: 'false'
-                  - attr-xmlns: urn:jboss:domain:infinispan:12.0
-                    cache-container:
-                      - attr-aliases: sfsb
-                        attr-default-cache: passivation
-                        attr-modules: org.wildfly.clustering.ejb.infinispan
-                        attr-name: ejb
-                        local-cache:
-                          attr-name: passivation
-                          file-store:
-                            attr-passivation: 'true'
-                            attr-purge: 'false'
-                      - attr-default-cache: passivation
-                        attr-modules: org.wildfly.clustering.web.infinispan
-                        attr-name: web
-                        local-cache:
-                          - attr-name: passivation
-                            file-store:
-                              attr-passivation: 'true'
-                              attr-purge: 'false'
-                          - attr-name: sso
-                      - attr-default-cache: default
-                        attr-modules: org.wildfly.clustering.server
-                        attr-name: server
-                        local-cache:
-                          attr-name: default
-                      - attr-modules: org.infinispan.hibernate-cache
-                        attr-name: hibernate
-                        local-cache:
-                          - attr-name: entity
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: local-query
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: timestamps
-                          - attr-name: pending-puts
-                            expiration:
-                              attr-max-idle: '60000'
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:jaxrs:2.0
-                  - archive-validation:
-                      attr-enabled: 'true'
-                      attr-fail-on-error: 'true'
-                      attr-fail-on-warn: 'false'
-                    attr-xmlns: urn:jboss:domain:jca:5.0
-                    bean-validation:
-                      attr-enabled: 'true'
-                    cached-connection-manager: null
-                    default-workmanager:
-                      long-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                      short-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                  - attr-xmlns: urn:jboss:domain:jdr:1.0
-                  - attr-xmlns: urn:jboss:domain:jmx:1.3
-                    expose-expression-model: null
-                    expose-resolved-model: null
-                  - attr-xmlns: urn:jboss:domain:jpa:1.1
-                    jpa:
-                      attr-default-extended-persistence-inheritance: DEEP
-                  - attr-xmlns: urn:jboss:domain:jsf:1.1
-                  - attr-xmlns: urn:jboss:domain:jsr77:1.0
-                  - attr-xmlns: urn:jboss:domain:mail:4.0
-                    mail-session:
-                      attr-jndi-name: java:jboss/mail/Default
-                      attr-name: default
-                      smtp-server:
-                        attr-outbound-socket-binding-ref: mail-smtp
-                  - attr-xmlns: urn:jboss:domain:messaging-activemq:13.0
-                    server:
-                      address-setting:
-                        attr-dead-letter-address: jms.queue.DLQ
-                        attr-expiry-address: jms.queue.ExpiryQueue
-                        attr-max-size-bytes: '10485760'
-                        attr-message-counter-history-day-limit: '10'
-                        attr-name: '#'
-                        attr-page-size-bytes: '2097152'
-                      attr-name: default
-                      connection-factory:
-                        - attr-connectors: in-vm
-                          attr-entries: java:/ConnectionFactory
-                          attr-name: InVmConnectionFactory
-                        - attr-connectors: http-connector
-                          attr-entries: java:jboss/exported/jms/RemoteConnectionFactory
-                          attr-name: RemoteConnectionFactory
-                      http-acceptor:
-                        - attr-http-listener: default
-                          attr-name: http-acceptor
-                        - attr-http-listener: default
-                          attr-name: http-acceptor-throughput
-                          param:
-                            - attr-name: batch-delay
-                              attr-value: '50'
-                            - attr-name: direct-deliver
-                              attr-value: 'false'
-                      http-connector:
-                        - attr-endpoint: http-acceptor
-                          attr-name: http-connector
-                          attr-socket-binding: http
-                        - attr-endpoint: http-acceptor-throughput
-                          attr-name: http-connector-throughput
-                          attr-socket-binding: http
-                          param:
-                            attr-name: batch-delay
-                            attr-value: '50'
-                      in-vm-acceptor:
-                        attr-name: in-vm
-                        attr-server-id: '0'
-                        param:
-                          attr-name: buffer-pooling
-                          attr-value: 'false'
-                      in-vm-connector:
-                        attr-name: in-vm
-                        attr-server-id: '0'
-                        param:
-                          attr-name: buffer-pooling
-                          attr-value: 'false'
-                      jms-queue:
-                        - attr-entries: java:/jms/queue/ExpiryQueue
-                          attr-name: ExpiryQueue
-                        - attr-entries: java:/jms/queue/DLQ
-                          attr-name: DLQ
-                      pooled-connection-factory:
-                        attr-connectors: in-vm
-                        attr-entries: java:/JmsXA java:jboss/DefaultJMSConnectionFactory
-                        attr-name: activemq-ra
-                        attr-transaction: xa
-                      security-setting:
-                        attr-name: '#'
-                        role:
-                          attr-consume: 'true'
-                          attr-create-non-durable-queue: 'true'
-                          attr-delete-non-durable-queue: 'true'
-                          attr-name: guest
-                          attr-send: 'true'
-                      statistics:
-                        attr-enabled: ${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}
-                  - attr-xmlns: urn:jboss:domain:naming:2.0
-                    remote-naming: null
-                  - attr-xmlns: urn:jboss:domain:pojo:1.0
-                  - attr-xmlns: urn:jboss:domain:remoting:4.0
-                    http-connector:
-                      attr-connector-ref: default
-                      attr-name: http-remoting-connector
-                      attr-security-realm: ApplicationRealm
-                  - attr-xmlns: urn:jboss:domain:request-controller:1.0
-                  - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
-                  - attr-xmlns: urn:jboss:domain:sar:1.0
-                  - attr-xmlns: urn:jboss:domain:security:2.0
-                    security-domains:
-                      security-domain:
-                        - attr-cache-type: default
-                          attr-name: other
-                          authentication:
-                            login-module:
-                              - attr-code: Remoting
-                                attr-flag: optional
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                              - attr-code: RealmDirect
-                                attr-flag: required
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                        - attr-cache-type: default
-                          attr-name: jboss-web-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                        - attr-cache-type: default
-                          attr-name: jaspitest
-                          authentication-jaspi:
-                            auth-module:
-                              attr-code: Dummy
-                            login-module-stack:
-                              attr-name: dummy
-                              login-module:
-                                attr-code: Dummy
-                                attr-flag: optional
-                        - attr-cache-type: default
-                          attr-name: jboss-ejb-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                  - attr-xmlns: urn:jboss:domain:security-manager:1.0
-                    deployment-permissions:
-                      maximum-set:
-                        permission:
-                          attr-class: java.security.AllPermission
-                  - attr-xmlns: urn:jboss:domain:transactions:6.0
-                    coordinator-environment:
-                      attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    core-environment:
-                      attr-node-identifier: ${jboss.tx.node.id:1}
-                      process-id:
-                        uuid: null
-                    object-store:
-                      attr-path: tx-object-store
-                      attr-relative-to: jboss.server.data.dir
-                    recovery-environment:
-                      attr-socket-binding: txn-recovery-environment
-                      attr-status-socket-binding: txn-status-manager
-                  - attr-default-security-domain: other
-                    attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    handlers:
-                      file:
-                        attr-name: welcome-content
-                        attr-path: ${jboss.home.dir}/welcome-content
-                    server:
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        http-invoker:
-                          attr-security-realm: ApplicationRealm
-                        location:
-                          attr-handler: welcome-content
-                          attr-name: /
-                      http-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: default
-                        attr-redirect-socket: https
-                        attr-socket-binding: http
-                      https-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: https
-                        attr-security-realm: ApplicationRealm
-                        attr-socket-binding: https
-                    servlet-container:
-                      attr-name: default
-                      jsp-config: null
-                      websockets: null
-                  - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:webservices:2.0
-                    client-config:
-                      attr-name: Standard-Client-Config
-                    endpoint-config:
-                      - attr-name: Standard-Endpoint-Config
-                      - attr-name: Recording-Endpoint-Config
-                        pre-handler-chain:
-                          attr-name: recording-handlers
-                          attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM'
-                          handler:
-                            attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
-                            attr-name: RecordingHandler
-                    wsdl-host: ${jboss.bind.address:127.0.0.1}
-                  - attr-xmlns: urn:jboss:domain:weld:4.0
-              - attr-name: full-ha
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
-                    default-job-repository:
-                      attr-name: in-memory
-                    default-thread-pool:
-                      attr-name: batch
-                    job-repository:
-                      attr-name: in-memory
-                      in-memory: null
-                    thread-pool:
-                      attr-name: batch
-                      keepalive-time:
-                        attr-time: '30'
-                        attr-unit: seconds
-                      max-threads:
-                        attr-count: '10'
-                  - attr-xmlns: urn:jboss:domain:bean-validation:1.0
-                  - attr-xmlns: urn:jboss:domain:core-management:1.0
-                  - attr-xmlns: urn:jboss:domain:datasources:6.0
-                    datasources:
-                      datasource:
-                        attr-enabled: 'true'
-                        attr-jndi-name: java:jboss/datasources/ExampleDS
-                        attr-pool-name: ExampleDS
-                        attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
-                        attr-use-java-context: 'true'
-                        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-                        driver: h2
-                        security:
-                          password: sa
-                          user-name: sa
-                      drivers:
-                        driver:
-                          attr-module: com.h2database.h2
-                          attr-name: h2
-                          xa-datasource-class: org.h2.jdbcx.JdbcDataSource
-                  - attr-xmlns: urn:jboss:domain:discovery:1.0
-                  - attr-default-session-management: default
-                    attr-default-single-sign-on-management: default
-                    attr-xmlns: urn:jboss:domain:distributable-web:2.0
-                    infinispan-routing:
-                      attr-cache: routing
-                      attr-cache-container: web
-                    infinispan-session-management:
-                      attr-cache-container: web
-                      attr-granularity: SESSION
-                      attr-name: default
-                      primary-owner-affinity: null
-                    infinispan-single-sign-on-management:
-                      attr-cache: sso
-                      attr-cache-container: web
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:ee:6.0
-                    concurrent:
-                      context-services:
-                        context-service:
-                          attr-jndi-name: java:jboss/ee/concurrency/context/default
-                          attr-name: default
-                          attr-use-transaction-setup-provider: 'true'
-                      managed-executor-services:
-                        managed-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/executor/default
-                          attr-keepalive-time: '5000'
-                          attr-name: default
-                      managed-scheduled-executor-services:
-                        managed-scheduled-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
-                          attr-keepalive-time: '3000'
-                          attr-name: default
-                      managed-thread-factories:
-                        managed-thread-factory:
-                          attr-context-service: default
-                          attr-jndi-name: java:jboss/ee/concurrency/factory/default
-                          attr-name: default
-                    default-bindings:
-                      attr-context-service: java:jboss/ee/concurrency/context/default
-                      attr-datasource: java:jboss/datasources/ExampleDS
-                      attr-jms-connection-factory: java:jboss/DefaultJMSConnectionFactory
-                      attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
-                      attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
-                      attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
-                    spec-descriptor-property-replacement: 'false'
-                  - attr-xmlns: urn:jboss:domain:ee-security:1.0
-                  - async:
-                      attr-thread-pool-name: default
-                    attr-xmlns: urn:jboss:domain:ejb3:9.0
-                    caches:
-                      cache:
-                        - attr-name: simple
-                        - attr-aliases: passivating clustered
-                          attr-name: distributable
-                          attr-passivation-store-ref: infinispan
-                    default-missing-method-permissions-deny-access:
-                      attr-value: 'true'
-                    default-security-domain:
-                      attr-value: other
-                    iiop:
-                      attr-enable-by-default: 'false'
-                      attr-use-qualified-name: 'false'
-                    log-system-exceptions:
-                      attr-value: 'true'
-                    mdb:
-                      bean-instance-pool-ref:
-                        attr-pool-name: mdb-strict-max-pool
-                      resource-adapter-ref:
-                        attr-resource-adapter-name: ${ejb.resource-adapter-name:activemq-ra.rar}
-                    passivation-stores:
-                      passivation-store:
-                        attr-cache-container: ejb
-                        attr-max-size: '10000'
-                        attr-name: infinispan
-                    pools:
-                      bean-instance-pools:
-                        strict-max-pool:
-                          - attr-derive-size: from-cpu-count
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: mdb-strict-max-pool
-                          - attr-derive-size: from-worker-pools
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: slsb-strict-max-pool
-                    remote:
-                      attr-cluster: ejb
-                      attr-connectors: http-remoting-connector
-                      attr-thread-pool-name: default
-                      channel-creation-options:
-                        option:
-                          attr-name: MAX_OUTBOUND_MESSAGES
-                          attr-type: remoting
-                          attr-value: '1234'
-                    session-bean:
-                      singleton:
-                        attr-default-access-timeout: '5000'
-                      stateful:
-                        attr-cache-ref: distributable
-                        attr-default-access-timeout: '5000'
-                        attr-passivation-disabled-cache-ref: simple
-                      stateless:
-                        bean-instance-pool-ref:
-                          attr-pool-name: slsb-strict-max-pool
-                    statistics:
-                      attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    thread-pools:
-                      thread-pool:
-                        attr-name: default
-                        keepalive-time:
-                          attr-time: '60'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '10'
-                    timer-service:
-                      attr-default-data-store: default-file-store
-                      attr-thread-pool-name: default
-                      data-stores:
-                        file-data-store:
-                          attr-name: default-file-store
-                          attr-path: timer-service-data
-                          attr-relative-to: jboss.server.data.dir
-                  - attr-disallowed-providers: OracleUcrypto
-                    attr-final-providers: combined-providers
-                    attr-xmlns: urn:wildfly:elytron:13.0
-                    audit-logging:
-                      file-audit-log:
-                        attr-format: JSON
-                        attr-name: local-audit
-                        attr-path: audit.log
-                        attr-relative-to: jboss.server.log.dir
-                    http:
-                      provider-http-server-mechanism-factory:
-                        attr-name: global
-                    mappers:
-                      constant-realm-mapper:
-                        attr-name: local
-                        attr-realm-name: local
-                      constant-role-mapper:
-                        attr-name: super-user-mapper
-                        role:
-                          attr-name: SuperUser
-                      simple-permission-mapper:
-                        attr-mapping-mode: first
-                        attr-name: default-permission-mapper
-                        permission-mapping:
-                          - permission-set:
-                              attr-name: default-permissions
-                            principal:
-                              attr-name: anonymous
-                          - attr-match-all: 'true'
-                            permission-set:
-                              - attr-name: login-permission
-                              - attr-name: default-permissions
-                      simple-role-decoder:
-                        attr-attribute: groups
-                        attr-name: groups-to-roles
-                    permission-sets:
-                      permission-set:
-                        - attr-name: login-permission
-                          permission:
-                            attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                        - attr-name: default-permissions
-                          permission:
-                            - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
-                              attr-module: org.wildfly.extension.batch.jberet
-                              attr-target-name: '*'
-                            - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
-                              attr-module: org.wildfly.transaction.client
-                            - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
-                              attr-module: org.jboss.ejb-client
-                    providers:
-                      aggregate-providers:
-                        attr-name: combined-providers
-                        providers:
-                          - attr-name: elytron
-                          - attr-name: openssl
-                      provider-loader:
-                        - attr-module: org.wildfly.security.elytron
-                          attr-name: elytron
-                        - attr-module: org.wildfly.openssl
-                          attr-name: openssl
-                    sasl:
-                      configurable-sasl-server-factory:
-                        attr-name: configured
-                        attr-sasl-server-factory: elytron
-                        properties:
-                          property:
-                            attr-name: wildfly.sasl.local-user.default-user
-                            attr-value: $local
-                      mechanism-provider-filtering-sasl-server-factory:
-                        attr-name: elytron
-                        attr-sasl-server-factory: global
-                        filters:
-                          filter:
-                            attr-provider-name: WildFlyElytron
-                      provider-sasl-server-factory:
-                        attr-name: global
-                      sasl-authentication-factory:
-                        attr-name: application-sasl-authentication
-                        attr-sasl-server-factory: configured
-                        attr-security-domain: ApplicationDomain
-                        mechanism-configuration:
-                          mechanism:
-                            - attr-mechanism-name: JBOSS-LOCAL-USER
-                              attr-realm-mapper: local
-                            - attr-mechanism-name: DIGEST-MD5
-                              mechanism-realm:
-                                attr-realm-name: ApplicationRealm
-                    security-domains:
-                      security-domain:
-                        attr-default-realm: ApplicationRealm
-                        attr-name: ApplicationDomain
-                        attr-permission-mapper: default-permission-mapper
-                        realm:
-                          attr-name: ApplicationRealm
-                          attr-role-decoder: groups-to-roles
-                    security-realms:
-                      identity-realm:
-                        attr-identity: $local
-                        attr-name: local
-                      properties-realm:
-                        attr-name: ApplicationRealm
-                        groups-properties:
-                          attr-path: application-roles.properties
-                          attr-relative-to: jboss.domain.config.dir
-                        users-properties:
-                          attr-digest-realm-name: ApplicationRealm
-                          attr-path: application-users.properties
-                          attr-relative-to: jboss.domain.config.dir
-                    tls:
-                      key-managers:
-                        key-manager:
-                          attr-generate-self-signed-certificate-host: localhost
-                          attr-key-store: applicationKS
-                          attr-name: applicationKM
-                          credential-reference:
-                            attr-clear-text: password
-                      key-stores:
-                        key-store:
-                          attr-name: applicationKS
-                          credential-reference:
-                            attr-clear-text: password
-                          file:
-                            attr-path: application.keystore
-                            attr-relative-to: jboss.domain.config.dir
-                          implementation:
-                            attr-type: JKS
-                      server-ssl-contexts:
-                        server-ssl-context:
-                          attr-key-manager: applicationKM
-                          attr-name: applicationSSC
-                  - attr-xmlns: urn:jboss:domain:iiop-openjdk:2.1
-                    initializers:
-                      attr-security: identity
-                      attr-transactions: spec
-                    orb:
-                      attr-socket-binding: iiop
-                    security:
-                      attr-client-requires-ssl: 'false'
-                      attr-server-requires-ssl: 'false'
-                  - attr-xmlns: urn:jboss:domain:infinispan:12.0
-                    cache-container:
-                      - attr-aliases: sfsb
-                        attr-default-cache: dist
-                        attr-modules: org.wildfly.clustering.ejb.infinispan
-                        attr-name: ejb
-                        distributed-cache:
-                          attr-name: dist
-                          file-store: null
-                          locking:
-                            attr-isolation: REPEATABLE_READ
-                          transaction:
-                            attr-mode: BATCH
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-aliases: singleton cluster
-                        attr-default-cache: default
-                        attr-modules: org.wildfly.clustering.server
-                        attr-name: server
-                        replicated-cache:
-                          attr-name: default
-                          transaction:
-                            attr-mode: BATCH
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-default-cache: dist
-                        attr-modules: org.wildfly.clustering.web.infinispan
-                        attr-name: web
-                        distributed-cache:
-                          attr-name: dist
-                          file-store: null
-                          locking:
-                            attr-isolation: REPEATABLE_READ
-                          transaction:
-                            attr-mode: BATCH
-                        replicated-cache:
-                          - attr-name: sso
-                            locking:
-                              attr-isolation: REPEATABLE_READ
-                            transaction:
-                              attr-mode: BATCH
-                          - attr-name: routing
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-modules: org.infinispan.hibernate-cache
-                        attr-name: hibernate
-                        invalidation-cache:
-                          attr-name: entity
-                          expiration:
-                            attr-max-idle: '100000'
-                          heap-memory:
-                            attr-size: '10000'
-                        local-cache:
-                          - attr-name: local-query
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: pending-puts
-                            expiration:
-                              attr-max-idle: '60000'
-                        replicated-cache:
-                          attr-name: timestamps
-                        transport:
-                          attr-lock-timeout: '60000'
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:jaxrs:2.0
-                  - archive-validation:
-                      attr-enabled: 'true'
-                      attr-fail-on-error: 'true'
-                      attr-fail-on-warn: 'false'
-                    attr-xmlns: urn:jboss:domain:jca:5.0
-                    bean-validation:
-                      attr-enabled: 'true'
-                    cached-connection-manager: null
-                    default-workmanager:
-                      long-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                      short-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                  - attr-xmlns: urn:jboss:domain:jdr:1.0
-                  - attr-xmlns: urn:jboss:domain:jgroups:8.0
-                    channels:
-                      attr-default: ee
-                      channel:
-                        attr-cluster: ejb
-                        attr-name: ee
-                        attr-stack: udp
-                    stacks:
-                      stack:
-                        - attr-name: udp
-                          protocol:
-                            - attr-type: PING
-                            - attr-type: MERGE3
-                            - attr-type: FD_ALL
-                            - attr-type: VERIFY_SUSPECT
-                            - attr-type: pbcast.NAKACK2
-                            - attr-type: UNICAST3
-                            - attr-type: pbcast.STABLE
-                            - attr-type: pbcast.GMS
-                            - attr-type: UFC
-                            - attr-type: MFC
-                            - attr-type: FRAG3
-                          socket-protocol:
-                            attr-socket-binding: jgroups-udp-fd
-                            attr-type: FD_SOCK
-                          transport:
-                            attr-socket-binding: jgroups-udp
-                            attr-type: UDP
-                        - attr-name: tcp
-                          protocol:
-                            - attr-type: MERGE3
-                            - attr-type: FD_ALL
-                            - attr-type: VERIFY_SUSPECT
-                            - attr-type: pbcast.NAKACK2
-                            - attr-type: UNICAST3
-                            - attr-type: pbcast.STABLE
-                            - attr-type: pbcast.GMS
-                            - attr-type: MFC
-                            - attr-type: FRAG3
-                          socket-protocol:
-                            - attr-socket-binding: jgroups-mping
-                              attr-type: MPING
-                            - attr-socket-binding: jgroups-tcp-fd
-                              attr-type: FD_SOCK
-                          transport:
-                            attr-socket-binding: jgroups-tcp
-                            attr-type: TCP
-                  - attr-xmlns: urn:jboss:domain:jmx:1.3
-                    expose-expression-model: null
-                    expose-resolved-model: null
-                  - attr-xmlns: urn:jboss:domain:jpa:1.1
-                    jpa:
-                      attr-default-extended-persistence-inheritance: DEEP
-                  - attr-xmlns: urn:jboss:domain:jsf:1.1
-                  - attr-xmlns: urn:jboss:domain:jsr77:1.0
-                  - attr-xmlns: urn:jboss:domain:mail:4.0
-                    mail-session:
-                      attr-jndi-name: java:jboss/mail/Default
-                      attr-name: default
-                      smtp-server:
-                        attr-outbound-socket-binding-ref: mail-smtp
-                  - attr-xmlns: urn:jboss:domain:messaging-activemq:13.0
-                    server:
-                      address-setting:
-                        attr-dead-letter-address: jms.queue.DLQ
-                        attr-expiry-address: jms.queue.ExpiryQueue
-                        attr-max-size-bytes: '10485760'
-                        attr-message-counter-history-day-limit: '10'
-                        attr-name: '#'
-                        attr-page-size-bytes: '2097152'
-                        attr-redistribution-delay: '1000'
-                      attr-name: default
-                      cluster:
-                        attr-password: ${jboss.messaging.cluster.password:CHANGE ME!!}
-                      cluster-connection:
-                        attr-address: jms
-                        attr-connector-name: http-connector
-                        attr-discovery-group: dg-group1
-                        attr-name: my-cluster
-                      connection-factory:
-                        - attr-connectors: in-vm
-                          attr-entries: java:/ConnectionFactory
-                          attr-name: InVmConnectionFactory
-                        - attr-block-on-acknowledge: 'true'
-                          attr-connectors: http-connector
-                          attr-entries: java:jboss/exported/jms/RemoteConnectionFactory
-                          attr-ha: 'true'
-                          attr-name: RemoteConnectionFactory
-                          attr-reconnect-attempts: '-1'
-                      http-acceptor:
-                        - attr-http-listener: default
-                          attr-name: http-acceptor
-                        - attr-http-listener: default
-                          attr-name: http-acceptor-throughput
-                          param:
-                            - attr-name: batch-delay
-                              attr-value: '50'
-                            - attr-name: direct-deliver
-                              attr-value: 'false'
-                      http-connector:
-                        - attr-endpoint: http-acceptor
-                          attr-name: http-connector
-                          attr-socket-binding: http
-                        - attr-endpoint: http-acceptor-throughput
-                          attr-name: http-connector-throughput
-                          attr-socket-binding: http
-                          param:
-                            attr-name: batch-delay
-                            attr-value: '50'
-                      in-vm-acceptor:
-                        attr-name: in-vm
-                        attr-server-id: '0'
-                        param:
-                          attr-name: buffer-pooling
-                          attr-value: 'false'
-                      in-vm-connector:
-                        attr-name: in-vm
-                        attr-server-id: '0'
-                        param:
-                          attr-name: buffer-pooling
-                          attr-value: 'false'
-                      jgroups-broadcast-group:
-                        attr-connectors: http-connector
-                        attr-jgroups-cluster: activemq-cluster
-                        attr-name: bg-group1
-                      jgroups-discovery-group:
-                        attr-jgroups-cluster: activemq-cluster
-                        attr-name: dg-group1
-                      jms-queue:
-                        - attr-entries: java:/jms/queue/ExpiryQueue
-                          attr-name: ExpiryQueue
-                        - attr-entries: java:/jms/queue/DLQ
-                          attr-name: DLQ
-                      pooled-connection-factory:
-                        attr-connectors: in-vm
-                        attr-entries: java:/JmsXA java:jboss/DefaultJMSConnectionFactory
-                        attr-name: activemq-ra
-                        attr-transaction: xa
-                      security-setting:
-                        attr-name: '#'
-                        role:
-                          attr-consume: 'true'
-                          attr-create-non-durable-queue: 'true'
-                          attr-delete-non-durable-queue: 'true'
-                          attr-name: guest
-                          attr-send: 'true'
-                      statistics:
-                        attr-enabled: ${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}
-                  - attr-xmlns: urn:jboss:domain:modcluster:5.0
-                    proxy:
-                      attr-advertise-socket: modcluster
-                      attr-listener: ajp
-                      attr-name: default
-                      dynamic-load-provider:
-                        load-metric:
-                          attr-type: cpu
-                  - attr-xmlns: urn:jboss:domain:naming:2.0
-                    remote-naming: null
-                  - attr-xmlns: urn:jboss:domain:pojo:1.0
-                  - attr-xmlns: urn:jboss:domain:remoting:4.0
-                    http-connector:
-                      attr-connector-ref: default
-                      attr-name: http-remoting-connector
-                      attr-security-realm: ApplicationRealm
-                  - attr-xmlns: urn:jboss:domain:request-controller:1.0
-                  - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
-                  - attr-xmlns: urn:jboss:domain:sar:1.0
-                  - attr-xmlns: urn:jboss:domain:security:2.0
-                    security-domains:
-                      security-domain:
-                        - attr-cache-type: default
-                          attr-name: other
-                          authentication:
-                            login-module:
-                              - attr-code: Remoting
-                                attr-flag: optional
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                              - attr-code: RealmDirect
-                                attr-flag: required
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                        - attr-cache-type: default
-                          attr-name: jboss-web-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                        - attr-cache-type: default
-                          attr-name: jaspitest
-                          authentication-jaspi:
-                            auth-module:
-                              attr-code: Dummy
-                            login-module-stack:
-                              attr-name: dummy
-                              login-module:
-                                attr-code: Dummy
-                                attr-flag: optional
-                        - attr-cache-type: default
-                          attr-name: jboss-ejb-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                  - attr-xmlns: urn:jboss:domain:security-manager:1.0
-                    deployment-permissions:
-                      maximum-set:
-                        permission:
-                          attr-class: java.security.AllPermission
-                  - attr-xmlns: urn:jboss:domain:singleton:1.0
-                    singleton-policies:
-                      attr-default: default
-                      singleton-policy:
-                        attr-cache-container: server
-                        attr-name: default
-                        simple-election-policy: null
-                  - attr-xmlns: urn:jboss:domain:transactions:6.0
-                    coordinator-environment:
-                      attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    core-environment:
-                      attr-node-identifier: ${jboss.tx.node.id:1}
-                      process-id:
-                        uuid: null
-                    object-store:
-                      attr-path: tx-object-store
-                      attr-relative-to: jboss.server.data.dir
-                    recovery-environment:
-                      attr-socket-binding: txn-recovery-environment
-                      attr-status-socket-binding: txn-status-manager
-                  - attr-default-security-domain: other
-                    attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    handlers:
-                      file:
-                        attr-name: welcome-content
-                        attr-path: ${jboss.home.dir}/welcome-content
-                    server:
-                      ajp-listener:
-                        attr-name: ajp
-                        attr-socket-binding: ajp
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        http-invoker:
-                          attr-security-realm: ApplicationRealm
-                        location:
-                          attr-handler: welcome-content
-                          attr-name: /
-                      http-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: default
-                        attr-redirect-socket: https
-                        attr-socket-binding: http
-                      https-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: https
-                        attr-security-realm: ApplicationRealm
-                        attr-socket-binding: https
-                    servlet-container:
-                      attr-name: default
-                      jsp-config: null
-                      websockets: null
-                  - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:webservices:2.0
-                    client-config:
-                      attr-name: Standard-Client-Config
-                    endpoint-config:
-                      - attr-name: Standard-Endpoint-Config
-                      - attr-name: Recording-Endpoint-Config
-                        pre-handler-chain:
-                          attr-name: recording-handlers
-                          attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM'
-                          handler:
-                            attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
-                            attr-name: RecordingHandler
-                    wsdl-host: ${jboss.bind.address:127.0.0.1}
-                  - attr-xmlns: urn:jboss:domain:weld:4.0
-              - attr-name: load-balancer
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    filters:
-                      mod-cluster:
-                        attr-advertise-socket-binding: modcluster
-                        attr-enable-http2: 'true'
-                        attr-management-socket-binding: mcmp-management
-                        attr-max-retries: '3'
-                        attr-name: load-balancer
-                        single-affinity: null
-                    server:
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        filter-ref:
-                          attr-name: load-balancer
-                      http-listener:
-                        - attr-enable-http2: 'true'
-                          attr-name: default
-                          attr-redirect-socket: https
-                          attr-socket-binding: http
-                        - attr-enable-http2: 'true'
-                          attr-name: management
-                          attr-socket-binding: mcmp-management
-                    servlet-container:
-                      attr-name: default
-          server-groups:
-            server-group:
-              - attr-name: main-server-group
-                attr-profile: full-ha
-                jvm:
-                  attr-name: default
-                  heap:
-                    attr-max-size: 1000m
-                    attr-size: 1000m
-                socket-binding-group:
-                  attr-ref: full-ha-sockets
-              - attr-name: second-server-group
-                attr-profile: full-ha
-                jvm:
-                  attr-name: default
-                  heap:
-                    attr-max-size: 1000m
-                    attr-size: 1000m
-                socket-binding-group:
-                  attr-ref: full-ha-sockets
-          socket-binding-groups:
-            socket-binding-group:
-              - attr-default-interface: public
-                attr-name: standard-sockets
-                outbound-socket-binding:
-                  attr-name: mail-smtp
-                  remote-destination:
-                    attr-host: ${jboss.mail.server.host:localhost}
-                    attr-port: ${jboss.mail.server.port:25}
-                socket-binding:
-                  - attr-name: ajp
-                    attr-port: ${jboss.ajp.port:8009}
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-name: txn-recovery-environment
-                    attr-port: '4712'
-                  - attr-name: txn-status-manager
-                    attr-port: '4713'
-              - attr-default-interface: public
-                attr-name: ha-sockets
-                outbound-socket-binding:
-                  attr-name: mail-smtp
-                  remote-destination:
-                    attr-host: ${jboss.mail.server.host:localhost}
-                    attr-port: ${jboss.mail.server.port:25}
-                socket-binding:
-                  - attr-name: ajp
-                    attr-port: ${jboss.ajp.port:8009}
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
-                    attr-multicast-port: '45700'
-                    attr-name: jgroups-mping
-                  - attr-interface: private
-                    attr-name: jgroups-tcp
-                    attr-port: '7600'
-                  - attr-interface: private
-                    attr-name: jgroups-tcp-fd
-                    attr-port: '57600'
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
-                    attr-multicast-port: '45688'
-                    attr-name: jgroups-udp
-                    attr-port: '55200'
-                  - attr-interface: private
-                    attr-name: jgroups-udp-fd
-                    attr-port: '54200'
-                  - attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
-                    attr-multicast-port: '23364'
-                    attr-name: modcluster
-                  - attr-name: txn-recovery-environment
-                    attr-port: '4712'
-                  - attr-name: txn-status-manager
-                    attr-port: '4713'
-              - attr-default-interface: public
-                attr-name: full-sockets
-                outbound-socket-binding:
-                  attr-name: mail-smtp
-                  remote-destination:
-                    attr-host: ${jboss.mail.server.host:localhost}
-                    attr-port: ${jboss.mail.server.port:25}
-                socket-binding:
-                  - attr-name: ajp
-                    attr-port: ${jboss.ajp.port:8009}
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-interface: unsecure
-                    attr-name: iiop
-                    attr-port: '3528'
-                  - attr-interface: unsecure
-                    attr-name: iiop-ssl
-                    attr-port: '3529'
-                  - attr-name: txn-recovery-environment
-                    attr-port: '4712'
-                  - attr-name: txn-status-manager
-                    attr-port: '4713'
-              - attr-default-interface: public
-                attr-name: full-ha-sockets
-                outbound-socket-binding:
-                  attr-name: mail-smtp
-                  remote-destination:
-                    attr-host: ${jboss.mail.server.host:localhost}
-                    attr-port: ${jboss.mail.server.port:25}
-                socket-binding:
-                  - attr-name: ajp
-                    attr-port: ${jboss.ajp.port:8009}
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-interface: unsecure
-                    attr-name: iiop
-                    attr-port: '3528'
-                  - attr-interface: unsecure
-                    attr-name: iiop-ssl
-                    attr-port: '3529'
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
-                    attr-multicast-port: '45700'
-                    attr-name: jgroups-mping
-                  - attr-interface: private
-                    attr-name: jgroups-tcp
-                    attr-port: '7600'
-                  - attr-interface: private
-                    attr-name: jgroups-tcp-fd
-                    attr-port: '57600'
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
-                    attr-multicast-port: '45688'
-                    attr-name: jgroups-udp
-                    attr-port: '55200'
-                  - attr-interface: private
-                    attr-name: jgroups-udp-fd
-                    attr-port: '54200'
-                  - attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
-                    attr-multicast-port: '23364'
-                    attr-name: modcluster
-                  - attr-name: txn-recovery-environment
-                    attr-port: '4712'
-                  - attr-name: txn-status-manager
-                    attr-port: '4713'
-              - attr-default-interface: public
-                attr-name: load-balancer-sockets
-                socket-binding:
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-interface: private
-                    attr-name: mcmp-management
-                    attr-port: ${jboss.mcmp.port:8090}
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
-                    attr-multicast-port: '23364'
-                    attr-name: modcluster
-          system-properties:
-            property:
-              attr-name: java.net.preferIPv4Stack
-              attr-value: 'true'
-
-expected_result:
-  - bindings:
-      - address: 127.0.0.1
-        class: service
-        port: 3528
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        port: 8009
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        port: 8080
-        protocol: tcp
-      - address: 127.0.0.1
-        class: service
-        port: 54200
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        port: 8443
-        protocol: tcp
-      - address: 230.0.0.4
-        class: service
-        port: 45688
-        protocol: udp
-      - address: 224.0.1.105
-        class: service
-        port: 23364
-        protocol: udp
-      - address: 127.0.0.1
-        class: service
-        port: 55200
-        protocol: udp
-      - class: ajp
-        port: 8009
-      - class: http
-        port: 8080
-      - class: https
-        port: 8443
-      - class: iiop
-        port: 3528
-      - class: iiop_ssl
-        port: 3529
-      - class: jgroups_tcp
-        port: 7600
-      - class: jgroups_tcp_fd
-        port: 57600
-      - class: jgroups_udp
-        port: 55200
-      - class: jgroups_udp_fd
-        port: 54200
-      - class: txn_recovery_environment
-        port: 4712
-      - class: txn_status_manager
-        port: 4713
-      - class: listener
-        port: 9990
-    configuration:
-      domain_xml:
-        domain:
-          attr-xmlns: urn:jboss:domain:16.0
-          extensions:
-            extension:
-              - attr-module: org.jboss.as.clustering.infinispan
-              - attr-module: org.jboss.as.clustering.jgroups
-              - attr-module: org.jboss.as.connector
-              - attr-module: org.jboss.as.ee
-              - attr-module: org.jboss.as.ejb3
-              - attr-module: org.jboss.as.jaxrs
-              - attr-module: org.jboss.as.jdr
-              - attr-module: org.jboss.as.jmx
-              - attr-module: org.jboss.as.jpa
-              - attr-module: org.jboss.as.jsf
-              - attr-module: org.jboss.as.jsr77
-              - attr-module: org.jboss.as.logging
-              - attr-module: org.jboss.as.mail
-              - attr-module: org.jboss.as.modcluster
-              - attr-module: org.jboss.as.naming
-              - attr-module: org.jboss.as.pojo
-              - attr-module: org.jboss.as.remoting
-              - attr-module: org.jboss.as.sar
-              - attr-module: org.jboss.as.security
-              - attr-module: org.jboss.as.transactions
-              - attr-module: org.jboss.as.webservices
-              - attr-module: org.jboss.as.weld
-              - attr-module: org.wildfly.extension.batch.jberet
-              - attr-module: org.wildfly.extension.bean-validation
-              - attr-module: org.wildfly.extension.clustering.singleton
-              - attr-module: org.wildfly.extension.clustering.web
-              - attr-module: org.wildfly.extension.core-management
-              - attr-module: org.wildfly.extension.discovery
-              - attr-module: org.wildfly.extension.ee-security
-              - attr-module: org.wildfly.extension.elytron
-              - attr-module: org.wildfly.extension.io
-              - attr-module: org.wildfly.extension.messaging-activemq
-              - attr-module: org.wildfly.extension.request-controller
-              - attr-module: org.wildfly.extension.security.manager
-              - attr-module: org.wildfly.extension.undertow
-              - attr-module: org.wildfly.iiop-openjdk
-          host-excludes:
-            host-exclude:
-              - attr-name: EAP62
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.batch.jberet
-                    - attr-module: org.wildfly.extension.bean-validation
-                    - attr-module: org.wildfly.extension.clustering.singleton
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.io
-                    - attr-module: org.wildfly.extension.messaging-activemq
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.picketlink
-                    - attr-module: org.wildfly.extension.request-controller
-                    - attr-module: org.wildfly.extension.rts
-                    - attr-module: org.wildfly.extension.security.manager
-                    - attr-module: org.wildfly.extension.undertow
-                    - attr-module: org.wildfly.iiop-openjdk
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP6.2
-              - attr-name: EAP63
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.batch.jberet
-                    - attr-module: org.wildfly.extension.bean-validation
-                    - attr-module: org.wildfly.extension.clustering.singleton
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.io
-                    - attr-module: org.wildfly.extension.messaging-activemq
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.request-controller
-                    - attr-module: org.wildfly.extension.rts
-                    - attr-module: org.wildfly.extension.security.manager
-                    - attr-module: org.wildfly.extension.undertow
-                    - attr-module: org.wildfly.iiop-openjdk
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP6.3
-              - attr-name: EAP64
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.batch.jberet
-                    - attr-module: org.wildfly.extension.bean-validation
-                    - attr-module: org.wildfly.extension.clustering.singleton
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.io
-                    - attr-module: org.wildfly.extension.messaging-activemq
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.request-controller
-                    - attr-module: org.wildfly.extension.rts
-                    - attr-module: org.wildfly.extension.security.manager
-                    - attr-module: org.wildfly.extension.undertow
-                    - attr-module: org.wildfly.iiop-openjdk
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP6.4
-              - attr-name: EAP64z
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.batch.jberet
-                    - attr-module: org.wildfly.extension.bean-validation
-                    - attr-module: org.wildfly.extension.clustering.singleton
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.io
-                    - attr-module: org.wildfly.extension.messaging-activemq
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.request-controller
-                    - attr-module: org.wildfly.extension.rts
-                    - attr-module: org.wildfly.extension.security.manager
-                    - attr-module: org.wildfly.extension.undertow
-                    - attr-module: org.wildfly.iiop-openjdk
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-api-version:
-                  attr-major-version: '1'
-                  attr-minor-version: '8'
-              - attr-name: EAP70
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.core-management
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.discovery
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.elytron
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP7.0
-              - attr-name: EAP71
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.datasources-agroal
-                    - attr-module: org.wildfly.extension.ee-security
-                    - attr-module: org.wildfly.extension.microprofile.config-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.health-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP7.1
-              - attr-name: EAP72
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.clustering.web
-                    - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP7.2
-              - attr-name: EAP73
-                excluded-extensions:
-                  extension:
-                    - attr-module: org.wildfly.extension.health
-                    - attr-module: org.wildfly.extension.metrics
-                host-release:
-                  attr-id: EAP7.3
-          interfaces:
-            interface:
-              - attr-name: management
-              - attr-name: private
-                inet-address:
-                  attr-value: ${jboss.bind.address.private:127.0.0.1}
-              - any-address: null
-                attr-name: public
-              - attr-name: unsecure
-                inet-address:
-                  attr-value: ${jboss.bind.address.unsecure:127.0.0.1}
-          management:
-            access-control:
-              attr-provider: simple
-              role-mapping:
-                role:
-                  attr-name: SuperUser
-                  include:
-                    user:
-                      attr-name: $local
-          profiles:
-            profile:
-              - attr-name: default
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
-                    default-job-repository:
-                      attr-name: in-memory
-                    default-thread-pool:
-                      attr-name: batch
-                    job-repository:
-                      attr-name: in-memory
-                      in-memory: null
-                    thread-pool:
-                      attr-name: batch
-                      keepalive-time:
-                        attr-time: '30'
-                        attr-unit: seconds
-                      max-threads:
-                        attr-count: '10'
-                  - attr-xmlns: urn:jboss:domain:bean-validation:1.0
-                  - attr-xmlns: urn:jboss:domain:core-management:1.0
-                  - attr-xmlns: urn:jboss:domain:datasources:6.0
-                    datasources:
-                      datasource:
-                        attr-enabled: 'true'
-                        attr-jndi-name: java:jboss/datasources/ExampleDS
-                        attr-pool-name: ExampleDS
-                        attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
-                        attr-use-java-context: 'true'
-                        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-                        driver: h2
-                        security:
-                          password: sa
-                          user-name: sa
-                      drivers:
-                        driver:
-                          attr-module: com.h2database.h2
-                          attr-name: h2
-                          xa-datasource-class: org.h2.jdbcx.JdbcDataSource
-                  - attr-xmlns: urn:jboss:domain:discovery:1.0
-                  - attr-default-session-management: default
-                    attr-default-single-sign-on-management: default
-                    attr-xmlns: urn:jboss:domain:distributable-web:2.0
-                    infinispan-session-management:
-                      attr-cache-container: web
-                      attr-granularity: SESSION
-                      attr-name: default
-                      local-affinity: null
-                    infinispan-single-sign-on-management:
-                      attr-cache: sso
-                      attr-cache-container: web
-                      attr-name: default
-                    local-routing: null
-                  - attr-xmlns: urn:jboss:domain:ee:6.0
-                    concurrent:
-                      context-services:
-                        context-service:
-                          attr-jndi-name: java:jboss/ee/concurrency/context/default
-                          attr-name: default
-                          attr-use-transaction-setup-provider: 'true'
-                      managed-executor-services:
-                        managed-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/executor/default
-                          attr-keepalive-time: '5000'
-                          attr-name: default
-                      managed-scheduled-executor-services:
-                        managed-scheduled-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
-                          attr-keepalive-time: '3000'
-                          attr-name: default
-                      managed-thread-factories:
-                        managed-thread-factory:
-                          attr-context-service: default
-                          attr-jndi-name: java:jboss/ee/concurrency/factory/default
-                          attr-name: default
-                    default-bindings:
-                      attr-context-service: java:jboss/ee/concurrency/context/default
-                      attr-datasource: java:jboss/datasources/ExampleDS
-                      attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
-                      attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
-                      attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
-                    spec-descriptor-property-replacement: 'false'
-                  - attr-xmlns: urn:jboss:domain:ee-security:1.0
-                  - async:
-                      attr-thread-pool-name: default
-                    attr-xmlns: urn:jboss:domain:ejb3:9.0
-                    caches:
-                      cache:
-                        - attr-name: simple
-                        - attr-aliases: passivating clustered
-                          attr-name: distributable
-                          attr-passivation-store-ref: infinispan
-                    default-missing-method-permissions-deny-access:
-                      attr-value: 'true'
-                    default-security-domain:
-                      attr-value: other
-                    log-system-exceptions:
-                      attr-value: 'true'
-                    passivation-stores:
-                      passivation-store:
-                        attr-cache-container: ejb
-                        attr-max-size: '10000'
-                        attr-name: infinispan
-                    pools:
-                      bean-instance-pools:
-                        strict-max-pool:
-                          - attr-derive-size: from-cpu-count
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: mdb-strict-max-pool
-                          - attr-derive-size: from-worker-pools
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: slsb-strict-max-pool
-                    remote:
-                      attr-cluster: ejb
-                      attr-connectors: http-remoting-connector
-                      attr-thread-pool-name: default
-                      channel-creation-options:
-                        option:
-                          attr-name: MAX_OUTBOUND_MESSAGES
-                          attr-type: remoting
-                          attr-value: '1234'
-                    session-bean:
-                      singleton:
-                        attr-default-access-timeout: '5000'
-                      stateful:
-                        attr-cache-ref: simple
-                        attr-default-access-timeout: '5000'
-                        attr-passivation-disabled-cache-ref: simple
-                      stateless:
-                        bean-instance-pool-ref:
-                          attr-pool-name: slsb-strict-max-pool
-                    statistics:
-                      attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    thread-pools:
-                      thread-pool:
-                        attr-name: default
-                        keepalive-time:
-                          attr-time: '60'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '10'
-                    timer-service:
-                      attr-default-data-store: default-file-store
-                      attr-thread-pool-name: default
-                      data-stores:
-                        file-data-store:
-                          attr-name: default-file-store
-                          attr-path: timer-service-data
-                          attr-relative-to: jboss.server.data.dir
-                  - attr-disallowed-providers: OracleUcrypto
-                    attr-final-providers: combined-providers
-                    attr-xmlns: urn:wildfly:elytron:13.0
-                    audit-logging:
-                      file-audit-log:
-                        attr-format: JSON
-                        attr-name: local-audit
-                        attr-path: audit.log
-                        attr-relative-to: jboss.server.log.dir
-                    http:
-                      provider-http-server-mechanism-factory:
-                        attr-name: global
-                    mappers:
-                      constant-realm-mapper:
-                        attr-name: local
-                        attr-realm-name: local
-                      constant-role-mapper:
-                        attr-name: super-user-mapper
-                        role:
-                          attr-name: SuperUser
-                      simple-permission-mapper:
-                        attr-mapping-mode: first
-                        attr-name: default-permission-mapper
-                        permission-mapping:
-                          - permission-set:
-                              attr-name: default-permissions
-                            principal:
-                              attr-name: anonymous
-                          - attr-match-all: 'true'
-                            permission-set:
-                              - attr-name: login-permission
-                              - attr-name: default-permissions
-                      simple-role-decoder:
-                        attr-attribute: groups
-                        attr-name: groups-to-roles
-                    permission-sets:
-                      permission-set:
-                        - attr-name: login-permission
-                          permission:
-                            attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                        - attr-name: default-permissions
-                          permission:
-                            - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
-                              attr-module: org.wildfly.extension.batch.jberet
-                              attr-target-name: '*'
-                            - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
-                              attr-module: org.wildfly.transaction.client
-                            - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
-                              attr-module: org.jboss.ejb-client
-                    providers:
-                      aggregate-providers:
-                        attr-name: combined-providers
-                        providers:
-                          - attr-name: elytron
-                          - attr-name: openssl
-                      provider-loader:
-                        - attr-module: org.wildfly.security.elytron
-                          attr-name: elytron
-                        - attr-module: org.wildfly.openssl
-                          attr-name: openssl
-                    sasl:
-                      configurable-sasl-server-factory:
-                        attr-name: configured
-                        attr-sasl-server-factory: elytron
-                        properties:
-                          property:
-                            attr-name: wildfly.sasl.local-user.default-user
-                            attr-value: $local
-                      mechanism-provider-filtering-sasl-server-factory:
-                        attr-name: elytron
-                        attr-sasl-server-factory: global
-                        filters:
-                          filter:
-                            attr-provider-name: WildFlyElytron
-                      provider-sasl-server-factory:
-                        attr-name: global
-                      sasl-authentication-factory:
-                        attr-name: application-sasl-authentication
-                        attr-sasl-server-factory: configured
-                        attr-security-domain: ApplicationDomain
-                        mechanism-configuration:
-                          mechanism:
-                            - attr-mechanism-name: JBOSS-LOCAL-USER
-                              attr-realm-mapper: local
-                            - attr-mechanism-name: DIGEST-MD5
-                              mechanism-realm:
-                                attr-realm-name: ApplicationRealm
-                    security-domains:
-                      security-domain:
-                        attr-default-realm: ApplicationRealm
-                        attr-name: ApplicationDomain
-                        attr-permission-mapper: default-permission-mapper
-                        realm:
-                          attr-name: ApplicationRealm
-                          attr-role-decoder: groups-to-roles
-                    security-realms:
-                      identity-realm:
-                        attr-identity: $local
-                        attr-name: local
-                      properties-realm:
-                        attr-name: ApplicationRealm
-                        groups-properties:
-                          attr-path: application-roles.properties
-                          attr-relative-to: jboss.domain.config.dir
-                        users-properties:
-                          attr-digest-realm-name: ApplicationRealm
-                          attr-path: application-users.properties
-                          attr-relative-to: jboss.domain.config.dir
-                    tls:
-                      key-managers:
-                        key-manager:
-                          attr-generate-self-signed-certificate-host: localhost
-                          attr-key-store: applicationKS
-                          attr-name: applicationKM
-                          credential-reference:
-                            attr-clear-text: password
-                      key-stores:
-                        key-store:
-                          attr-name: applicationKS
-                          credential-reference:
-                            attr-clear-text: password
-                          file:
-                            attr-path: application.keystore
-                            attr-relative-to: jboss.domain.config.dir
-                          implementation:
-                            attr-type: JKS
-                      server-ssl-contexts:
-                        server-ssl-context:
-                          attr-key-manager: applicationKM
-                          attr-name: applicationSSC
-                  - attr-xmlns: urn:jboss:domain:infinispan:12.0
-                    cache-container:
-                      - attr-aliases: sfsb
-                        attr-default-cache: passivation
-                        attr-modules: org.wildfly.clustering.ejb.infinispan
-                        attr-name: ejb
-                        local-cache:
-                          attr-name: passivation
-                          file-store:
-                            attr-passivation: 'true'
-                            attr-purge: 'false'
-                      - attr-default-cache: passivation
-                        attr-modules: org.wildfly.clustering.web.infinispan
-                        attr-name: web
-                        local-cache:
-                          - attr-name: passivation
-                            file-store:
-                              attr-passivation: 'true'
-                              attr-purge: 'false'
-                          - attr-name: sso
-                      - attr-default-cache: default
-                        attr-modules: org.wildfly.clustering.server
-                        attr-name: server
-                        local-cache:
-                          attr-name: default
-                      - attr-modules: org.infinispan.hibernate-cache
-                        attr-name: hibernate
-                        local-cache:
-                          - attr-name: entity
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: local-query
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: timestamps
-                          - attr-name: pending-puts
-                            expiration:
-                              attr-max-idle: '60000'
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:jaxrs:2.0
-                  - archive-validation:
-                      attr-enabled: 'true'
-                      attr-fail-on-error: 'true'
-                      attr-fail-on-warn: 'false'
-                    attr-xmlns: urn:jboss:domain:jca:5.0
-                    bean-validation:
-                      attr-enabled: 'true'
-                    cached-connection-manager: null
-                    default-workmanager:
-                      long-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                      short-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                  - attr-xmlns: urn:jboss:domain:jdr:1.0
-                  - attr-xmlns: urn:jboss:domain:jmx:1.3
-                    expose-expression-model: null
-                    expose-resolved-model: null
-                  - attr-xmlns: urn:jboss:domain:jpa:1.1
-                    jpa:
-                      attr-default-extended-persistence-inheritance: DEEP
-                  - attr-xmlns: urn:jboss:domain:jsf:1.1
-                  - attr-xmlns: urn:jboss:domain:mail:4.0
-                    mail-session:
-                      attr-jndi-name: java:jboss/mail/Default
-                      attr-name: default
-                      smtp-server:
-                        attr-outbound-socket-binding-ref: mail-smtp
-                  - attr-xmlns: urn:jboss:domain:naming:2.0
-                    remote-naming: null
-                  - attr-xmlns: urn:jboss:domain:pojo:1.0
-                  - attr-xmlns: urn:jboss:domain:remoting:4.0
-                    http-connector:
-                      attr-connector-ref: default
-                      attr-name: http-remoting-connector
-                      attr-security-realm: ApplicationRealm
-                  - attr-xmlns: urn:jboss:domain:request-controller:1.0
-                  - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
-                  - attr-xmlns: urn:jboss:domain:sar:1.0
-                  - attr-xmlns: urn:jboss:domain:security:2.0
-                    security-domains:
-                      security-domain:
-                        - attr-cache-type: default
-                          attr-name: other
-                          authentication:
-                            login-module:
-                              - attr-code: Remoting
-                                attr-flag: optional
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                              - attr-code: RealmDirect
-                                attr-flag: required
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                        - attr-cache-type: default
-                          attr-name: jboss-web-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                        - attr-cache-type: default
-                          attr-name: jaspitest
-                          authentication-jaspi:
-                            auth-module:
-                              attr-code: Dummy
-                            login-module-stack:
-                              attr-name: dummy
-                              login-module:
-                                attr-code: Dummy
-                                attr-flag: optional
-                        - attr-cache-type: default
-                          attr-name: jboss-ejb-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                  - attr-xmlns: urn:jboss:domain:security-manager:1.0
-                    deployment-permissions:
-                      maximum-set:
-                        permission:
-                          attr-class: java.security.AllPermission
-                  - attr-xmlns: urn:jboss:domain:transactions:6.0
-                    coordinator-environment:
-                      attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    core-environment:
-                      attr-node-identifier: ${jboss.tx.node.id:1}
-                      process-id:
-                        uuid: null
-                    object-store:
-                      attr-path: tx-object-store
-                      attr-relative-to: jboss.server.data.dir
-                    recovery-environment:
-                      attr-socket-binding: txn-recovery-environment
-                      attr-status-socket-binding: txn-status-manager
-                  - attr-default-security-domain: other
-                    attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    handlers:
-                      file:
-                        attr-name: welcome-content
-                        attr-path: ${jboss.home.dir}/welcome-content
-                    server:
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        http-invoker:
-                          attr-security-realm: ApplicationRealm
-                        location:
-                          attr-handler: welcome-content
-                          attr-name: /
-                      http-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: default
-                        attr-redirect-socket: https
-                        attr-socket-binding: http
-                      https-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: https
-                        attr-security-realm: ApplicationRealm
-                        attr-socket-binding: https
-                    servlet-container:
-                      attr-name: default
-                      jsp-config: null
-                      websockets: null
-                  - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:webservices:2.0
-                    client-config:
-                      attr-name: Standard-Client-Config
-                    endpoint-config:
-                      - attr-name: Standard-Endpoint-Config
-                      - attr-name: Recording-Endpoint-Config
-                        pre-handler-chain:
-                          attr-name: recording-handlers
-                          attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM'
-                          handler:
-                            attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
-                            attr-name: RecordingHandler
-                    wsdl-host: ${jboss.bind.address:127.0.0.1}
-                  - attr-xmlns: urn:jboss:domain:weld:4.0
-              - attr-name: ha
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
-                    default-job-repository:
-                      attr-name: in-memory
-                    default-thread-pool:
-                      attr-name: batch
-                    job-repository:
-                      attr-name: in-memory
-                      in-memory: null
-                    thread-pool:
-                      attr-name: batch
-                      keepalive-time:
-                        attr-time: '30'
-                        attr-unit: seconds
-                      max-threads:
-                        attr-count: '10'
-                  - attr-xmlns: urn:jboss:domain:bean-validation:1.0
-                  - attr-xmlns: urn:jboss:domain:core-management:1.0
-                  - attr-xmlns: urn:jboss:domain:datasources:6.0
-                    datasources:
-                      datasource:
-                        attr-enabled: 'true'
-                        attr-jndi-name: java:jboss/datasources/ExampleDS
-                        attr-pool-name: ExampleDS
-                        attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
-                        attr-use-java-context: 'true'
-                        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-                        driver: h2
-                        security:
-                          password: sa
-                          user-name: sa
-                      drivers:
-                        driver:
-                          attr-module: com.h2database.h2
-                          attr-name: h2
-                          xa-datasource-class: org.h2.jdbcx.JdbcDataSource
-                  - attr-xmlns: urn:jboss:domain:discovery:1.0
-                  - attr-default-session-management: default
-                    attr-default-single-sign-on-management: default
-                    attr-xmlns: urn:jboss:domain:distributable-web:2.0
-                    infinispan-routing:
-                      attr-cache: routing
-                      attr-cache-container: web
-                    infinispan-session-management:
-                      attr-cache-container: web
-                      attr-granularity: SESSION
-                      attr-name: default
-                      primary-owner-affinity: null
-                    infinispan-single-sign-on-management:
-                      attr-cache: sso
-                      attr-cache-container: web
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:ee:6.0
-                    concurrent:
-                      context-services:
-                        context-service:
-                          attr-jndi-name: java:jboss/ee/concurrency/context/default
-                          attr-name: default
-                          attr-use-transaction-setup-provider: 'true'
-                      managed-executor-services:
-                        managed-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/executor/default
-                          attr-keepalive-time: '5000'
-                          attr-name: default
-                      managed-scheduled-executor-services:
-                        managed-scheduled-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
-                          attr-keepalive-time: '3000'
-                          attr-name: default
-                      managed-thread-factories:
-                        managed-thread-factory:
-                          attr-context-service: default
-                          attr-jndi-name: java:jboss/ee/concurrency/factory/default
-                          attr-name: default
-                    default-bindings:
-                      attr-context-service: java:jboss/ee/concurrency/context/default
-                      attr-datasource: java:jboss/datasources/ExampleDS
-                      attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
-                      attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
-                      attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
-                    spec-descriptor-property-replacement: 'false'
-                  - attr-xmlns: urn:jboss:domain:ee-security:1.0
-                  - async:
-                      attr-thread-pool-name: default
-                    attr-xmlns: urn:jboss:domain:ejb3:9.0
-                    caches:
-                      cache:
-                        - attr-name: simple
-                        - attr-aliases: passivating clustered
-                          attr-name: distributable
-                          attr-passivation-store-ref: infinispan
-                    default-missing-method-permissions-deny-access:
-                      attr-value: 'true'
-                    default-security-domain:
-                      attr-value: other
-                    log-system-exceptions:
-                      attr-value: 'true'
-                    passivation-stores:
-                      passivation-store:
-                        attr-cache-container: ejb
-                        attr-max-size: '10000'
-                        attr-name: infinispan
-                    pools:
-                      bean-instance-pools:
-                        strict-max-pool:
-                          - attr-derive-size: from-cpu-count
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: mdb-strict-max-pool
-                          - attr-derive-size: from-worker-pools
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: slsb-strict-max-pool
-                    remote:
-                      attr-cluster: ejb
-                      attr-connectors: http-remoting-connector
-                      attr-thread-pool-name: default
-                      channel-creation-options:
-                        option:
-                          attr-name: MAX_OUTBOUND_MESSAGES
-                          attr-type: remoting
-                          attr-value: '1234'
-                    session-bean:
-                      singleton:
-                        attr-default-access-timeout: '5000'
-                      stateful:
-                        attr-cache-ref: distributable
-                        attr-default-access-timeout: '5000'
-                        attr-passivation-disabled-cache-ref: simple
-                      stateless:
-                        bean-instance-pool-ref:
-                          attr-pool-name: slsb-strict-max-pool
-                    statistics:
-                      attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    thread-pools:
-                      thread-pool:
-                        attr-name: default
-                        keepalive-time:
-                          attr-time: '60'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '10'
-                    timer-service:
-                      attr-default-data-store: default-file-store
-                      attr-thread-pool-name: default
-                      data-stores:
-                        file-data-store:
-                          attr-name: default-file-store
-                          attr-path: timer-service-data
-                          attr-relative-to: jboss.server.data.dir
-                  - attr-disallowed-providers: OracleUcrypto
-                    attr-final-providers: combined-providers
-                    attr-xmlns: urn:wildfly:elytron:13.0
-                    audit-logging:
-                      file-audit-log:
-                        attr-format: JSON
-                        attr-name: local-audit
-                        attr-path: audit.log
-                        attr-relative-to: jboss.server.log.dir
-                    http:
-                      provider-http-server-mechanism-factory:
-                        attr-name: global
-                    mappers:
-                      constant-realm-mapper:
-                        attr-name: local
-                        attr-realm-name: local
-                      constant-role-mapper:
-                        attr-name: super-user-mapper
-                        role:
-                          attr-name: SuperUser
-                      simple-permission-mapper:
-                        attr-mapping-mode: first
-                        attr-name: default-permission-mapper
-                        permission-mapping:
-                          - permission-set:
-                              attr-name: default-permissions
-                            principal:
-                              attr-name: anonymous
-                          - attr-match-all: 'true'
-                            permission-set:
-                              - attr-name: login-permission
-                              - attr-name: default-permissions
-                      simple-role-decoder:
-                        attr-attribute: groups
-                        attr-name: groups-to-roles
-                    permission-sets:
-                      permission-set:
-                        - attr-name: login-permission
-                          permission:
-                            attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                        - attr-name: default-permissions
-                          permission:
-                            - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
-                              attr-module: org.wildfly.extension.batch.jberet
-                              attr-target-name: '*'
-                            - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
-                              attr-module: org.wildfly.transaction.client
-                            - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
-                              attr-module: org.jboss.ejb-client
-                    providers:
-                      aggregate-providers:
-                        attr-name: combined-providers
-                        providers:
-                          - attr-name: elytron
-                          - attr-name: openssl
-                      provider-loader:
-                        - attr-module: org.wildfly.security.elytron
-                          attr-name: elytron
-                        - attr-module: org.wildfly.openssl
-                          attr-name: openssl
-                    sasl:
-                      configurable-sasl-server-factory:
-                        attr-name: configured
-                        attr-sasl-server-factory: elytron
-                        properties:
-                          property:
-                            attr-name: wildfly.sasl.local-user.default-user
-                            attr-value: $local
-                      mechanism-provider-filtering-sasl-server-factory:
-                        attr-name: elytron
-                        attr-sasl-server-factory: global
-                        filters:
-                          filter:
-                            attr-provider-name: WildFlyElytron
-                      provider-sasl-server-factory:
-                        attr-name: global
-                      sasl-authentication-factory:
-                        attr-name: application-sasl-authentication
-                        attr-sasl-server-factory: configured
-                        attr-security-domain: ApplicationDomain
-                        mechanism-configuration:
-                          mechanism:
-                            - attr-mechanism-name: JBOSS-LOCAL-USER
-                              attr-realm-mapper: local
-                            - attr-mechanism-name: DIGEST-MD5
-                              mechanism-realm:
-                                attr-realm-name: ApplicationRealm
-                    security-domains:
-                      security-domain:
-                        attr-default-realm: ApplicationRealm
-                        attr-name: ApplicationDomain
-                        attr-permission-mapper: default-permission-mapper
-                        realm:
-                          attr-name: ApplicationRealm
-                          attr-role-decoder: groups-to-roles
-                    security-realms:
-                      identity-realm:
-                        attr-identity: $local
-                        attr-name: local
-                      properties-realm:
-                        attr-name: ApplicationRealm
-                        groups-properties:
-                          attr-path: application-roles.properties
-                          attr-relative-to: jboss.domain.config.dir
-                        users-properties:
-                          attr-digest-realm-name: ApplicationRealm
-                          attr-path: application-users.properties
-                          attr-relative-to: jboss.domain.config.dir
-                    tls:
-                      key-managers:
-                        key-manager:
-                          attr-generate-self-signed-certificate-host: localhost
-                          attr-key-store: applicationKS
-                          attr-name: applicationKM
-                          credential-reference:
-                            attr-clear-text: password
-                      key-stores:
-                        key-store:
-                          attr-name: applicationKS
-                          credential-reference:
-                            attr-clear-text: password
-                          file:
-                            attr-path: application.keystore
-                            attr-relative-to: jboss.domain.config.dir
-                          implementation:
-                            attr-type: JKS
-                      server-ssl-contexts:
-                        server-ssl-context:
-                          attr-key-manager: applicationKM
-                          attr-name: applicationSSC
-                  - attr-xmlns: urn:jboss:domain:infinispan:12.0
-                    cache-container:
-                      - attr-aliases: sfsb
-                        attr-default-cache: dist
-                        attr-modules: org.wildfly.clustering.ejb.infinispan
-                        attr-name: ejb
-                        distributed-cache:
-                          attr-name: dist
-                          file-store: null
-                          locking:
-                            attr-isolation: REPEATABLE_READ
-                          transaction:
-                            attr-mode: BATCH
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-aliases: singleton cluster
-                        attr-default-cache: default
-                        attr-modules: org.wildfly.clustering.server
-                        attr-name: server
-                        replicated-cache:
-                          attr-name: default
-                          transaction:
-                            attr-mode: BATCH
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-default-cache: dist
-                        attr-modules: org.wildfly.clustering.web.infinispan
-                        attr-name: web
-                        distributed-cache:
-                          attr-name: dist
-                          file-store: null
-                          locking:
-                            attr-isolation: REPEATABLE_READ
-                          transaction:
-                            attr-mode: BATCH
-                        replicated-cache:
-                          - attr-name: sso
-                            locking:
-                              attr-isolation: REPEATABLE_READ
-                            transaction:
-                              attr-mode: BATCH
-                          - attr-name: routing
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-modules: org.infinispan.hibernate-cache
-                        attr-name: hibernate
-                        invalidation-cache:
-                          attr-name: entity
-                          expiration:
-                            attr-max-idle: '100000'
-                          heap-memory:
-                            attr-size: '10000'
-                        local-cache:
-                          - attr-name: local-query
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: pending-puts
-                            expiration:
-                              attr-max-idle: '60000'
-                        replicated-cache:
-                          attr-name: timestamps
-                        transport:
-                          attr-lock-timeout: '60000'
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:jaxrs:2.0
-                  - archive-validation:
-                      attr-enabled: 'true'
-                      attr-fail-on-error: 'true'
-                      attr-fail-on-warn: 'false'
-                    attr-xmlns: urn:jboss:domain:jca:5.0
-                    bean-validation:
-                      attr-enabled: 'true'
-                    cached-connection-manager: null
-                    default-workmanager:
-                      long-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                      short-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                  - attr-xmlns: urn:jboss:domain:jdr:1.0
-                  - attr-xmlns: urn:jboss:domain:jgroups:8.0
-                    channels:
-                      attr-default: ee
-                      channel:
-                        attr-cluster: ejb
-                        attr-name: ee
-                        attr-stack: udp
-                    stacks:
-                      stack:
-                        - attr-name: udp
-                          protocol:
-                            - attr-type: PING
-                            - attr-type: MERGE3
-                            - attr-type: FD_ALL
-                            - attr-type: VERIFY_SUSPECT
-                            - attr-type: pbcast.NAKACK2
-                            - attr-type: UNICAST3
-                            - attr-type: pbcast.STABLE
-                            - attr-type: pbcast.GMS
-                            - attr-type: UFC
-                            - attr-type: MFC
-                            - attr-type: FRAG3
-                          socket-protocol:
-                            attr-socket-binding: jgroups-udp-fd
-                            attr-type: FD_SOCK
-                          transport:
-                            attr-socket-binding: jgroups-udp
-                            attr-type: UDP
-                        - attr-name: tcp
-                          protocol:
-                            - attr-type: MERGE3
-                            - attr-type: FD_ALL
-                            - attr-type: VERIFY_SUSPECT
-                            - attr-type: pbcast.NAKACK2
-                            - attr-type: UNICAST3
-                            - attr-type: pbcast.STABLE
-                            - attr-type: pbcast.GMS
-                            - attr-type: MFC
-                            - attr-type: FRAG3
-                          socket-protocol:
-                            - attr-socket-binding: jgroups-mping
-                              attr-type: MPING
-                            - attr-socket-binding: jgroups-tcp-fd
-                              attr-type: FD_SOCK
-                          transport:
-                            attr-socket-binding: jgroups-tcp
-                            attr-type: TCP
-                  - attr-xmlns: urn:jboss:domain:jmx:1.3
-                    expose-expression-model: null
-                    expose-resolved-model: null
-                  - attr-xmlns: urn:jboss:domain:jpa:1.1
-                    jpa:
-                      attr-default-extended-persistence-inheritance: DEEP
-                  - attr-xmlns: urn:jboss:domain:jsf:1.1
-                  - attr-xmlns: urn:jboss:domain:mail:4.0
-                    mail-session:
-                      attr-jndi-name: java:jboss/mail/Default
-                      attr-name: default
-                      smtp-server:
-                        attr-outbound-socket-binding-ref: mail-smtp
-                  - attr-xmlns: urn:jboss:domain:modcluster:5.0
-                    proxy:
-                      attr-advertise-socket: modcluster
-                      attr-listener: ajp
-                      attr-name: default
-                      dynamic-load-provider:
-                        load-metric:
-                          attr-type: cpu
-                  - attr-xmlns: urn:jboss:domain:naming:2.0
-                    remote-naming: null
-                  - attr-xmlns: urn:jboss:domain:pojo:1.0
-                  - attr-xmlns: urn:jboss:domain:remoting:4.0
-                    http-connector:
-                      attr-connector-ref: default
-                      attr-name: http-remoting-connector
-                      attr-security-realm: ApplicationRealm
-                  - attr-xmlns: urn:jboss:domain:request-controller:1.0
-                  - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
-                  - attr-xmlns: urn:jboss:domain:sar:1.0
-                  - attr-xmlns: urn:jboss:domain:security:2.0
-                    security-domains:
-                      security-domain:
-                        - attr-cache-type: default
-                          attr-name: other
-                          authentication:
-                            login-module:
-                              - attr-code: Remoting
-                                attr-flag: optional
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                              - attr-code: RealmDirect
-                                attr-flag: required
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                        - attr-cache-type: default
-                          attr-name: jboss-web-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                        - attr-cache-type: default
-                          attr-name: jaspitest
-                          authentication-jaspi:
-                            auth-module:
-                              attr-code: Dummy
-                            login-module-stack:
-                              attr-name: dummy
-                              login-module:
-                                attr-code: Dummy
-                                attr-flag: optional
-                        - attr-cache-type: default
-                          attr-name: jboss-ejb-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                  - attr-xmlns: urn:jboss:domain:security-manager:1.0
-                    deployment-permissions:
-                      maximum-set:
-                        permission:
-                          attr-class: java.security.AllPermission
-                  - attr-xmlns: urn:jboss:domain:singleton:1.0
-                    singleton-policies:
-                      attr-default: default
-                      singleton-policy:
-                        attr-cache-container: server
-                        attr-name: default
-                        simple-election-policy: null
-                  - attr-xmlns: urn:jboss:domain:transactions:6.0
-                    coordinator-environment:
-                      attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    core-environment:
-                      attr-node-identifier: ${jboss.tx.node.id:1}
-                      process-id:
-                        uuid: null
-                    object-store:
-                      attr-path: tx-object-store
-                      attr-relative-to: jboss.server.data.dir
-                    recovery-environment:
-                      attr-socket-binding: txn-recovery-environment
-                      attr-status-socket-binding: txn-status-manager
-                  - attr-default-security-domain: other
-                    attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    handlers:
-                      file:
-                        attr-name: welcome-content
-                        attr-path: ${jboss.home.dir}/welcome-content
-                    server:
-                      ajp-listener:
-                        attr-name: ajp
-                        attr-socket-binding: ajp
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        http-invoker:
-                          attr-security-realm: ApplicationRealm
-                        location:
-                          attr-handler: welcome-content
-                          attr-name: /
-                      http-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: default
-                        attr-redirect-socket: https
-                        attr-socket-binding: http
-                      https-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: https
-                        attr-security-realm: ApplicationRealm
-                        attr-socket-binding: https
-                    servlet-container:
-                      attr-name: default
-                      jsp-config: null
-                      websockets: null
-                  - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:webservices:2.0
-                    client-config:
-                      attr-name: Standard-Client-Config
-                    endpoint-config:
-                      - attr-name: Standard-Endpoint-Config
-                      - attr-name: Recording-Endpoint-Config
-                        pre-handler-chain:
-                          attr-name: recording-handlers
-                          attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM'
-                          handler:
-                            attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
-                            attr-name: RecordingHandler
-                    wsdl-host: ${jboss.bind.address:127.0.0.1}
-                  - attr-xmlns: urn:jboss:domain:weld:4.0
-              - attr-name: full
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
-                    default-job-repository:
-                      attr-name: in-memory
-                    default-thread-pool:
-                      attr-name: batch
-                    job-repository:
-                      attr-name: in-memory
-                      in-memory: null
-                    thread-pool:
-                      attr-name: batch
-                      keepalive-time:
-                        attr-time: '30'
-                        attr-unit: seconds
-                      max-threads:
-                        attr-count: '10'
-                  - attr-xmlns: urn:jboss:domain:bean-validation:1.0
-                  - attr-xmlns: urn:jboss:domain:core-management:1.0
-                  - attr-xmlns: urn:jboss:domain:datasources:6.0
-                    datasources:
-                      datasource:
-                        attr-enabled: 'true'
-                        attr-jndi-name: java:jboss/datasources/ExampleDS
-                        attr-pool-name: ExampleDS
-                        attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
-                        attr-use-java-context: 'true'
-                        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-                        driver: h2
-                        security:
-                          password: sa
-                          user-name: sa
-                      drivers:
-                        driver:
-                          attr-module: com.h2database.h2
-                          attr-name: h2
-                          xa-datasource-class: org.h2.jdbcx.JdbcDataSource
-                  - attr-xmlns: urn:jboss:domain:discovery:1.0
-                  - attr-default-session-management: default
-                    attr-default-single-sign-on-management: default
-                    attr-xmlns: urn:jboss:domain:distributable-web:2.0
-                    infinispan-session-management:
-                      attr-cache-container: web
-                      attr-granularity: SESSION
-                      attr-name: default
-                      local-affinity: null
-                    infinispan-single-sign-on-management:
-                      attr-cache: sso
-                      attr-cache-container: web
-                      attr-name: default
-                    local-routing: null
-                  - attr-xmlns: urn:jboss:domain:ee:6.0
-                    concurrent:
-                      context-services:
-                        context-service:
-                          attr-jndi-name: java:jboss/ee/concurrency/context/default
-                          attr-name: default
-                          attr-use-transaction-setup-provider: 'true'
-                      managed-executor-services:
-                        managed-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/executor/default
-                          attr-keepalive-time: '5000'
-                          attr-name: default
-                      managed-scheduled-executor-services:
-                        managed-scheduled-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
-                          attr-keepalive-time: '3000'
-                          attr-name: default
-                      managed-thread-factories:
-                        managed-thread-factory:
-                          attr-context-service: default
-                          attr-jndi-name: java:jboss/ee/concurrency/factory/default
-                          attr-name: default
-                    default-bindings:
-                      attr-context-service: java:jboss/ee/concurrency/context/default
-                      attr-datasource: java:jboss/datasources/ExampleDS
-                      attr-jms-connection-factory: java:jboss/DefaultJMSConnectionFactory
-                      attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
-                      attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
-                      attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
-                    spec-descriptor-property-replacement: 'false'
-                  - attr-xmlns: urn:jboss:domain:ee-security:1.0
-                  - async:
-                      attr-thread-pool-name: default
-                    attr-xmlns: urn:jboss:domain:ejb3:9.0
-                    caches:
-                      cache:
-                        - attr-name: simple
-                        - attr-aliases: passivating clustered
-                          attr-name: distributable
-                          attr-passivation-store-ref: infinispan
-                    default-missing-method-permissions-deny-access:
-                      attr-value: 'true'
-                    default-security-domain:
-                      attr-value: other
-                    iiop:
-                      attr-enable-by-default: 'false'
-                      attr-use-qualified-name: 'false'
-                    log-system-exceptions:
-                      attr-value: 'true'
-                    mdb:
-                      bean-instance-pool-ref:
-                        attr-pool-name: mdb-strict-max-pool
-                      resource-adapter-ref:
-                        attr-resource-adapter-name: ${ejb.resource-adapter-name:activemq-ra.rar}
-                    passivation-stores:
-                      passivation-store:
-                        attr-cache-container: ejb
-                        attr-max-size: '10000'
-                        attr-name: infinispan
-                    pools:
-                      bean-instance-pools:
-                        strict-max-pool:
-                          - attr-derive-size: from-cpu-count
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: mdb-strict-max-pool
-                          - attr-derive-size: from-worker-pools
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: slsb-strict-max-pool
-                    remote:
-                      attr-cluster: ejb
-                      attr-connectors: http-remoting-connector
-                      attr-thread-pool-name: default
-                      channel-creation-options:
-                        option:
-                          attr-name: MAX_OUTBOUND_MESSAGES
-                          attr-type: remoting
-                          attr-value: '1234'
-                    session-bean:
-                      singleton:
-                        attr-default-access-timeout: '5000'
-                      stateful:
-                        attr-cache-ref: simple
-                        attr-default-access-timeout: '5000'
-                        attr-passivation-disabled-cache-ref: simple
-                      stateless:
-                        bean-instance-pool-ref:
-                          attr-pool-name: slsb-strict-max-pool
-                    statistics:
-                      attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    thread-pools:
-                      thread-pool:
-                        attr-name: default
-                        keepalive-time:
-                          attr-time: '60'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '10'
-                    timer-service:
-                      attr-default-data-store: default-file-store
-                      attr-thread-pool-name: default
-                      data-stores:
-                        file-data-store:
-                          attr-name: default-file-store
-                          attr-path: timer-service-data
-                          attr-relative-to: jboss.server.data.dir
-                  - attr-disallowed-providers: OracleUcrypto
-                    attr-final-providers: combined-providers
-                    attr-xmlns: urn:wildfly:elytron:13.0
-                    audit-logging:
-                      file-audit-log:
-                        attr-format: JSON
-                        attr-name: local-audit
-                        attr-path: audit.log
-                        attr-relative-to: jboss.server.log.dir
-                    http:
-                      provider-http-server-mechanism-factory:
-                        attr-name: global
-                    mappers:
-                      constant-realm-mapper:
-                        attr-name: local
-                        attr-realm-name: local
-                      constant-role-mapper:
-                        attr-name: super-user-mapper
-                        role:
-                          attr-name: SuperUser
-                      simple-permission-mapper:
-                        attr-mapping-mode: first
-                        attr-name: default-permission-mapper
-                        permission-mapping:
-                          - permission-set:
-                              attr-name: default-permissions
-                            principal:
-                              attr-name: anonymous
-                          - attr-match-all: 'true'
-                            permission-set:
-                              - attr-name: login-permission
-                              - attr-name: default-permissions
-                      simple-role-decoder:
-                        attr-attribute: groups
-                        attr-name: groups-to-roles
-                    permission-sets:
-                      permission-set:
-                        - attr-name: login-permission
-                          permission:
-                            attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                        - attr-name: default-permissions
-                          permission:
-                            - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
-                              attr-module: org.wildfly.extension.batch.jberet
-                              attr-target-name: '*'
-                            - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
-                              attr-module: org.wildfly.transaction.client
-                            - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
-                              attr-module: org.jboss.ejb-client
-                    providers:
-                      aggregate-providers:
-                        attr-name: combined-providers
-                        providers:
-                          - attr-name: elytron
-                          - attr-name: openssl
-                      provider-loader:
-                        - attr-module: org.wildfly.security.elytron
-                          attr-name: elytron
-                        - attr-module: org.wildfly.openssl
-                          attr-name: openssl
-                    sasl:
-                      configurable-sasl-server-factory:
-                        attr-name: configured
-                        attr-sasl-server-factory: elytron
-                        properties:
-                          property:
-                            attr-name: wildfly.sasl.local-user.default-user
-                            attr-value: $local
-                      mechanism-provider-filtering-sasl-server-factory:
-                        attr-name: elytron
-                        attr-sasl-server-factory: global
-                        filters:
-                          filter:
-                            attr-provider-name: WildFlyElytron
-                      provider-sasl-server-factory:
-                        attr-name: global
-                      sasl-authentication-factory:
-                        attr-name: application-sasl-authentication
-                        attr-sasl-server-factory: configured
-                        attr-security-domain: ApplicationDomain
-                        mechanism-configuration:
-                          mechanism:
-                            - attr-mechanism-name: JBOSS-LOCAL-USER
-                              attr-realm-mapper: local
-                            - attr-mechanism-name: DIGEST-MD5
-                              mechanism-realm:
-                                attr-realm-name: ApplicationRealm
-                    security-domains:
-                      security-domain:
-                        attr-default-realm: ApplicationRealm
-                        attr-name: ApplicationDomain
-                        attr-permission-mapper: default-permission-mapper
-                        realm:
-                          attr-name: ApplicationRealm
-                          attr-role-decoder: groups-to-roles
-                    security-realms:
-                      identity-realm:
-                        attr-identity: $local
-                        attr-name: local
-                      properties-realm:
-                        attr-name: ApplicationRealm
-                        groups-properties:
-                          attr-path: application-roles.properties
-                          attr-relative-to: jboss.domain.config.dir
-                        users-properties:
-                          attr-digest-realm-name: ApplicationRealm
-                          attr-path: application-users.properties
-                          attr-relative-to: jboss.domain.config.dir
-                    tls:
-                      key-managers:
-                        key-manager:
-                          attr-generate-self-signed-certificate-host: localhost
-                          attr-key-store: applicationKS
-                          attr-name: applicationKM
-                          credential-reference:
-                            attr-clear-text: password
-                      key-stores:
-                        key-store:
-                          attr-name: applicationKS
-                          credential-reference:
-                            attr-clear-text: password
-                          file:
-                            attr-path: application.keystore
-                            attr-relative-to: jboss.domain.config.dir
-                          implementation:
-                            attr-type: JKS
-                      server-ssl-contexts:
-                        server-ssl-context:
-                          attr-key-manager: applicationKM
-                          attr-name: applicationSSC
-                  - attr-xmlns: urn:jboss:domain:iiop-openjdk:2.1
-                    initializers:
-                      attr-security: identity
-                      attr-transactions: spec
-                    orb:
-                      attr-socket-binding: iiop
-                    security:
-                      attr-client-requires-ssl: 'false'
-                      attr-server-requires-ssl: 'false'
-                  - attr-xmlns: urn:jboss:domain:infinispan:12.0
-                    cache-container:
-                      - attr-aliases: sfsb
-                        attr-default-cache: passivation
-                        attr-modules: org.wildfly.clustering.ejb.infinispan
-                        attr-name: ejb
-                        local-cache:
-                          attr-name: passivation
-                          file-store:
-                            attr-passivation: 'true'
-                            attr-purge: 'false'
-                      - attr-default-cache: passivation
-                        attr-modules: org.wildfly.clustering.web.infinispan
-                        attr-name: web
-                        local-cache:
-                          - attr-name: passivation
-                            file-store:
-                              attr-passivation: 'true'
-                              attr-purge: 'false'
-                          - attr-name: sso
-                      - attr-default-cache: default
-                        attr-modules: org.wildfly.clustering.server
-                        attr-name: server
-                        local-cache:
-                          attr-name: default
-                      - attr-modules: org.infinispan.hibernate-cache
-                        attr-name: hibernate
-                        local-cache:
-                          - attr-name: entity
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: local-query
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: timestamps
-                          - attr-name: pending-puts
-                            expiration:
-                              attr-max-idle: '60000'
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:jaxrs:2.0
-                  - archive-validation:
-                      attr-enabled: 'true'
-                      attr-fail-on-error: 'true'
-                      attr-fail-on-warn: 'false'
-                    attr-xmlns: urn:jboss:domain:jca:5.0
-                    bean-validation:
-                      attr-enabled: 'true'
-                    cached-connection-manager: null
-                    default-workmanager:
-                      long-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                      short-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                  - attr-xmlns: urn:jboss:domain:jdr:1.0
-                  - attr-xmlns: urn:jboss:domain:jmx:1.3
-                    expose-expression-model: null
-                    expose-resolved-model: null
-                  - attr-xmlns: urn:jboss:domain:jpa:1.1
-                    jpa:
-                      attr-default-extended-persistence-inheritance: DEEP
-                  - attr-xmlns: urn:jboss:domain:jsf:1.1
-                  - attr-xmlns: urn:jboss:domain:jsr77:1.0
-                  - attr-xmlns: urn:jboss:domain:mail:4.0
-                    mail-session:
-                      attr-jndi-name: java:jboss/mail/Default
-                      attr-name: default
-                      smtp-server:
-                        attr-outbound-socket-binding-ref: mail-smtp
-                  - attr-xmlns: urn:jboss:domain:messaging-activemq:13.0
-                    server:
-                      address-setting:
-                        attr-dead-letter-address: jms.queue.DLQ
-                        attr-expiry-address: jms.queue.ExpiryQueue
-                        attr-max-size-bytes: '10485760'
-                        attr-message-counter-history-day-limit: '10'
-                        attr-name: '#'
-                        attr-page-size-bytes: '2097152'
-                      attr-name: default
-                      connection-factory:
-                        - attr-connectors: in-vm
-                          attr-entries: java:/ConnectionFactory
-                          attr-name: InVmConnectionFactory
-                        - attr-connectors: http-connector
-                          attr-entries: java:jboss/exported/jms/RemoteConnectionFactory
-                          attr-name: RemoteConnectionFactory
-                      http-acceptor:
-                        - attr-http-listener: default
-                          attr-name: http-acceptor
-                        - attr-http-listener: default
-                          attr-name: http-acceptor-throughput
-                          param:
-                            - attr-name: batch-delay
-                              attr-value: '50'
-                            - attr-name: direct-deliver
-                              attr-value: 'false'
-                      http-connector:
-                        - attr-endpoint: http-acceptor
-                          attr-name: http-connector
-                          attr-socket-binding: http
-                        - attr-endpoint: http-acceptor-throughput
-                          attr-name: http-connector-throughput
-                          attr-socket-binding: http
-                          param:
-                            attr-name: batch-delay
-                            attr-value: '50'
-                      in-vm-acceptor:
-                        attr-name: in-vm
-                        attr-server-id: '0'
-                        param:
-                          attr-name: buffer-pooling
-                          attr-value: 'false'
-                      in-vm-connector:
-                        attr-name: in-vm
-                        attr-server-id: '0'
-                        param:
-                          attr-name: buffer-pooling
-                          attr-value: 'false'
-                      jms-queue:
-                        - attr-entries: java:/jms/queue/ExpiryQueue
-                          attr-name: ExpiryQueue
-                        - attr-entries: java:/jms/queue/DLQ
-                          attr-name: DLQ
-                      pooled-connection-factory:
-                        attr-connectors: in-vm
-                        attr-entries: java:/JmsXA java:jboss/DefaultJMSConnectionFactory
-                        attr-name: activemq-ra
-                        attr-transaction: xa
-                      security-setting:
-                        attr-name: '#'
-                        role:
-                          attr-consume: 'true'
-                          attr-create-non-durable-queue: 'true'
-                          attr-delete-non-durable-queue: 'true'
-                          attr-name: guest
-                          attr-send: 'true'
-                      statistics:
-                        attr-enabled: ${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}
-                  - attr-xmlns: urn:jboss:domain:naming:2.0
-                    remote-naming: null
-                  - attr-xmlns: urn:jboss:domain:pojo:1.0
-                  - attr-xmlns: urn:jboss:domain:remoting:4.0
-                    http-connector:
-                      attr-connector-ref: default
-                      attr-name: http-remoting-connector
-                      attr-security-realm: ApplicationRealm
-                  - attr-xmlns: urn:jboss:domain:request-controller:1.0
-                  - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
-                  - attr-xmlns: urn:jboss:domain:sar:1.0
-                  - attr-xmlns: urn:jboss:domain:security:2.0
-                    security-domains:
-                      security-domain:
-                        - attr-cache-type: default
-                          attr-name: other
-                          authentication:
-                            login-module:
-                              - attr-code: Remoting
-                                attr-flag: optional
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                              - attr-code: RealmDirect
-                                attr-flag: required
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                        - attr-cache-type: default
-                          attr-name: jboss-web-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                        - attr-cache-type: default
-                          attr-name: jaspitest
-                          authentication-jaspi:
-                            auth-module:
-                              attr-code: Dummy
-                            login-module-stack:
-                              attr-name: dummy
-                              login-module:
-                                attr-code: Dummy
-                                attr-flag: optional
-                        - attr-cache-type: default
-                          attr-name: jboss-ejb-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                  - attr-xmlns: urn:jboss:domain:security-manager:1.0
-                    deployment-permissions:
-                      maximum-set:
-                        permission:
-                          attr-class: java.security.AllPermission
-                  - attr-xmlns: urn:jboss:domain:transactions:6.0
-                    coordinator-environment:
-                      attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    core-environment:
-                      attr-node-identifier: ${jboss.tx.node.id:1}
-                      process-id:
-                        uuid: null
-                    object-store:
-                      attr-path: tx-object-store
-                      attr-relative-to: jboss.server.data.dir
-                    recovery-environment:
-                      attr-socket-binding: txn-recovery-environment
-                      attr-status-socket-binding: txn-status-manager
-                  - attr-default-security-domain: other
-                    attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    handlers:
-                      file:
-                        attr-name: welcome-content
-                        attr-path: ${jboss.home.dir}/welcome-content
-                    server:
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        http-invoker:
-                          attr-security-realm: ApplicationRealm
-                        location:
-                          attr-handler: welcome-content
-                          attr-name: /
-                      http-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: default
-                        attr-redirect-socket: https
-                        attr-socket-binding: http
-                      https-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: https
-                        attr-security-realm: ApplicationRealm
-                        attr-socket-binding: https
-                    servlet-container:
-                      attr-name: default
-                      jsp-config: null
-                      websockets: null
-                  - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:webservices:2.0
-                    client-config:
-                      attr-name: Standard-Client-Config
-                    endpoint-config:
-                      - attr-name: Standard-Endpoint-Config
-                      - attr-name: Recording-Endpoint-Config
-                        pre-handler-chain:
-                          attr-name: recording-handlers
-                          attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM'
-                          handler:
-                            attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
-                            attr-name: RecordingHandler
-                    wsdl-host: ${jboss.bind.address:127.0.0.1}
-                  - attr-xmlns: urn:jboss:domain:weld:4.0
-              - attr-name: full-ha
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
-                    default-job-repository:
-                      attr-name: in-memory
-                    default-thread-pool:
-                      attr-name: batch
-                    job-repository:
-                      attr-name: in-memory
-                      in-memory: null
-                    thread-pool:
-                      attr-name: batch
-                      keepalive-time:
-                        attr-time: '30'
-                        attr-unit: seconds
-                      max-threads:
-                        attr-count: '10'
-                  - attr-xmlns: urn:jboss:domain:bean-validation:1.0
-                  - attr-xmlns: urn:jboss:domain:core-management:1.0
-                  - attr-xmlns: urn:jboss:domain:datasources:6.0
-                    datasources:
-                      datasource:
-                        attr-enabled: 'true'
-                        attr-jndi-name: java:jboss/datasources/ExampleDS
-                        attr-pool-name: ExampleDS
-                        attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
-                        attr-use-java-context: 'true'
-                        connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-                        driver: h2
-                        security:
-                          password: sa
-                          user-name: sa
-                      drivers:
-                        driver:
-                          attr-module: com.h2database.h2
-                          attr-name: h2
-                          xa-datasource-class: org.h2.jdbcx.JdbcDataSource
-                  - attr-xmlns: urn:jboss:domain:discovery:1.0
-                  - attr-default-session-management: default
-                    attr-default-single-sign-on-management: default
-                    attr-xmlns: urn:jboss:domain:distributable-web:2.0
-                    infinispan-routing:
-                      attr-cache: routing
-                      attr-cache-container: web
-                    infinispan-session-management:
-                      attr-cache-container: web
-                      attr-granularity: SESSION
-                      attr-name: default
-                      primary-owner-affinity: null
-                    infinispan-single-sign-on-management:
-                      attr-cache: sso
-                      attr-cache-container: web
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:ee:6.0
-                    concurrent:
-                      context-services:
-                        context-service:
-                          attr-jndi-name: java:jboss/ee/concurrency/context/default
-                          attr-name: default
-                          attr-use-transaction-setup-provider: 'true'
-                      managed-executor-services:
-                        managed-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/executor/default
-                          attr-keepalive-time: '5000'
-                          attr-name: default
-                      managed-scheduled-executor-services:
-                        managed-scheduled-executor-service:
-                          attr-context-service: default
-                          attr-hung-task-termination-period: '0'
-                          attr-hung-task-threshold: '60000'
-                          attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
-                          attr-keepalive-time: '3000'
-                          attr-name: default
-                      managed-thread-factories:
-                        managed-thread-factory:
-                          attr-context-service: default
-                          attr-jndi-name: java:jboss/ee/concurrency/factory/default
-                          attr-name: default
-                    default-bindings:
-                      attr-context-service: java:jboss/ee/concurrency/context/default
-                      attr-datasource: java:jboss/datasources/ExampleDS
-                      attr-jms-connection-factory: java:jboss/DefaultJMSConnectionFactory
-                      attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
-                      attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
-                      attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
-                    spec-descriptor-property-replacement: 'false'
-                  - attr-xmlns: urn:jboss:domain:ee-security:1.0
-                  - async:
-                      attr-thread-pool-name: default
-                    attr-xmlns: urn:jboss:domain:ejb3:9.0
-                    caches:
-                      cache:
-                        - attr-name: simple
-                        - attr-aliases: passivating clustered
-                          attr-name: distributable
-                          attr-passivation-store-ref: infinispan
-                    default-missing-method-permissions-deny-access:
-                      attr-value: 'true'
-                    default-security-domain:
-                      attr-value: other
-                    iiop:
-                      attr-enable-by-default: 'false'
-                      attr-use-qualified-name: 'false'
-                    log-system-exceptions:
-                      attr-value: 'true'
-                    mdb:
-                      bean-instance-pool-ref:
-                        attr-pool-name: mdb-strict-max-pool
-                      resource-adapter-ref:
-                        attr-resource-adapter-name: ${ejb.resource-adapter-name:activemq-ra.rar}
-                    passivation-stores:
-                      passivation-store:
-                        attr-cache-container: ejb
-                        attr-max-size: '10000'
-                        attr-name: infinispan
-                    pools:
-                      bean-instance-pools:
-                        strict-max-pool:
-                          - attr-derive-size: from-cpu-count
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: mdb-strict-max-pool
-                          - attr-derive-size: from-worker-pools
-                            attr-instance-acquisition-timeout: '5'
-                            attr-instance-acquisition-timeout-unit: MINUTES
-                            attr-name: slsb-strict-max-pool
-                    remote:
-                      attr-cluster: ejb
-                      attr-connectors: http-remoting-connector
-                      attr-thread-pool-name: default
-                      channel-creation-options:
-                        option:
-                          attr-name: MAX_OUTBOUND_MESSAGES
-                          attr-type: remoting
-                          attr-value: '1234'
-                    session-bean:
-                      singleton:
-                        attr-default-access-timeout: '5000'
-                      stateful:
-                        attr-cache-ref: distributable
-                        attr-default-access-timeout: '5000'
-                        attr-passivation-disabled-cache-ref: simple
-                      stateless:
-                        bean-instance-pool-ref:
-                          attr-pool-name: slsb-strict-max-pool
-                    statistics:
-                      attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    thread-pools:
-                      thread-pool:
-                        attr-name: default
-                        keepalive-time:
-                          attr-time: '60'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '10'
-                    timer-service:
-                      attr-default-data-store: default-file-store
-                      attr-thread-pool-name: default
-                      data-stores:
-                        file-data-store:
-                          attr-name: default-file-store
-                          attr-path: timer-service-data
-                          attr-relative-to: jboss.server.data.dir
-                  - attr-disallowed-providers: OracleUcrypto
-                    attr-final-providers: combined-providers
-                    attr-xmlns: urn:wildfly:elytron:13.0
-                    audit-logging:
-                      file-audit-log:
-                        attr-format: JSON
-                        attr-name: local-audit
-                        attr-path: audit.log
-                        attr-relative-to: jboss.server.log.dir
-                    http:
-                      provider-http-server-mechanism-factory:
-                        attr-name: global
-                    mappers:
-                      constant-realm-mapper:
-                        attr-name: local
-                        attr-realm-name: local
-                      constant-role-mapper:
-                        attr-name: super-user-mapper
-                        role:
-                          attr-name: SuperUser
-                      simple-permission-mapper:
-                        attr-mapping-mode: first
-                        attr-name: default-permission-mapper
-                        permission-mapping:
-                          - permission-set:
-                              attr-name: default-permissions
-                            principal:
-                              attr-name: anonymous
-                          - attr-match-all: 'true'
-                            permission-set:
-                              - attr-name: login-permission
-                              - attr-name: default-permissions
-                      simple-role-decoder:
-                        attr-attribute: groups
-                        attr-name: groups-to-roles
-                    permission-sets:
-                      permission-set:
-                        - attr-name: login-permission
-                          permission:
-                            attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                        - attr-name: default-permissions
-                          permission:
-                            - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
-                              attr-module: org.wildfly.extension.batch.jberet
-                              attr-target-name: '*'
-                            - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
-                              attr-module: org.wildfly.transaction.client
-                            - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
-                              attr-module: org.jboss.ejb-client
-                    providers:
-                      aggregate-providers:
-                        attr-name: combined-providers
-                        providers:
-                          - attr-name: elytron
-                          - attr-name: openssl
-                      provider-loader:
-                        - attr-module: org.wildfly.security.elytron
-                          attr-name: elytron
-                        - attr-module: org.wildfly.openssl
-                          attr-name: openssl
-                    sasl:
-                      configurable-sasl-server-factory:
-                        attr-name: configured
-                        attr-sasl-server-factory: elytron
-                        properties:
-                          property:
-                            attr-name: wildfly.sasl.local-user.default-user
-                            attr-value: $local
-                      mechanism-provider-filtering-sasl-server-factory:
-                        attr-name: elytron
-                        attr-sasl-server-factory: global
-                        filters:
-                          filter:
-                            attr-provider-name: WildFlyElytron
-                      provider-sasl-server-factory:
-                        attr-name: global
-                      sasl-authentication-factory:
-                        attr-name: application-sasl-authentication
-                        attr-sasl-server-factory: configured
-                        attr-security-domain: ApplicationDomain
-                        mechanism-configuration:
-                          mechanism:
-                            - attr-mechanism-name: JBOSS-LOCAL-USER
-                              attr-realm-mapper: local
-                            - attr-mechanism-name: DIGEST-MD5
-                              mechanism-realm:
-                                attr-realm-name: ApplicationRealm
-                    security-domains:
-                      security-domain:
-                        attr-default-realm: ApplicationRealm
-                        attr-name: ApplicationDomain
-                        attr-permission-mapper: default-permission-mapper
-                        realm:
-                          attr-name: ApplicationRealm
-                          attr-role-decoder: groups-to-roles
-                    security-realms:
-                      identity-realm:
-                        attr-identity: $local
-                        attr-name: local
-                      properties-realm:
-                        attr-name: ApplicationRealm
-                        groups-properties:
-                          attr-path: application-roles.properties
-                          attr-relative-to: jboss.domain.config.dir
-                        users-properties:
-                          attr-digest-realm-name: ApplicationRealm
-                          attr-path: application-users.properties
-                          attr-relative-to: jboss.domain.config.dir
-                    tls:
-                      key-managers:
-                        key-manager:
-                          attr-generate-self-signed-certificate-host: localhost
-                          attr-key-store: applicationKS
-                          attr-name: applicationKM
-                          credential-reference:
-                            attr-clear-text: password
-                      key-stores:
-                        key-store:
-                          attr-name: applicationKS
-                          credential-reference:
-                            attr-clear-text: password
-                          file:
-                            attr-path: application.keystore
-                            attr-relative-to: jboss.domain.config.dir
-                          implementation:
-                            attr-type: JKS
-                      server-ssl-contexts:
-                        server-ssl-context:
-                          attr-key-manager: applicationKM
-                          attr-name: applicationSSC
-                  - attr-xmlns: urn:jboss:domain:iiop-openjdk:2.1
-                    initializers:
-                      attr-security: identity
-                      attr-transactions: spec
-                    orb:
-                      attr-socket-binding: iiop
-                    security:
-                      attr-client-requires-ssl: 'false'
-                      attr-server-requires-ssl: 'false'
-                  - attr-xmlns: urn:jboss:domain:infinispan:12.0
-                    cache-container:
-                      - attr-aliases: sfsb
-                        attr-default-cache: dist
-                        attr-modules: org.wildfly.clustering.ejb.infinispan
-                        attr-name: ejb
-                        distributed-cache:
-                          attr-name: dist
-                          file-store: null
-                          locking:
-                            attr-isolation: REPEATABLE_READ
-                          transaction:
-                            attr-mode: BATCH
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-aliases: singleton cluster
-                        attr-default-cache: default
-                        attr-modules: org.wildfly.clustering.server
-                        attr-name: server
-                        replicated-cache:
-                          attr-name: default
-                          transaction:
-                            attr-mode: BATCH
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-default-cache: dist
-                        attr-modules: org.wildfly.clustering.web.infinispan
-                        attr-name: web
-                        distributed-cache:
-                          attr-name: dist
-                          file-store: null
-                          locking:
-                            attr-isolation: REPEATABLE_READ
-                          transaction:
-                            attr-mode: BATCH
-                        replicated-cache:
-                          - attr-name: sso
-                            locking:
-                              attr-isolation: REPEATABLE_READ
-                            transaction:
-                              attr-mode: BATCH
-                          - attr-name: routing
-                        transport:
-                          attr-lock-timeout: '60000'
-                      - attr-modules: org.infinispan.hibernate-cache
-                        attr-name: hibernate
-                        invalidation-cache:
-                          attr-name: entity
-                          expiration:
-                            attr-max-idle: '100000'
-                          heap-memory:
-                            attr-size: '10000'
-                        local-cache:
-                          - attr-name: local-query
-                            expiration:
-                              attr-max-idle: '100000'
-                            heap-memory:
-                              attr-size: '10000'
-                          - attr-name: pending-puts
-                            expiration:
-                              attr-max-idle: '60000'
-                        replicated-cache:
-                          attr-name: timestamps
-                        transport:
-                          attr-lock-timeout: '60000'
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-xmlns: urn:jboss:domain:jaxrs:2.0
-                  - archive-validation:
-                      attr-enabled: 'true'
-                      attr-fail-on-error: 'true'
-                      attr-fail-on-warn: 'false'
-                    attr-xmlns: urn:jboss:domain:jca:5.0
-                    bean-validation:
-                      attr-enabled: 'true'
-                    cached-connection-manager: null
-                    default-workmanager:
-                      long-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                      short-running-threads:
-                        core-threads:
-                          attr-count: '50'
-                        keepalive-time:
-                          attr-time: '10'
-                          attr-unit: seconds
-                        max-threads:
-                          attr-count: '50'
-                        queue-length:
-                          attr-count: '50'
-                  - attr-xmlns: urn:jboss:domain:jdr:1.0
-                  - attr-xmlns: urn:jboss:domain:jgroups:8.0
-                    channels:
-                      attr-default: ee
-                      channel:
-                        attr-cluster: ejb
-                        attr-name: ee
-                        attr-stack: udp
-                    stacks:
-                      stack:
-                        - attr-name: udp
-                          protocol:
-                            - attr-type: PING
-                            - attr-type: MERGE3
-                            - attr-type: FD_ALL
-                            - attr-type: VERIFY_SUSPECT
-                            - attr-type: pbcast.NAKACK2
-                            - attr-type: UNICAST3
-                            - attr-type: pbcast.STABLE
-                            - attr-type: pbcast.GMS
-                            - attr-type: UFC
-                            - attr-type: MFC
-                            - attr-type: FRAG3
-                          socket-protocol:
-                            attr-socket-binding: jgroups-udp-fd
-                            attr-type: FD_SOCK
-                          transport:
-                            attr-socket-binding: jgroups-udp
-                            attr-type: UDP
-                        - attr-name: tcp
-                          protocol:
-                            - attr-type: MERGE3
-                            - attr-type: FD_ALL
-                            - attr-type: VERIFY_SUSPECT
-                            - attr-type: pbcast.NAKACK2
-                            - attr-type: UNICAST3
-                            - attr-type: pbcast.STABLE
-                            - attr-type: pbcast.GMS
-                            - attr-type: MFC
-                            - attr-type: FRAG3
-                          socket-protocol:
-                            - attr-socket-binding: jgroups-mping
-                              attr-type: MPING
-                            - attr-socket-binding: jgroups-tcp-fd
-                              attr-type: FD_SOCK
-                          transport:
-                            attr-socket-binding: jgroups-tcp
-                            attr-type: TCP
-                  - attr-xmlns: urn:jboss:domain:jmx:1.3
-                    expose-expression-model: null
-                    expose-resolved-model: null
-                  - attr-xmlns: urn:jboss:domain:jpa:1.1
-                    jpa:
-                      attr-default-extended-persistence-inheritance: DEEP
-                  - attr-xmlns: urn:jboss:domain:jsf:1.1
-                  - attr-xmlns: urn:jboss:domain:jsr77:1.0
-                  - attr-xmlns: urn:jboss:domain:mail:4.0
-                    mail-session:
-                      attr-jndi-name: java:jboss/mail/Default
-                      attr-name: default
-                      smtp-server:
-                        attr-outbound-socket-binding-ref: mail-smtp
-                  - attr-xmlns: urn:jboss:domain:messaging-activemq:13.0
-                    server:
-                      address-setting:
-                        attr-dead-letter-address: jms.queue.DLQ
-                        attr-expiry-address: jms.queue.ExpiryQueue
-                        attr-max-size-bytes: '10485760'
-                        attr-message-counter-history-day-limit: '10'
-                        attr-name: '#'
-                        attr-page-size-bytes: '2097152'
-                        attr-redistribution-delay: '1000'
-                      attr-name: default
-                      cluster:
-                        attr-password: ${jboss.messaging.cluster.password:CHANGE ME!!}
-                      cluster-connection:
-                        attr-address: jms
-                        attr-connector-name: http-connector
-                        attr-discovery-group: dg-group1
-                        attr-name: my-cluster
-                      connection-factory:
-                        - attr-connectors: in-vm
-                          attr-entries: java:/ConnectionFactory
-                          attr-name: InVmConnectionFactory
-                        - attr-block-on-acknowledge: 'true'
-                          attr-connectors: http-connector
-                          attr-entries: java:jboss/exported/jms/RemoteConnectionFactory
-                          attr-ha: 'true'
-                          attr-name: RemoteConnectionFactory
-                          attr-reconnect-attempts: '-1'
-                      http-acceptor:
-                        - attr-http-listener: default
-                          attr-name: http-acceptor
-                        - attr-http-listener: default
-                          attr-name: http-acceptor-throughput
-                          param:
-                            - attr-name: batch-delay
-                              attr-value: '50'
-                            - attr-name: direct-deliver
-                              attr-value: 'false'
-                      http-connector:
-                        - attr-endpoint: http-acceptor
-                          attr-name: http-connector
-                          attr-socket-binding: http
-                        - attr-endpoint: http-acceptor-throughput
-                          attr-name: http-connector-throughput
-                          attr-socket-binding: http
-                          param:
-                            attr-name: batch-delay
-                            attr-value: '50'
-                      in-vm-acceptor:
-                        attr-name: in-vm
-                        attr-server-id: '0'
-                        param:
-                          attr-name: buffer-pooling
-                          attr-value: 'false'
-                      in-vm-connector:
-                        attr-name: in-vm
-                        attr-server-id: '0'
-                        param:
-                          attr-name: buffer-pooling
-                          attr-value: 'false'
-                      jgroups-broadcast-group:
-                        attr-connectors: http-connector
-                        attr-jgroups-cluster: activemq-cluster
-                        attr-name: bg-group1
-                      jgroups-discovery-group:
-                        attr-jgroups-cluster: activemq-cluster
-                        attr-name: dg-group1
-                      jms-queue:
-                        - attr-entries: java:/jms/queue/ExpiryQueue
-                          attr-name: ExpiryQueue
-                        - attr-entries: java:/jms/queue/DLQ
-                          attr-name: DLQ
-                      pooled-connection-factory:
-                        attr-connectors: in-vm
-                        attr-entries: java:/JmsXA java:jboss/DefaultJMSConnectionFactory
-                        attr-name: activemq-ra
-                        attr-transaction: xa
-                      security-setting:
-                        attr-name: '#'
-                        role:
-                          attr-consume: 'true'
-                          attr-create-non-durable-queue: 'true'
-                          attr-delete-non-durable-queue: 'true'
-                          attr-name: guest
-                          attr-send: 'true'
-                      statistics:
-                        attr-enabled: ${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}
-                  - attr-xmlns: urn:jboss:domain:modcluster:5.0
-                    proxy:
-                      attr-advertise-socket: modcluster
-                      attr-listener: ajp
-                      attr-name: default
-                      dynamic-load-provider:
-                        load-metric:
-                          attr-type: cpu
-                  - attr-xmlns: urn:jboss:domain:naming:2.0
-                    remote-naming: null
-                  - attr-xmlns: urn:jboss:domain:pojo:1.0
-                  - attr-xmlns: urn:jboss:domain:remoting:4.0
-                    http-connector:
-                      attr-connector-ref: default
-                      attr-name: http-remoting-connector
-                      attr-security-realm: ApplicationRealm
-                  - attr-xmlns: urn:jboss:domain:request-controller:1.0
-                  - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
-                  - attr-xmlns: urn:jboss:domain:sar:1.0
-                  - attr-xmlns: urn:jboss:domain:security:2.0
-                    security-domains:
-                      security-domain:
-                        - attr-cache-type: default
-                          attr-name: other
-                          authentication:
-                            login-module:
-                              - attr-code: Remoting
-                                attr-flag: optional
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                              - attr-code: RealmDirect
-                                attr-flag: required
-                                module-option:
-                                  attr-name: password-stacking
-                                  attr-value: useFirstPass
-                        - attr-cache-type: default
-                          attr-name: jboss-web-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                        - attr-cache-type: default
-                          attr-name: jaspitest
-                          authentication-jaspi:
-                            auth-module:
-                              attr-code: Dummy
-                            login-module-stack:
-                              attr-name: dummy
-                              login-module:
-                                attr-code: Dummy
-                                attr-flag: optional
-                        - attr-cache-type: default
-                          attr-name: jboss-ejb-policy
-                          authorization:
-                            policy-module:
-                              attr-code: Delegating
-                              attr-flag: required
-                  - attr-xmlns: urn:jboss:domain:security-manager:1.0
-                    deployment-permissions:
-                      maximum-set:
-                        permission:
-                          attr-class: java.security.AllPermission
-                  - attr-xmlns: urn:jboss:domain:singleton:1.0
-                    singleton-policies:
-                      attr-default: default
-                      singleton-policy:
-                        attr-cache-container: server
-                        attr-name: default
-                        simple-election-policy: null
-                  - attr-xmlns: urn:jboss:domain:transactions:6.0
-                    coordinator-environment:
-                      attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    core-environment:
-                      attr-node-identifier: ${jboss.tx.node.id:1}
-                      process-id:
-                        uuid: null
-                    object-store:
-                      attr-path: tx-object-store
-                      attr-relative-to: jboss.server.data.dir
-                    recovery-environment:
-                      attr-socket-binding: txn-recovery-environment
-                      attr-status-socket-binding: txn-status-manager
-                  - attr-default-security-domain: other
-                    attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    handlers:
-                      file:
-                        attr-name: welcome-content
-                        attr-path: ${jboss.home.dir}/welcome-content
-                    server:
-                      ajp-listener:
-                        attr-name: ajp
-                        attr-socket-binding: ajp
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        http-invoker:
-                          attr-security-realm: ApplicationRealm
-                        location:
-                          attr-handler: welcome-content
-                          attr-name: /
-                      http-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: default
-                        attr-redirect-socket: https
-                        attr-socket-binding: http
-                      https-listener:
-                        attr-enable-http2: 'true'
-                        attr-name: https
-                        attr-security-realm: ApplicationRealm
-                        attr-socket-binding: https
-                    servlet-container:
-                      attr-name: default
-                      jsp-config: null
-                      websockets: null
-                  - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:webservices:2.0
-                    client-config:
-                      attr-name: Standard-Client-Config
-                    endpoint-config:
-                      - attr-name: Standard-Endpoint-Config
-                      - attr-name: Recording-Endpoint-Config
-                        pre-handler-chain:
-                          attr-name: recording-handlers
-                          attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM'
-                          handler:
-                            attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
-                            attr-name: RecordingHandler
-                    wsdl-host: ${jboss.bind.address:127.0.0.1}
-                  - attr-xmlns: urn:jboss:domain:weld:4.0
-              - attr-name: load-balancer
-                subsystem:
-                  - attr-xmlns: urn:jboss:domain:logging:8.0
-                    formatter:
-                      - attr-name: PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                      - attr-name: COLOR-PATTERN
-                        pattern-formatter:
-                          attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                    logger:
-                      - attr-category: com.arjuna
-                        level:
-                          attr-name: WARN
-                      - attr-category: io.jaegertracing.Configuration
-                        level:
-                          attr-name: WARN
-                      - attr-category: org.jboss.as.config
-                        level:
-                          attr-name: DEBUG
-                      - attr-category: sun.rmi
-                        level:
-                          attr-name: WARN
-                    periodic-rotating-file-handler:
-                      append:
-                        attr-value: 'true'
-                      attr-autoflush: 'true'
-                      attr-name: FILE
-                      file:
-                        attr-path: server.log
-                        attr-relative-to: jboss.server.log.dir
-                      formatter:
-                        named-formatter:
-                          attr-name: PATTERN
-                      suffix:
-                        attr-value: .yyyy-MM-dd
-                    root-logger:
-                      handlers:
-                        handler:
-                          attr-name: FILE
-                      level:
-                        attr-name: INFO
-                  - attr-xmlns: urn:jboss:domain:io:3.0
-                    buffer-pool:
-                      attr-name: default
-                    worker:
-                      attr-name: default
-                  - attr-default-server: default-server
-                    attr-default-servlet-container: default
-                    attr-default-virtual-host: default-host
-                    attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-xmlns: urn:jboss:domain:undertow:12.0
-                    buffer-cache:
-                      attr-name: default
-                    filters:
-                      mod-cluster:
-                        attr-advertise-socket-binding: modcluster
-                        attr-enable-http2: 'true'
-                        attr-management-socket-binding: mcmp-management
-                        attr-max-retries: '3'
-                        attr-name: load-balancer
-                        single-affinity: null
-                    server:
-                      attr-name: default-server
-                      host:
-                        attr-alias: localhost
-                        attr-name: default-host
-                        filter-ref:
-                          attr-name: load-balancer
-                      http-listener:
-                        - attr-enable-http2: 'true'
-                          attr-name: default
-                          attr-redirect-socket: https
-                          attr-socket-binding: http
-                        - attr-enable-http2: 'true'
-                          attr-name: management
-                          attr-socket-binding: mcmp-management
-                    servlet-container:
-                      attr-name: default
-          server-groups:
-            server-group:
-              - attr-name: main-server-group
-                attr-profile: full-ha
-                jvm:
-                  attr-name: default
-                  heap:
-                    attr-max-size: 1000m
-                    attr-size: 1000m
-                socket-binding-group:
-                  attr-ref: full-ha-sockets
-              - attr-name: second-server-group
-                attr-profile: full-ha
-                jvm:
-                  attr-name: default
-                  heap:
-                    attr-max-size: 1000m
-                    attr-size: 1000m
-                socket-binding-group:
-                  attr-ref: full-ha-sockets
-          socket-binding-groups:
-            socket-binding-group:
-              - attr-default-interface: public
-                attr-name: standard-sockets
-                outbound-socket-binding:
-                  attr-name: mail-smtp
-                  remote-destination:
-                    attr-host: ${jboss.mail.server.host:localhost}
-                    attr-port: ${jboss.mail.server.port:25}
-                socket-binding:
-                  - attr-name: ajp
-                    attr-port: ${jboss.ajp.port:8009}
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-name: txn-recovery-environment
-                    attr-port: '4712'
-                  - attr-name: txn-status-manager
-                    attr-port: '4713'
-              - attr-default-interface: public
-                attr-name: ha-sockets
-                outbound-socket-binding:
-                  attr-name: mail-smtp
-                  remote-destination:
-                    attr-host: ${jboss.mail.server.host:localhost}
-                    attr-port: ${jboss.mail.server.port:25}
-                socket-binding:
-                  - attr-name: ajp
-                    attr-port: ${jboss.ajp.port:8009}
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
-                    attr-multicast-port: '45700'
-                    attr-name: jgroups-mping
-                  - attr-interface: private
-                    attr-name: jgroups-tcp
-                    attr-port: '7600'
-                  - attr-interface: private
-                    attr-name: jgroups-tcp-fd
-                    attr-port: '57600'
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
-                    attr-multicast-port: '45688'
-                    attr-name: jgroups-udp
-                    attr-port: '55200'
-                  - attr-interface: private
-                    attr-name: jgroups-udp-fd
-                    attr-port: '54200'
-                  - attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
-                    attr-multicast-port: '23364'
-                    attr-name: modcluster
-                  - attr-name: txn-recovery-environment
-                    attr-port: '4712'
-                  - attr-name: txn-status-manager
-                    attr-port: '4713'
-              - attr-default-interface: public
-                attr-name: full-sockets
-                outbound-socket-binding:
-                  attr-name: mail-smtp
-                  remote-destination:
-                    attr-host: ${jboss.mail.server.host:localhost}
-                    attr-port: ${jboss.mail.server.port:25}
-                socket-binding:
-                  - attr-name: ajp
-                    attr-port: ${jboss.ajp.port:8009}
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-interface: unsecure
-                    attr-name: iiop
-                    attr-port: '3528'
-                  - attr-interface: unsecure
-                    attr-name: iiop-ssl
-                    attr-port: '3529'
-                  - attr-name: txn-recovery-environment
-                    attr-port: '4712'
-                  - attr-name: txn-status-manager
-                    attr-port: '4713'
-              - attr-default-interface: public
-                attr-name: full-ha-sockets
-                outbound-socket-binding:
-                  attr-name: mail-smtp
-                  remote-destination:
-                    attr-host: ${jboss.mail.server.host:localhost}
-                    attr-port: ${jboss.mail.server.port:25}
-                socket-binding:
-                  - attr-name: ajp
-                    attr-port: ${jboss.ajp.port:8009}
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-interface: unsecure
-                    attr-name: iiop
-                    attr-port: '3528'
-                  - attr-interface: unsecure
-                    attr-name: iiop-ssl
-                    attr-port: '3529'
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
-                    attr-multicast-port: '45700'
-                    attr-name: jgroups-mping
-                  - attr-interface: private
-                    attr-name: jgroups-tcp
-                    attr-port: '7600'
-                  - attr-interface: private
-                    attr-name: jgroups-tcp-fd
-                    attr-port: '57600'
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
-                    attr-multicast-port: '45688'
-                    attr-name: jgroups-udp
-                    attr-port: '55200'
-                  - attr-interface: private
-                    attr-name: jgroups-udp-fd
-                    attr-port: '54200'
-                  - attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
-                    attr-multicast-port: '23364'
-                    attr-name: modcluster
-                  - attr-name: txn-recovery-environment
-                    attr-port: '4712'
-                  - attr-name: txn-status-manager
-                    attr-port: '4713'
-              - attr-default-interface: public
-                attr-name: load-balancer-sockets
-                socket-binding:
-                  - attr-name: http
-                    attr-port: ${jboss.http.port:8080}
-                  - attr-name: https
-                    attr-port: ${jboss.https.port:8443}
-                  - attr-interface: private
-                    attr-name: mcmp-management
-                    attr-port: ${jboss.mcmp.port:8090}
-                  - attr-interface: private
-                    attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
-                    attr-multicast-port: '23364'
-                    attr-name: modcluster
-          system-properties:
-            property:
-              attr-name: java.net.preferIPv4Stack
-              attr-value: 'true'
-      host_xml:
-        host:
-          attr-name: nodo1-master
-          attr-xmlns: urn:jboss:domain:16.0
-          domain-controller:
-            local: null
-          extensions:
-            extension:
-              - attr-module: org.jboss.as.jmx
-              - attr-module: org.wildfly.extension.core-management
-              - attr-module: org.wildfly.extension.elytron
-          interfaces:
-            interface:
-              - attr-name: management
-                inet-address:
-                  attr-value: ${jboss.bind.address.management:0.0.0.0}
-              - attr-name: public
-                inet-address:
-                  attr-value: ${jboss.bind.address:0.0.0.0}
-          jvms:
-            jvm:
-              attr-name: default
-              heap:
-                attr-max-size: 256m
-                attr-size: 64m
-              jvm-options:
-                option:
-                  - attr-value: -server
-                  - attr-value: -XX:MetaspaceSize=96m
-                  - attr-value: -XX:MaxMetaspaceSize=256m
-          management:
-            audit-log:
-              formatters:
-                json-formatter:
-                  attr-name: json-formatter
-              handlers:
-                file-handler:
-                  - attr-formatter: json-formatter
-                    attr-name: host-file
-                    attr-path: audit-log.log
-                    attr-relative-to: jboss.domain.data.dir
-                  - attr-formatter: json-formatter
-                    attr-name: server-file
-                    attr-path: audit-log.log
-                    attr-relative-to: jboss.server.data.dir
-              logger:
-                attr-enabled: 'false'
-                attr-log-boot: 'true'
-                attr-log-read-only: 'false'
-                handlers:
-                  handler:
-                    attr-name: host-file
-              server-logger:
-                attr-enabled: 'false'
-                attr-log-boot: 'true'
-                attr-log-read-only: 'false'
-                handlers:
-                  handler:
-                    attr-name: server-file
-            management-interfaces:
-              http-interface:
-                attr-security-realm: ManagementRealm
-                http-upgrade:
-                  attr-enabled: 'true'
-                socket:
-                  attr-interface: management
-                  attr-port: ${jboss.management.http.port:9990}
-              native-interface:
-                socket:
-                  attr-interface: management
-                  attr-port: ${jboss.management.native.port:9999}
-            security-realms:
-              security-realm:
-                - attr-name: ManagementRealm
-                  authentication:
-                    local:
-                      attr-default-user: $local
-                      attr-skip-group-loading: 'true'
-                    properties:
-                      attr-path: mgmt-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  authorization:
-                    attr-map-groups-to-roles: 'false'
-                    properties:
-                      attr-path: mgmt-groups.properties
-                      attr-relative-to: jboss.domain.config.dir
-                - attr-name: ApplicationRealm
-                  authentication:
-                    local:
-                      attr-allowed-users: '*'
-                      attr-default-user: $local
-                      attr-skip-group-loading: 'true'
-                    properties:
-                      attr-path: application-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  authorization:
-                    properties:
-                      attr-path: application-roles.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  server-identities:
-                    ssl:
-                      keystore:
-                        attr-alias: server
-                        attr-generate-self-signed-certificate-host: localhost
-                        attr-key-password: password
-                        attr-keystore-password: password
-                        attr-path: application.keystore
-                        attr-relative-to: jboss.domain.config.dir
-          profile:
-            subsystem:
-              - attr-xmlns: urn:jboss:domain:core-management:1.0
-              - attr-disallowed-providers: OracleUcrypto
-                attr-final-providers: combined-providers
-                attr-xmlns: urn:wildfly:elytron:13.0
-                audit-logging:
-                  file-audit-log:
-                    attr-format: JSON
-                    attr-name: local-audit
-                    attr-path: audit.log
-                    attr-relative-to: jboss.domain.log.dir
-                http:
-                  http-authentication-factory:
-                    attr-http-server-mechanism-factory: global
-                    attr-name: management-http-authentication
-                    attr-security-domain: ManagementDomain
-                    mechanism-configuration:
-                      mechanism:
-                        attr-mechanism-name: BASIC
-                        mechanism-realm:
-                          attr-realm-name: Management Realm
-                  provider-http-server-mechanism-factory:
-                    attr-name: global
-                mappers:
-                  constant-realm-mapper:
-                    attr-name: local
-                    attr-realm-name: local
-                  constant-role-mapper:
-                    attr-name: super-user-mapper
-                    role:
-                      attr-name: SuperUser
-                  simple-permission-mapper:
-                    attr-mapping-mode: first
-                    attr-name: default-permission-mapper
-                    permission-mapping:
-                      - permission-set:
-                          attr-name: default-permissions
-                        principal:
-                          attr-name: anonymous
-                      - attr-match-all: 'true'
-                        permission-set:
-                          - attr-name: login-permission
-                          - attr-name: default-permissions
-                  simple-role-decoder:
-                    attr-attribute: groups
-                    attr-name: groups-to-roles
-                permission-sets:
-                  permission-set:
-                    - attr-name: login-permission
-                      permission:
-                        attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                    - attr-name: default-permissions
-                providers:
-                  aggregate-providers:
-                    attr-name: combined-providers
-                    providers:
-                      - attr-name: elytron
-                      - attr-name: openssl
-                  provider-loader:
-                    - attr-module: org.wildfly.security.elytron
-                      attr-name: elytron
-                    - attr-module: org.wildfly.openssl
-                      attr-name: openssl
-                sasl:
-                  configurable-sasl-server-factory:
-                    attr-name: configured
-                    attr-sasl-server-factory: elytron
-                    properties:
-                      property:
-                        attr-name: wildfly.sasl.local-user.default-user
-                        attr-value: $local
-                  mechanism-provider-filtering-sasl-server-factory:
-                    attr-name: elytron
-                    attr-sasl-server-factory: global
-                    filters:
-                      filter:
-                        attr-provider-name: WildFlyElytron
-                  provider-sasl-server-factory:
-                    attr-name: global
-                  sasl-authentication-factory:
-                    attr-name: management-sasl-authentication
-                    attr-sasl-server-factory: configured
-                    attr-security-domain: ManagementDomain
-                    mechanism-configuration:
-                      mechanism:
-                        - attr-mechanism-name: JBOSS-LOCAL-USER
-                          attr-realm-mapper: local
-                        - attr-mechanism-name: DIGEST-MD5
-                          mechanism-realm:
-                            attr-realm-name: ManagementRealm
-                security-domains:
-                  security-domain:
-                    attr-default-realm: ManagementRealm
-                    attr-name: ManagementDomain
-                    attr-permission-mapper: default-permission-mapper
-                    realm:
-                      - attr-name: ManagementRealm
-                        attr-role-decoder: groups-to-roles
-                      - attr-name: local
-                        attr-role-mapper: super-user-mapper
-                security-realms:
-                  identity-realm:
-                    attr-identity: $local
-                    attr-name: local
-                  properties-realm:
-                    attr-name: ManagementRealm
-                    groups-properties:
-                      attr-path: mgmt-groups.properties
-                      attr-relative-to: jboss.domain.config.dir
-                    users-properties:
-                      attr-digest-realm-name: ManagementRealm
-                      attr-path: mgmt-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-              - attr-xmlns: urn:jboss:domain:jmx:1.3
-                expose-expression-model: null
-                expose-resolved-model: null
-                remoting-connector: null
-          servers:
-            server:
-              - attr-auto-start: 'true'
-                attr-group: main-server-group
-                attr-name: nodo1-server1
-              - attr-auto-start: 'true'
-                attr-group: second-server-group
-                attr-name: nodo1-server2
-                jvm:
-                  attr-name: default
-                socket-bindings:
-                  attr-port-offset: '150'
-    discovery_time: '2022-06-23T20:39:27+02:00'
-    extra_data:
-      heap_initial_allocation_memory: 1000m
-      heap_max_memory: 1000m
-      domain_role: master
-      server:
-        group: main-server-group
-        name: nodo1-server1
-        port_offset: '0'
-        profile: full-ha
-      mode: domain
-    files:
-      - path: /opt/jboss/domain/servers/nodo1-server1/log
-        subtype: generic
-        type: log
-      - name: server.log
-        path: /opt/jboss/domain/servers/nodo1-server1/log
-        subtype: generic
-        type: log
-      - name: logging.properties
-        path: /opt/jboss/domain/servers/nodo1-server1/data
-        subtype: generic
-        type: log
-      - name: host.xml
-        path: /opt/jboss/domain/configuration
-        subtype: host
-        type: config
-      - name: domain.xml
-        path: /opt/jboss/domain/configuration
-        subtype: domain
-        type: config
-      - path: /opt/jboss
-        subtype: generic
-        type: data
-    listening_ports:
-      - 3528
-      - 8009
-      - 8080
-      - 8443
-      - 23364
-      - 45688
-      - 54200
-      - 55200
-    packages:
-      - arch: noarch
-        epoch: null
-        name: jboss-el-2.2-api
-        release: 0.7.20120212git2fabd8.el7
-        source: rpm
-        version: 1.0.1
-      - arch: noarch
-        epoch: null
-        name: jboss-jaxrpc-1.1-api
-        release: 7.el7
-        source: rpm
-        version: 1.0.1
-      - arch: noarch
-        epoch: null
-        name: jboss-servlet-3.0-api
-        release: 9.el7
-        source: rpm
-        version: 1.0.1
-      - arch: noarch
-        epoch: null
-        name: jboss-transaction-1.1-api
-        release: 8.el7
-        source: rpm
-        version: 1.0.1
-      - arch: noarch
-        epoch: null
-        name: jboss-ejb-3.1-api
-        release: 10.el7
-        source: rpm
-        version: 1.0.2
-      - arch: noarch
-        epoch: null
-        name: jboss-interceptors-1.1-api
-        release: 0.9.20120319git49a904.el7
-        source: rpm
-        version: 1.0.2
-    process:
-      cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/java -D[Server:nodo1-server1] -D[pcid:1449119893] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo1-server1/log -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo1-server1/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo1-server1/data -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo1-server1/data/logging.properties -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
-      listening_ports:
-        - 3528
-        - 8009
-        - 8080
-        - 8443
-        - 23364
-        - 45688
-        - 54200
-        - 55200
-      pid: '17878'
-      ppid: '17764'
-      user: wildfly
-    type: JBoss Application Server
-    version:
-      - number: 1.0.1
-        type: package
-      - number: 1.0.2
-        type: package
-      - number: 7.4.0
-        type: file
-
-software_list:
-  - cmd_regexp: org\.jboss\.Main|org\.jboss\.(?:Main|as\.(?:standalone|server))
-    name: JBoss Application Server
-    pkg_regexp: jboss
-    process_type: parent
-    return_children: false
-    return_packages: true
-    vars:
-      credentials:
-        management_user: admin
-        management_password: password
-      default_management_port: '9990'
-    custom_tasks:
-      - name: Include JBoss specific plugins
-        include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/jboss.yaml"
-
 dockers:
-  containers: [ ]
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  aether-api:
-    - arch: noarch
-      epoch: null
-      name: aether-api
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
-  aether-connector-wagon:
-    - arch: noarch
-      epoch: null
-      name: aether-connector-wagon
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
-  aether-impl:
-    - arch: noarch
-      epoch: null
-      name: aether-impl
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
-  aether-spi:
-    - arch: noarch
-      epoch: null
-      name: aether-spi
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
-  aether-util:
-    - arch: noarch
-      epoch: null
-      name: aether-util
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
-  alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
-  aopalliance:
-    - arch: noarch
-      epoch: 0
-      name: aopalliance
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  apache-commons-cli:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-cli
-      release: 13.el7
-      source: rpm
-      version: '1.2'
-  apache-commons-codec:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-codec
-      release: 7.el7
-      source: rpm
-      version: '1.8'
-  apache-commons-io:
-    - arch: noarch
-      epoch: 1
-      name: apache-commons-io
-      release: 12.el7
-      source: rpm
-      version: '2.4'
-  apache-commons-lang:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-lang
-      release: 15.el7
-      source: rpm
-      version: '2.6'
-  apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
-  apache-commons-net:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-net
-      release: 8.el7.centos
-      source: rpm
-      version: '3.2'
-  apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
-  apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
-  atinject:
-    - arch: noarch
-      epoch: null
-      name: atinject
-      release: 13.20100611svn86.el7
-      source: rpm
-      version: '1'
-  atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
-  avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
-  avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 35.el7_9
-      source: rpm
-      version: 4.2.46
-  bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
-  bcel:
-    - arch: noarch
-      epoch: 0
-      name: bcel
-      release: 18.el7
-      source: rpm
-      version: '5.2'
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 72.el7_9
-      source: rpm
-      version: 2021.2.50
-  cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
-  cal10n:
-    - arch: noarch
-      epoch: null
-      name: cal10n
-      release: 4.el7
-      source: rpm
-      version: 0.7.7
-  cdi-api:
-    - arch: noarch
-      epoch: null
-      name: cdi-api
-      release: 11.SP4.el7
-      source: rpm
-      version: '1.0'
-  centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
-  cglib:
-    - arch: noarch
-      epoch: null
-      name: cglib
-      release: 18.el7
-      source: rpm
-      version: '2.2'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 7.el7.centos.6
-      source: rpm
-      version: '19.4'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
-  copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
-  cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
-  cyrus-sasl-gssapi:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-gssapi
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
-  cyrus-sasl-plain:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-plain
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  easymock2:
-    - arch: noarch
-      epoch: null
-      name: easymock2
-      release: 12.el7
-      source: rpm
-      version: 2.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '14'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  felix-framework:
-    - arch: noarch
-      epoch: null
-      name: felix-framework
-      release: 5.el7
-      source: rpm
-      version: 4.2.1
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  geronimo-annotation:
-    - arch: noarch
-      epoch: null
-      name: geronimo-annotation
-      release: 15.el7
-      source: rpm
-      version: '1.0'
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  google-guice:
-    - arch: noarch
-      epoch: null
-      name: google-guice
-      release: 9.el7
-      source: rpm
-      version: 3.1.3
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 61b8bab7
-      source: rpm
-      version: 3a79bd29
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 5c4058fb
-      source: rpm
-      version: 5072e1f5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 5eb44ee6
-      source: rpm
-      version: a3219f7b
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 602c28d5
-      source: rpm
-      version: e2c63c11
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 5ced7aac
-      source: rpm
-      version: 90cfb1f5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  guava:
-    - arch: noarch
-      epoch: null
-      name: guava
-      release: 6.el7
-      source: rpm
-      version: '13.0'
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hamcrest:
-    - arch: noarch
-      epoch: 0
-      name: hamcrest
-      release: 6.el7
-      source: rpm
-      version: '1.3'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  httpcomponents-client:
-    - arch: noarch
-      epoch: null
-      name: httpcomponents-client
-      release: 5.el7_0
-      source: rpm
-      version: 4.2.5
-  httpcomponents-core:
-    - arch: noarch
-      epoch: null
-      name: httpcomponents-core
-      release: 6.el7
-      source: rpm
-      version: 4.2.4
-  httpd:
-    - arch: x86_64
-      epoch: null
-      name: httpd
-      release: 97.el7.centos.4
-      source: rpm
-      version: 2.4.6
-  httpd-tools:
-    - arch: x86_64
-      epoch: null
-      name: httpd-tools
-      release: 97.el7.centos.4
-      source: rpm
-      version: 2.4.6
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-commons-httpclient:
-    - arch: noarch
-      epoch: 1
-      name: jakarta-commons-httpclient
-      release: 16.el7_0
-      source: rpm
-      version: '3.1'
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-devel:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-devel
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  javassist:
-    - arch: noarch
-      epoch: null
-      name: javassist
-      release: 10.el7
-      source: rpm
-      version: 3.16.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  jboss-ejb-3.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-ejb-3.1-api
-      release: 10.el7
-      source: rpm
-      version: 1.0.2
-  jboss-el-2.2-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-el-2.2-api
-      release: 0.7.20120212git2fabd8.el7
-      source: rpm
-      version: 1.0.1
-  jboss-interceptors-1.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-interceptors-1.1-api
-      release: 0.9.20120319git49a904.el7
-      source: rpm
-      version: 1.0.2
-  jboss-jaxrpc-1.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-jaxrpc-1.1-api
-      release: 7.el7
-      source: rpm
-      version: 1.0.1
-  jboss-servlet-3.0-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-servlet-3.0-api
-      release: 9.el7
-      source: rpm
-      version: 1.0.1
-  jboss-transaction-1.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-transaction-1.1-api
-      release: 8.el7
-      source: rpm
-      version: 1.0.1
-  jline:
-    - arch: noarch
-      epoch: null
-      name: jline
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  jsch:
-    - arch: noarch
-      epoch: 0
-      name: jsch
-      release: 5.el7
-      source: rpm
-      version: 0.1.50
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  jsoup:
-    - arch: noarch
-      epoch: null
-      name: jsoup
-      release: 10.el7
-      source: rpm
-      version: 1.6.1
-  junit:
-    - arch: noarch
-      epoch: 0
-      name: junit
-      release: 8.el7
-      source: rpm
-      version: '4.11'
-  jzlib:
-    - arch: noarch
-      epoch: 0
-      name: jzlib
-      release: 6.el7
-      source: rpm
-      version: 1.1.1
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.49.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.3
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 135.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 18.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  maven:
-    - arch: noarch
-      epoch: null
-      name: maven
-      release: 17.el7
-      source: rpm
-      version: 3.0.5
-  maven-wagon:
-    - arch: noarch
-      epoch: 0
-      name: maven-wagon
-      release: 3.el7
-      source: rpm
-      version: '2.4'
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mongodb-database-tools:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-database-tools
-      release: '1'
-      source: rpm
-      version: 100.5.2
-  mongodb-org:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-database-tools-extra:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-database-tools-extra
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-mongos:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-mongos
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-server:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-server
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-shell:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-shell
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-tools:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-tools
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mysql-community-client:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-client
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-client-plugins:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-client-plugins
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-common:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-common
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-icu-data-files:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-icu-data-files
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-libs:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-libs
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-libs-compat:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-libs-compat
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-server:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-server
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql80-community-release:
-    - arch: noarch
-      epoch: null
-      name: mysql80-community-release
-      release: '3'
-      source: rpm
-      version: el8
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  nekohtml:
-    - arch: noarch
-      epoch: 0
-      name: nekohtml
-      release: 13.el7
-      source: rpm
-      version: 1.9.14
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7.2
-      source: rpm
-      version: 1.3.0
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  objectweb-asm:
-    - arch: noarch
-      epoch: 0
-      name: objectweb-asm
-      release: 9.el7
-      source: rpm
-      version: 3.3.1
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 25.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  packer:
-    - arch: x86_64
-      epoch: null
-      name: packer
-      release: '1'
-      source: rpm
-      version: 1.7.10
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  plexus-cipher:
-    - arch: noarch
-      epoch: null
-      name: plexus-cipher
-      release: 5.el7
-      source: rpm
-      version: '1.7'
-  plexus-classworlds:
-    - arch: noarch
-      epoch: null
-      name: plexus-classworlds
-      release: 8.el7
-      source: rpm
-      version: 2.4.2
-  plexus-component-api:
-    - arch: noarch
-      epoch: null
-      name: plexus-component-api
-      release: 0.16.alpha15.el7
-      source: rpm
-      version: '1.0'
-  plexus-containers-component-annotations:
-    - arch: noarch
-      epoch: null
-      name: plexus-containers-component-annotations
-      release: 14.el7
-      source: rpm
-      version: 1.5.5
-  plexus-containers-container-default:
-    - arch: noarch
-      epoch: null
-      name: plexus-containers-container-default
-      release: 14.el7
-      source: rpm
-      version: 1.5.5
-  plexus-interactivity:
-    - arch: noarch
-      epoch: 0
-      name: plexus-interactivity
-      release: 0.14.alpha6.el7
-      source: rpm
-      version: '1.0'
-  plexus-interpolation:
-    - arch: noarch
-      epoch: null
-      name: plexus-interpolation
-      release: 8.el7
-      source: rpm
-      version: '1.15'
-  plexus-sec-dispatcher:
-    - arch: noarch
-      epoch: null
-      name: plexus-sec-dispatcher
-      release: 13.el7
-      source: rpm
-      version: '1.4'
-  plexus-utils:
-    - arch: noarch
-      epoch: null
-      name: plexus-utils
-      release: 9.el7
-      source: rpm
-      version: 3.0.9
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 10.el7
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qdox:
-    - arch: noarch
-      epoch: 0
-      name: qdox
-      release: 10.el7
-      source: rpm
-      version: 1.12.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  regexp:
-    - arch: noarch
-      epoch: 0
-      name: regexp
-      release: 13.el7
-      source: rpm
-      version: '1.5'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9.1
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  sisu-inject-bean:
-    - arch: noarch
-      epoch: null
-      name: sisu-inject-bean
-      release: 11.el7
-      source: rpm
-      version: 2.3.0
-  sisu-inject-plexus:
-    - arch: noarch
-      epoch: null
-      name: sisu-inject-plexus
-      release: 11.el7
-      source: rpm
-      version: 2.3.0
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slf4j:
-    - arch: noarch
-      epoch: 0
-      name: slf4j
-      release: 4.el7_4
-      source: rpm
-      version: 1.7.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.2
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 66.el7
-      source: rpm
-      version: '0.17'
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 24.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7_9.1
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xbean:
-    - arch: noarch
-      epoch: null
-      name: xbean
-      release: 6.el7
-      source: rpm
-      version: '3.13'
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '113'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '192'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '193'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '260'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '266'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '267'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '281'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '282'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '283'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '408'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '447'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '471'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '512'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '539'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '548'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /sbin/rpcbind -w
-    pid: '550'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '554'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '562'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '563'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/sbin/chronyd
-    pid: '566'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H test-norm01 eth0
-    pid: '808'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '864'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '866'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/java -Xms64M -Xmx1G -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config -Dcom.sun.management.jmxremote -Djava.awt.headless=true -Djava.io.tmpdir=/opt/apache-activemq-5.14.3//tmp -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/: -Dactivemq.home=/opt/apache-activemq-5.14.3/ -Dactivemq.base=/opt/apache-activemq-5.14.3/ -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf -Dactivemq.data=/opt/apache-activemq-5.14.3//data -jar /opt/apache-activemq-5.14.3//bin/activemq.jar start'
-    pid: '967'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1100'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1106'
-    ppid: '1100'
-    user: postfix
-  - cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '1147'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1148'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1159'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1181'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1182'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1183'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/mongod -f /etc/mongod.conf
-    pid: '1239'
-    ppid: '1'
-    user: mongod
-  - cmdline: /usr/sbin/mysqld
-    pid: '1535'
-    ppid: '1'
-    user: mysql
-  - cmdline: ''
-    pid: '1993'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2191'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2192'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2193'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2194'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2195'
-    ppid: '866'
-    user: apache
-  - cmdline: ''
-    pid: '3613'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '6346'
-    ppid: '1100'
-    user: postfix
-  - cmdline: 'sshd: centos [priv]'
-    pid: '12465'
-    ppid: '1159'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '12468'
-    ppid: '12465'
-    user: centos
-  - cmdline: -bash
-    pid: '12469'
-    ppid: '12468'
-    user: centos
-  - cmdline: sudo su
-    pid: '12624'
-    ppid: '12469'
-    user: root
-  - cmdline: su
-    pid: '12625'
-    ppid: '12624'
-    user: root
-  - cmdline: bash
-    pid: '12626'
-    ppid: '12625'
-    user: root
-  - cmdline: ''
-    pid: '13638'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13894'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '14201'
-    ppid: '1159'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '14204'
-    ppid: '14201'
-    user: centos
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-fuaxmatzfqmqdqgdvmixffwrycdkvoch ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009536.0534809-88841-259616145208073/AnsiballZ_process_facts.py' && sleep 0
-    pid: '14357'
-    ppid: '14204'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-fuaxmatzfqmqdqgdvmixffwrycdkvoch ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009536.0534809-88841-259616145208073/AnsiballZ_process_facts.py
-    pid: '14370'
-    ppid: '14357'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-fuaxmatzfqmqdqgdvmixffwrycdkvoch ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009536.0534809-88841-259616145208073/AnsiballZ_process_facts.py
-    pid: '14371'
-    ppid: '14370'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009536.0534809-88841-259616145208073/AnsiballZ_process_facts.py
-    pid: '14372'
-    ppid: '14371'
-    user: root
-  - cmdline: ''
-    pid: '17543'
-    ppid: '2'
-    user: root
-  - cmdline: /bin/sh /opt/jboss/bin/domain.sh --domain-config=domain.xml --host-config=host.xml
-    pid: '17678'
-    ppid: '1'
-    user: wildfly
-  - cmdline: java -D[Process Controller] -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/process-controller.log -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.process-controller -jboss-home /opt/jboss -jvm java -mp /opt/jboss/modules -- -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -- -default-jvm java --domain-config=domain.xml --host-config=host.xml
-    pid: '17764'
-    ppid: '17678'
-    user: wildfly
-  - cmdline: java -D[Host Controller] -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.host-controller -mp /opt/jboss/modules --pc-address 127.0.0.1 --pc-port 42816 -default-jvm java --domain-config=domain.xml --host-config=host.xml -Djboss.home.dir=/opt/jboss
-    pid: '17780'
-    ppid: '17764'
-    user: wildfly
-  - cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/java -D[Server:nodo1-server1] -D[pcid:1449119893] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo1-server1/log -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo1-server1/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo1-server1/data -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo1-server1/data/logging.properties -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
+  containers: []
+expected_result:
+- bindings:
+  - address: 127.0.0.1
+    class: service
+    port: 3528
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 8009
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 8080
+    protocol: tcp
+  - address: 127.0.0.1
+    class: service
+    port: 54200
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 8443
+    protocol: tcp
+  - address: 230.0.0.4
+    class: service
+    port: 45688
+    protocol: udp
+  - address: 224.0.1.105
+    class: service
+    port: 23364
+    protocol: udp
+  - address: 127.0.0.1
+    class: service
+    port: 55200
+    protocol: udp
+  - class: ajp
+    port: 8009
+  - class: http
+    port: 8080
+  - class: https
+    port: 8443
+  - class: iiop
+    port: 3528
+  - class: iiop_ssl
+    port: 3529
+  - class: jgroups_tcp
+    port: 7600
+  - class: jgroups_tcp_fd
+    port: 57600
+  - class: jgroups_udp
+    port: 55200
+  - class: jgroups_udp_fd
+    port: 54200
+  - class: txn_recovery_environment
+    port: 4712
+  - class: txn_status_manager
+    port: 4713
+  - class: listener
+    port: 9990
+  configuration:
+    domain_xml:
+      domain:
+        attr-xmlns: urn:jboss:domain:16.0
+        extensions:
+          extension:
+          - attr-module: org.jboss.as.clustering.infinispan
+          - attr-module: org.jboss.as.clustering.jgroups
+          - attr-module: org.jboss.as.connector
+          - attr-module: org.jboss.as.ee
+          - attr-module: org.jboss.as.ejb3
+          - attr-module: org.jboss.as.jaxrs
+          - attr-module: org.jboss.as.jdr
+          - attr-module: org.jboss.as.jmx
+          - attr-module: org.jboss.as.jpa
+          - attr-module: org.jboss.as.jsf
+          - attr-module: org.jboss.as.jsr77
+          - attr-module: org.jboss.as.logging
+          - attr-module: org.jboss.as.mail
+          - attr-module: org.jboss.as.modcluster
+          - attr-module: org.jboss.as.naming
+          - attr-module: org.jboss.as.pojo
+          - attr-module: org.jboss.as.remoting
+          - attr-module: org.jboss.as.sar
+          - attr-module: org.jboss.as.security
+          - attr-module: org.jboss.as.transactions
+          - attr-module: org.jboss.as.webservices
+          - attr-module: org.jboss.as.weld
+          - attr-module: org.wildfly.extension.batch.jberet
+          - attr-module: org.wildfly.extension.bean-validation
+          - attr-module: org.wildfly.extension.clustering.singleton
+          - attr-module: org.wildfly.extension.clustering.web
+          - attr-module: org.wildfly.extension.core-management
+          - attr-module: org.wildfly.extension.discovery
+          - attr-module: org.wildfly.extension.ee-security
+          - attr-module: org.wildfly.extension.elytron
+          - attr-module: org.wildfly.extension.io
+          - attr-module: org.wildfly.extension.messaging-activemq
+          - attr-module: org.wildfly.extension.request-controller
+          - attr-module: org.wildfly.extension.security.manager
+          - attr-module: org.wildfly.extension.undertow
+          - attr-module: org.wildfly.iiop-openjdk
+        host-excludes:
+          host-exclude:
+          - attr-name: EAP62
+            excluded-extensions:
+              extension:
+              - attr-module: org.wildfly.extension.batch.jberet
+              - attr-module: org.wildfly.extension.bean-validation
+              - attr-module: org.wildfly.extension.clustering.singleton
+              - attr-module: org.wildfly.extension.clustering.web
+              - attr-module: org.wildfly.extension.core-management
+              - attr-module: org.wildfly.extension.datasources-agroal
+              - attr-module: org.wildfly.extension.discovery
+              - attr-module: org.wildfly.extension.ee-security
+              - attr-module: org.wildfly.extension.elytron
+              - attr-module: org.wildfly.extension.io
+              - attr-module: org.wildfly.extension.messaging-activemq
+              - attr-module: org.wildfly.extension.microprofile.config-smallrye
+              - attr-module: org.wildfly.extension.microprofile.health-smallrye
+              - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+              - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+              - attr-module: org.wildfly.extension.picketlink
+              - attr-module: org.wildfly.extension.request-controller
+              - attr-module: org.wildfly.extension.rts
+              - attr-module: org.wildfly.extension.security.manager
+              - attr-module: org.wildfly.extension.undertow
+              - attr-module: org.wildfly.iiop-openjdk
+              - attr-module: org.wildfly.extension.health
+              - attr-module: org.wildfly.extension.metrics
+            host-release:
+              attr-id: EAP6.2
+          - attr-name: EAP63
+            excluded-extensions:
+              extension:
+              - attr-module: org.wildfly.extension.batch.jberet
+              - attr-module: org.wildfly.extension.bean-validation
+              - attr-module: org.wildfly.extension.clustering.singleton
+              - attr-module: org.wildfly.extension.clustering.web
+              - attr-module: org.wildfly.extension.core-management
+              - attr-module: org.wildfly.extension.datasources-agroal
+              - attr-module: org.wildfly.extension.discovery
+              - attr-module: org.wildfly.extension.ee-security
+              - attr-module: org.wildfly.extension.elytron
+              - attr-module: org.wildfly.extension.io
+              - attr-module: org.wildfly.extension.messaging-activemq
+              - attr-module: org.wildfly.extension.microprofile.config-smallrye
+              - attr-module: org.wildfly.extension.microprofile.health-smallrye
+              - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+              - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+              - attr-module: org.wildfly.extension.request-controller
+              - attr-module: org.wildfly.extension.rts
+              - attr-module: org.wildfly.extension.security.manager
+              - attr-module: org.wildfly.extension.undertow
+              - attr-module: org.wildfly.iiop-openjdk
+              - attr-module: org.wildfly.extension.health
+              - attr-module: org.wildfly.extension.metrics
+            host-release:
+              attr-id: EAP6.3
+          - attr-name: EAP64
+            excluded-extensions:
+              extension:
+              - attr-module: org.wildfly.extension.batch.jberet
+              - attr-module: org.wildfly.extension.bean-validation
+              - attr-module: org.wildfly.extension.clustering.singleton
+              - attr-module: org.wildfly.extension.clustering.web
+              - attr-module: org.wildfly.extension.core-management
+              - attr-module: org.wildfly.extension.datasources-agroal
+              - attr-module: org.wildfly.extension.discovery
+              - attr-module: org.wildfly.extension.ee-security
+              - attr-module: org.wildfly.extension.elytron
+              - attr-module: org.wildfly.extension.io
+              - attr-module: org.wildfly.extension.messaging-activemq
+              - attr-module: org.wildfly.extension.microprofile.config-smallrye
+              - attr-module: org.wildfly.extension.microprofile.health-smallrye
+              - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+              - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+              - attr-module: org.wildfly.extension.request-controller
+              - attr-module: org.wildfly.extension.rts
+              - attr-module: org.wildfly.extension.security.manager
+              - attr-module: org.wildfly.extension.undertow
+              - attr-module: org.wildfly.iiop-openjdk
+              - attr-module: org.wildfly.extension.health
+              - attr-module: org.wildfly.extension.metrics
+            host-release:
+              attr-id: EAP6.4
+          - attr-name: EAP64z
+            excluded-extensions:
+              extension:
+              - attr-module: org.wildfly.extension.batch.jberet
+              - attr-module: org.wildfly.extension.bean-validation
+              - attr-module: org.wildfly.extension.clustering.singleton
+              - attr-module: org.wildfly.extension.clustering.web
+              - attr-module: org.wildfly.extension.core-management
+              - attr-module: org.wildfly.extension.datasources-agroal
+              - attr-module: org.wildfly.extension.discovery
+              - attr-module: org.wildfly.extension.ee-security
+              - attr-module: org.wildfly.extension.elytron
+              - attr-module: org.wildfly.extension.io
+              - attr-module: org.wildfly.extension.messaging-activemq
+              - attr-module: org.wildfly.extension.microprofile.config-smallrye
+              - attr-module: org.wildfly.extension.microprofile.health-smallrye
+              - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+              - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+              - attr-module: org.wildfly.extension.request-controller
+              - attr-module: org.wildfly.extension.rts
+              - attr-module: org.wildfly.extension.security.manager
+              - attr-module: org.wildfly.extension.undertow
+              - attr-module: org.wildfly.iiop-openjdk
+              - attr-module: org.wildfly.extension.health
+              - attr-module: org.wildfly.extension.metrics
+            host-api-version:
+              attr-major-version: '1'
+              attr-minor-version: '8'
+          - attr-name: EAP70
+            excluded-extensions:
+              extension:
+              - attr-module: org.wildfly.extension.clustering.web
+              - attr-module: org.wildfly.extension.core-management
+              - attr-module: org.wildfly.extension.datasources-agroal
+              - attr-module: org.wildfly.extension.discovery
+              - attr-module: org.wildfly.extension.ee-security
+              - attr-module: org.wildfly.extension.elytron
+              - attr-module: org.wildfly.extension.microprofile.config-smallrye
+              - attr-module: org.wildfly.extension.microprofile.health-smallrye
+              - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+              - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+              - attr-module: org.wildfly.extension.health
+              - attr-module: org.wildfly.extension.metrics
+            host-release:
+              attr-id: EAP7.0
+          - attr-name: EAP71
+            excluded-extensions:
+              extension:
+              - attr-module: org.wildfly.extension.clustering.web
+              - attr-module: org.wildfly.extension.datasources-agroal
+              - attr-module: org.wildfly.extension.ee-security
+              - attr-module: org.wildfly.extension.microprofile.config-smallrye
+              - attr-module: org.wildfly.extension.microprofile.health-smallrye
+              - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+              - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+              - attr-module: org.wildfly.extension.health
+              - attr-module: org.wildfly.extension.metrics
+            host-release:
+              attr-id: EAP7.1
+          - attr-name: EAP72
+            excluded-extensions:
+              extension:
+              - attr-module: org.wildfly.extension.clustering.web
+              - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+              - attr-module: org.wildfly.extension.health
+              - attr-module: org.wildfly.extension.metrics
+            host-release:
+              attr-id: EAP7.2
+          - attr-name: EAP73
+            excluded-extensions:
+              extension:
+              - attr-module: org.wildfly.extension.health
+              - attr-module: org.wildfly.extension.metrics
+            host-release:
+              attr-id: EAP7.3
+        interfaces:
+          interface:
+          - attr-name: management
+          - attr-name: private
+            inet-address:
+              attr-value: ${jboss.bind.address.private:127.0.0.1}
+          - any-address: null
+            attr-name: public
+          - attr-name: unsecure
+            inet-address:
+              attr-value: ${jboss.bind.address.unsecure:127.0.0.1}
+        management:
+          access-control:
+            attr-provider: simple
+            role-mapping:
+              role:
+                attr-name: SuperUser
+                include:
+                  user:
+                    attr-name: $local
+        profiles:
+          profile:
+          - attr-name: default
+            subsystem:
+            - attr-xmlns: urn:jboss:domain:logging:8.0
+              formatter:
+              - attr-name: PATTERN
+                pattern-formatter:
+                  attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              - attr-name: COLOR-PATTERN
+                pattern-formatter:
+                  attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              logger:
+              - attr-category: com.arjuna
+                level:
+                  attr-name: WARN
+              - attr-category: io.jaegertracing.Configuration
+                level:
+                  attr-name: WARN
+              - attr-category: org.jboss.as.config
+                level:
+                  attr-name: DEBUG
+              - attr-category: sun.rmi
+                level:
+                  attr-name: WARN
+              periodic-rotating-file-handler:
+                append:
+                  attr-value: 'true'
+                attr-autoflush: 'true'
+                attr-name: FILE
+                file:
+                  attr-path: server.log
+                  attr-relative-to: jboss.server.log.dir
+                formatter:
+                  named-formatter:
+                    attr-name: PATTERN
+                suffix:
+                  attr-value: .yyyy-MM-dd
+              root-logger:
+                handlers:
+                  handler:
+                    attr-name: FILE
+                level:
+                  attr-name: INFO
+            - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+              default-job-repository:
+                attr-name: in-memory
+              default-thread-pool:
+                attr-name: batch
+              job-repository:
+                attr-name: in-memory
+                in-memory: null
+              thread-pool:
+                attr-name: batch
+                keepalive-time:
+                  attr-time: '30'
+                  attr-unit: seconds
+                max-threads:
+                  attr-count: '10'
+            - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+            - attr-xmlns: urn:jboss:domain:core-management:1.0
+            - attr-xmlns: urn:jboss:domain:datasources:6.0
+              datasources:
+                datasource:
+                  attr-enabled: 'true'
+                  attr-jndi-name: java:jboss/datasources/ExampleDS
+                  attr-pool-name: ExampleDS
+                  attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                  attr-use-java-context: 'true'
+                  connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                  driver: h2
+                  security:
+                    password: sa
+                    user-name: sa
+                drivers:
+                  driver:
+                    attr-module: com.h2database.h2
+                    attr-name: h2
+                    xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+            - attr-xmlns: urn:jboss:domain:discovery:1.0
+            - attr-default-session-management: default
+              attr-default-single-sign-on-management: default
+              attr-xmlns: urn:jboss:domain:distributable-web:2.0
+              infinispan-session-management:
+                attr-cache-container: web
+                attr-granularity: SESSION
+                attr-name: default
+                local-affinity: null
+              infinispan-single-sign-on-management:
+                attr-cache: sso
+                attr-cache-container: web
+                attr-name: default
+              local-routing: null
+            - attr-xmlns: urn:jboss:domain:ee:6.0
+              concurrent:
+                context-services:
+                  context-service:
+                    attr-jndi-name: java:jboss/ee/concurrency/context/default
+                    attr-name: default
+                    attr-use-transaction-setup-provider: 'true'
+                managed-executor-services:
+                  managed-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                    attr-keepalive-time: '5000'
+                    attr-name: default
+                managed-scheduled-executor-services:
+                  managed-scheduled-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                    attr-keepalive-time: '3000'
+                    attr-name: default
+                managed-thread-factories:
+                  managed-thread-factory:
+                    attr-context-service: default
+                    attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                    attr-name: default
+              default-bindings:
+                attr-context-service: java:jboss/ee/concurrency/context/default
+                attr-datasource: java:jboss/datasources/ExampleDS
+                attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+                attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+                attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+              spec-descriptor-property-replacement: 'false'
+            - attr-xmlns: urn:jboss:domain:ee-security:1.0
+            - async:
+                attr-thread-pool-name: default
+              attr-xmlns: urn:jboss:domain:ejb3:9.0
+              caches:
+                cache:
+                - attr-name: simple
+                - attr-aliases: passivating clustered
+                  attr-name: distributable
+                  attr-passivation-store-ref: infinispan
+              default-missing-method-permissions-deny-access:
+                attr-value: 'true'
+              default-security-domain:
+                attr-value: other
+              log-system-exceptions:
+                attr-value: 'true'
+              passivation-stores:
+                passivation-store:
+                  attr-cache-container: ejb
+                  attr-max-size: '10000'
+                  attr-name: infinispan
+              pools:
+                bean-instance-pools:
+                  strict-max-pool:
+                  - attr-derive-size: from-cpu-count
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: mdb-strict-max-pool
+                  - attr-derive-size: from-worker-pools
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: slsb-strict-max-pool
+              remote:
+                attr-cluster: ejb
+                attr-connectors: http-remoting-connector
+                attr-thread-pool-name: default
+                channel-creation-options:
+                  option:
+                    attr-name: MAX_OUTBOUND_MESSAGES
+                    attr-type: remoting
+                    attr-value: '1234'
+              session-bean:
+                singleton:
+                  attr-default-access-timeout: '5000'
+                stateful:
+                  attr-cache-ref: simple
+                  attr-default-access-timeout: '5000'
+                  attr-passivation-disabled-cache-ref: simple
+                stateless:
+                  bean-instance-pool-ref:
+                    attr-pool-name: slsb-strict-max-pool
+              statistics:
+                attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+              thread-pools:
+                thread-pool:
+                  attr-name: default
+                  keepalive-time:
+                    attr-time: '60'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '10'
+              timer-service:
+                attr-default-data-store: default-file-store
+                attr-thread-pool-name: default
+                data-stores:
+                  file-data-store:
+                    attr-name: default-file-store
+                    attr-path: timer-service-data
+                    attr-relative-to: jboss.server.data.dir
+            - attr-disallowed-providers: OracleUcrypto
+              attr-final-providers: combined-providers
+              attr-xmlns: urn:wildfly:elytron:13.0
+              audit-logging:
+                file-audit-log:
+                  attr-format: JSON
+                  attr-name: local-audit
+                  attr-path: audit.log
+                  attr-relative-to: jboss.server.log.dir
+              http:
+                provider-http-server-mechanism-factory:
+                  attr-name: global
+              mappers:
+                constant-realm-mapper:
+                  attr-name: local
+                  attr-realm-name: local
+                constant-role-mapper:
+                  attr-name: super-user-mapper
+                  role:
+                    attr-name: SuperUser
+                simple-permission-mapper:
+                  attr-mapping-mode: first
+                  attr-name: default-permission-mapper
+                  permission-mapping:
+                  - permission-set:
+                      attr-name: default-permissions
+                    principal:
+                      attr-name: anonymous
+                  - attr-match-all: 'true'
+                    permission-set:
+                    - attr-name: login-permission
+                    - attr-name: default-permissions
+                simple-role-decoder:
+                  attr-attribute: groups
+                  attr-name: groups-to-roles
+              permission-sets:
+                permission-set:
+                - attr-name: login-permission
+                  permission:
+                    attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                - attr-name: default-permissions
+                  permission:
+                  - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                    attr-module: org.wildfly.extension.batch.jberet
+                    attr-target-name: '*'
+                  - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                    attr-module: org.wildfly.transaction.client
+                  - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                    attr-module: org.jboss.ejb-client
+              providers:
+                aggregate-providers:
+                  attr-name: combined-providers
+                  providers:
+                  - attr-name: elytron
+                  - attr-name: openssl
+                provider-loader:
+                - attr-module: org.wildfly.security.elytron
+                  attr-name: elytron
+                - attr-module: org.wildfly.openssl
+                  attr-name: openssl
+              sasl:
+                configurable-sasl-server-factory:
+                  attr-name: configured
+                  attr-sasl-server-factory: elytron
+                  properties:
+                    property:
+                      attr-name: wildfly.sasl.local-user.default-user
+                      attr-value: $local
+                mechanism-provider-filtering-sasl-server-factory:
+                  attr-name: elytron
+                  attr-sasl-server-factory: global
+                  filters:
+                    filter:
+                      attr-provider-name: WildFlyElytron
+                provider-sasl-server-factory:
+                  attr-name: global
+                sasl-authentication-factory:
+                  attr-name: application-sasl-authentication
+                  attr-sasl-server-factory: configured
+                  attr-security-domain: ApplicationDomain
+                  mechanism-configuration:
+                    mechanism:
+                    - attr-mechanism-name: JBOSS-LOCAL-USER
+                      attr-realm-mapper: local
+                    - attr-mechanism-name: DIGEST-MD5
+                      mechanism-realm:
+                        attr-realm-name: ApplicationRealm
+              security-domains:
+                security-domain:
+                  attr-default-realm: ApplicationRealm
+                  attr-name: ApplicationDomain
+                  attr-permission-mapper: default-permission-mapper
+                  realm:
+                    attr-name: ApplicationRealm
+                    attr-role-decoder: groups-to-roles
+              security-realms:
+                identity-realm:
+                  attr-identity: $local
+                  attr-name: local
+                properties-realm:
+                  attr-name: ApplicationRealm
+                  groups-properties:
+                    attr-path: application-roles.properties
+                    attr-relative-to: jboss.domain.config.dir
+                  users-properties:
+                    attr-digest-realm-name: ApplicationRealm
+                    attr-path: application-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+              tls:
+                key-managers:
+                  key-manager:
+                    attr-generate-self-signed-certificate-host: localhost
+                    attr-key-store: applicationKS
+                    attr-name: applicationKM
+                    credential-reference:
+                      attr-clear-text: password
+                key-stores:
+                  key-store:
+                    attr-name: applicationKS
+                    credential-reference:
+                      attr-clear-text: password
+                    file:
+                      attr-path: application.keystore
+                      attr-relative-to: jboss.domain.config.dir
+                    implementation:
+                      attr-type: JKS
+                server-ssl-contexts:
+                  server-ssl-context:
+                    attr-key-manager: applicationKM
+                    attr-name: applicationSSC
+            - attr-xmlns: urn:jboss:domain:infinispan:12.0
+              cache-container:
+              - attr-aliases: sfsb
+                attr-default-cache: passivation
+                attr-modules: org.wildfly.clustering.ejb.infinispan
+                attr-name: ejb
+                local-cache:
+                  attr-name: passivation
+                  file-store:
+                    attr-passivation: 'true'
+                    attr-purge: 'false'
+              - attr-default-cache: passivation
+                attr-modules: org.wildfly.clustering.web.infinispan
+                attr-name: web
+                local-cache:
+                - attr-name: passivation
+                  file-store:
+                    attr-passivation: 'true'
+                    attr-purge: 'false'
+                - attr-name: sso
+              - attr-default-cache: default
+                attr-modules: org.wildfly.clustering.server
+                attr-name: server
+                local-cache:
+                  attr-name: default
+              - attr-modules: org.infinispan.hibernate-cache
+                attr-name: hibernate
+                local-cache:
+                - attr-name: entity
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                - attr-name: local-query
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                - attr-name: timestamps
+                - attr-name: pending-puts
+                  expiration:
+                    attr-max-idle: '60000'
+            - attr-xmlns: urn:jboss:domain:io:3.0
+              buffer-pool:
+                attr-name: default
+              worker:
+                attr-name: default
+            - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+            - archive-validation:
+                attr-enabled: 'true'
+                attr-fail-on-error: 'true'
+                attr-fail-on-warn: 'false'
+              attr-xmlns: urn:jboss:domain:jca:5.0
+              bean-validation:
+                attr-enabled: 'true'
+              cached-connection-manager: null
+              default-workmanager:
+                long-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+                short-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+            - attr-xmlns: urn:jboss:domain:jdr:1.0
+            - attr-xmlns: urn:jboss:domain:jmx:1.3
+              expose-expression-model: null
+              expose-resolved-model: null
+            - attr-xmlns: urn:jboss:domain:jpa:1.1
+              jpa:
+                attr-default-extended-persistence-inheritance: DEEP
+            - attr-xmlns: urn:jboss:domain:jsf:1.1
+            - attr-xmlns: urn:jboss:domain:mail:4.0
+              mail-session:
+                attr-jndi-name: java:jboss/mail/Default
+                attr-name: default
+                smtp-server:
+                  attr-outbound-socket-binding-ref: mail-smtp
+            - attr-xmlns: urn:jboss:domain:naming:2.0
+              remote-naming: null
+            - attr-xmlns: urn:jboss:domain:pojo:1.0
+            - attr-xmlns: urn:jboss:domain:remoting:4.0
+              http-connector:
+                attr-connector-ref: default
+                attr-name: http-remoting-connector
+                attr-security-realm: ApplicationRealm
+            - attr-xmlns: urn:jboss:domain:request-controller:1.0
+            - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+            - attr-xmlns: urn:jboss:domain:sar:1.0
+            - attr-xmlns: urn:jboss:domain:security:2.0
+              security-domains:
+                security-domain:
+                - attr-cache-type: default
+                  attr-name: other
+                  authentication:
+                    login-module:
+                    - attr-code: Remoting
+                      attr-flag: optional
+                      module-option:
+                        attr-name: password-stacking
+                        attr-value: useFirstPass
+                    - attr-code: RealmDirect
+                      attr-flag: required
+                      module-option:
+                        attr-name: password-stacking
+                        attr-value: useFirstPass
+                - attr-cache-type: default
+                  attr-name: jboss-web-policy
+                  authorization:
+                    policy-module:
+                      attr-code: Delegating
+                      attr-flag: required
+                - attr-cache-type: default
+                  attr-name: jaspitest
+                  authentication-jaspi:
+                    auth-module:
+                      attr-code: Dummy
+                    login-module-stack:
+                      attr-name: dummy
+                      login-module:
+                        attr-code: Dummy
+                        attr-flag: optional
+                - attr-cache-type: default
+                  attr-name: jboss-ejb-policy
+                  authorization:
+                    policy-module:
+                      attr-code: Delegating
+                      attr-flag: required
+            - attr-xmlns: urn:jboss:domain:security-manager:1.0
+              deployment-permissions:
+                maximum-set:
+                  permission:
+                    attr-class: java.security.AllPermission
+            - attr-xmlns: urn:jboss:domain:transactions:6.0
+              coordinator-environment:
+                attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+              core-environment:
+                attr-node-identifier: ${jboss.tx.node.id:1}
+                process-id:
+                  uuid: null
+              object-store:
+                attr-path: tx-object-store
+                attr-relative-to: jboss.server.data.dir
+              recovery-environment:
+                attr-socket-binding: txn-recovery-environment
+                attr-status-socket-binding: txn-status-manager
+            - attr-default-security-domain: other
+              attr-default-server: default-server
+              attr-default-servlet-container: default
+              attr-default-virtual-host: default-host
+              attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:undertow:12.0
+              buffer-cache:
+                attr-name: default
+              handlers:
+                file:
+                  attr-name: welcome-content
+                  attr-path: ${jboss.home.dir}/welcome-content
+              server:
+                attr-name: default-server
+                host:
+                  attr-alias: localhost
+                  attr-name: default-host
+                  http-invoker:
+                    attr-security-realm: ApplicationRealm
+                  location:
+                    attr-handler: welcome-content
+                    attr-name: /
+                http-listener:
+                  attr-enable-http2: 'true'
+                  attr-name: default
+                  attr-redirect-socket: https
+                  attr-socket-binding: http
+                https-listener:
+                  attr-enable-http2: 'true'
+                  attr-name: https
+                  attr-security-realm: ApplicationRealm
+                  attr-socket-binding: https
+              servlet-container:
+                attr-name: default
+                jsp-config: null
+                websockets: null
+            - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:webservices:2.0
+              client-config:
+                attr-name: Standard-Client-Config
+              endpoint-config:
+              - attr-name: Standard-Endpoint-Config
+              - attr-name: Recording-Endpoint-Config
+                pre-handler-chain:
+                  attr-name: recording-handlers
+                  attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                    ##SOAP12_HTTP_MTOM'
+                  handler:
+                    attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                    attr-name: RecordingHandler
+              wsdl-host: ${jboss.bind.address:127.0.0.1}
+            - attr-xmlns: urn:jboss:domain:weld:4.0
+          - attr-name: ha
+            subsystem:
+            - attr-xmlns: urn:jboss:domain:logging:8.0
+              formatter:
+              - attr-name: PATTERN
+                pattern-formatter:
+                  attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              - attr-name: COLOR-PATTERN
+                pattern-formatter:
+                  attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              logger:
+              - attr-category: com.arjuna
+                level:
+                  attr-name: WARN
+              - attr-category: io.jaegertracing.Configuration
+                level:
+                  attr-name: WARN
+              - attr-category: org.jboss.as.config
+                level:
+                  attr-name: DEBUG
+              - attr-category: sun.rmi
+                level:
+                  attr-name: WARN
+              periodic-rotating-file-handler:
+                append:
+                  attr-value: 'true'
+                attr-autoflush: 'true'
+                attr-name: FILE
+                file:
+                  attr-path: server.log
+                  attr-relative-to: jboss.server.log.dir
+                formatter:
+                  named-formatter:
+                    attr-name: PATTERN
+                suffix:
+                  attr-value: .yyyy-MM-dd
+              root-logger:
+                handlers:
+                  handler:
+                    attr-name: FILE
+                level:
+                  attr-name: INFO
+            - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+              default-job-repository:
+                attr-name: in-memory
+              default-thread-pool:
+                attr-name: batch
+              job-repository:
+                attr-name: in-memory
+                in-memory: null
+              thread-pool:
+                attr-name: batch
+                keepalive-time:
+                  attr-time: '30'
+                  attr-unit: seconds
+                max-threads:
+                  attr-count: '10'
+            - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+            - attr-xmlns: urn:jboss:domain:core-management:1.0
+            - attr-xmlns: urn:jboss:domain:datasources:6.0
+              datasources:
+                datasource:
+                  attr-enabled: 'true'
+                  attr-jndi-name: java:jboss/datasources/ExampleDS
+                  attr-pool-name: ExampleDS
+                  attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                  attr-use-java-context: 'true'
+                  connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                  driver: h2
+                  security:
+                    password: sa
+                    user-name: sa
+                drivers:
+                  driver:
+                    attr-module: com.h2database.h2
+                    attr-name: h2
+                    xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+            - attr-xmlns: urn:jboss:domain:discovery:1.0
+            - attr-default-session-management: default
+              attr-default-single-sign-on-management: default
+              attr-xmlns: urn:jboss:domain:distributable-web:2.0
+              infinispan-routing:
+                attr-cache: routing
+                attr-cache-container: web
+              infinispan-session-management:
+                attr-cache-container: web
+                attr-granularity: SESSION
+                attr-name: default
+                primary-owner-affinity: null
+              infinispan-single-sign-on-management:
+                attr-cache: sso
+                attr-cache-container: web
+                attr-name: default
+            - attr-xmlns: urn:jboss:domain:ee:6.0
+              concurrent:
+                context-services:
+                  context-service:
+                    attr-jndi-name: java:jboss/ee/concurrency/context/default
+                    attr-name: default
+                    attr-use-transaction-setup-provider: 'true'
+                managed-executor-services:
+                  managed-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                    attr-keepalive-time: '5000'
+                    attr-name: default
+                managed-scheduled-executor-services:
+                  managed-scheduled-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                    attr-keepalive-time: '3000'
+                    attr-name: default
+                managed-thread-factories:
+                  managed-thread-factory:
+                    attr-context-service: default
+                    attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                    attr-name: default
+              default-bindings:
+                attr-context-service: java:jboss/ee/concurrency/context/default
+                attr-datasource: java:jboss/datasources/ExampleDS
+                attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+                attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+                attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+              spec-descriptor-property-replacement: 'false'
+            - attr-xmlns: urn:jboss:domain:ee-security:1.0
+            - async:
+                attr-thread-pool-name: default
+              attr-xmlns: urn:jboss:domain:ejb3:9.0
+              caches:
+                cache:
+                - attr-name: simple
+                - attr-aliases: passivating clustered
+                  attr-name: distributable
+                  attr-passivation-store-ref: infinispan
+              default-missing-method-permissions-deny-access:
+                attr-value: 'true'
+              default-security-domain:
+                attr-value: other
+              log-system-exceptions:
+                attr-value: 'true'
+              passivation-stores:
+                passivation-store:
+                  attr-cache-container: ejb
+                  attr-max-size: '10000'
+                  attr-name: infinispan
+              pools:
+                bean-instance-pools:
+                  strict-max-pool:
+                  - attr-derive-size: from-cpu-count
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: mdb-strict-max-pool
+                  - attr-derive-size: from-worker-pools
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: slsb-strict-max-pool
+              remote:
+                attr-cluster: ejb
+                attr-connectors: http-remoting-connector
+                attr-thread-pool-name: default
+                channel-creation-options:
+                  option:
+                    attr-name: MAX_OUTBOUND_MESSAGES
+                    attr-type: remoting
+                    attr-value: '1234'
+              session-bean:
+                singleton:
+                  attr-default-access-timeout: '5000'
+                stateful:
+                  attr-cache-ref: distributable
+                  attr-default-access-timeout: '5000'
+                  attr-passivation-disabled-cache-ref: simple
+                stateless:
+                  bean-instance-pool-ref:
+                    attr-pool-name: slsb-strict-max-pool
+              statistics:
+                attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+              thread-pools:
+                thread-pool:
+                  attr-name: default
+                  keepalive-time:
+                    attr-time: '60'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '10'
+              timer-service:
+                attr-default-data-store: default-file-store
+                attr-thread-pool-name: default
+                data-stores:
+                  file-data-store:
+                    attr-name: default-file-store
+                    attr-path: timer-service-data
+                    attr-relative-to: jboss.server.data.dir
+            - attr-disallowed-providers: OracleUcrypto
+              attr-final-providers: combined-providers
+              attr-xmlns: urn:wildfly:elytron:13.0
+              audit-logging:
+                file-audit-log:
+                  attr-format: JSON
+                  attr-name: local-audit
+                  attr-path: audit.log
+                  attr-relative-to: jboss.server.log.dir
+              http:
+                provider-http-server-mechanism-factory:
+                  attr-name: global
+              mappers:
+                constant-realm-mapper:
+                  attr-name: local
+                  attr-realm-name: local
+                constant-role-mapper:
+                  attr-name: super-user-mapper
+                  role:
+                    attr-name: SuperUser
+                simple-permission-mapper:
+                  attr-mapping-mode: first
+                  attr-name: default-permission-mapper
+                  permission-mapping:
+                  - permission-set:
+                      attr-name: default-permissions
+                    principal:
+                      attr-name: anonymous
+                  - attr-match-all: 'true'
+                    permission-set:
+                    - attr-name: login-permission
+                    - attr-name: default-permissions
+                simple-role-decoder:
+                  attr-attribute: groups
+                  attr-name: groups-to-roles
+              permission-sets:
+                permission-set:
+                - attr-name: login-permission
+                  permission:
+                    attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                - attr-name: default-permissions
+                  permission:
+                  - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                    attr-module: org.wildfly.extension.batch.jberet
+                    attr-target-name: '*'
+                  - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                    attr-module: org.wildfly.transaction.client
+                  - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                    attr-module: org.jboss.ejb-client
+              providers:
+                aggregate-providers:
+                  attr-name: combined-providers
+                  providers:
+                  - attr-name: elytron
+                  - attr-name: openssl
+                provider-loader:
+                - attr-module: org.wildfly.security.elytron
+                  attr-name: elytron
+                - attr-module: org.wildfly.openssl
+                  attr-name: openssl
+              sasl:
+                configurable-sasl-server-factory:
+                  attr-name: configured
+                  attr-sasl-server-factory: elytron
+                  properties:
+                    property:
+                      attr-name: wildfly.sasl.local-user.default-user
+                      attr-value: $local
+                mechanism-provider-filtering-sasl-server-factory:
+                  attr-name: elytron
+                  attr-sasl-server-factory: global
+                  filters:
+                    filter:
+                      attr-provider-name: WildFlyElytron
+                provider-sasl-server-factory:
+                  attr-name: global
+                sasl-authentication-factory:
+                  attr-name: application-sasl-authentication
+                  attr-sasl-server-factory: configured
+                  attr-security-domain: ApplicationDomain
+                  mechanism-configuration:
+                    mechanism:
+                    - attr-mechanism-name: JBOSS-LOCAL-USER
+                      attr-realm-mapper: local
+                    - attr-mechanism-name: DIGEST-MD5
+                      mechanism-realm:
+                        attr-realm-name: ApplicationRealm
+              security-domains:
+                security-domain:
+                  attr-default-realm: ApplicationRealm
+                  attr-name: ApplicationDomain
+                  attr-permission-mapper: default-permission-mapper
+                  realm:
+                    attr-name: ApplicationRealm
+                    attr-role-decoder: groups-to-roles
+              security-realms:
+                identity-realm:
+                  attr-identity: $local
+                  attr-name: local
+                properties-realm:
+                  attr-name: ApplicationRealm
+                  groups-properties:
+                    attr-path: application-roles.properties
+                    attr-relative-to: jboss.domain.config.dir
+                  users-properties:
+                    attr-digest-realm-name: ApplicationRealm
+                    attr-path: application-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+              tls:
+                key-managers:
+                  key-manager:
+                    attr-generate-self-signed-certificate-host: localhost
+                    attr-key-store: applicationKS
+                    attr-name: applicationKM
+                    credential-reference:
+                      attr-clear-text: password
+                key-stores:
+                  key-store:
+                    attr-name: applicationKS
+                    credential-reference:
+                      attr-clear-text: password
+                    file:
+                      attr-path: application.keystore
+                      attr-relative-to: jboss.domain.config.dir
+                    implementation:
+                      attr-type: JKS
+                server-ssl-contexts:
+                  server-ssl-context:
+                    attr-key-manager: applicationKM
+                    attr-name: applicationSSC
+            - attr-xmlns: urn:jboss:domain:infinispan:12.0
+              cache-container:
+              - attr-aliases: sfsb
+                attr-default-cache: dist
+                attr-modules: org.wildfly.clustering.ejb.infinispan
+                attr-name: ejb
+                distributed-cache:
+                  attr-name: dist
+                  file-store: null
+                  locking:
+                    attr-isolation: REPEATABLE_READ
+                  transaction:
+                    attr-mode: BATCH
+                transport:
+                  attr-lock-timeout: '60000'
+              - attr-aliases: singleton cluster
+                attr-default-cache: default
+                attr-modules: org.wildfly.clustering.server
+                attr-name: server
+                replicated-cache:
+                  attr-name: default
+                  transaction:
+                    attr-mode: BATCH
+                transport:
+                  attr-lock-timeout: '60000'
+              - attr-default-cache: dist
+                attr-modules: org.wildfly.clustering.web.infinispan
+                attr-name: web
+                distributed-cache:
+                  attr-name: dist
+                  file-store: null
+                  locking:
+                    attr-isolation: REPEATABLE_READ
+                  transaction:
+                    attr-mode: BATCH
+                replicated-cache:
+                - attr-name: sso
+                  locking:
+                    attr-isolation: REPEATABLE_READ
+                  transaction:
+                    attr-mode: BATCH
+                - attr-name: routing
+                transport:
+                  attr-lock-timeout: '60000'
+              - attr-modules: org.infinispan.hibernate-cache
+                attr-name: hibernate
+                invalidation-cache:
+                  attr-name: entity
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                local-cache:
+                - attr-name: local-query
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                - attr-name: pending-puts
+                  expiration:
+                    attr-max-idle: '60000'
+                replicated-cache:
+                  attr-name: timestamps
+                transport:
+                  attr-lock-timeout: '60000'
+            - attr-xmlns: urn:jboss:domain:io:3.0
+              buffer-pool:
+                attr-name: default
+              worker:
+                attr-name: default
+            - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+            - archive-validation:
+                attr-enabled: 'true'
+                attr-fail-on-error: 'true'
+                attr-fail-on-warn: 'false'
+              attr-xmlns: urn:jboss:domain:jca:5.0
+              bean-validation:
+                attr-enabled: 'true'
+              cached-connection-manager: null
+              default-workmanager:
+                long-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+                short-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+            - attr-xmlns: urn:jboss:domain:jdr:1.0
+            - attr-xmlns: urn:jboss:domain:jgroups:8.0
+              channels:
+                attr-default: ee
+                channel:
+                  attr-cluster: ejb
+                  attr-name: ee
+                  attr-stack: udp
+              stacks:
+                stack:
+                - attr-name: udp
+                  protocol:
+                  - attr-type: PING
+                  - attr-type: MERGE3
+                  - attr-type: FD_ALL
+                  - attr-type: VERIFY_SUSPECT
+                  - attr-type: pbcast.NAKACK2
+                  - attr-type: UNICAST3
+                  - attr-type: pbcast.STABLE
+                  - attr-type: pbcast.GMS
+                  - attr-type: UFC
+                  - attr-type: MFC
+                  - attr-type: FRAG3
+                  socket-protocol:
+                    attr-socket-binding: jgroups-udp-fd
+                    attr-type: FD_SOCK
+                  transport:
+                    attr-socket-binding: jgroups-udp
+                    attr-type: UDP
+                - attr-name: tcp
+                  protocol:
+                  - attr-type: MERGE3
+                  - attr-type: FD_ALL
+                  - attr-type: VERIFY_SUSPECT
+                  - attr-type: pbcast.NAKACK2
+                  - attr-type: UNICAST3
+                  - attr-type: pbcast.STABLE
+                  - attr-type: pbcast.GMS
+                  - attr-type: MFC
+                  - attr-type: FRAG3
+                  socket-protocol:
+                  - attr-socket-binding: jgroups-mping
+                    attr-type: MPING
+                  - attr-socket-binding: jgroups-tcp-fd
+                    attr-type: FD_SOCK
+                  transport:
+                    attr-socket-binding: jgroups-tcp
+                    attr-type: TCP
+            - attr-xmlns: urn:jboss:domain:jmx:1.3
+              expose-expression-model: null
+              expose-resolved-model: null
+            - attr-xmlns: urn:jboss:domain:jpa:1.1
+              jpa:
+                attr-default-extended-persistence-inheritance: DEEP
+            - attr-xmlns: urn:jboss:domain:jsf:1.1
+            - attr-xmlns: urn:jboss:domain:mail:4.0
+              mail-session:
+                attr-jndi-name: java:jboss/mail/Default
+                attr-name: default
+                smtp-server:
+                  attr-outbound-socket-binding-ref: mail-smtp
+            - attr-xmlns: urn:jboss:domain:modcluster:5.0
+              proxy:
+                attr-advertise-socket: modcluster
+                attr-listener: ajp
+                attr-name: default
+                dynamic-load-provider:
+                  load-metric:
+                    attr-type: cpu
+            - attr-xmlns: urn:jboss:domain:naming:2.0
+              remote-naming: null
+            - attr-xmlns: urn:jboss:domain:pojo:1.0
+            - attr-xmlns: urn:jboss:domain:remoting:4.0
+              http-connector:
+                attr-connector-ref: default
+                attr-name: http-remoting-connector
+                attr-security-realm: ApplicationRealm
+            - attr-xmlns: urn:jboss:domain:request-controller:1.0
+            - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+            - attr-xmlns: urn:jboss:domain:sar:1.0
+            - attr-xmlns: urn:jboss:domain:security:2.0
+              security-domains:
+                security-domain:
+                - attr-cache-type: default
+                  attr-name: other
+                  authentication:
+                    login-module:
+                    - attr-code: Remoting
+                      attr-flag: optional
+                      module-option:
+                        attr-name: password-stacking
+                        attr-value: useFirstPass
+                    - attr-code: RealmDirect
+                      attr-flag: required
+                      module-option:
+                        attr-name: password-stacking
+                        attr-value: useFirstPass
+                - attr-cache-type: default
+                  attr-name: jboss-web-policy
+                  authorization:
+                    policy-module:
+                      attr-code: Delegating
+                      attr-flag: required
+                - attr-cache-type: default
+                  attr-name: jaspitest
+                  authentication-jaspi:
+                    auth-module:
+                      attr-code: Dummy
+                    login-module-stack:
+                      attr-name: dummy
+                      login-module:
+                        attr-code: Dummy
+                        attr-flag: optional
+                - attr-cache-type: default
+                  attr-name: jboss-ejb-policy
+                  authorization:
+                    policy-module:
+                      attr-code: Delegating
+                      attr-flag: required
+            - attr-xmlns: urn:jboss:domain:security-manager:1.0
+              deployment-permissions:
+                maximum-set:
+                  permission:
+                    attr-class: java.security.AllPermission
+            - attr-xmlns: urn:jboss:domain:singleton:1.0
+              singleton-policies:
+                attr-default: default
+                singleton-policy:
+                  attr-cache-container: server
+                  attr-name: default
+                  simple-election-policy: null
+            - attr-xmlns: urn:jboss:domain:transactions:6.0
+              coordinator-environment:
+                attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+              core-environment:
+                attr-node-identifier: ${jboss.tx.node.id:1}
+                process-id:
+                  uuid: null
+              object-store:
+                attr-path: tx-object-store
+                attr-relative-to: jboss.server.data.dir
+              recovery-environment:
+                attr-socket-binding: txn-recovery-environment
+                attr-status-socket-binding: txn-status-manager
+            - attr-default-security-domain: other
+              attr-default-server: default-server
+              attr-default-servlet-container: default
+              attr-default-virtual-host: default-host
+              attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:undertow:12.0
+              buffer-cache:
+                attr-name: default
+              handlers:
+                file:
+                  attr-name: welcome-content
+                  attr-path: ${jboss.home.dir}/welcome-content
+              server:
+                ajp-listener:
+                  attr-name: ajp
+                  attr-socket-binding: ajp
+                attr-name: default-server
+                host:
+                  attr-alias: localhost
+                  attr-name: default-host
+                  http-invoker:
+                    attr-security-realm: ApplicationRealm
+                  location:
+                    attr-handler: welcome-content
+                    attr-name: /
+                http-listener:
+                  attr-enable-http2: 'true'
+                  attr-name: default
+                  attr-redirect-socket: https
+                  attr-socket-binding: http
+                https-listener:
+                  attr-enable-http2: 'true'
+                  attr-name: https
+                  attr-security-realm: ApplicationRealm
+                  attr-socket-binding: https
+              servlet-container:
+                attr-name: default
+                jsp-config: null
+                websockets: null
+            - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:webservices:2.0
+              client-config:
+                attr-name: Standard-Client-Config
+              endpoint-config:
+              - attr-name: Standard-Endpoint-Config
+              - attr-name: Recording-Endpoint-Config
+                pre-handler-chain:
+                  attr-name: recording-handlers
+                  attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                    ##SOAP12_HTTP_MTOM'
+                  handler:
+                    attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                    attr-name: RecordingHandler
+              wsdl-host: ${jboss.bind.address:127.0.0.1}
+            - attr-xmlns: urn:jboss:domain:weld:4.0
+          - attr-name: full
+            subsystem:
+            - attr-xmlns: urn:jboss:domain:logging:8.0
+              formatter:
+              - attr-name: PATTERN
+                pattern-formatter:
+                  attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              - attr-name: COLOR-PATTERN
+                pattern-formatter:
+                  attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              logger:
+              - attr-category: com.arjuna
+                level:
+                  attr-name: WARN
+              - attr-category: io.jaegertracing.Configuration
+                level:
+                  attr-name: WARN
+              - attr-category: org.jboss.as.config
+                level:
+                  attr-name: DEBUG
+              - attr-category: sun.rmi
+                level:
+                  attr-name: WARN
+              periodic-rotating-file-handler:
+                append:
+                  attr-value: 'true'
+                attr-autoflush: 'true'
+                attr-name: FILE
+                file:
+                  attr-path: server.log
+                  attr-relative-to: jboss.server.log.dir
+                formatter:
+                  named-formatter:
+                    attr-name: PATTERN
+                suffix:
+                  attr-value: .yyyy-MM-dd
+              root-logger:
+                handlers:
+                  handler:
+                    attr-name: FILE
+                level:
+                  attr-name: INFO
+            - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+              default-job-repository:
+                attr-name: in-memory
+              default-thread-pool:
+                attr-name: batch
+              job-repository:
+                attr-name: in-memory
+                in-memory: null
+              thread-pool:
+                attr-name: batch
+                keepalive-time:
+                  attr-time: '30'
+                  attr-unit: seconds
+                max-threads:
+                  attr-count: '10'
+            - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+            - attr-xmlns: urn:jboss:domain:core-management:1.0
+            - attr-xmlns: urn:jboss:domain:datasources:6.0
+              datasources:
+                datasource:
+                  attr-enabled: 'true'
+                  attr-jndi-name: java:jboss/datasources/ExampleDS
+                  attr-pool-name: ExampleDS
+                  attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                  attr-use-java-context: 'true'
+                  connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                  driver: h2
+                  security:
+                    password: sa
+                    user-name: sa
+                drivers:
+                  driver:
+                    attr-module: com.h2database.h2
+                    attr-name: h2
+                    xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+            - attr-xmlns: urn:jboss:domain:discovery:1.0
+            - attr-default-session-management: default
+              attr-default-single-sign-on-management: default
+              attr-xmlns: urn:jboss:domain:distributable-web:2.0
+              infinispan-session-management:
+                attr-cache-container: web
+                attr-granularity: SESSION
+                attr-name: default
+                local-affinity: null
+              infinispan-single-sign-on-management:
+                attr-cache: sso
+                attr-cache-container: web
+                attr-name: default
+              local-routing: null
+            - attr-xmlns: urn:jboss:domain:ee:6.0
+              concurrent:
+                context-services:
+                  context-service:
+                    attr-jndi-name: java:jboss/ee/concurrency/context/default
+                    attr-name: default
+                    attr-use-transaction-setup-provider: 'true'
+                managed-executor-services:
+                  managed-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                    attr-keepalive-time: '5000'
+                    attr-name: default
+                managed-scheduled-executor-services:
+                  managed-scheduled-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                    attr-keepalive-time: '3000'
+                    attr-name: default
+                managed-thread-factories:
+                  managed-thread-factory:
+                    attr-context-service: default
+                    attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                    attr-name: default
+              default-bindings:
+                attr-context-service: java:jboss/ee/concurrency/context/default
+                attr-datasource: java:jboss/datasources/ExampleDS
+                attr-jms-connection-factory: java:jboss/DefaultJMSConnectionFactory
+                attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+                attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+                attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+              spec-descriptor-property-replacement: 'false'
+            - attr-xmlns: urn:jboss:domain:ee-security:1.0
+            - async:
+                attr-thread-pool-name: default
+              attr-xmlns: urn:jboss:domain:ejb3:9.0
+              caches:
+                cache:
+                - attr-name: simple
+                - attr-aliases: passivating clustered
+                  attr-name: distributable
+                  attr-passivation-store-ref: infinispan
+              default-missing-method-permissions-deny-access:
+                attr-value: 'true'
+              default-security-domain:
+                attr-value: other
+              iiop:
+                attr-enable-by-default: 'false'
+                attr-use-qualified-name: 'false'
+              log-system-exceptions:
+                attr-value: 'true'
+              mdb:
+                bean-instance-pool-ref:
+                  attr-pool-name: mdb-strict-max-pool
+                resource-adapter-ref:
+                  attr-resource-adapter-name: ${ejb.resource-adapter-name:activemq-ra.rar}
+              passivation-stores:
+                passivation-store:
+                  attr-cache-container: ejb
+                  attr-max-size: '10000'
+                  attr-name: infinispan
+              pools:
+                bean-instance-pools:
+                  strict-max-pool:
+                  - attr-derive-size: from-cpu-count
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: mdb-strict-max-pool
+                  - attr-derive-size: from-worker-pools
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: slsb-strict-max-pool
+              remote:
+                attr-cluster: ejb
+                attr-connectors: http-remoting-connector
+                attr-thread-pool-name: default
+                channel-creation-options:
+                  option:
+                    attr-name: MAX_OUTBOUND_MESSAGES
+                    attr-type: remoting
+                    attr-value: '1234'
+              session-bean:
+                singleton:
+                  attr-default-access-timeout: '5000'
+                stateful:
+                  attr-cache-ref: simple
+                  attr-default-access-timeout: '5000'
+                  attr-passivation-disabled-cache-ref: simple
+                stateless:
+                  bean-instance-pool-ref:
+                    attr-pool-name: slsb-strict-max-pool
+              statistics:
+                attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+              thread-pools:
+                thread-pool:
+                  attr-name: default
+                  keepalive-time:
+                    attr-time: '60'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '10'
+              timer-service:
+                attr-default-data-store: default-file-store
+                attr-thread-pool-name: default
+                data-stores:
+                  file-data-store:
+                    attr-name: default-file-store
+                    attr-path: timer-service-data
+                    attr-relative-to: jboss.server.data.dir
+            - attr-disallowed-providers: OracleUcrypto
+              attr-final-providers: combined-providers
+              attr-xmlns: urn:wildfly:elytron:13.0
+              audit-logging:
+                file-audit-log:
+                  attr-format: JSON
+                  attr-name: local-audit
+                  attr-path: audit.log
+                  attr-relative-to: jboss.server.log.dir
+              http:
+                provider-http-server-mechanism-factory:
+                  attr-name: global
+              mappers:
+                constant-realm-mapper:
+                  attr-name: local
+                  attr-realm-name: local
+                constant-role-mapper:
+                  attr-name: super-user-mapper
+                  role:
+                    attr-name: SuperUser
+                simple-permission-mapper:
+                  attr-mapping-mode: first
+                  attr-name: default-permission-mapper
+                  permission-mapping:
+                  - permission-set:
+                      attr-name: default-permissions
+                    principal:
+                      attr-name: anonymous
+                  - attr-match-all: 'true'
+                    permission-set:
+                    - attr-name: login-permission
+                    - attr-name: default-permissions
+                simple-role-decoder:
+                  attr-attribute: groups
+                  attr-name: groups-to-roles
+              permission-sets:
+                permission-set:
+                - attr-name: login-permission
+                  permission:
+                    attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                - attr-name: default-permissions
+                  permission:
+                  - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                    attr-module: org.wildfly.extension.batch.jberet
+                    attr-target-name: '*'
+                  - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                    attr-module: org.wildfly.transaction.client
+                  - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                    attr-module: org.jboss.ejb-client
+              providers:
+                aggregate-providers:
+                  attr-name: combined-providers
+                  providers:
+                  - attr-name: elytron
+                  - attr-name: openssl
+                provider-loader:
+                - attr-module: org.wildfly.security.elytron
+                  attr-name: elytron
+                - attr-module: org.wildfly.openssl
+                  attr-name: openssl
+              sasl:
+                configurable-sasl-server-factory:
+                  attr-name: configured
+                  attr-sasl-server-factory: elytron
+                  properties:
+                    property:
+                      attr-name: wildfly.sasl.local-user.default-user
+                      attr-value: $local
+                mechanism-provider-filtering-sasl-server-factory:
+                  attr-name: elytron
+                  attr-sasl-server-factory: global
+                  filters:
+                    filter:
+                      attr-provider-name: WildFlyElytron
+                provider-sasl-server-factory:
+                  attr-name: global
+                sasl-authentication-factory:
+                  attr-name: application-sasl-authentication
+                  attr-sasl-server-factory: configured
+                  attr-security-domain: ApplicationDomain
+                  mechanism-configuration:
+                    mechanism:
+                    - attr-mechanism-name: JBOSS-LOCAL-USER
+                      attr-realm-mapper: local
+                    - attr-mechanism-name: DIGEST-MD5
+                      mechanism-realm:
+                        attr-realm-name: ApplicationRealm
+              security-domains:
+                security-domain:
+                  attr-default-realm: ApplicationRealm
+                  attr-name: ApplicationDomain
+                  attr-permission-mapper: default-permission-mapper
+                  realm:
+                    attr-name: ApplicationRealm
+                    attr-role-decoder: groups-to-roles
+              security-realms:
+                identity-realm:
+                  attr-identity: $local
+                  attr-name: local
+                properties-realm:
+                  attr-name: ApplicationRealm
+                  groups-properties:
+                    attr-path: application-roles.properties
+                    attr-relative-to: jboss.domain.config.dir
+                  users-properties:
+                    attr-digest-realm-name: ApplicationRealm
+                    attr-path: application-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+              tls:
+                key-managers:
+                  key-manager:
+                    attr-generate-self-signed-certificate-host: localhost
+                    attr-key-store: applicationKS
+                    attr-name: applicationKM
+                    credential-reference:
+                      attr-clear-text: password
+                key-stores:
+                  key-store:
+                    attr-name: applicationKS
+                    credential-reference:
+                      attr-clear-text: password
+                    file:
+                      attr-path: application.keystore
+                      attr-relative-to: jboss.domain.config.dir
+                    implementation:
+                      attr-type: JKS
+                server-ssl-contexts:
+                  server-ssl-context:
+                    attr-key-manager: applicationKM
+                    attr-name: applicationSSC
+            - attr-xmlns: urn:jboss:domain:iiop-openjdk:2.1
+              initializers:
+                attr-security: identity
+                attr-transactions: spec
+              orb:
+                attr-socket-binding: iiop
+              security:
+                attr-client-requires-ssl: 'false'
+                attr-server-requires-ssl: 'false'
+            - attr-xmlns: urn:jboss:domain:infinispan:12.0
+              cache-container:
+              - attr-aliases: sfsb
+                attr-default-cache: passivation
+                attr-modules: org.wildfly.clustering.ejb.infinispan
+                attr-name: ejb
+                local-cache:
+                  attr-name: passivation
+                  file-store:
+                    attr-passivation: 'true'
+                    attr-purge: 'false'
+              - attr-default-cache: passivation
+                attr-modules: org.wildfly.clustering.web.infinispan
+                attr-name: web
+                local-cache:
+                - attr-name: passivation
+                  file-store:
+                    attr-passivation: 'true'
+                    attr-purge: 'false'
+                - attr-name: sso
+              - attr-default-cache: default
+                attr-modules: org.wildfly.clustering.server
+                attr-name: server
+                local-cache:
+                  attr-name: default
+              - attr-modules: org.infinispan.hibernate-cache
+                attr-name: hibernate
+                local-cache:
+                - attr-name: entity
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                - attr-name: local-query
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                - attr-name: timestamps
+                - attr-name: pending-puts
+                  expiration:
+                    attr-max-idle: '60000'
+            - attr-xmlns: urn:jboss:domain:io:3.0
+              buffer-pool:
+                attr-name: default
+              worker:
+                attr-name: default
+            - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+            - archive-validation:
+                attr-enabled: 'true'
+                attr-fail-on-error: 'true'
+                attr-fail-on-warn: 'false'
+              attr-xmlns: urn:jboss:domain:jca:5.0
+              bean-validation:
+                attr-enabled: 'true'
+              cached-connection-manager: null
+              default-workmanager:
+                long-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+                short-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+            - attr-xmlns: urn:jboss:domain:jdr:1.0
+            - attr-xmlns: urn:jboss:domain:jmx:1.3
+              expose-expression-model: null
+              expose-resolved-model: null
+            - attr-xmlns: urn:jboss:domain:jpa:1.1
+              jpa:
+                attr-default-extended-persistence-inheritance: DEEP
+            - attr-xmlns: urn:jboss:domain:jsf:1.1
+            - attr-xmlns: urn:jboss:domain:jsr77:1.0
+            - attr-xmlns: urn:jboss:domain:mail:4.0
+              mail-session:
+                attr-jndi-name: java:jboss/mail/Default
+                attr-name: default
+                smtp-server:
+                  attr-outbound-socket-binding-ref: mail-smtp
+            - attr-xmlns: urn:jboss:domain:messaging-activemq:13.0
+              server:
+                address-setting:
+                  attr-dead-letter-address: jms.queue.DLQ
+                  attr-expiry-address: jms.queue.ExpiryQueue
+                  attr-max-size-bytes: '10485760'
+                  attr-message-counter-history-day-limit: '10'
+                  attr-name: '#'
+                  attr-page-size-bytes: '2097152'
+                attr-name: default
+                connection-factory:
+                - attr-connectors: in-vm
+                  attr-entries: java:/ConnectionFactory
+                  attr-name: InVmConnectionFactory
+                - attr-connectors: http-connector
+                  attr-entries: java:jboss/exported/jms/RemoteConnectionFactory
+                  attr-name: RemoteConnectionFactory
+                http-acceptor:
+                - attr-http-listener: default
+                  attr-name: http-acceptor
+                - attr-http-listener: default
+                  attr-name: http-acceptor-throughput
+                  param:
+                  - attr-name: batch-delay
+                    attr-value: '50'
+                  - attr-name: direct-deliver
+                    attr-value: 'false'
+                http-connector:
+                - attr-endpoint: http-acceptor
+                  attr-name: http-connector
+                  attr-socket-binding: http
+                - attr-endpoint: http-acceptor-throughput
+                  attr-name: http-connector-throughput
+                  attr-socket-binding: http
+                  param:
+                    attr-name: batch-delay
+                    attr-value: '50'
+                in-vm-acceptor:
+                  attr-name: in-vm
+                  attr-server-id: '0'
+                  param:
+                    attr-name: buffer-pooling
+                    attr-value: 'false'
+                in-vm-connector:
+                  attr-name: in-vm
+                  attr-server-id: '0'
+                  param:
+                    attr-name: buffer-pooling
+                    attr-value: 'false'
+                jms-queue:
+                - attr-entries: java:/jms/queue/ExpiryQueue
+                  attr-name: ExpiryQueue
+                - attr-entries: java:/jms/queue/DLQ
+                  attr-name: DLQ
+                pooled-connection-factory:
+                  attr-connectors: in-vm
+                  attr-entries: java:/JmsXA java:jboss/DefaultJMSConnectionFactory
+                  attr-name: activemq-ra
+                  attr-transaction: xa
+                security-setting:
+                  attr-name: '#'
+                  role:
+                    attr-consume: 'true'
+                    attr-create-non-durable-queue: 'true'
+                    attr-delete-non-durable-queue: 'true'
+                    attr-name: guest
+                    attr-send: 'true'
+                statistics:
+                  attr-enabled: ${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}
+            - attr-xmlns: urn:jboss:domain:naming:2.0
+              remote-naming: null
+            - attr-xmlns: urn:jboss:domain:pojo:1.0
+            - attr-xmlns: urn:jboss:domain:remoting:4.0
+              http-connector:
+                attr-connector-ref: default
+                attr-name: http-remoting-connector
+                attr-security-realm: ApplicationRealm
+            - attr-xmlns: urn:jboss:domain:request-controller:1.0
+            - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+            - attr-xmlns: urn:jboss:domain:sar:1.0
+            - attr-xmlns: urn:jboss:domain:security:2.0
+              security-domains:
+                security-domain:
+                - attr-cache-type: default
+                  attr-name: other
+                  authentication:
+                    login-module:
+                    - attr-code: Remoting
+                      attr-flag: optional
+                      module-option:
+                        attr-name: password-stacking
+                        attr-value: useFirstPass
+                    - attr-code: RealmDirect
+                      attr-flag: required
+                      module-option:
+                        attr-name: password-stacking
+                        attr-value: useFirstPass
+                - attr-cache-type: default
+                  attr-name: jboss-web-policy
+                  authorization:
+                    policy-module:
+                      attr-code: Delegating
+                      attr-flag: required
+                - attr-cache-type: default
+                  attr-name: jaspitest
+                  authentication-jaspi:
+                    auth-module:
+                      attr-code: Dummy
+                    login-module-stack:
+                      attr-name: dummy
+                      login-module:
+                        attr-code: Dummy
+                        attr-flag: optional
+                - attr-cache-type: default
+                  attr-name: jboss-ejb-policy
+                  authorization:
+                    policy-module:
+                      attr-code: Delegating
+                      attr-flag: required
+            - attr-xmlns: urn:jboss:domain:security-manager:1.0
+              deployment-permissions:
+                maximum-set:
+                  permission:
+                    attr-class: java.security.AllPermission
+            - attr-xmlns: urn:jboss:domain:transactions:6.0
+              coordinator-environment:
+                attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+              core-environment:
+                attr-node-identifier: ${jboss.tx.node.id:1}
+                process-id:
+                  uuid: null
+              object-store:
+                attr-path: tx-object-store
+                attr-relative-to: jboss.server.data.dir
+              recovery-environment:
+                attr-socket-binding: txn-recovery-environment
+                attr-status-socket-binding: txn-status-manager
+            - attr-default-security-domain: other
+              attr-default-server: default-server
+              attr-default-servlet-container: default
+              attr-default-virtual-host: default-host
+              attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:undertow:12.0
+              buffer-cache:
+                attr-name: default
+              handlers:
+                file:
+                  attr-name: welcome-content
+                  attr-path: ${jboss.home.dir}/welcome-content
+              server:
+                attr-name: default-server
+                host:
+                  attr-alias: localhost
+                  attr-name: default-host
+                  http-invoker:
+                    attr-security-realm: ApplicationRealm
+                  location:
+                    attr-handler: welcome-content
+                    attr-name: /
+                http-listener:
+                  attr-enable-http2: 'true'
+                  attr-name: default
+                  attr-redirect-socket: https
+                  attr-socket-binding: http
+                https-listener:
+                  attr-enable-http2: 'true'
+                  attr-name: https
+                  attr-security-realm: ApplicationRealm
+                  attr-socket-binding: https
+              servlet-container:
+                attr-name: default
+                jsp-config: null
+                websockets: null
+            - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:webservices:2.0
+              client-config:
+                attr-name: Standard-Client-Config
+              endpoint-config:
+              - attr-name: Standard-Endpoint-Config
+              - attr-name: Recording-Endpoint-Config
+                pre-handler-chain:
+                  attr-name: recording-handlers
+                  attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                    ##SOAP12_HTTP_MTOM'
+                  handler:
+                    attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                    attr-name: RecordingHandler
+              wsdl-host: ${jboss.bind.address:127.0.0.1}
+            - attr-xmlns: urn:jboss:domain:weld:4.0
+          - attr-name: full-ha
+            subsystem:
+            - attr-xmlns: urn:jboss:domain:logging:8.0
+              formatter:
+              - attr-name: PATTERN
+                pattern-formatter:
+                  attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              - attr-name: COLOR-PATTERN
+                pattern-formatter:
+                  attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              logger:
+              - attr-category: com.arjuna
+                level:
+                  attr-name: WARN
+              - attr-category: io.jaegertracing.Configuration
+                level:
+                  attr-name: WARN
+              - attr-category: org.jboss.as.config
+                level:
+                  attr-name: DEBUG
+              - attr-category: sun.rmi
+                level:
+                  attr-name: WARN
+              periodic-rotating-file-handler:
+                append:
+                  attr-value: 'true'
+                attr-autoflush: 'true'
+                attr-name: FILE
+                file:
+                  attr-path: server.log
+                  attr-relative-to: jboss.server.log.dir
+                formatter:
+                  named-formatter:
+                    attr-name: PATTERN
+                suffix:
+                  attr-value: .yyyy-MM-dd
+              root-logger:
+                handlers:
+                  handler:
+                    attr-name: FILE
+                level:
+                  attr-name: INFO
+            - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+              default-job-repository:
+                attr-name: in-memory
+              default-thread-pool:
+                attr-name: batch
+              job-repository:
+                attr-name: in-memory
+                in-memory: null
+              thread-pool:
+                attr-name: batch
+                keepalive-time:
+                  attr-time: '30'
+                  attr-unit: seconds
+                max-threads:
+                  attr-count: '10'
+            - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+            - attr-xmlns: urn:jboss:domain:core-management:1.0
+            - attr-xmlns: urn:jboss:domain:datasources:6.0
+              datasources:
+                datasource:
+                  attr-enabled: 'true'
+                  attr-jndi-name: java:jboss/datasources/ExampleDS
+                  attr-pool-name: ExampleDS
+                  attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                  attr-use-java-context: 'true'
+                  connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                  driver: h2
+                  security:
+                    password: sa
+                    user-name: sa
+                drivers:
+                  driver:
+                    attr-module: com.h2database.h2
+                    attr-name: h2
+                    xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+            - attr-xmlns: urn:jboss:domain:discovery:1.0
+            - attr-default-session-management: default
+              attr-default-single-sign-on-management: default
+              attr-xmlns: urn:jboss:domain:distributable-web:2.0
+              infinispan-routing:
+                attr-cache: routing
+                attr-cache-container: web
+              infinispan-session-management:
+                attr-cache-container: web
+                attr-granularity: SESSION
+                attr-name: default
+                primary-owner-affinity: null
+              infinispan-single-sign-on-management:
+                attr-cache: sso
+                attr-cache-container: web
+                attr-name: default
+            - attr-xmlns: urn:jboss:domain:ee:6.0
+              concurrent:
+                context-services:
+                  context-service:
+                    attr-jndi-name: java:jboss/ee/concurrency/context/default
+                    attr-name: default
+                    attr-use-transaction-setup-provider: 'true'
+                managed-executor-services:
+                  managed-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                    attr-keepalive-time: '5000'
+                    attr-name: default
+                managed-scheduled-executor-services:
+                  managed-scheduled-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                    attr-keepalive-time: '3000'
+                    attr-name: default
+                managed-thread-factories:
+                  managed-thread-factory:
+                    attr-context-service: default
+                    attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                    attr-name: default
+              default-bindings:
+                attr-context-service: java:jboss/ee/concurrency/context/default
+                attr-datasource: java:jboss/datasources/ExampleDS
+                attr-jms-connection-factory: java:jboss/DefaultJMSConnectionFactory
+                attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+                attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+                attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+              spec-descriptor-property-replacement: 'false'
+            - attr-xmlns: urn:jboss:domain:ee-security:1.0
+            - async:
+                attr-thread-pool-name: default
+              attr-xmlns: urn:jboss:domain:ejb3:9.0
+              caches:
+                cache:
+                - attr-name: simple
+                - attr-aliases: passivating clustered
+                  attr-name: distributable
+                  attr-passivation-store-ref: infinispan
+              default-missing-method-permissions-deny-access:
+                attr-value: 'true'
+              default-security-domain:
+                attr-value: other
+              iiop:
+                attr-enable-by-default: 'false'
+                attr-use-qualified-name: 'false'
+              log-system-exceptions:
+                attr-value: 'true'
+              mdb:
+                bean-instance-pool-ref:
+                  attr-pool-name: mdb-strict-max-pool
+                resource-adapter-ref:
+                  attr-resource-adapter-name: ${ejb.resource-adapter-name:activemq-ra.rar}
+              passivation-stores:
+                passivation-store:
+                  attr-cache-container: ejb
+                  attr-max-size: '10000'
+                  attr-name: infinispan
+              pools:
+                bean-instance-pools:
+                  strict-max-pool:
+                  - attr-derive-size: from-cpu-count
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: mdb-strict-max-pool
+                  - attr-derive-size: from-worker-pools
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: slsb-strict-max-pool
+              remote:
+                attr-cluster: ejb
+                attr-connectors: http-remoting-connector
+                attr-thread-pool-name: default
+                channel-creation-options:
+                  option:
+                    attr-name: MAX_OUTBOUND_MESSAGES
+                    attr-type: remoting
+                    attr-value: '1234'
+              session-bean:
+                singleton:
+                  attr-default-access-timeout: '5000'
+                stateful:
+                  attr-cache-ref: distributable
+                  attr-default-access-timeout: '5000'
+                  attr-passivation-disabled-cache-ref: simple
+                stateless:
+                  bean-instance-pool-ref:
+                    attr-pool-name: slsb-strict-max-pool
+              statistics:
+                attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+              thread-pools:
+                thread-pool:
+                  attr-name: default
+                  keepalive-time:
+                    attr-time: '60'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '10'
+              timer-service:
+                attr-default-data-store: default-file-store
+                attr-thread-pool-name: default
+                data-stores:
+                  file-data-store:
+                    attr-name: default-file-store
+                    attr-path: timer-service-data
+                    attr-relative-to: jboss.server.data.dir
+            - attr-disallowed-providers: OracleUcrypto
+              attr-final-providers: combined-providers
+              attr-xmlns: urn:wildfly:elytron:13.0
+              audit-logging:
+                file-audit-log:
+                  attr-format: JSON
+                  attr-name: local-audit
+                  attr-path: audit.log
+                  attr-relative-to: jboss.server.log.dir
+              http:
+                provider-http-server-mechanism-factory:
+                  attr-name: global
+              mappers:
+                constant-realm-mapper:
+                  attr-name: local
+                  attr-realm-name: local
+                constant-role-mapper:
+                  attr-name: super-user-mapper
+                  role:
+                    attr-name: SuperUser
+                simple-permission-mapper:
+                  attr-mapping-mode: first
+                  attr-name: default-permission-mapper
+                  permission-mapping:
+                  - permission-set:
+                      attr-name: default-permissions
+                    principal:
+                      attr-name: anonymous
+                  - attr-match-all: 'true'
+                    permission-set:
+                    - attr-name: login-permission
+                    - attr-name: default-permissions
+                simple-role-decoder:
+                  attr-attribute: groups
+                  attr-name: groups-to-roles
+              permission-sets:
+                permission-set:
+                - attr-name: login-permission
+                  permission:
+                    attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                - attr-name: default-permissions
+                  permission:
+                  - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                    attr-module: org.wildfly.extension.batch.jberet
+                    attr-target-name: '*'
+                  - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                    attr-module: org.wildfly.transaction.client
+                  - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                    attr-module: org.jboss.ejb-client
+              providers:
+                aggregate-providers:
+                  attr-name: combined-providers
+                  providers:
+                  - attr-name: elytron
+                  - attr-name: openssl
+                provider-loader:
+                - attr-module: org.wildfly.security.elytron
+                  attr-name: elytron
+                - attr-module: org.wildfly.openssl
+                  attr-name: openssl
+              sasl:
+                configurable-sasl-server-factory:
+                  attr-name: configured
+                  attr-sasl-server-factory: elytron
+                  properties:
+                    property:
+                      attr-name: wildfly.sasl.local-user.default-user
+                      attr-value: $local
+                mechanism-provider-filtering-sasl-server-factory:
+                  attr-name: elytron
+                  attr-sasl-server-factory: global
+                  filters:
+                    filter:
+                      attr-provider-name: WildFlyElytron
+                provider-sasl-server-factory:
+                  attr-name: global
+                sasl-authentication-factory:
+                  attr-name: application-sasl-authentication
+                  attr-sasl-server-factory: configured
+                  attr-security-domain: ApplicationDomain
+                  mechanism-configuration:
+                    mechanism:
+                    - attr-mechanism-name: JBOSS-LOCAL-USER
+                      attr-realm-mapper: local
+                    - attr-mechanism-name: DIGEST-MD5
+                      mechanism-realm:
+                        attr-realm-name: ApplicationRealm
+              security-domains:
+                security-domain:
+                  attr-default-realm: ApplicationRealm
+                  attr-name: ApplicationDomain
+                  attr-permission-mapper: default-permission-mapper
+                  realm:
+                    attr-name: ApplicationRealm
+                    attr-role-decoder: groups-to-roles
+              security-realms:
+                identity-realm:
+                  attr-identity: $local
+                  attr-name: local
+                properties-realm:
+                  attr-name: ApplicationRealm
+                  groups-properties:
+                    attr-path: application-roles.properties
+                    attr-relative-to: jboss.domain.config.dir
+                  users-properties:
+                    attr-digest-realm-name: ApplicationRealm
+                    attr-path: application-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+              tls:
+                key-managers:
+                  key-manager:
+                    attr-generate-self-signed-certificate-host: localhost
+                    attr-key-store: applicationKS
+                    attr-name: applicationKM
+                    credential-reference:
+                      attr-clear-text: password
+                key-stores:
+                  key-store:
+                    attr-name: applicationKS
+                    credential-reference:
+                      attr-clear-text: password
+                    file:
+                      attr-path: application.keystore
+                      attr-relative-to: jboss.domain.config.dir
+                    implementation:
+                      attr-type: JKS
+                server-ssl-contexts:
+                  server-ssl-context:
+                    attr-key-manager: applicationKM
+                    attr-name: applicationSSC
+            - attr-xmlns: urn:jboss:domain:iiop-openjdk:2.1
+              initializers:
+                attr-security: identity
+                attr-transactions: spec
+              orb:
+                attr-socket-binding: iiop
+              security:
+                attr-client-requires-ssl: 'false'
+                attr-server-requires-ssl: 'false'
+            - attr-xmlns: urn:jboss:domain:infinispan:12.0
+              cache-container:
+              - attr-aliases: sfsb
+                attr-default-cache: dist
+                attr-modules: org.wildfly.clustering.ejb.infinispan
+                attr-name: ejb
+                distributed-cache:
+                  attr-name: dist
+                  file-store: null
+                  locking:
+                    attr-isolation: REPEATABLE_READ
+                  transaction:
+                    attr-mode: BATCH
+                transport:
+                  attr-lock-timeout: '60000'
+              - attr-aliases: singleton cluster
+                attr-default-cache: default
+                attr-modules: org.wildfly.clustering.server
+                attr-name: server
+                replicated-cache:
+                  attr-name: default
+                  transaction:
+                    attr-mode: BATCH
+                transport:
+                  attr-lock-timeout: '60000'
+              - attr-default-cache: dist
+                attr-modules: org.wildfly.clustering.web.infinispan
+                attr-name: web
+                distributed-cache:
+                  attr-name: dist
+                  file-store: null
+                  locking:
+                    attr-isolation: REPEATABLE_READ
+                  transaction:
+                    attr-mode: BATCH
+                replicated-cache:
+                - attr-name: sso
+                  locking:
+                    attr-isolation: REPEATABLE_READ
+                  transaction:
+                    attr-mode: BATCH
+                - attr-name: routing
+                transport:
+                  attr-lock-timeout: '60000'
+              - attr-modules: org.infinispan.hibernate-cache
+                attr-name: hibernate
+                invalidation-cache:
+                  attr-name: entity
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                local-cache:
+                - attr-name: local-query
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                - attr-name: pending-puts
+                  expiration:
+                    attr-max-idle: '60000'
+                replicated-cache:
+                  attr-name: timestamps
+                transport:
+                  attr-lock-timeout: '60000'
+            - attr-xmlns: urn:jboss:domain:io:3.0
+              buffer-pool:
+                attr-name: default
+              worker:
+                attr-name: default
+            - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+            - archive-validation:
+                attr-enabled: 'true'
+                attr-fail-on-error: 'true'
+                attr-fail-on-warn: 'false'
+              attr-xmlns: urn:jboss:domain:jca:5.0
+              bean-validation:
+                attr-enabled: 'true'
+              cached-connection-manager: null
+              default-workmanager:
+                long-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+                short-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+            - attr-xmlns: urn:jboss:domain:jdr:1.0
+            - attr-xmlns: urn:jboss:domain:jgroups:8.0
+              channels:
+                attr-default: ee
+                channel:
+                  attr-cluster: ejb
+                  attr-name: ee
+                  attr-stack: udp
+              stacks:
+                stack:
+                - attr-name: udp
+                  protocol:
+                  - attr-type: PING
+                  - attr-type: MERGE3
+                  - attr-type: FD_ALL
+                  - attr-type: VERIFY_SUSPECT
+                  - attr-type: pbcast.NAKACK2
+                  - attr-type: UNICAST3
+                  - attr-type: pbcast.STABLE
+                  - attr-type: pbcast.GMS
+                  - attr-type: UFC
+                  - attr-type: MFC
+                  - attr-type: FRAG3
+                  socket-protocol:
+                    attr-socket-binding: jgroups-udp-fd
+                    attr-type: FD_SOCK
+                  transport:
+                    attr-socket-binding: jgroups-udp
+                    attr-type: UDP
+                - attr-name: tcp
+                  protocol:
+                  - attr-type: MERGE3
+                  - attr-type: FD_ALL
+                  - attr-type: VERIFY_SUSPECT
+                  - attr-type: pbcast.NAKACK2
+                  - attr-type: UNICAST3
+                  - attr-type: pbcast.STABLE
+                  - attr-type: pbcast.GMS
+                  - attr-type: MFC
+                  - attr-type: FRAG3
+                  socket-protocol:
+                  - attr-socket-binding: jgroups-mping
+                    attr-type: MPING
+                  - attr-socket-binding: jgroups-tcp-fd
+                    attr-type: FD_SOCK
+                  transport:
+                    attr-socket-binding: jgroups-tcp
+                    attr-type: TCP
+            - attr-xmlns: urn:jboss:domain:jmx:1.3
+              expose-expression-model: null
+              expose-resolved-model: null
+            - attr-xmlns: urn:jboss:domain:jpa:1.1
+              jpa:
+                attr-default-extended-persistence-inheritance: DEEP
+            - attr-xmlns: urn:jboss:domain:jsf:1.1
+            - attr-xmlns: urn:jboss:domain:jsr77:1.0
+            - attr-xmlns: urn:jboss:domain:mail:4.0
+              mail-session:
+                attr-jndi-name: java:jboss/mail/Default
+                attr-name: default
+                smtp-server:
+                  attr-outbound-socket-binding-ref: mail-smtp
+            - attr-xmlns: urn:jboss:domain:messaging-activemq:13.0
+              server:
+                address-setting:
+                  attr-dead-letter-address: jms.queue.DLQ
+                  attr-expiry-address: jms.queue.ExpiryQueue
+                  attr-max-size-bytes: '10485760'
+                  attr-message-counter-history-day-limit: '10'
+                  attr-name: '#'
+                  attr-page-size-bytes: '2097152'
+                  attr-redistribution-delay: '1000'
+                attr-name: default
+                cluster:
+                  attr-password: ${jboss.messaging.cluster.password:CHANGE ME!!}
+                cluster-connection:
+                  attr-address: jms
+                  attr-connector-name: http-connector
+                  attr-discovery-group: dg-group1
+                  attr-name: my-cluster
+                connection-factory:
+                - attr-connectors: in-vm
+                  attr-entries: java:/ConnectionFactory
+                  attr-name: InVmConnectionFactory
+                - attr-block-on-acknowledge: 'true'
+                  attr-connectors: http-connector
+                  attr-entries: java:jboss/exported/jms/RemoteConnectionFactory
+                  attr-ha: 'true'
+                  attr-name: RemoteConnectionFactory
+                  attr-reconnect-attempts: '-1'
+                http-acceptor:
+                - attr-http-listener: default
+                  attr-name: http-acceptor
+                - attr-http-listener: default
+                  attr-name: http-acceptor-throughput
+                  param:
+                  - attr-name: batch-delay
+                    attr-value: '50'
+                  - attr-name: direct-deliver
+                    attr-value: 'false'
+                http-connector:
+                - attr-endpoint: http-acceptor
+                  attr-name: http-connector
+                  attr-socket-binding: http
+                - attr-endpoint: http-acceptor-throughput
+                  attr-name: http-connector-throughput
+                  attr-socket-binding: http
+                  param:
+                    attr-name: batch-delay
+                    attr-value: '50'
+                in-vm-acceptor:
+                  attr-name: in-vm
+                  attr-server-id: '0'
+                  param:
+                    attr-name: buffer-pooling
+                    attr-value: 'false'
+                in-vm-connector:
+                  attr-name: in-vm
+                  attr-server-id: '0'
+                  param:
+                    attr-name: buffer-pooling
+                    attr-value: 'false'
+                jgroups-broadcast-group:
+                  attr-connectors: http-connector
+                  attr-jgroups-cluster: activemq-cluster
+                  attr-name: bg-group1
+                jgroups-discovery-group:
+                  attr-jgroups-cluster: activemq-cluster
+                  attr-name: dg-group1
+                jms-queue:
+                - attr-entries: java:/jms/queue/ExpiryQueue
+                  attr-name: ExpiryQueue
+                - attr-entries: java:/jms/queue/DLQ
+                  attr-name: DLQ
+                pooled-connection-factory:
+                  attr-connectors: in-vm
+                  attr-entries: java:/JmsXA java:jboss/DefaultJMSConnectionFactory
+                  attr-name: activemq-ra
+                  attr-transaction: xa
+                security-setting:
+                  attr-name: '#'
+                  role:
+                    attr-consume: 'true'
+                    attr-create-non-durable-queue: 'true'
+                    attr-delete-non-durable-queue: 'true'
+                    attr-name: guest
+                    attr-send: 'true'
+                statistics:
+                  attr-enabled: ${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}
+            - attr-xmlns: urn:jboss:domain:modcluster:5.0
+              proxy:
+                attr-advertise-socket: modcluster
+                attr-listener: ajp
+                attr-name: default
+                dynamic-load-provider:
+                  load-metric:
+                    attr-type: cpu
+            - attr-xmlns: urn:jboss:domain:naming:2.0
+              remote-naming: null
+            - attr-xmlns: urn:jboss:domain:pojo:1.0
+            - attr-xmlns: urn:jboss:domain:remoting:4.0
+              http-connector:
+                attr-connector-ref: default
+                attr-name: http-remoting-connector
+                attr-security-realm: ApplicationRealm
+            - attr-xmlns: urn:jboss:domain:request-controller:1.0
+            - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+            - attr-xmlns: urn:jboss:domain:sar:1.0
+            - attr-xmlns: urn:jboss:domain:security:2.0
+              security-domains:
+                security-domain:
+                - attr-cache-type: default
+                  attr-name: other
+                  authentication:
+                    login-module:
+                    - attr-code: Remoting
+                      attr-flag: optional
+                      module-option:
+                        attr-name: password-stacking
+                        attr-value: useFirstPass
+                    - attr-code: RealmDirect
+                      attr-flag: required
+                      module-option:
+                        attr-name: password-stacking
+                        attr-value: useFirstPass
+                - attr-cache-type: default
+                  attr-name: jboss-web-policy
+                  authorization:
+                    policy-module:
+                      attr-code: Delegating
+                      attr-flag: required
+                - attr-cache-type: default
+                  attr-name: jaspitest
+                  authentication-jaspi:
+                    auth-module:
+                      attr-code: Dummy
+                    login-module-stack:
+                      attr-name: dummy
+                      login-module:
+                        attr-code: Dummy
+                        attr-flag: optional
+                - attr-cache-type: default
+                  attr-name: jboss-ejb-policy
+                  authorization:
+                    policy-module:
+                      attr-code: Delegating
+                      attr-flag: required
+            - attr-xmlns: urn:jboss:domain:security-manager:1.0
+              deployment-permissions:
+                maximum-set:
+                  permission:
+                    attr-class: java.security.AllPermission
+            - attr-xmlns: urn:jboss:domain:singleton:1.0
+              singleton-policies:
+                attr-default: default
+                singleton-policy:
+                  attr-cache-container: server
+                  attr-name: default
+                  simple-election-policy: null
+            - attr-xmlns: urn:jboss:domain:transactions:6.0
+              coordinator-environment:
+                attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+              core-environment:
+                attr-node-identifier: ${jboss.tx.node.id:1}
+                process-id:
+                  uuid: null
+              object-store:
+                attr-path: tx-object-store
+                attr-relative-to: jboss.server.data.dir
+              recovery-environment:
+                attr-socket-binding: txn-recovery-environment
+                attr-status-socket-binding: txn-status-manager
+            - attr-default-security-domain: other
+              attr-default-server: default-server
+              attr-default-servlet-container: default
+              attr-default-virtual-host: default-host
+              attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:undertow:12.0
+              buffer-cache:
+                attr-name: default
+              handlers:
+                file:
+                  attr-name: welcome-content
+                  attr-path: ${jboss.home.dir}/welcome-content
+              server:
+                ajp-listener:
+                  attr-name: ajp
+                  attr-socket-binding: ajp
+                attr-name: default-server
+                host:
+                  attr-alias: localhost
+                  attr-name: default-host
+                  http-invoker:
+                    attr-security-realm: ApplicationRealm
+                  location:
+                    attr-handler: welcome-content
+                    attr-name: /
+                http-listener:
+                  attr-enable-http2: 'true'
+                  attr-name: default
+                  attr-redirect-socket: https
+                  attr-socket-binding: http
+                https-listener:
+                  attr-enable-http2: 'true'
+                  attr-name: https
+                  attr-security-realm: ApplicationRealm
+                  attr-socket-binding: https
+              servlet-container:
+                attr-name: default
+                jsp-config: null
+                websockets: null
+            - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:webservices:2.0
+              client-config:
+                attr-name: Standard-Client-Config
+              endpoint-config:
+              - attr-name: Standard-Endpoint-Config
+              - attr-name: Recording-Endpoint-Config
+                pre-handler-chain:
+                  attr-name: recording-handlers
+                  attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                    ##SOAP12_HTTP_MTOM'
+                  handler:
+                    attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                    attr-name: RecordingHandler
+              wsdl-host: ${jboss.bind.address:127.0.0.1}
+            - attr-xmlns: urn:jboss:domain:weld:4.0
+          - attr-name: load-balancer
+            subsystem:
+            - attr-xmlns: urn:jboss:domain:logging:8.0
+              formatter:
+              - attr-name: PATTERN
+                pattern-formatter:
+                  attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              - attr-name: COLOR-PATTERN
+                pattern-formatter:
+                  attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              logger:
+              - attr-category: com.arjuna
+                level:
+                  attr-name: WARN
+              - attr-category: io.jaegertracing.Configuration
+                level:
+                  attr-name: WARN
+              - attr-category: org.jboss.as.config
+                level:
+                  attr-name: DEBUG
+              - attr-category: sun.rmi
+                level:
+                  attr-name: WARN
+              periodic-rotating-file-handler:
+                append:
+                  attr-value: 'true'
+                attr-autoflush: 'true'
+                attr-name: FILE
+                file:
+                  attr-path: server.log
+                  attr-relative-to: jboss.server.log.dir
+                formatter:
+                  named-formatter:
+                    attr-name: PATTERN
+                suffix:
+                  attr-value: .yyyy-MM-dd
+              root-logger:
+                handlers:
+                  handler:
+                    attr-name: FILE
+                level:
+                  attr-name: INFO
+            - attr-xmlns: urn:jboss:domain:io:3.0
+              buffer-pool:
+                attr-name: default
+              worker:
+                attr-name: default
+            - attr-default-server: default-server
+              attr-default-servlet-container: default
+              attr-default-virtual-host: default-host
+              attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:undertow:12.0
+              buffer-cache:
+                attr-name: default
+              filters:
+                mod-cluster:
+                  attr-advertise-socket-binding: modcluster
+                  attr-enable-http2: 'true'
+                  attr-management-socket-binding: mcmp-management
+                  attr-max-retries: '3'
+                  attr-name: load-balancer
+                  single-affinity: null
+              server:
+                attr-name: default-server
+                host:
+                  attr-alias: localhost
+                  attr-name: default-host
+                  filter-ref:
+                    attr-name: load-balancer
+                http-listener:
+                - attr-enable-http2: 'true'
+                  attr-name: default
+                  attr-redirect-socket: https
+                  attr-socket-binding: http
+                - attr-enable-http2: 'true'
+                  attr-name: management
+                  attr-socket-binding: mcmp-management
+              servlet-container:
+                attr-name: default
+        server-groups:
+          server-group:
+          - attr-name: main-server-group
+            attr-profile: full-ha
+            jvm:
+              attr-name: default
+              heap:
+                attr-max-size: 1000m
+                attr-size: 1000m
+            socket-binding-group:
+              attr-ref: full-ha-sockets
+          - attr-name: second-server-group
+            attr-profile: full-ha
+            jvm:
+              attr-name: default
+              heap:
+                attr-max-size: 1000m
+                attr-size: 1000m
+            socket-binding-group:
+              attr-ref: full-ha-sockets
+        socket-binding-groups:
+          socket-binding-group:
+          - attr-default-interface: public
+            attr-name: standard-sockets
+            outbound-socket-binding:
+              attr-name: mail-smtp
+              remote-destination:
+                attr-host: ${jboss.mail.server.host:localhost}
+                attr-port: ${jboss.mail.server.port:25}
+            socket-binding:
+            - attr-name: ajp
+              attr-port: ${jboss.ajp.port:8009}
+            - attr-name: http
+              attr-port: ${jboss.http.port:8080}
+            - attr-name: https
+              attr-port: ${jboss.https.port:8443}
+            - attr-name: txn-recovery-environment
+              attr-port: '4712'
+            - attr-name: txn-status-manager
+              attr-port: '4713'
+          - attr-default-interface: public
+            attr-name: ha-sockets
+            outbound-socket-binding:
+              attr-name: mail-smtp
+              remote-destination:
+                attr-host: ${jboss.mail.server.host:localhost}
+                attr-port: ${jboss.mail.server.port:25}
+            socket-binding:
+            - attr-name: ajp
+              attr-port: ${jboss.ajp.port:8009}
+            - attr-name: http
+              attr-port: ${jboss.http.port:8080}
+            - attr-name: https
+              attr-port: ${jboss.https.port:8443}
+            - attr-interface: private
+              attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
+              attr-multicast-port: '45700'
+              attr-name: jgroups-mping
+            - attr-interface: private
+              attr-name: jgroups-tcp
+              attr-port: '7600'
+            - attr-interface: private
+              attr-name: jgroups-tcp-fd
+              attr-port: '57600'
+            - attr-interface: private
+              attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
+              attr-multicast-port: '45688'
+              attr-name: jgroups-udp
+              attr-port: '55200'
+            - attr-interface: private
+              attr-name: jgroups-udp-fd
+              attr-port: '54200'
+            - attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
+              attr-multicast-port: '23364'
+              attr-name: modcluster
+            - attr-name: txn-recovery-environment
+              attr-port: '4712'
+            - attr-name: txn-status-manager
+              attr-port: '4713'
+          - attr-default-interface: public
+            attr-name: full-sockets
+            outbound-socket-binding:
+              attr-name: mail-smtp
+              remote-destination:
+                attr-host: ${jboss.mail.server.host:localhost}
+                attr-port: ${jboss.mail.server.port:25}
+            socket-binding:
+            - attr-name: ajp
+              attr-port: ${jboss.ajp.port:8009}
+            - attr-name: http
+              attr-port: ${jboss.http.port:8080}
+            - attr-name: https
+              attr-port: ${jboss.https.port:8443}
+            - attr-interface: unsecure
+              attr-name: iiop
+              attr-port: '3528'
+            - attr-interface: unsecure
+              attr-name: iiop-ssl
+              attr-port: '3529'
+            - attr-name: txn-recovery-environment
+              attr-port: '4712'
+            - attr-name: txn-status-manager
+              attr-port: '4713'
+          - attr-default-interface: public
+            attr-name: full-ha-sockets
+            outbound-socket-binding:
+              attr-name: mail-smtp
+              remote-destination:
+                attr-host: ${jboss.mail.server.host:localhost}
+                attr-port: ${jboss.mail.server.port:25}
+            socket-binding:
+            - attr-name: ajp
+              attr-port: ${jboss.ajp.port:8009}
+            - attr-name: http
+              attr-port: ${jboss.http.port:8080}
+            - attr-name: https
+              attr-port: ${jboss.https.port:8443}
+            - attr-interface: unsecure
+              attr-name: iiop
+              attr-port: '3528'
+            - attr-interface: unsecure
+              attr-name: iiop-ssl
+              attr-port: '3529'
+            - attr-interface: private
+              attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
+              attr-multicast-port: '45700'
+              attr-name: jgroups-mping
+            - attr-interface: private
+              attr-name: jgroups-tcp
+              attr-port: '7600'
+            - attr-interface: private
+              attr-name: jgroups-tcp-fd
+              attr-port: '57600'
+            - attr-interface: private
+              attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
+              attr-multicast-port: '45688'
+              attr-name: jgroups-udp
+              attr-port: '55200'
+            - attr-interface: private
+              attr-name: jgroups-udp-fd
+              attr-port: '54200'
+            - attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
+              attr-multicast-port: '23364'
+              attr-name: modcluster
+            - attr-name: txn-recovery-environment
+              attr-port: '4712'
+            - attr-name: txn-status-manager
+              attr-port: '4713'
+          - attr-default-interface: public
+            attr-name: load-balancer-sockets
+            socket-binding:
+            - attr-name: http
+              attr-port: ${jboss.http.port:8080}
+            - attr-name: https
+              attr-port: ${jboss.https.port:8443}
+            - attr-interface: private
+              attr-name: mcmp-management
+              attr-port: ${jboss.mcmp.port:8090}
+            - attr-interface: private
+              attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
+              attr-multicast-port: '23364'
+              attr-name: modcluster
+        system-properties:
+          property:
+            attr-name: java.net.preferIPv4Stack
+            attr-value: 'true'
+    host_xml:
+      host:
+        attr-name: nodo1-master
+        attr-xmlns: urn:jboss:domain:16.0
+        domain-controller:
+          local: null
+        extensions:
+          extension:
+          - attr-module: org.jboss.as.jmx
+          - attr-module: org.wildfly.extension.core-management
+          - attr-module: org.wildfly.extension.elytron
+        interfaces:
+          interface:
+          - attr-name: management
+            inet-address:
+              attr-value: ${jboss.bind.address.management:0.0.0.0}
+          - attr-name: public
+            inet-address:
+              attr-value: ${jboss.bind.address:0.0.0.0}
+        jvms:
+          jvm:
+            attr-name: default
+            heap:
+              attr-max-size: 256m
+              attr-size: 64m
+            jvm-options:
+              option:
+              - attr-value: -server
+              - attr-value: -XX:MetaspaceSize=96m
+              - attr-value: -XX:MaxMetaspaceSize=256m
+        management:
+          audit-log:
+            formatters:
+              json-formatter:
+                attr-name: json-formatter
+            handlers:
+              file-handler:
+              - attr-formatter: json-formatter
+                attr-name: host-file
+                attr-path: audit-log.log
+                attr-relative-to: jboss.domain.data.dir
+              - attr-formatter: json-formatter
+                attr-name: server-file
+                attr-path: audit-log.log
+                attr-relative-to: jboss.server.data.dir
+            logger:
+              attr-enabled: 'false'
+              attr-log-boot: 'true'
+              attr-log-read-only: 'false'
+              handlers:
+                handler:
+                  attr-name: host-file
+            server-logger:
+              attr-enabled: 'false'
+              attr-log-boot: 'true'
+              attr-log-read-only: 'false'
+              handlers:
+                handler:
+                  attr-name: server-file
+          management-interfaces:
+            http-interface:
+              attr-security-realm: ManagementRealm
+              http-upgrade:
+                attr-enabled: 'true'
+              socket:
+                attr-interface: management
+                attr-port: ${jboss.management.http.port:9990}
+            native-interface:
+              socket:
+                attr-interface: management
+                attr-port: ${jboss.management.native.port:9999}
+          security-realms:
+            security-realm:
+            - attr-name: ManagementRealm
+              authentication:
+                local:
+                  attr-default-user: $local
+                  attr-skip-group-loading: 'true'
+                properties:
+                  attr-path: mgmt-users.properties
+                  attr-relative-to: jboss.domain.config.dir
+              authorization:
+                attr-map-groups-to-roles: 'false'
+                properties:
+                  attr-path: mgmt-groups.properties
+                  attr-relative-to: jboss.domain.config.dir
+            - attr-name: ApplicationRealm
+              authentication:
+                local:
+                  attr-allowed-users: '*'
+                  attr-default-user: $local
+                  attr-skip-group-loading: 'true'
+                properties:
+                  attr-path: application-users.properties
+                  attr-relative-to: jboss.domain.config.dir
+              authorization:
+                properties:
+                  attr-path: application-roles.properties
+                  attr-relative-to: jboss.domain.config.dir
+              server-identities:
+                ssl:
+                  keystore:
+                    attr-alias: server
+                    attr-generate-self-signed-certificate-host: localhost
+                    attr-key-password: password
+                    attr-keystore-password: password
+                    attr-path: application.keystore
+                    attr-relative-to: jboss.domain.config.dir
+        profile:
+          subsystem:
+          - attr-xmlns: urn:jboss:domain:core-management:1.0
+          - attr-disallowed-providers: OracleUcrypto
+            attr-final-providers: combined-providers
+            attr-xmlns: urn:wildfly:elytron:13.0
+            audit-logging:
+              file-audit-log:
+                attr-format: JSON
+                attr-name: local-audit
+                attr-path: audit.log
+                attr-relative-to: jboss.domain.log.dir
+            http:
+              http-authentication-factory:
+                attr-http-server-mechanism-factory: global
+                attr-name: management-http-authentication
+                attr-security-domain: ManagementDomain
+                mechanism-configuration:
+                  mechanism:
+                    attr-mechanism-name: BASIC
+                    mechanism-realm:
+                      attr-realm-name: Management Realm
+              provider-http-server-mechanism-factory:
+                attr-name: global
+            mappers:
+              constant-realm-mapper:
+                attr-name: local
+                attr-realm-name: local
+              constant-role-mapper:
+                attr-name: super-user-mapper
+                role:
+                  attr-name: SuperUser
+              simple-permission-mapper:
+                attr-mapping-mode: first
+                attr-name: default-permission-mapper
+                permission-mapping:
+                - permission-set:
+                    attr-name: default-permissions
+                  principal:
+                    attr-name: anonymous
+                - attr-match-all: 'true'
+                  permission-set:
+                  - attr-name: login-permission
+                  - attr-name: default-permissions
+              simple-role-decoder:
+                attr-attribute: groups
+                attr-name: groups-to-roles
+            permission-sets:
+              permission-set:
+              - attr-name: login-permission
+                permission:
+                  attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+              - attr-name: default-permissions
+            providers:
+              aggregate-providers:
+                attr-name: combined-providers
+                providers:
+                - attr-name: elytron
+                - attr-name: openssl
+              provider-loader:
+              - attr-module: org.wildfly.security.elytron
+                attr-name: elytron
+              - attr-module: org.wildfly.openssl
+                attr-name: openssl
+            sasl:
+              configurable-sasl-server-factory:
+                attr-name: configured
+                attr-sasl-server-factory: elytron
+                properties:
+                  property:
+                    attr-name: wildfly.sasl.local-user.default-user
+                    attr-value: $local
+              mechanism-provider-filtering-sasl-server-factory:
+                attr-name: elytron
+                attr-sasl-server-factory: global
+                filters:
+                  filter:
+                    attr-provider-name: WildFlyElytron
+              provider-sasl-server-factory:
+                attr-name: global
+              sasl-authentication-factory:
+                attr-name: management-sasl-authentication
+                attr-sasl-server-factory: configured
+                attr-security-domain: ManagementDomain
+                mechanism-configuration:
+                  mechanism:
+                  - attr-mechanism-name: JBOSS-LOCAL-USER
+                    attr-realm-mapper: local
+                  - attr-mechanism-name: DIGEST-MD5
+                    mechanism-realm:
+                      attr-realm-name: ManagementRealm
+            security-domains:
+              security-domain:
+                attr-default-realm: ManagementRealm
+                attr-name: ManagementDomain
+                attr-permission-mapper: default-permission-mapper
+                realm:
+                - attr-name: ManagementRealm
+                  attr-role-decoder: groups-to-roles
+                - attr-name: local
+                  attr-role-mapper: super-user-mapper
+            security-realms:
+              identity-realm:
+                attr-identity: $local
+                attr-name: local
+              properties-realm:
+                attr-name: ManagementRealm
+                groups-properties:
+                  attr-path: mgmt-groups.properties
+                  attr-relative-to: jboss.domain.config.dir
+                users-properties:
+                  attr-digest-realm-name: ManagementRealm
+                  attr-path: mgmt-users.properties
+                  attr-relative-to: jboss.domain.config.dir
+          - attr-xmlns: urn:jboss:domain:jmx:1.3
+            expose-expression-model: null
+            expose-resolved-model: null
+            remoting-connector: null
+        servers:
+          server:
+          - attr-auto-start: 'true'
+            attr-group: main-server-group
+            attr-name: nodo1-server1
+          - attr-auto-start: 'true'
+            attr-group: second-server-group
+            attr-name: nodo1-server2
+            jvm:
+              attr-name: default
+            socket-bindings:
+              attr-port-offset: '150'
+  discovery_time: '2022-06-23T20:39:27+02:00'
+  extra_data:
+    domain_role: master
+    heap_initial_allocation_memory: 1000m
+    heap_max_memory: 1000m
+    mode: domain
+    server:
+      group: main-server-group
+      name: nodo1-server1
+      port_offset: '0'
+      profile: full-ha
+  files:
+  - path: /opt/jboss/domain/servers/nodo1-server1/log
+    subtype: generic
+    type: log
+  - name: server.log
+    path: /opt/jboss/domain/servers/nodo1-server1/log
+    subtype: generic
+    type: log
+  - name: logging.properties
+    path: /opt/jboss/domain/servers/nodo1-server1/data
+    subtype: generic
+    type: log
+  - name: host.xml
+    path: /opt/jboss/domain/configuration
+    subtype: host
+    type: config
+  - name: domain.xml
+    path: /opt/jboss/domain/configuration
+    subtype: domain
+    type: config
+  - path: /opt/jboss
+    subtype: generic
+    type: data
+  listening_ports:
+  - 3528
+  - 8009
+  - 8080
+  - 8443
+  - 23364
+  - 45688
+  - 54200
+  - 55200
+  packages:
+  - arch: noarch
+    epoch: null
+    name: jboss-el-2.2-api
+    release: 0.7.20120212git2fabd8.el7
+    source: rpm
+    version: 1.0.1
+  - arch: noarch
+    epoch: null
+    name: jboss-jaxrpc-1.1-api
+    release: 7.el7
+    source: rpm
+    version: 1.0.1
+  - arch: noarch
+    epoch: null
+    name: jboss-servlet-3.0-api
+    release: 9.el7
+    source: rpm
+    version: 1.0.1
+  - arch: noarch
+    epoch: null
+    name: jboss-transaction-1.1-api
+    release: 8.el7
+    source: rpm
+    version: 1.0.1
+  - arch: noarch
+    epoch: null
+    name: jboss-ejb-3.1-api
+    release: 10.el7
+    source: rpm
+    version: 1.0.2
+  - arch: noarch
+    epoch: null
+    name: jboss-interceptors-1.1-api
+    release: 0.9.20120319git49a904.el7
+    source: rpm
+    version: 1.0.2
+  process:
+    cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/java
+      -D[Server:nodo1-server1] -D[pcid:1449119893] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m
+      -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true
+      -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo1-server1/log
+      -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo1-server1/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo1-server1/data
+      -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo1-server1/data/logging.properties
+      -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
+    cwd: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/
+    listening_ports:
+    - 3528
+    - 8009
+    - 8080
+    - 8443
+    - 23364
+    - 45688
+    - 54200
+    - 55200
     pid: '17878'
     ppid: '17764'
     user: wildfly
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '18901'
-    ppid: '866'
-    user: apache
-tcp_listen:
-  - address: 0.0.0.0
-    name: java
-    pid: 17924
-    port: 8230
-    protocol: tcp
-    stime: Thu Jun 23 09:01:35 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: java
-    pid: 17780
-    port: 9990
-    protocol: tcp
-    stime: Thu Jun 23 09:01:15 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17878
-    port: 3528
-    protocol: tcp
-    stime: Thu Jun 23 09:01:29 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: java
-    pid: 17878
-    port: 8009
-    protocol: tcp
-    stime: Thu Jun 23 09:01:29 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: mongod
-    pid: 1239
-    port: 27017
-    protocol: tcp
-    stime: Thu Jun 16 14:10:00 2022
-    user: mongod
-  - address: 0.0.0.0
-    name: java
-    pid: 17780
-    port: 9999
-    protocol: tcp
-    stime: Thu Jun 23 09:01:15 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 550
-    port: 111
-    protocol: tcp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: 0.0.0.0
-    name: java
-    pid: 17878
-    port: 8080
-    protocol: tcp
-    stime: Thu Jun 23 09:01:29 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: java
-    pid: 17924
-    port: 8593
-    protocol: tcp
-    stime: Thu Jun 23 09:01:35 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1159
-    port: 22
-    protocol: tcp
-    stime: Thu Jun 16 14:09:58 2022
-    user: root
-  - address: 127.0.0.1
-    name: java
-    pid: 17878
-    port: 54200
-    protocol: tcp
-    stime: Thu Jun 23 09:01:29 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17924
-    port: 54201
-    protocol: tcp
-    stime: Thu Jun 23 09:01:35 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: master
-    pid: 1100
-    port: 25
-    protocol: tcp
-    stime: Thu Jun 16 14:09:57 2022
-    user: root
-  - address: 0.0.0.0
-    name: java
-    pid: 17878
-    port: 8443
-    protocol: tcp
-    stime: Thu Jun 23 09:01:29 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17924
-    port: 3678
-    protocol: tcp
-    stime: Thu Jun 23 09:01:35 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: java
-    pid: 17924
-    port: 8159
-    protocol: tcp
-    stime: Thu Jun 23 09:01:35 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17764
-    port: 42816
-    protocol: tcp
-    stime: Thu Jun 23 09:01:13 2022
-    user: wildfly
-  - address: '::'
-    name: java
-    pid: 967
-    port: 5672
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 42825
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: mysqld
-    pid: 1535
-    port: 3306
-    protocol: tcp
-    stime: Thu Jun 16 14:10:11 2022
-    user: mysql
-  - address: '::'
-    name: java
-    pid: 967
-    port: 61613
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 61614
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 550
-    port: 111
-    protocol: tcp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: '::'
-    name: java
-    pid: 967
-    port: 61616
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: httpd
-    pid: 866
-    port: 80
-    protocol: tcp
-    stime: Thu Jun 16 14:09:53 2022
-    user: root
-  - address: '::'
-    name: httpd
-    pid: 866
-    port: 81
-    protocol: tcp
-    stime: Thu Jun 16 14:09:53 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1159
-    port: 22
-    protocol: tcp
-    stime: Thu Jun 16 14:09:58 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1100
-    port: 25
-    protocol: tcp
-    stime: Thu Jun 16 14:09:57 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 1883
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 8161
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-udp_listen:
-  - address: 230.0.0.4
-    name: java
-    pid: 17924
-    port: 45688
-    protocol: udp
-    stime: Thu Jun 23 09:01:35 2022
-    user: wildfly
-  - address: 230.0.0.4
-    name: java
-    pid: 17878
-    port: 45688
-    protocol: udp
-    stime: Thu Jun 23 09:01:29 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 550
-    port: 721
-    protocol: udp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: 224.0.1.105
-    name: java
-    pid: 17924
-    port: 23364
-    protocol: udp
-    stime: Thu Jun 23 09:01:35 2022
-    user: wildfly
-  - address: 224.0.1.105
-    name: java
-    pid: 17878
-    port: 23364
-    protocol: udp
-    stime: Thu Jun 23 09:01:29 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17878
-    port: 55200
-    protocol: udp
-    stime: Thu Jun 23 09:01:29 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 17924
-    port: 55350
-    protocol: udp
-    stime: Thu Jun 23 09:01:35 2022
-    user: wildfly
-  - address: 0.0.0.0
+  type: JBoss Application Server
+  version:
+  - number: 1.0.1
+    type: package
+  - number: 1.0.2
+    type: package
+  - number: 7.4.0
+    type: file
+mocked_plugin_tasks:
+  Check if controller information is available:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Check if domain_xml_file is accessible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /opt/jboss/domain/configuration/domain.xml
+    plugin_result:
+      failed: false
+  Check if host_xml_file is accessible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /opt/jboss/domain/configuration/host.xml
+    plugin_result:
+      failed: false
+  Check if logging_conf_file is accessible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /opt/jboss/domain/servers/nodo1-server1/data/logging.properties
+    plugin_result:
+      failed: false
+  Check if version file is accessible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /opt/jboss/version.txt
+    plugin_result:
+      failed: false
+  Read domain_xml_file:
+    expected_args:
+      delegate_reading: false
+      file_path: /opt/jboss/domain/configuration/domain.xml
+      in_docker: true
+      parser: xml
+      parser_params: null
+    plugin_result:
+      failed: false
+      parsed:
+        domain:
+          attr-xmlns: urn:jboss:domain:16.0
+          extensions:
+            extension:
+            - attr-module: org.jboss.as.clustering.infinispan
+            - attr-module: org.jboss.as.clustering.jgroups
+            - attr-module: org.jboss.as.connector
+            - attr-module: org.jboss.as.ee
+            - attr-module: org.jboss.as.ejb3
+            - attr-module: org.jboss.as.jaxrs
+            - attr-module: org.jboss.as.jdr
+            - attr-module: org.jboss.as.jmx
+            - attr-module: org.jboss.as.jpa
+            - attr-module: org.jboss.as.jsf
+            - attr-module: org.jboss.as.jsr77
+            - attr-module: org.jboss.as.logging
+            - attr-module: org.jboss.as.mail
+            - attr-module: org.jboss.as.modcluster
+            - attr-module: org.jboss.as.naming
+            - attr-module: org.jboss.as.pojo
+            - attr-module: org.jboss.as.remoting
+            - attr-module: org.jboss.as.sar
+            - attr-module: org.jboss.as.security
+            - attr-module: org.jboss.as.transactions
+            - attr-module: org.jboss.as.webservices
+            - attr-module: org.jboss.as.weld
+            - attr-module: org.wildfly.extension.batch.jberet
+            - attr-module: org.wildfly.extension.bean-validation
+            - attr-module: org.wildfly.extension.clustering.singleton
+            - attr-module: org.wildfly.extension.clustering.web
+            - attr-module: org.wildfly.extension.core-management
+            - attr-module: org.wildfly.extension.discovery
+            - attr-module: org.wildfly.extension.ee-security
+            - attr-module: org.wildfly.extension.elytron
+            - attr-module: org.wildfly.extension.io
+            - attr-module: org.wildfly.extension.messaging-activemq
+            - attr-module: org.wildfly.extension.request-controller
+            - attr-module: org.wildfly.extension.security.manager
+            - attr-module: org.wildfly.extension.undertow
+            - attr-module: org.wildfly.iiop-openjdk
+          host-excludes:
+            host-exclude:
+            - attr-name: EAP62
+              excluded-extensions:
+                extension:
+                - attr-module: org.wildfly.extension.batch.jberet
+                - attr-module: org.wildfly.extension.bean-validation
+                - attr-module: org.wildfly.extension.clustering.singleton
+                - attr-module: org.wildfly.extension.clustering.web
+                - attr-module: org.wildfly.extension.core-management
+                - attr-module: org.wildfly.extension.datasources-agroal
+                - attr-module: org.wildfly.extension.discovery
+                - attr-module: org.wildfly.extension.ee-security
+                - attr-module: org.wildfly.extension.elytron
+                - attr-module: org.wildfly.extension.io
+                - attr-module: org.wildfly.extension.messaging-activemq
+                - attr-module: org.wildfly.extension.microprofile.config-smallrye
+                - attr-module: org.wildfly.extension.microprofile.health-smallrye
+                - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+                - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+                - attr-module: org.wildfly.extension.picketlink
+                - attr-module: org.wildfly.extension.request-controller
+                - attr-module: org.wildfly.extension.rts
+                - attr-module: org.wildfly.extension.security.manager
+                - attr-module: org.wildfly.extension.undertow
+                - attr-module: org.wildfly.iiop-openjdk
+                - attr-module: org.wildfly.extension.health
+                - attr-module: org.wildfly.extension.metrics
+              host-release:
+                attr-id: EAP6.2
+            - attr-name: EAP63
+              excluded-extensions:
+                extension:
+                - attr-module: org.wildfly.extension.batch.jberet
+                - attr-module: org.wildfly.extension.bean-validation
+                - attr-module: org.wildfly.extension.clustering.singleton
+                - attr-module: org.wildfly.extension.clustering.web
+                - attr-module: org.wildfly.extension.core-management
+                - attr-module: org.wildfly.extension.datasources-agroal
+                - attr-module: org.wildfly.extension.discovery
+                - attr-module: org.wildfly.extension.ee-security
+                - attr-module: org.wildfly.extension.elytron
+                - attr-module: org.wildfly.extension.io
+                - attr-module: org.wildfly.extension.messaging-activemq
+                - attr-module: org.wildfly.extension.microprofile.config-smallrye
+                - attr-module: org.wildfly.extension.microprofile.health-smallrye
+                - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+                - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+                - attr-module: org.wildfly.extension.request-controller
+                - attr-module: org.wildfly.extension.rts
+                - attr-module: org.wildfly.extension.security.manager
+                - attr-module: org.wildfly.extension.undertow
+                - attr-module: org.wildfly.iiop-openjdk
+                - attr-module: org.wildfly.extension.health
+                - attr-module: org.wildfly.extension.metrics
+              host-release:
+                attr-id: EAP6.3
+            - attr-name: EAP64
+              excluded-extensions:
+                extension:
+                - attr-module: org.wildfly.extension.batch.jberet
+                - attr-module: org.wildfly.extension.bean-validation
+                - attr-module: org.wildfly.extension.clustering.singleton
+                - attr-module: org.wildfly.extension.clustering.web
+                - attr-module: org.wildfly.extension.core-management
+                - attr-module: org.wildfly.extension.datasources-agroal
+                - attr-module: org.wildfly.extension.discovery
+                - attr-module: org.wildfly.extension.ee-security
+                - attr-module: org.wildfly.extension.elytron
+                - attr-module: org.wildfly.extension.io
+                - attr-module: org.wildfly.extension.messaging-activemq
+                - attr-module: org.wildfly.extension.microprofile.config-smallrye
+                - attr-module: org.wildfly.extension.microprofile.health-smallrye
+                - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+                - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+                - attr-module: org.wildfly.extension.request-controller
+                - attr-module: org.wildfly.extension.rts
+                - attr-module: org.wildfly.extension.security.manager
+                - attr-module: org.wildfly.extension.undertow
+                - attr-module: org.wildfly.iiop-openjdk
+                - attr-module: org.wildfly.extension.health
+                - attr-module: org.wildfly.extension.metrics
+              host-release:
+                attr-id: EAP6.4
+            - attr-name: EAP64z
+              excluded-extensions:
+                extension:
+                - attr-module: org.wildfly.extension.batch.jberet
+                - attr-module: org.wildfly.extension.bean-validation
+                - attr-module: org.wildfly.extension.clustering.singleton
+                - attr-module: org.wildfly.extension.clustering.web
+                - attr-module: org.wildfly.extension.core-management
+                - attr-module: org.wildfly.extension.datasources-agroal
+                - attr-module: org.wildfly.extension.discovery
+                - attr-module: org.wildfly.extension.ee-security
+                - attr-module: org.wildfly.extension.elytron
+                - attr-module: org.wildfly.extension.io
+                - attr-module: org.wildfly.extension.messaging-activemq
+                - attr-module: org.wildfly.extension.microprofile.config-smallrye
+                - attr-module: org.wildfly.extension.microprofile.health-smallrye
+                - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+                - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+                - attr-module: org.wildfly.extension.request-controller
+                - attr-module: org.wildfly.extension.rts
+                - attr-module: org.wildfly.extension.security.manager
+                - attr-module: org.wildfly.extension.undertow
+                - attr-module: org.wildfly.iiop-openjdk
+                - attr-module: org.wildfly.extension.health
+                - attr-module: org.wildfly.extension.metrics
+              host-api-version:
+                attr-major-version: '1'
+                attr-minor-version: '8'
+            - attr-name: EAP70
+              excluded-extensions:
+                extension:
+                - attr-module: org.wildfly.extension.clustering.web
+                - attr-module: org.wildfly.extension.core-management
+                - attr-module: org.wildfly.extension.datasources-agroal
+                - attr-module: org.wildfly.extension.discovery
+                - attr-module: org.wildfly.extension.ee-security
+                - attr-module: org.wildfly.extension.elytron
+                - attr-module: org.wildfly.extension.microprofile.config-smallrye
+                - attr-module: org.wildfly.extension.microprofile.health-smallrye
+                - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+                - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+                - attr-module: org.wildfly.extension.health
+                - attr-module: org.wildfly.extension.metrics
+              host-release:
+                attr-id: EAP7.0
+            - attr-name: EAP71
+              excluded-extensions:
+                extension:
+                - attr-module: org.wildfly.extension.clustering.web
+                - attr-module: org.wildfly.extension.datasources-agroal
+                - attr-module: org.wildfly.extension.ee-security
+                - attr-module: org.wildfly.extension.microprofile.config-smallrye
+                - attr-module: org.wildfly.extension.microprofile.health-smallrye
+                - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+                - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+                - attr-module: org.wildfly.extension.health
+                - attr-module: org.wildfly.extension.metrics
+              host-release:
+                attr-id: EAP7.1
+            - attr-name: EAP72
+              excluded-extensions:
+                extension:
+                - attr-module: org.wildfly.extension.clustering.web
+                - attr-module: org.wildfly.extension.microprofile.metrics-smallrye
+                - attr-module: org.wildfly.extension.health
+                - attr-module: org.wildfly.extension.metrics
+              host-release:
+                attr-id: EAP7.2
+            - attr-name: EAP73
+              excluded-extensions:
+                extension:
+                - attr-module: org.wildfly.extension.health
+                - attr-module: org.wildfly.extension.metrics
+              host-release:
+                attr-id: EAP7.3
+          interfaces:
+            interface:
+            - attr-name: management
+            - attr-name: private
+              inet-address:
+                attr-value: ${jboss.bind.address.private:127.0.0.1}
+            - any-address: null
+              attr-name: public
+            - attr-name: unsecure
+              inet-address:
+                attr-value: ${jboss.bind.address.unsecure:127.0.0.1}
+          management:
+            access-control:
+              attr-provider: simple
+              role-mapping:
+                role:
+                  attr-name: SuperUser
+                  include:
+                    user:
+                      attr-name: $local
+          profiles:
+            profile:
+            - attr-name: default
+              subsystem:
+              - attr-xmlns: urn:jboss:domain:logging:8.0
+                formatter:
+                - attr-name: PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                - attr-name: COLOR-PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                logger:
+                - attr-category: com.arjuna
+                  level:
+                    attr-name: WARN
+                - attr-category: io.jaegertracing.Configuration
+                  level:
+                    attr-name: WARN
+                - attr-category: org.jboss.as.config
+                  level:
+                    attr-name: DEBUG
+                - attr-category: sun.rmi
+                  level:
+                    attr-name: WARN
+                periodic-rotating-file-handler:
+                  append:
+                    attr-value: 'true'
+                  attr-autoflush: 'true'
+                  attr-name: FILE
+                  file:
+                    attr-path: server.log
+                    attr-relative-to: jboss.server.log.dir
+                  formatter:
+                    named-formatter:
+                      attr-name: PATTERN
+                  suffix:
+                    attr-value: .yyyy-MM-dd
+                root-logger:
+                  handlers:
+                    handler:
+                      attr-name: FILE
+                  level:
+                    attr-name: INFO
+              - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+                default-job-repository:
+                  attr-name: in-memory
+                default-thread-pool:
+                  attr-name: batch
+                job-repository:
+                  attr-name: in-memory
+                  in-memory: null
+                thread-pool:
+                  attr-name: batch
+                  keepalive-time:
+                    attr-time: '30'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '10'
+              - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+              - attr-xmlns: urn:jboss:domain:core-management:1.0
+              - attr-xmlns: urn:jboss:domain:datasources:6.0
+                datasources:
+                  datasource:
+                    attr-enabled: 'true'
+                    attr-jndi-name: java:jboss/datasources/ExampleDS
+                    attr-pool-name: ExampleDS
+                    attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                    attr-use-java-context: 'true'
+                    connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                    driver: h2
+                    security:
+                      password: sa
+                      user-name: sa
+                  drivers:
+                    driver:
+                      attr-module: com.h2database.h2
+                      attr-name: h2
+                      xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+              - attr-xmlns: urn:jboss:domain:discovery:1.0
+              - attr-default-session-management: default
+                attr-default-single-sign-on-management: default
+                attr-xmlns: urn:jboss:domain:distributable-web:2.0
+                infinispan-session-management:
+                  attr-cache-container: web
+                  attr-granularity: SESSION
+                  attr-name: default
+                  local-affinity: null
+                infinispan-single-sign-on-management:
+                  attr-cache: sso
+                  attr-cache-container: web
+                  attr-name: default
+                local-routing: null
+              - attr-xmlns: urn:jboss:domain:ee:6.0
+                concurrent:
+                  context-services:
+                    context-service:
+                      attr-jndi-name: java:jboss/ee/concurrency/context/default
+                      attr-name: default
+                      attr-use-transaction-setup-provider: 'true'
+                  managed-executor-services:
+                    managed-executor-service:
+                      attr-context-service: default
+                      attr-hung-task-termination-period: '0'
+                      attr-hung-task-threshold: '60000'
+                      attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                      attr-keepalive-time: '5000'
+                      attr-name: default
+                  managed-scheduled-executor-services:
+                    managed-scheduled-executor-service:
+                      attr-context-service: default
+                      attr-hung-task-termination-period: '0'
+                      attr-hung-task-threshold: '60000'
+                      attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                      attr-keepalive-time: '3000'
+                      attr-name: default
+                  managed-thread-factories:
+                    managed-thread-factory:
+                      attr-context-service: default
+                      attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                      attr-name: default
+                default-bindings:
+                  attr-context-service: java:jboss/ee/concurrency/context/default
+                  attr-datasource: java:jboss/datasources/ExampleDS
+                  attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+                  attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+                  attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+                spec-descriptor-property-replacement: 'false'
+              - attr-xmlns: urn:jboss:domain:ee-security:1.0
+              - async:
+                  attr-thread-pool-name: default
+                attr-xmlns: urn:jboss:domain:ejb3:9.0
+                caches:
+                  cache:
+                  - attr-name: simple
+                  - attr-aliases: passivating clustered
+                    attr-name: distributable
+                    attr-passivation-store-ref: infinispan
+                default-missing-method-permissions-deny-access:
+                  attr-value: 'true'
+                default-security-domain:
+                  attr-value: other
+                log-system-exceptions:
+                  attr-value: 'true'
+                passivation-stores:
+                  passivation-store:
+                    attr-cache-container: ejb
+                    attr-max-size: '10000'
+                    attr-name: infinispan
+                pools:
+                  bean-instance-pools:
+                    strict-max-pool:
+                    - attr-derive-size: from-cpu-count
+                      attr-instance-acquisition-timeout: '5'
+                      attr-instance-acquisition-timeout-unit: MINUTES
+                      attr-name: mdb-strict-max-pool
+                    - attr-derive-size: from-worker-pools
+                      attr-instance-acquisition-timeout: '5'
+                      attr-instance-acquisition-timeout-unit: MINUTES
+                      attr-name: slsb-strict-max-pool
+                remote:
+                  attr-cluster: ejb
+                  attr-connectors: http-remoting-connector
+                  attr-thread-pool-name: default
+                  channel-creation-options:
+                    option:
+                      attr-name: MAX_OUTBOUND_MESSAGES
+                      attr-type: remoting
+                      attr-value: '1234'
+                session-bean:
+                  singleton:
+                    attr-default-access-timeout: '5000'
+                  stateful:
+                    attr-cache-ref: simple
+                    attr-default-access-timeout: '5000'
+                    attr-passivation-disabled-cache-ref: simple
+                  stateless:
+                    bean-instance-pool-ref:
+                      attr-pool-name: slsb-strict-max-pool
+                statistics:
+                  attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+                thread-pools:
+                  thread-pool:
+                    attr-name: default
+                    keepalive-time:
+                      attr-time: '60'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '10'
+                timer-service:
+                  attr-default-data-store: default-file-store
+                  attr-thread-pool-name: default
+                  data-stores:
+                    file-data-store:
+                      attr-name: default-file-store
+                      attr-path: timer-service-data
+                      attr-relative-to: jboss.server.data.dir
+              - attr-disallowed-providers: OracleUcrypto
+                attr-final-providers: combined-providers
+                attr-xmlns: urn:wildfly:elytron:13.0
+                audit-logging:
+                  file-audit-log:
+                    attr-format: JSON
+                    attr-name: local-audit
+                    attr-path: audit.log
+                    attr-relative-to: jboss.server.log.dir
+                http:
+                  provider-http-server-mechanism-factory:
+                    attr-name: global
+                mappers:
+                  constant-realm-mapper:
+                    attr-name: local
+                    attr-realm-name: local
+                  constant-role-mapper:
+                    attr-name: super-user-mapper
+                    role:
+                      attr-name: SuperUser
+                  simple-permission-mapper:
+                    attr-mapping-mode: first
+                    attr-name: default-permission-mapper
+                    permission-mapping:
+                    - permission-set:
+                        attr-name: default-permissions
+                      principal:
+                        attr-name: anonymous
+                    - attr-match-all: 'true'
+                      permission-set:
+                      - attr-name: login-permission
+                      - attr-name: default-permissions
+                  simple-role-decoder:
+                    attr-attribute: groups
+                    attr-name: groups-to-roles
+                permission-sets:
+                  permission-set:
+                  - attr-name: login-permission
+                    permission:
+                      attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                  - attr-name: default-permissions
+                    permission:
+                    - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                      attr-module: org.wildfly.extension.batch.jberet
+                      attr-target-name: '*'
+                    - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                      attr-module: org.wildfly.transaction.client
+                    - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                      attr-module: org.jboss.ejb-client
+                providers:
+                  aggregate-providers:
+                    attr-name: combined-providers
+                    providers:
+                    - attr-name: elytron
+                    - attr-name: openssl
+                  provider-loader:
+                  - attr-module: org.wildfly.security.elytron
+                    attr-name: elytron
+                  - attr-module: org.wildfly.openssl
+                    attr-name: openssl
+                sasl:
+                  configurable-sasl-server-factory:
+                    attr-name: configured
+                    attr-sasl-server-factory: elytron
+                    properties:
+                      property:
+                        attr-name: wildfly.sasl.local-user.default-user
+                        attr-value: $local
+                  mechanism-provider-filtering-sasl-server-factory:
+                    attr-name: elytron
+                    attr-sasl-server-factory: global
+                    filters:
+                      filter:
+                        attr-provider-name: WildFlyElytron
+                  provider-sasl-server-factory:
+                    attr-name: global
+                  sasl-authentication-factory:
+                    attr-name: application-sasl-authentication
+                    attr-sasl-server-factory: configured
+                    attr-security-domain: ApplicationDomain
+                    mechanism-configuration:
+                      mechanism:
+                      - attr-mechanism-name: JBOSS-LOCAL-USER
+                        attr-realm-mapper: local
+                      - attr-mechanism-name: DIGEST-MD5
+                        mechanism-realm:
+                          attr-realm-name: ApplicationRealm
+                security-domains:
+                  security-domain:
+                    attr-default-realm: ApplicationRealm
+                    attr-name: ApplicationDomain
+                    attr-permission-mapper: default-permission-mapper
+                    realm:
+                      attr-name: ApplicationRealm
+                      attr-role-decoder: groups-to-roles
+                security-realms:
+                  identity-realm:
+                    attr-identity: $local
+                    attr-name: local
+                  properties-realm:
+                    attr-name: ApplicationRealm
+                    groups-properties:
+                      attr-path: application-roles.properties
+                      attr-relative-to: jboss.domain.config.dir
+                    users-properties:
+                      attr-digest-realm-name: ApplicationRealm
+                      attr-path: application-users.properties
+                      attr-relative-to: jboss.domain.config.dir
+                tls:
+                  key-managers:
+                    key-manager:
+                      attr-generate-self-signed-certificate-host: localhost
+                      attr-key-store: applicationKS
+                      attr-name: applicationKM
+                      credential-reference:
+                        attr-clear-text: password
+                  key-stores:
+                    key-store:
+                      attr-name: applicationKS
+                      credential-reference:
+                        attr-clear-text: password
+                      file:
+                        attr-path: application.keystore
+                        attr-relative-to: jboss.domain.config.dir
+                      implementation:
+                        attr-type: JKS
+                  server-ssl-contexts:
+                    server-ssl-context:
+                      attr-key-manager: applicationKM
+                      attr-name: applicationSSC
+              - attr-xmlns: urn:jboss:domain:infinispan:12.0
+                cache-container:
+                - attr-aliases: sfsb
+                  attr-default-cache: passivation
+                  attr-modules: org.wildfly.clustering.ejb.infinispan
+                  attr-name: ejb
+                  local-cache:
+                    attr-name: passivation
+                    file-store:
+                      attr-passivation: 'true'
+                      attr-purge: 'false'
+                - attr-default-cache: passivation
+                  attr-modules: org.wildfly.clustering.web.infinispan
+                  attr-name: web
+                  local-cache:
+                  - attr-name: passivation
+                    file-store:
+                      attr-passivation: 'true'
+                      attr-purge: 'false'
+                  - attr-name: sso
+                - attr-default-cache: default
+                  attr-modules: org.wildfly.clustering.server
+                  attr-name: server
+                  local-cache:
+                    attr-name: default
+                - attr-modules: org.infinispan.hibernate-cache
+                  attr-name: hibernate
+                  local-cache:
+                  - attr-name: entity
+                    expiration:
+                      attr-max-idle: '100000'
+                    heap-memory:
+                      attr-size: '10000'
+                  - attr-name: local-query
+                    expiration:
+                      attr-max-idle: '100000'
+                    heap-memory:
+                      attr-size: '10000'
+                  - attr-name: timestamps
+                  - attr-name: pending-puts
+                    expiration:
+                      attr-max-idle: '60000'
+              - attr-xmlns: urn:jboss:domain:io:3.0
+                buffer-pool:
+                  attr-name: default
+                worker:
+                  attr-name: default
+              - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+              - archive-validation:
+                  attr-enabled: 'true'
+                  attr-fail-on-error: 'true'
+                  attr-fail-on-warn: 'false'
+                attr-xmlns: urn:jboss:domain:jca:5.0
+                bean-validation:
+                  attr-enabled: 'true'
+                cached-connection-manager: null
+                default-workmanager:
+                  long-running-threads:
+                    core-threads:
+                      attr-count: '50'
+                    keepalive-time:
+                      attr-time: '10'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '50'
+                    queue-length:
+                      attr-count: '50'
+                  short-running-threads:
+                    core-threads:
+                      attr-count: '50'
+                    keepalive-time:
+                      attr-time: '10'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '50'
+                    queue-length:
+                      attr-count: '50'
+              - attr-xmlns: urn:jboss:domain:jdr:1.0
+              - attr-xmlns: urn:jboss:domain:jmx:1.3
+                expose-expression-model: null
+                expose-resolved-model: null
+              - attr-xmlns: urn:jboss:domain:jpa:1.1
+                jpa:
+                  attr-default-extended-persistence-inheritance: DEEP
+              - attr-xmlns: urn:jboss:domain:jsf:1.1
+              - attr-xmlns: urn:jboss:domain:mail:4.0
+                mail-session:
+                  attr-jndi-name: java:jboss/mail/Default
+                  attr-name: default
+                  smtp-server:
+                    attr-outbound-socket-binding-ref: mail-smtp
+              - attr-xmlns: urn:jboss:domain:naming:2.0
+                remote-naming: null
+              - attr-xmlns: urn:jboss:domain:pojo:1.0
+              - attr-xmlns: urn:jboss:domain:remoting:4.0
+                http-connector:
+                  attr-connector-ref: default
+                  attr-name: http-remoting-connector
+                  attr-security-realm: ApplicationRealm
+              - attr-xmlns: urn:jboss:domain:request-controller:1.0
+              - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+              - attr-xmlns: urn:jboss:domain:sar:1.0
+              - attr-xmlns: urn:jboss:domain:security:2.0
+                security-domains:
+                  security-domain:
+                  - attr-cache-type: default
+                    attr-name: other
+                    authentication:
+                      login-module:
+                      - attr-code: Remoting
+                        attr-flag: optional
+                        module-option:
+                          attr-name: password-stacking
+                          attr-value: useFirstPass
+                      - attr-code: RealmDirect
+                        attr-flag: required
+                        module-option:
+                          attr-name: password-stacking
+                          attr-value: useFirstPass
+                  - attr-cache-type: default
+                    attr-name: jboss-web-policy
+                    authorization:
+                      policy-module:
+                        attr-code: Delegating
+                        attr-flag: required
+                  - attr-cache-type: default
+                    attr-name: jaspitest
+                    authentication-jaspi:
+                      auth-module:
+                        attr-code: Dummy
+                      login-module-stack:
+                        attr-name: dummy
+                        login-module:
+                          attr-code: Dummy
+                          attr-flag: optional
+                  - attr-cache-type: default
+                    attr-name: jboss-ejb-policy
+                    authorization:
+                      policy-module:
+                        attr-code: Delegating
+                        attr-flag: required
+              - attr-xmlns: urn:jboss:domain:security-manager:1.0
+                deployment-permissions:
+                  maximum-set:
+                    permission:
+                      attr-class: java.security.AllPermission
+              - attr-xmlns: urn:jboss:domain:transactions:6.0
+                coordinator-environment:
+                  attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+                core-environment:
+                  attr-node-identifier: ${jboss.tx.node.id:1}
+                  process-id:
+                    uuid: null
+                object-store:
+                  attr-path: tx-object-store
+                  attr-relative-to: jboss.server.data.dir
+                recovery-environment:
+                  attr-socket-binding: txn-recovery-environment
+                  attr-status-socket-binding: txn-status-manager
+              - attr-default-security-domain: other
+                attr-default-server: default-server
+                attr-default-servlet-container: default
+                attr-default-virtual-host: default-host
+                attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-xmlns: urn:jboss:domain:undertow:12.0
+                buffer-cache:
+                  attr-name: default
+                handlers:
+                  file:
+                    attr-name: welcome-content
+                    attr-path: ${jboss.home.dir}/welcome-content
+                server:
+                  attr-name: default-server
+                  host:
+                    attr-alias: localhost
+                    attr-name: default-host
+                    http-invoker:
+                      attr-security-realm: ApplicationRealm
+                    location:
+                      attr-handler: welcome-content
+                      attr-name: /
+                  http-listener:
+                    attr-enable-http2: 'true'
+                    attr-name: default
+                    attr-redirect-socket: https
+                    attr-socket-binding: http
+                  https-listener:
+                    attr-enable-http2: 'true'
+                    attr-name: https
+                    attr-security-realm: ApplicationRealm
+                    attr-socket-binding: https
+                servlet-container:
+                  attr-name: default
+                  jsp-config: null
+                  websockets: null
+              - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-xmlns: urn:jboss:domain:webservices:2.0
+                client-config:
+                  attr-name: Standard-Client-Config
+                endpoint-config:
+                - attr-name: Standard-Endpoint-Config
+                - attr-name: Recording-Endpoint-Config
+                  pre-handler-chain:
+                    attr-name: recording-handlers
+                    attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                      ##SOAP12_HTTP_MTOM'
+                    handler:
+                      attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                      attr-name: RecordingHandler
+                wsdl-host: ${jboss.bind.address:127.0.0.1}
+              - attr-xmlns: urn:jboss:domain:weld:4.0
+            - attr-name: ha
+              subsystem:
+              - attr-xmlns: urn:jboss:domain:logging:8.0
+                formatter:
+                - attr-name: PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                - attr-name: COLOR-PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                logger:
+                - attr-category: com.arjuna
+                  level:
+                    attr-name: WARN
+                - attr-category: io.jaegertracing.Configuration
+                  level:
+                    attr-name: WARN
+                - attr-category: org.jboss.as.config
+                  level:
+                    attr-name: DEBUG
+                - attr-category: sun.rmi
+                  level:
+                    attr-name: WARN
+                periodic-rotating-file-handler:
+                  append:
+                    attr-value: 'true'
+                  attr-autoflush: 'true'
+                  attr-name: FILE
+                  file:
+                    attr-path: server.log
+                    attr-relative-to: jboss.server.log.dir
+                  formatter:
+                    named-formatter:
+                      attr-name: PATTERN
+                  suffix:
+                    attr-value: .yyyy-MM-dd
+                root-logger:
+                  handlers:
+                    handler:
+                      attr-name: FILE
+                  level:
+                    attr-name: INFO
+              - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+                default-job-repository:
+                  attr-name: in-memory
+                default-thread-pool:
+                  attr-name: batch
+                job-repository:
+                  attr-name: in-memory
+                  in-memory: null
+                thread-pool:
+                  attr-name: batch
+                  keepalive-time:
+                    attr-time: '30'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '10'
+              - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+              - attr-xmlns: urn:jboss:domain:core-management:1.0
+              - attr-xmlns: urn:jboss:domain:datasources:6.0
+                datasources:
+                  datasource:
+                    attr-enabled: 'true'
+                    attr-jndi-name: java:jboss/datasources/ExampleDS
+                    attr-pool-name: ExampleDS
+                    attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                    attr-use-java-context: 'true'
+                    connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                    driver: h2
+                    security:
+                      password: sa
+                      user-name: sa
+                  drivers:
+                    driver:
+                      attr-module: com.h2database.h2
+                      attr-name: h2
+                      xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+              - attr-xmlns: urn:jboss:domain:discovery:1.0
+              - attr-default-session-management: default
+                attr-default-single-sign-on-management: default
+                attr-xmlns: urn:jboss:domain:distributable-web:2.0
+                infinispan-routing:
+                  attr-cache: routing
+                  attr-cache-container: web
+                infinispan-session-management:
+                  attr-cache-container: web
+                  attr-granularity: SESSION
+                  attr-name: default
+                  primary-owner-affinity: null
+                infinispan-single-sign-on-management:
+                  attr-cache: sso
+                  attr-cache-container: web
+                  attr-name: default
+              - attr-xmlns: urn:jboss:domain:ee:6.0
+                concurrent:
+                  context-services:
+                    context-service:
+                      attr-jndi-name: java:jboss/ee/concurrency/context/default
+                      attr-name: default
+                      attr-use-transaction-setup-provider: 'true'
+                  managed-executor-services:
+                    managed-executor-service:
+                      attr-context-service: default
+                      attr-hung-task-termination-period: '0'
+                      attr-hung-task-threshold: '60000'
+                      attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                      attr-keepalive-time: '5000'
+                      attr-name: default
+                  managed-scheduled-executor-services:
+                    managed-scheduled-executor-service:
+                      attr-context-service: default
+                      attr-hung-task-termination-period: '0'
+                      attr-hung-task-threshold: '60000'
+                      attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                      attr-keepalive-time: '3000'
+                      attr-name: default
+                  managed-thread-factories:
+                    managed-thread-factory:
+                      attr-context-service: default
+                      attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                      attr-name: default
+                default-bindings:
+                  attr-context-service: java:jboss/ee/concurrency/context/default
+                  attr-datasource: java:jboss/datasources/ExampleDS
+                  attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+                  attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+                  attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+                spec-descriptor-property-replacement: 'false'
+              - attr-xmlns: urn:jboss:domain:ee-security:1.0
+              - async:
+                  attr-thread-pool-name: default
+                attr-xmlns: urn:jboss:domain:ejb3:9.0
+                caches:
+                  cache:
+                  - attr-name: simple
+                  - attr-aliases: passivating clustered
+                    attr-name: distributable
+                    attr-passivation-store-ref: infinispan
+                default-missing-method-permissions-deny-access:
+                  attr-value: 'true'
+                default-security-domain:
+                  attr-value: other
+                log-system-exceptions:
+                  attr-value: 'true'
+                passivation-stores:
+                  passivation-store:
+                    attr-cache-container: ejb
+                    attr-max-size: '10000'
+                    attr-name: infinispan
+                pools:
+                  bean-instance-pools:
+                    strict-max-pool:
+                    - attr-derive-size: from-cpu-count
+                      attr-instance-acquisition-timeout: '5'
+                      attr-instance-acquisition-timeout-unit: MINUTES
+                      attr-name: mdb-strict-max-pool
+                    - attr-derive-size: from-worker-pools
+                      attr-instance-acquisition-timeout: '5'
+                      attr-instance-acquisition-timeout-unit: MINUTES
+                      attr-name: slsb-strict-max-pool
+                remote:
+                  attr-cluster: ejb
+                  attr-connectors: http-remoting-connector
+                  attr-thread-pool-name: default
+                  channel-creation-options:
+                    option:
+                      attr-name: MAX_OUTBOUND_MESSAGES
+                      attr-type: remoting
+                      attr-value: '1234'
+                session-bean:
+                  singleton:
+                    attr-default-access-timeout: '5000'
+                  stateful:
+                    attr-cache-ref: distributable
+                    attr-default-access-timeout: '5000'
+                    attr-passivation-disabled-cache-ref: simple
+                  stateless:
+                    bean-instance-pool-ref:
+                      attr-pool-name: slsb-strict-max-pool
+                statistics:
+                  attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+                thread-pools:
+                  thread-pool:
+                    attr-name: default
+                    keepalive-time:
+                      attr-time: '60'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '10'
+                timer-service:
+                  attr-default-data-store: default-file-store
+                  attr-thread-pool-name: default
+                  data-stores:
+                    file-data-store:
+                      attr-name: default-file-store
+                      attr-path: timer-service-data
+                      attr-relative-to: jboss.server.data.dir
+              - attr-disallowed-providers: OracleUcrypto
+                attr-final-providers: combined-providers
+                attr-xmlns: urn:wildfly:elytron:13.0
+                audit-logging:
+                  file-audit-log:
+                    attr-format: JSON
+                    attr-name: local-audit
+                    attr-path: audit.log
+                    attr-relative-to: jboss.server.log.dir
+                http:
+                  provider-http-server-mechanism-factory:
+                    attr-name: global
+                mappers:
+                  constant-realm-mapper:
+                    attr-name: local
+                    attr-realm-name: local
+                  constant-role-mapper:
+                    attr-name: super-user-mapper
+                    role:
+                      attr-name: SuperUser
+                  simple-permission-mapper:
+                    attr-mapping-mode: first
+                    attr-name: default-permission-mapper
+                    permission-mapping:
+                    - permission-set:
+                        attr-name: default-permissions
+                      principal:
+                        attr-name: anonymous
+                    - attr-match-all: 'true'
+                      permission-set:
+                      - attr-name: login-permission
+                      - attr-name: default-permissions
+                  simple-role-decoder:
+                    attr-attribute: groups
+                    attr-name: groups-to-roles
+                permission-sets:
+                  permission-set:
+                  - attr-name: login-permission
+                    permission:
+                      attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                  - attr-name: default-permissions
+                    permission:
+                    - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                      attr-module: org.wildfly.extension.batch.jberet
+                      attr-target-name: '*'
+                    - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                      attr-module: org.wildfly.transaction.client
+                    - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                      attr-module: org.jboss.ejb-client
+                providers:
+                  aggregate-providers:
+                    attr-name: combined-providers
+                    providers:
+                    - attr-name: elytron
+                    - attr-name: openssl
+                  provider-loader:
+                  - attr-module: org.wildfly.security.elytron
+                    attr-name: elytron
+                  - attr-module: org.wildfly.openssl
+                    attr-name: openssl
+                sasl:
+                  configurable-sasl-server-factory:
+                    attr-name: configured
+                    attr-sasl-server-factory: elytron
+                    properties:
+                      property:
+                        attr-name: wildfly.sasl.local-user.default-user
+                        attr-value: $local
+                  mechanism-provider-filtering-sasl-server-factory:
+                    attr-name: elytron
+                    attr-sasl-server-factory: global
+                    filters:
+                      filter:
+                        attr-provider-name: WildFlyElytron
+                  provider-sasl-server-factory:
+                    attr-name: global
+                  sasl-authentication-factory:
+                    attr-name: application-sasl-authentication
+                    attr-sasl-server-factory: configured
+                    attr-security-domain: ApplicationDomain
+                    mechanism-configuration:
+                      mechanism:
+                      - attr-mechanism-name: JBOSS-LOCAL-USER
+                        attr-realm-mapper: local
+                      - attr-mechanism-name: DIGEST-MD5
+                        mechanism-realm:
+                          attr-realm-name: ApplicationRealm
+                security-domains:
+                  security-domain:
+                    attr-default-realm: ApplicationRealm
+                    attr-name: ApplicationDomain
+                    attr-permission-mapper: default-permission-mapper
+                    realm:
+                      attr-name: ApplicationRealm
+                      attr-role-decoder: groups-to-roles
+                security-realms:
+                  identity-realm:
+                    attr-identity: $local
+                    attr-name: local
+                  properties-realm:
+                    attr-name: ApplicationRealm
+                    groups-properties:
+                      attr-path: application-roles.properties
+                      attr-relative-to: jboss.domain.config.dir
+                    users-properties:
+                      attr-digest-realm-name: ApplicationRealm
+                      attr-path: application-users.properties
+                      attr-relative-to: jboss.domain.config.dir
+                tls:
+                  key-managers:
+                    key-manager:
+                      attr-generate-self-signed-certificate-host: localhost
+                      attr-key-store: applicationKS
+                      attr-name: applicationKM
+                      credential-reference:
+                        attr-clear-text: password
+                  key-stores:
+                    key-store:
+                      attr-name: applicationKS
+                      credential-reference:
+                        attr-clear-text: password
+                      file:
+                        attr-path: application.keystore
+                        attr-relative-to: jboss.domain.config.dir
+                      implementation:
+                        attr-type: JKS
+                  server-ssl-contexts:
+                    server-ssl-context:
+                      attr-key-manager: applicationKM
+                      attr-name: applicationSSC
+              - attr-xmlns: urn:jboss:domain:infinispan:12.0
+                cache-container:
+                - attr-aliases: sfsb
+                  attr-default-cache: dist
+                  attr-modules: org.wildfly.clustering.ejb.infinispan
+                  attr-name: ejb
+                  distributed-cache:
+                    attr-name: dist
+                    file-store: null
+                    locking:
+                      attr-isolation: REPEATABLE_READ
+                    transaction:
+                      attr-mode: BATCH
+                  transport:
+                    attr-lock-timeout: '60000'
+                - attr-aliases: singleton cluster
+                  attr-default-cache: default
+                  attr-modules: org.wildfly.clustering.server
+                  attr-name: server
+                  replicated-cache:
+                    attr-name: default
+                    transaction:
+                      attr-mode: BATCH
+                  transport:
+                    attr-lock-timeout: '60000'
+                - attr-default-cache: dist
+                  attr-modules: org.wildfly.clustering.web.infinispan
+                  attr-name: web
+                  distributed-cache:
+                    attr-name: dist
+                    file-store: null
+                    locking:
+                      attr-isolation: REPEATABLE_READ
+                    transaction:
+                      attr-mode: BATCH
+                  replicated-cache:
+                  - attr-name: sso
+                    locking:
+                      attr-isolation: REPEATABLE_READ
+                    transaction:
+                      attr-mode: BATCH
+                  - attr-name: routing
+                  transport:
+                    attr-lock-timeout: '60000'
+                - attr-modules: org.infinispan.hibernate-cache
+                  attr-name: hibernate
+                  invalidation-cache:
+                    attr-name: entity
+                    expiration:
+                      attr-max-idle: '100000'
+                    heap-memory:
+                      attr-size: '10000'
+                  local-cache:
+                  - attr-name: local-query
+                    expiration:
+                      attr-max-idle: '100000'
+                    heap-memory:
+                      attr-size: '10000'
+                  - attr-name: pending-puts
+                    expiration:
+                      attr-max-idle: '60000'
+                  replicated-cache:
+                    attr-name: timestamps
+                  transport:
+                    attr-lock-timeout: '60000'
+              - attr-xmlns: urn:jboss:domain:io:3.0
+                buffer-pool:
+                  attr-name: default
+                worker:
+                  attr-name: default
+              - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+              - archive-validation:
+                  attr-enabled: 'true'
+                  attr-fail-on-error: 'true'
+                  attr-fail-on-warn: 'false'
+                attr-xmlns: urn:jboss:domain:jca:5.0
+                bean-validation:
+                  attr-enabled: 'true'
+                cached-connection-manager: null
+                default-workmanager:
+                  long-running-threads:
+                    core-threads:
+                      attr-count: '50'
+                    keepalive-time:
+                      attr-time: '10'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '50'
+                    queue-length:
+                      attr-count: '50'
+                  short-running-threads:
+                    core-threads:
+                      attr-count: '50'
+                    keepalive-time:
+                      attr-time: '10'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '50'
+                    queue-length:
+                      attr-count: '50'
+              - attr-xmlns: urn:jboss:domain:jdr:1.0
+              - attr-xmlns: urn:jboss:domain:jgroups:8.0
+                channels:
+                  attr-default: ee
+                  channel:
+                    attr-cluster: ejb
+                    attr-name: ee
+                    attr-stack: udp
+                stacks:
+                  stack:
+                  - attr-name: udp
+                    protocol:
+                    - attr-type: PING
+                    - attr-type: MERGE3
+                    - attr-type: FD_ALL
+                    - attr-type: VERIFY_SUSPECT
+                    - attr-type: pbcast.NAKACK2
+                    - attr-type: UNICAST3
+                    - attr-type: pbcast.STABLE
+                    - attr-type: pbcast.GMS
+                    - attr-type: UFC
+                    - attr-type: MFC
+                    - attr-type: FRAG3
+                    socket-protocol:
+                      attr-socket-binding: jgroups-udp-fd
+                      attr-type: FD_SOCK
+                    transport:
+                      attr-socket-binding: jgroups-udp
+                      attr-type: UDP
+                  - attr-name: tcp
+                    protocol:
+                    - attr-type: MERGE3
+                    - attr-type: FD_ALL
+                    - attr-type: VERIFY_SUSPECT
+                    - attr-type: pbcast.NAKACK2
+                    - attr-type: UNICAST3
+                    - attr-type: pbcast.STABLE
+                    - attr-type: pbcast.GMS
+                    - attr-type: MFC
+                    - attr-type: FRAG3
+                    socket-protocol:
+                    - attr-socket-binding: jgroups-mping
+                      attr-type: MPING
+                    - attr-socket-binding: jgroups-tcp-fd
+                      attr-type: FD_SOCK
+                    transport:
+                      attr-socket-binding: jgroups-tcp
+                      attr-type: TCP
+              - attr-xmlns: urn:jboss:domain:jmx:1.3
+                expose-expression-model: null
+                expose-resolved-model: null
+              - attr-xmlns: urn:jboss:domain:jpa:1.1
+                jpa:
+                  attr-default-extended-persistence-inheritance: DEEP
+              - attr-xmlns: urn:jboss:domain:jsf:1.1
+              - attr-xmlns: urn:jboss:domain:mail:4.0
+                mail-session:
+                  attr-jndi-name: java:jboss/mail/Default
+                  attr-name: default
+                  smtp-server:
+                    attr-outbound-socket-binding-ref: mail-smtp
+              - attr-xmlns: urn:jboss:domain:modcluster:5.0
+                proxy:
+                  attr-advertise-socket: modcluster
+                  attr-listener: ajp
+                  attr-name: default
+                  dynamic-load-provider:
+                    load-metric:
+                      attr-type: cpu
+              - attr-xmlns: urn:jboss:domain:naming:2.0
+                remote-naming: null
+              - attr-xmlns: urn:jboss:domain:pojo:1.0
+              - attr-xmlns: urn:jboss:domain:remoting:4.0
+                http-connector:
+                  attr-connector-ref: default
+                  attr-name: http-remoting-connector
+                  attr-security-realm: ApplicationRealm
+              - attr-xmlns: urn:jboss:domain:request-controller:1.0
+              - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+              - attr-xmlns: urn:jboss:domain:sar:1.0
+              - attr-xmlns: urn:jboss:domain:security:2.0
+                security-domains:
+                  security-domain:
+                  - attr-cache-type: default
+                    attr-name: other
+                    authentication:
+                      login-module:
+                      - attr-code: Remoting
+                        attr-flag: optional
+                        module-option:
+                          attr-name: password-stacking
+                          attr-value: useFirstPass
+                      - attr-code: RealmDirect
+                        attr-flag: required
+                        module-option:
+                          attr-name: password-stacking
+                          attr-value: useFirstPass
+                  - attr-cache-type: default
+                    attr-name: jboss-web-policy
+                    authorization:
+                      policy-module:
+                        attr-code: Delegating
+                        attr-flag: required
+                  - attr-cache-type: default
+                    attr-name: jaspitest
+                    authentication-jaspi:
+                      auth-module:
+                        attr-code: Dummy
+                      login-module-stack:
+                        attr-name: dummy
+                        login-module:
+                          attr-code: Dummy
+                          attr-flag: optional
+                  - attr-cache-type: default
+                    attr-name: jboss-ejb-policy
+                    authorization:
+                      policy-module:
+                        attr-code: Delegating
+                        attr-flag: required
+              - attr-xmlns: urn:jboss:domain:security-manager:1.0
+                deployment-permissions:
+                  maximum-set:
+                    permission:
+                      attr-class: java.security.AllPermission
+              - attr-xmlns: urn:jboss:domain:singleton:1.0
+                singleton-policies:
+                  attr-default: default
+                  singleton-policy:
+                    attr-cache-container: server
+                    attr-name: default
+                    simple-election-policy: null
+              - attr-xmlns: urn:jboss:domain:transactions:6.0
+                coordinator-environment:
+                  attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+                core-environment:
+                  attr-node-identifier: ${jboss.tx.node.id:1}
+                  process-id:
+                    uuid: null
+                object-store:
+                  attr-path: tx-object-store
+                  attr-relative-to: jboss.server.data.dir
+                recovery-environment:
+                  attr-socket-binding: txn-recovery-environment
+                  attr-status-socket-binding: txn-status-manager
+              - attr-default-security-domain: other
+                attr-default-server: default-server
+                attr-default-servlet-container: default
+                attr-default-virtual-host: default-host
+                attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-xmlns: urn:jboss:domain:undertow:12.0
+                buffer-cache:
+                  attr-name: default
+                handlers:
+                  file:
+                    attr-name: welcome-content
+                    attr-path: ${jboss.home.dir}/welcome-content
+                server:
+                  ajp-listener:
+                    attr-name: ajp
+                    attr-socket-binding: ajp
+                  attr-name: default-server
+                  host:
+                    attr-alias: localhost
+                    attr-name: default-host
+                    http-invoker:
+                      attr-security-realm: ApplicationRealm
+                    location:
+                      attr-handler: welcome-content
+                      attr-name: /
+                  http-listener:
+                    attr-enable-http2: 'true'
+                    attr-name: default
+                    attr-redirect-socket: https
+                    attr-socket-binding: http
+                  https-listener:
+                    attr-enable-http2: 'true'
+                    attr-name: https
+                    attr-security-realm: ApplicationRealm
+                    attr-socket-binding: https
+                servlet-container:
+                  attr-name: default
+                  jsp-config: null
+                  websockets: null
+              - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-xmlns: urn:jboss:domain:webservices:2.0
+                client-config:
+                  attr-name: Standard-Client-Config
+                endpoint-config:
+                - attr-name: Standard-Endpoint-Config
+                - attr-name: Recording-Endpoint-Config
+                  pre-handler-chain:
+                    attr-name: recording-handlers
+                    attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                      ##SOAP12_HTTP_MTOM'
+                    handler:
+                      attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                      attr-name: RecordingHandler
+                wsdl-host: ${jboss.bind.address:127.0.0.1}
+              - attr-xmlns: urn:jboss:domain:weld:4.0
+            - attr-name: full
+              subsystem:
+              - attr-xmlns: urn:jboss:domain:logging:8.0
+                formatter:
+                - attr-name: PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                - attr-name: COLOR-PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                logger:
+                - attr-category: com.arjuna
+                  level:
+                    attr-name: WARN
+                - attr-category: io.jaegertracing.Configuration
+                  level:
+                    attr-name: WARN
+                - attr-category: org.jboss.as.config
+                  level:
+                    attr-name: DEBUG
+                - attr-category: sun.rmi
+                  level:
+                    attr-name: WARN
+                periodic-rotating-file-handler:
+                  append:
+                    attr-value: 'true'
+                  attr-autoflush: 'true'
+                  attr-name: FILE
+                  file:
+                    attr-path: server.log
+                    attr-relative-to: jboss.server.log.dir
+                  formatter:
+                    named-formatter:
+                      attr-name: PATTERN
+                  suffix:
+                    attr-value: .yyyy-MM-dd
+                root-logger:
+                  handlers:
+                    handler:
+                      attr-name: FILE
+                  level:
+                    attr-name: INFO
+              - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+                default-job-repository:
+                  attr-name: in-memory
+                default-thread-pool:
+                  attr-name: batch
+                job-repository:
+                  attr-name: in-memory
+                  in-memory: null
+                thread-pool:
+                  attr-name: batch
+                  keepalive-time:
+                    attr-time: '30'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '10'
+              - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+              - attr-xmlns: urn:jboss:domain:core-management:1.0
+              - attr-xmlns: urn:jboss:domain:datasources:6.0
+                datasources:
+                  datasource:
+                    attr-enabled: 'true'
+                    attr-jndi-name: java:jboss/datasources/ExampleDS
+                    attr-pool-name: ExampleDS
+                    attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                    attr-use-java-context: 'true'
+                    connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                    driver: h2
+                    security:
+                      password: sa
+                      user-name: sa
+                  drivers:
+                    driver:
+                      attr-module: com.h2database.h2
+                      attr-name: h2
+                      xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+              - attr-xmlns: urn:jboss:domain:discovery:1.0
+              - attr-default-session-management: default
+                attr-default-single-sign-on-management: default
+                attr-xmlns: urn:jboss:domain:distributable-web:2.0
+                infinispan-session-management:
+                  attr-cache-container: web
+                  attr-granularity: SESSION
+                  attr-name: default
+                  local-affinity: null
+                infinispan-single-sign-on-management:
+                  attr-cache: sso
+                  attr-cache-container: web
+                  attr-name: default
+                local-routing: null
+              - attr-xmlns: urn:jboss:domain:ee:6.0
+                concurrent:
+                  context-services:
+                    context-service:
+                      attr-jndi-name: java:jboss/ee/concurrency/context/default
+                      attr-name: default
+                      attr-use-transaction-setup-provider: 'true'
+                  managed-executor-services:
+                    managed-executor-service:
+                      attr-context-service: default
+                      attr-hung-task-termination-period: '0'
+                      attr-hung-task-threshold: '60000'
+                      attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                      attr-keepalive-time: '5000'
+                      attr-name: default
+                  managed-scheduled-executor-services:
+                    managed-scheduled-executor-service:
+                      attr-context-service: default
+                      attr-hung-task-termination-period: '0'
+                      attr-hung-task-threshold: '60000'
+                      attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                      attr-keepalive-time: '3000'
+                      attr-name: default
+                  managed-thread-factories:
+                    managed-thread-factory:
+                      attr-context-service: default
+                      attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                      attr-name: default
+                default-bindings:
+                  attr-context-service: java:jboss/ee/concurrency/context/default
+                  attr-datasource: java:jboss/datasources/ExampleDS
+                  attr-jms-connection-factory: java:jboss/DefaultJMSConnectionFactory
+                  attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+                  attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+                  attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+                spec-descriptor-property-replacement: 'false'
+              - attr-xmlns: urn:jboss:domain:ee-security:1.0
+              - async:
+                  attr-thread-pool-name: default
+                attr-xmlns: urn:jboss:domain:ejb3:9.0
+                caches:
+                  cache:
+                  - attr-name: simple
+                  - attr-aliases: passivating clustered
+                    attr-name: distributable
+                    attr-passivation-store-ref: infinispan
+                default-missing-method-permissions-deny-access:
+                  attr-value: 'true'
+                default-security-domain:
+                  attr-value: other
+                iiop:
+                  attr-enable-by-default: 'false'
+                  attr-use-qualified-name: 'false'
+                log-system-exceptions:
+                  attr-value: 'true'
+                mdb:
+                  bean-instance-pool-ref:
+                    attr-pool-name: mdb-strict-max-pool
+                  resource-adapter-ref:
+                    attr-resource-adapter-name: ${ejb.resource-adapter-name:activemq-ra.rar}
+                passivation-stores:
+                  passivation-store:
+                    attr-cache-container: ejb
+                    attr-max-size: '10000'
+                    attr-name: infinispan
+                pools:
+                  bean-instance-pools:
+                    strict-max-pool:
+                    - attr-derive-size: from-cpu-count
+                      attr-instance-acquisition-timeout: '5'
+                      attr-instance-acquisition-timeout-unit: MINUTES
+                      attr-name: mdb-strict-max-pool
+                    - attr-derive-size: from-worker-pools
+                      attr-instance-acquisition-timeout: '5'
+                      attr-instance-acquisition-timeout-unit: MINUTES
+                      attr-name: slsb-strict-max-pool
+                remote:
+                  attr-cluster: ejb
+                  attr-connectors: http-remoting-connector
+                  attr-thread-pool-name: default
+                  channel-creation-options:
+                    option:
+                      attr-name: MAX_OUTBOUND_MESSAGES
+                      attr-type: remoting
+                      attr-value: '1234'
+                session-bean:
+                  singleton:
+                    attr-default-access-timeout: '5000'
+                  stateful:
+                    attr-cache-ref: simple
+                    attr-default-access-timeout: '5000'
+                    attr-passivation-disabled-cache-ref: simple
+                  stateless:
+                    bean-instance-pool-ref:
+                      attr-pool-name: slsb-strict-max-pool
+                statistics:
+                  attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+                thread-pools:
+                  thread-pool:
+                    attr-name: default
+                    keepalive-time:
+                      attr-time: '60'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '10'
+                timer-service:
+                  attr-default-data-store: default-file-store
+                  attr-thread-pool-name: default
+                  data-stores:
+                    file-data-store:
+                      attr-name: default-file-store
+                      attr-path: timer-service-data
+                      attr-relative-to: jboss.server.data.dir
+              - attr-disallowed-providers: OracleUcrypto
+                attr-final-providers: combined-providers
+                attr-xmlns: urn:wildfly:elytron:13.0
+                audit-logging:
+                  file-audit-log:
+                    attr-format: JSON
+                    attr-name: local-audit
+                    attr-path: audit.log
+                    attr-relative-to: jboss.server.log.dir
+                http:
+                  provider-http-server-mechanism-factory:
+                    attr-name: global
+                mappers:
+                  constant-realm-mapper:
+                    attr-name: local
+                    attr-realm-name: local
+                  constant-role-mapper:
+                    attr-name: super-user-mapper
+                    role:
+                      attr-name: SuperUser
+                  simple-permission-mapper:
+                    attr-mapping-mode: first
+                    attr-name: default-permission-mapper
+                    permission-mapping:
+                    - permission-set:
+                        attr-name: default-permissions
+                      principal:
+                        attr-name: anonymous
+                    - attr-match-all: 'true'
+                      permission-set:
+                      - attr-name: login-permission
+                      - attr-name: default-permissions
+                  simple-role-decoder:
+                    attr-attribute: groups
+                    attr-name: groups-to-roles
+                permission-sets:
+                  permission-set:
+                  - attr-name: login-permission
+                    permission:
+                      attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                  - attr-name: default-permissions
+                    permission:
+                    - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                      attr-module: org.wildfly.extension.batch.jberet
+                      attr-target-name: '*'
+                    - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                      attr-module: org.wildfly.transaction.client
+                    - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                      attr-module: org.jboss.ejb-client
+                providers:
+                  aggregate-providers:
+                    attr-name: combined-providers
+                    providers:
+                    - attr-name: elytron
+                    - attr-name: openssl
+                  provider-loader:
+                  - attr-module: org.wildfly.security.elytron
+                    attr-name: elytron
+                  - attr-module: org.wildfly.openssl
+                    attr-name: openssl
+                sasl:
+                  configurable-sasl-server-factory:
+                    attr-name: configured
+                    attr-sasl-server-factory: elytron
+                    properties:
+                      property:
+                        attr-name: wildfly.sasl.local-user.default-user
+                        attr-value: $local
+                  mechanism-provider-filtering-sasl-server-factory:
+                    attr-name: elytron
+                    attr-sasl-server-factory: global
+                    filters:
+                      filter:
+                        attr-provider-name: WildFlyElytron
+                  provider-sasl-server-factory:
+                    attr-name: global
+                  sasl-authentication-factory:
+                    attr-name: application-sasl-authentication
+                    attr-sasl-server-factory: configured
+                    attr-security-domain: ApplicationDomain
+                    mechanism-configuration:
+                      mechanism:
+                      - attr-mechanism-name: JBOSS-LOCAL-USER
+                        attr-realm-mapper: local
+                      - attr-mechanism-name: DIGEST-MD5
+                        mechanism-realm:
+                          attr-realm-name: ApplicationRealm
+                security-domains:
+                  security-domain:
+                    attr-default-realm: ApplicationRealm
+                    attr-name: ApplicationDomain
+                    attr-permission-mapper: default-permission-mapper
+                    realm:
+                      attr-name: ApplicationRealm
+                      attr-role-decoder: groups-to-roles
+                security-realms:
+                  identity-realm:
+                    attr-identity: $local
+                    attr-name: local
+                  properties-realm:
+                    attr-name: ApplicationRealm
+                    groups-properties:
+                      attr-path: application-roles.properties
+                      attr-relative-to: jboss.domain.config.dir
+                    users-properties:
+                      attr-digest-realm-name: ApplicationRealm
+                      attr-path: application-users.properties
+                      attr-relative-to: jboss.domain.config.dir
+                tls:
+                  key-managers:
+                    key-manager:
+                      attr-generate-self-signed-certificate-host: localhost
+                      attr-key-store: applicationKS
+                      attr-name: applicationKM
+                      credential-reference:
+                        attr-clear-text: password
+                  key-stores:
+                    key-store:
+                      attr-name: applicationKS
+                      credential-reference:
+                        attr-clear-text: password
+                      file:
+                        attr-path: application.keystore
+                        attr-relative-to: jboss.domain.config.dir
+                      implementation:
+                        attr-type: JKS
+                  server-ssl-contexts:
+                    server-ssl-context:
+                      attr-key-manager: applicationKM
+                      attr-name: applicationSSC
+              - attr-xmlns: urn:jboss:domain:iiop-openjdk:2.1
+                initializers:
+                  attr-security: identity
+                  attr-transactions: spec
+                orb:
+                  attr-socket-binding: iiop
+                security:
+                  attr-client-requires-ssl: 'false'
+                  attr-server-requires-ssl: 'false'
+              - attr-xmlns: urn:jboss:domain:infinispan:12.0
+                cache-container:
+                - attr-aliases: sfsb
+                  attr-default-cache: passivation
+                  attr-modules: org.wildfly.clustering.ejb.infinispan
+                  attr-name: ejb
+                  local-cache:
+                    attr-name: passivation
+                    file-store:
+                      attr-passivation: 'true'
+                      attr-purge: 'false'
+                - attr-default-cache: passivation
+                  attr-modules: org.wildfly.clustering.web.infinispan
+                  attr-name: web
+                  local-cache:
+                  - attr-name: passivation
+                    file-store:
+                      attr-passivation: 'true'
+                      attr-purge: 'false'
+                  - attr-name: sso
+                - attr-default-cache: default
+                  attr-modules: org.wildfly.clustering.server
+                  attr-name: server
+                  local-cache:
+                    attr-name: default
+                - attr-modules: org.infinispan.hibernate-cache
+                  attr-name: hibernate
+                  local-cache:
+                  - attr-name: entity
+                    expiration:
+                      attr-max-idle: '100000'
+                    heap-memory:
+                      attr-size: '10000'
+                  - attr-name: local-query
+                    expiration:
+                      attr-max-idle: '100000'
+                    heap-memory:
+                      attr-size: '10000'
+                  - attr-name: timestamps
+                  - attr-name: pending-puts
+                    expiration:
+                      attr-max-idle: '60000'
+              - attr-xmlns: urn:jboss:domain:io:3.0
+                buffer-pool:
+                  attr-name: default
+                worker:
+                  attr-name: default
+              - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+              - archive-validation:
+                  attr-enabled: 'true'
+                  attr-fail-on-error: 'true'
+                  attr-fail-on-warn: 'false'
+                attr-xmlns: urn:jboss:domain:jca:5.0
+                bean-validation:
+                  attr-enabled: 'true'
+                cached-connection-manager: null
+                default-workmanager:
+                  long-running-threads:
+                    core-threads:
+                      attr-count: '50'
+                    keepalive-time:
+                      attr-time: '10'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '50'
+                    queue-length:
+                      attr-count: '50'
+                  short-running-threads:
+                    core-threads:
+                      attr-count: '50'
+                    keepalive-time:
+                      attr-time: '10'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '50'
+                    queue-length:
+                      attr-count: '50'
+              - attr-xmlns: urn:jboss:domain:jdr:1.0
+              - attr-xmlns: urn:jboss:domain:jmx:1.3
+                expose-expression-model: null
+                expose-resolved-model: null
+              - attr-xmlns: urn:jboss:domain:jpa:1.1
+                jpa:
+                  attr-default-extended-persistence-inheritance: DEEP
+              - attr-xmlns: urn:jboss:domain:jsf:1.1
+              - attr-xmlns: urn:jboss:domain:jsr77:1.0
+              - attr-xmlns: urn:jboss:domain:mail:4.0
+                mail-session:
+                  attr-jndi-name: java:jboss/mail/Default
+                  attr-name: default
+                  smtp-server:
+                    attr-outbound-socket-binding-ref: mail-smtp
+              - attr-xmlns: urn:jboss:domain:messaging-activemq:13.0
+                server:
+                  address-setting:
+                    attr-dead-letter-address: jms.queue.DLQ
+                    attr-expiry-address: jms.queue.ExpiryQueue
+                    attr-max-size-bytes: '10485760'
+                    attr-message-counter-history-day-limit: '10'
+                    attr-name: '#'
+                    attr-page-size-bytes: '2097152'
+                  attr-name: default
+                  connection-factory:
+                  - attr-connectors: in-vm
+                    attr-entries: java:/ConnectionFactory
+                    attr-name: InVmConnectionFactory
+                  - attr-connectors: http-connector
+                    attr-entries: java:jboss/exported/jms/RemoteConnectionFactory
+                    attr-name: RemoteConnectionFactory
+                  http-acceptor:
+                  - attr-http-listener: default
+                    attr-name: http-acceptor
+                  - attr-http-listener: default
+                    attr-name: http-acceptor-throughput
+                    param:
+                    - attr-name: batch-delay
+                      attr-value: '50'
+                    - attr-name: direct-deliver
+                      attr-value: 'false'
+                  http-connector:
+                  - attr-endpoint: http-acceptor
+                    attr-name: http-connector
+                    attr-socket-binding: http
+                  - attr-endpoint: http-acceptor-throughput
+                    attr-name: http-connector-throughput
+                    attr-socket-binding: http
+                    param:
+                      attr-name: batch-delay
+                      attr-value: '50'
+                  in-vm-acceptor:
+                    attr-name: in-vm
+                    attr-server-id: '0'
+                    param:
+                      attr-name: buffer-pooling
+                      attr-value: 'false'
+                  in-vm-connector:
+                    attr-name: in-vm
+                    attr-server-id: '0'
+                    param:
+                      attr-name: buffer-pooling
+                      attr-value: 'false'
+                  jms-queue:
+                  - attr-entries: java:/jms/queue/ExpiryQueue
+                    attr-name: ExpiryQueue
+                  - attr-entries: java:/jms/queue/DLQ
+                    attr-name: DLQ
+                  pooled-connection-factory:
+                    attr-connectors: in-vm
+                    attr-entries: java:/JmsXA java:jboss/DefaultJMSConnectionFactory
+                    attr-name: activemq-ra
+                    attr-transaction: xa
+                  security-setting:
+                    attr-name: '#'
+                    role:
+                      attr-consume: 'true'
+                      attr-create-non-durable-queue: 'true'
+                      attr-delete-non-durable-queue: 'true'
+                      attr-name: guest
+                      attr-send: 'true'
+                  statistics:
+                    attr-enabled: ${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}
+              - attr-xmlns: urn:jboss:domain:naming:2.0
+                remote-naming: null
+              - attr-xmlns: urn:jboss:domain:pojo:1.0
+              - attr-xmlns: urn:jboss:domain:remoting:4.0
+                http-connector:
+                  attr-connector-ref: default
+                  attr-name: http-remoting-connector
+                  attr-security-realm: ApplicationRealm
+              - attr-xmlns: urn:jboss:domain:request-controller:1.0
+              - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+              - attr-xmlns: urn:jboss:domain:sar:1.0
+              - attr-xmlns: urn:jboss:domain:security:2.0
+                security-domains:
+                  security-domain:
+                  - attr-cache-type: default
+                    attr-name: other
+                    authentication:
+                      login-module:
+                      - attr-code: Remoting
+                        attr-flag: optional
+                        module-option:
+                          attr-name: password-stacking
+                          attr-value: useFirstPass
+                      - attr-code: RealmDirect
+                        attr-flag: required
+                        module-option:
+                          attr-name: password-stacking
+                          attr-value: useFirstPass
+                  - attr-cache-type: default
+                    attr-name: jboss-web-policy
+                    authorization:
+                      policy-module:
+                        attr-code: Delegating
+                        attr-flag: required
+                  - attr-cache-type: default
+                    attr-name: jaspitest
+                    authentication-jaspi:
+                      auth-module:
+                        attr-code: Dummy
+                      login-module-stack:
+                        attr-name: dummy
+                        login-module:
+                          attr-code: Dummy
+                          attr-flag: optional
+                  - attr-cache-type: default
+                    attr-name: jboss-ejb-policy
+                    authorization:
+                      policy-module:
+                        attr-code: Delegating
+                        attr-flag: required
+              - attr-xmlns: urn:jboss:domain:security-manager:1.0
+                deployment-permissions:
+                  maximum-set:
+                    permission:
+                      attr-class: java.security.AllPermission
+              - attr-xmlns: urn:jboss:domain:transactions:6.0
+                coordinator-environment:
+                  attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+                core-environment:
+                  attr-node-identifier: ${jboss.tx.node.id:1}
+                  process-id:
+                    uuid: null
+                object-store:
+                  attr-path: tx-object-store
+                  attr-relative-to: jboss.server.data.dir
+                recovery-environment:
+                  attr-socket-binding: txn-recovery-environment
+                  attr-status-socket-binding: txn-status-manager
+              - attr-default-security-domain: other
+                attr-default-server: default-server
+                attr-default-servlet-container: default
+                attr-default-virtual-host: default-host
+                attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-xmlns: urn:jboss:domain:undertow:12.0
+                buffer-cache:
+                  attr-name: default
+                handlers:
+                  file:
+                    attr-name: welcome-content
+                    attr-path: ${jboss.home.dir}/welcome-content
+                server:
+                  attr-name: default-server
+                  host:
+                    attr-alias: localhost
+                    attr-name: default-host
+                    http-invoker:
+                      attr-security-realm: ApplicationRealm
+                    location:
+                      attr-handler: welcome-content
+                      attr-name: /
+                  http-listener:
+                    attr-enable-http2: 'true'
+                    attr-name: default
+                    attr-redirect-socket: https
+                    attr-socket-binding: http
+                  https-listener:
+                    attr-enable-http2: 'true'
+                    attr-name: https
+                    attr-security-realm: ApplicationRealm
+                    attr-socket-binding: https
+                servlet-container:
+                  attr-name: default
+                  jsp-config: null
+                  websockets: null
+              - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-xmlns: urn:jboss:domain:webservices:2.0
+                client-config:
+                  attr-name: Standard-Client-Config
+                endpoint-config:
+                - attr-name: Standard-Endpoint-Config
+                - attr-name: Recording-Endpoint-Config
+                  pre-handler-chain:
+                    attr-name: recording-handlers
+                    attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                      ##SOAP12_HTTP_MTOM'
+                    handler:
+                      attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                      attr-name: RecordingHandler
+                wsdl-host: ${jboss.bind.address:127.0.0.1}
+              - attr-xmlns: urn:jboss:domain:weld:4.0
+            - attr-name: full-ha
+              subsystem:
+              - attr-xmlns: urn:jboss:domain:logging:8.0
+                formatter:
+                - attr-name: PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                - attr-name: COLOR-PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                logger:
+                - attr-category: com.arjuna
+                  level:
+                    attr-name: WARN
+                - attr-category: io.jaegertracing.Configuration
+                  level:
+                    attr-name: WARN
+                - attr-category: org.jboss.as.config
+                  level:
+                    attr-name: DEBUG
+                - attr-category: sun.rmi
+                  level:
+                    attr-name: WARN
+                periodic-rotating-file-handler:
+                  append:
+                    attr-value: 'true'
+                  attr-autoflush: 'true'
+                  attr-name: FILE
+                  file:
+                    attr-path: server.log
+                    attr-relative-to: jboss.server.log.dir
+                  formatter:
+                    named-formatter:
+                      attr-name: PATTERN
+                  suffix:
+                    attr-value: .yyyy-MM-dd
+                root-logger:
+                  handlers:
+                    handler:
+                      attr-name: FILE
+                  level:
+                    attr-name: INFO
+              - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+                default-job-repository:
+                  attr-name: in-memory
+                default-thread-pool:
+                  attr-name: batch
+                job-repository:
+                  attr-name: in-memory
+                  in-memory: null
+                thread-pool:
+                  attr-name: batch
+                  keepalive-time:
+                    attr-time: '30'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '10'
+              - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+              - attr-xmlns: urn:jboss:domain:core-management:1.0
+              - attr-xmlns: urn:jboss:domain:datasources:6.0
+                datasources:
+                  datasource:
+                    attr-enabled: 'true'
+                    attr-jndi-name: java:jboss/datasources/ExampleDS
+                    attr-pool-name: ExampleDS
+                    attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                    attr-use-java-context: 'true'
+                    connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                    driver: h2
+                    security:
+                      password: sa
+                      user-name: sa
+                  drivers:
+                    driver:
+                      attr-module: com.h2database.h2
+                      attr-name: h2
+                      xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+              - attr-xmlns: urn:jboss:domain:discovery:1.0
+              - attr-default-session-management: default
+                attr-default-single-sign-on-management: default
+                attr-xmlns: urn:jboss:domain:distributable-web:2.0
+                infinispan-routing:
+                  attr-cache: routing
+                  attr-cache-container: web
+                infinispan-session-management:
+                  attr-cache-container: web
+                  attr-granularity: SESSION
+                  attr-name: default
+                  primary-owner-affinity: null
+                infinispan-single-sign-on-management:
+                  attr-cache: sso
+                  attr-cache-container: web
+                  attr-name: default
+              - attr-xmlns: urn:jboss:domain:ee:6.0
+                concurrent:
+                  context-services:
+                    context-service:
+                      attr-jndi-name: java:jboss/ee/concurrency/context/default
+                      attr-name: default
+                      attr-use-transaction-setup-provider: 'true'
+                  managed-executor-services:
+                    managed-executor-service:
+                      attr-context-service: default
+                      attr-hung-task-termination-period: '0'
+                      attr-hung-task-threshold: '60000'
+                      attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                      attr-keepalive-time: '5000'
+                      attr-name: default
+                  managed-scheduled-executor-services:
+                    managed-scheduled-executor-service:
+                      attr-context-service: default
+                      attr-hung-task-termination-period: '0'
+                      attr-hung-task-threshold: '60000'
+                      attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                      attr-keepalive-time: '3000'
+                      attr-name: default
+                  managed-thread-factories:
+                    managed-thread-factory:
+                      attr-context-service: default
+                      attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                      attr-name: default
+                default-bindings:
+                  attr-context-service: java:jboss/ee/concurrency/context/default
+                  attr-datasource: java:jboss/datasources/ExampleDS
+                  attr-jms-connection-factory: java:jboss/DefaultJMSConnectionFactory
+                  attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+                  attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+                  attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+                spec-descriptor-property-replacement: 'false'
+              - attr-xmlns: urn:jboss:domain:ee-security:1.0
+              - async:
+                  attr-thread-pool-name: default
+                attr-xmlns: urn:jboss:domain:ejb3:9.0
+                caches:
+                  cache:
+                  - attr-name: simple
+                  - attr-aliases: passivating clustered
+                    attr-name: distributable
+                    attr-passivation-store-ref: infinispan
+                default-missing-method-permissions-deny-access:
+                  attr-value: 'true'
+                default-security-domain:
+                  attr-value: other
+                iiop:
+                  attr-enable-by-default: 'false'
+                  attr-use-qualified-name: 'false'
+                log-system-exceptions:
+                  attr-value: 'true'
+                mdb:
+                  bean-instance-pool-ref:
+                    attr-pool-name: mdb-strict-max-pool
+                  resource-adapter-ref:
+                    attr-resource-adapter-name: ${ejb.resource-adapter-name:activemq-ra.rar}
+                passivation-stores:
+                  passivation-store:
+                    attr-cache-container: ejb
+                    attr-max-size: '10000'
+                    attr-name: infinispan
+                pools:
+                  bean-instance-pools:
+                    strict-max-pool:
+                    - attr-derive-size: from-cpu-count
+                      attr-instance-acquisition-timeout: '5'
+                      attr-instance-acquisition-timeout-unit: MINUTES
+                      attr-name: mdb-strict-max-pool
+                    - attr-derive-size: from-worker-pools
+                      attr-instance-acquisition-timeout: '5'
+                      attr-instance-acquisition-timeout-unit: MINUTES
+                      attr-name: slsb-strict-max-pool
+                remote:
+                  attr-cluster: ejb
+                  attr-connectors: http-remoting-connector
+                  attr-thread-pool-name: default
+                  channel-creation-options:
+                    option:
+                      attr-name: MAX_OUTBOUND_MESSAGES
+                      attr-type: remoting
+                      attr-value: '1234'
+                session-bean:
+                  singleton:
+                    attr-default-access-timeout: '5000'
+                  stateful:
+                    attr-cache-ref: distributable
+                    attr-default-access-timeout: '5000'
+                    attr-passivation-disabled-cache-ref: simple
+                  stateless:
+                    bean-instance-pool-ref:
+                      attr-pool-name: slsb-strict-max-pool
+                statistics:
+                  attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+                thread-pools:
+                  thread-pool:
+                    attr-name: default
+                    keepalive-time:
+                      attr-time: '60'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '10'
+                timer-service:
+                  attr-default-data-store: default-file-store
+                  attr-thread-pool-name: default
+                  data-stores:
+                    file-data-store:
+                      attr-name: default-file-store
+                      attr-path: timer-service-data
+                      attr-relative-to: jboss.server.data.dir
+              - attr-disallowed-providers: OracleUcrypto
+                attr-final-providers: combined-providers
+                attr-xmlns: urn:wildfly:elytron:13.0
+                audit-logging:
+                  file-audit-log:
+                    attr-format: JSON
+                    attr-name: local-audit
+                    attr-path: audit.log
+                    attr-relative-to: jboss.server.log.dir
+                http:
+                  provider-http-server-mechanism-factory:
+                    attr-name: global
+                mappers:
+                  constant-realm-mapper:
+                    attr-name: local
+                    attr-realm-name: local
+                  constant-role-mapper:
+                    attr-name: super-user-mapper
+                    role:
+                      attr-name: SuperUser
+                  simple-permission-mapper:
+                    attr-mapping-mode: first
+                    attr-name: default-permission-mapper
+                    permission-mapping:
+                    - permission-set:
+                        attr-name: default-permissions
+                      principal:
+                        attr-name: anonymous
+                    - attr-match-all: 'true'
+                      permission-set:
+                      - attr-name: login-permission
+                      - attr-name: default-permissions
+                  simple-role-decoder:
+                    attr-attribute: groups
+                    attr-name: groups-to-roles
+                permission-sets:
+                  permission-set:
+                  - attr-name: login-permission
+                    permission:
+                      attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                  - attr-name: default-permissions
+                    permission:
+                    - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                      attr-module: org.wildfly.extension.batch.jberet
+                      attr-target-name: '*'
+                    - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                      attr-module: org.wildfly.transaction.client
+                    - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                      attr-module: org.jboss.ejb-client
+                providers:
+                  aggregate-providers:
+                    attr-name: combined-providers
+                    providers:
+                    - attr-name: elytron
+                    - attr-name: openssl
+                  provider-loader:
+                  - attr-module: org.wildfly.security.elytron
+                    attr-name: elytron
+                  - attr-module: org.wildfly.openssl
+                    attr-name: openssl
+                sasl:
+                  configurable-sasl-server-factory:
+                    attr-name: configured
+                    attr-sasl-server-factory: elytron
+                    properties:
+                      property:
+                        attr-name: wildfly.sasl.local-user.default-user
+                        attr-value: $local
+                  mechanism-provider-filtering-sasl-server-factory:
+                    attr-name: elytron
+                    attr-sasl-server-factory: global
+                    filters:
+                      filter:
+                        attr-provider-name: WildFlyElytron
+                  provider-sasl-server-factory:
+                    attr-name: global
+                  sasl-authentication-factory:
+                    attr-name: application-sasl-authentication
+                    attr-sasl-server-factory: configured
+                    attr-security-domain: ApplicationDomain
+                    mechanism-configuration:
+                      mechanism:
+                      - attr-mechanism-name: JBOSS-LOCAL-USER
+                        attr-realm-mapper: local
+                      - attr-mechanism-name: DIGEST-MD5
+                        mechanism-realm:
+                          attr-realm-name: ApplicationRealm
+                security-domains:
+                  security-domain:
+                    attr-default-realm: ApplicationRealm
+                    attr-name: ApplicationDomain
+                    attr-permission-mapper: default-permission-mapper
+                    realm:
+                      attr-name: ApplicationRealm
+                      attr-role-decoder: groups-to-roles
+                security-realms:
+                  identity-realm:
+                    attr-identity: $local
+                    attr-name: local
+                  properties-realm:
+                    attr-name: ApplicationRealm
+                    groups-properties:
+                      attr-path: application-roles.properties
+                      attr-relative-to: jboss.domain.config.dir
+                    users-properties:
+                      attr-digest-realm-name: ApplicationRealm
+                      attr-path: application-users.properties
+                      attr-relative-to: jboss.domain.config.dir
+                tls:
+                  key-managers:
+                    key-manager:
+                      attr-generate-self-signed-certificate-host: localhost
+                      attr-key-store: applicationKS
+                      attr-name: applicationKM
+                      credential-reference:
+                        attr-clear-text: password
+                  key-stores:
+                    key-store:
+                      attr-name: applicationKS
+                      credential-reference:
+                        attr-clear-text: password
+                      file:
+                        attr-path: application.keystore
+                        attr-relative-to: jboss.domain.config.dir
+                      implementation:
+                        attr-type: JKS
+                  server-ssl-contexts:
+                    server-ssl-context:
+                      attr-key-manager: applicationKM
+                      attr-name: applicationSSC
+              - attr-xmlns: urn:jboss:domain:iiop-openjdk:2.1
+                initializers:
+                  attr-security: identity
+                  attr-transactions: spec
+                orb:
+                  attr-socket-binding: iiop
+                security:
+                  attr-client-requires-ssl: 'false'
+                  attr-server-requires-ssl: 'false'
+              - attr-xmlns: urn:jboss:domain:infinispan:12.0
+                cache-container:
+                - attr-aliases: sfsb
+                  attr-default-cache: dist
+                  attr-modules: org.wildfly.clustering.ejb.infinispan
+                  attr-name: ejb
+                  distributed-cache:
+                    attr-name: dist
+                    file-store: null
+                    locking:
+                      attr-isolation: REPEATABLE_READ
+                    transaction:
+                      attr-mode: BATCH
+                  transport:
+                    attr-lock-timeout: '60000'
+                - attr-aliases: singleton cluster
+                  attr-default-cache: default
+                  attr-modules: org.wildfly.clustering.server
+                  attr-name: server
+                  replicated-cache:
+                    attr-name: default
+                    transaction:
+                      attr-mode: BATCH
+                  transport:
+                    attr-lock-timeout: '60000'
+                - attr-default-cache: dist
+                  attr-modules: org.wildfly.clustering.web.infinispan
+                  attr-name: web
+                  distributed-cache:
+                    attr-name: dist
+                    file-store: null
+                    locking:
+                      attr-isolation: REPEATABLE_READ
+                    transaction:
+                      attr-mode: BATCH
+                  replicated-cache:
+                  - attr-name: sso
+                    locking:
+                      attr-isolation: REPEATABLE_READ
+                    transaction:
+                      attr-mode: BATCH
+                  - attr-name: routing
+                  transport:
+                    attr-lock-timeout: '60000'
+                - attr-modules: org.infinispan.hibernate-cache
+                  attr-name: hibernate
+                  invalidation-cache:
+                    attr-name: entity
+                    expiration:
+                      attr-max-idle: '100000'
+                    heap-memory:
+                      attr-size: '10000'
+                  local-cache:
+                  - attr-name: local-query
+                    expiration:
+                      attr-max-idle: '100000'
+                    heap-memory:
+                      attr-size: '10000'
+                  - attr-name: pending-puts
+                    expiration:
+                      attr-max-idle: '60000'
+                  replicated-cache:
+                    attr-name: timestamps
+                  transport:
+                    attr-lock-timeout: '60000'
+              - attr-xmlns: urn:jboss:domain:io:3.0
+                buffer-pool:
+                  attr-name: default
+                worker:
+                  attr-name: default
+              - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+              - archive-validation:
+                  attr-enabled: 'true'
+                  attr-fail-on-error: 'true'
+                  attr-fail-on-warn: 'false'
+                attr-xmlns: urn:jboss:domain:jca:5.0
+                bean-validation:
+                  attr-enabled: 'true'
+                cached-connection-manager: null
+                default-workmanager:
+                  long-running-threads:
+                    core-threads:
+                      attr-count: '50'
+                    keepalive-time:
+                      attr-time: '10'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '50'
+                    queue-length:
+                      attr-count: '50'
+                  short-running-threads:
+                    core-threads:
+                      attr-count: '50'
+                    keepalive-time:
+                      attr-time: '10'
+                      attr-unit: seconds
+                    max-threads:
+                      attr-count: '50'
+                    queue-length:
+                      attr-count: '50'
+              - attr-xmlns: urn:jboss:domain:jdr:1.0
+              - attr-xmlns: urn:jboss:domain:jgroups:8.0
+                channels:
+                  attr-default: ee
+                  channel:
+                    attr-cluster: ejb
+                    attr-name: ee
+                    attr-stack: udp
+                stacks:
+                  stack:
+                  - attr-name: udp
+                    protocol:
+                    - attr-type: PING
+                    - attr-type: MERGE3
+                    - attr-type: FD_ALL
+                    - attr-type: VERIFY_SUSPECT
+                    - attr-type: pbcast.NAKACK2
+                    - attr-type: UNICAST3
+                    - attr-type: pbcast.STABLE
+                    - attr-type: pbcast.GMS
+                    - attr-type: UFC
+                    - attr-type: MFC
+                    - attr-type: FRAG3
+                    socket-protocol:
+                      attr-socket-binding: jgroups-udp-fd
+                      attr-type: FD_SOCK
+                    transport:
+                      attr-socket-binding: jgroups-udp
+                      attr-type: UDP
+                  - attr-name: tcp
+                    protocol:
+                    - attr-type: MERGE3
+                    - attr-type: FD_ALL
+                    - attr-type: VERIFY_SUSPECT
+                    - attr-type: pbcast.NAKACK2
+                    - attr-type: UNICAST3
+                    - attr-type: pbcast.STABLE
+                    - attr-type: pbcast.GMS
+                    - attr-type: MFC
+                    - attr-type: FRAG3
+                    socket-protocol:
+                    - attr-socket-binding: jgroups-mping
+                      attr-type: MPING
+                    - attr-socket-binding: jgroups-tcp-fd
+                      attr-type: FD_SOCK
+                    transport:
+                      attr-socket-binding: jgroups-tcp
+                      attr-type: TCP
+              - attr-xmlns: urn:jboss:domain:jmx:1.3
+                expose-expression-model: null
+                expose-resolved-model: null
+              - attr-xmlns: urn:jboss:domain:jpa:1.1
+                jpa:
+                  attr-default-extended-persistence-inheritance: DEEP
+              - attr-xmlns: urn:jboss:domain:jsf:1.1
+              - attr-xmlns: urn:jboss:domain:jsr77:1.0
+              - attr-xmlns: urn:jboss:domain:mail:4.0
+                mail-session:
+                  attr-jndi-name: java:jboss/mail/Default
+                  attr-name: default
+                  smtp-server:
+                    attr-outbound-socket-binding-ref: mail-smtp
+              - attr-xmlns: urn:jboss:domain:messaging-activemq:13.0
+                server:
+                  address-setting:
+                    attr-dead-letter-address: jms.queue.DLQ
+                    attr-expiry-address: jms.queue.ExpiryQueue
+                    attr-max-size-bytes: '10485760'
+                    attr-message-counter-history-day-limit: '10'
+                    attr-name: '#'
+                    attr-page-size-bytes: '2097152'
+                    attr-redistribution-delay: '1000'
+                  attr-name: default
+                  cluster:
+                    attr-password: ${jboss.messaging.cluster.password:CHANGE ME!!}
+                  cluster-connection:
+                    attr-address: jms
+                    attr-connector-name: http-connector
+                    attr-discovery-group: dg-group1
+                    attr-name: my-cluster
+                  connection-factory:
+                  - attr-connectors: in-vm
+                    attr-entries: java:/ConnectionFactory
+                    attr-name: InVmConnectionFactory
+                  - attr-block-on-acknowledge: 'true'
+                    attr-connectors: http-connector
+                    attr-entries: java:jboss/exported/jms/RemoteConnectionFactory
+                    attr-ha: 'true'
+                    attr-name: RemoteConnectionFactory
+                    attr-reconnect-attempts: '-1'
+                  http-acceptor:
+                  - attr-http-listener: default
+                    attr-name: http-acceptor
+                  - attr-http-listener: default
+                    attr-name: http-acceptor-throughput
+                    param:
+                    - attr-name: batch-delay
+                      attr-value: '50'
+                    - attr-name: direct-deliver
+                      attr-value: 'false'
+                  http-connector:
+                  - attr-endpoint: http-acceptor
+                    attr-name: http-connector
+                    attr-socket-binding: http
+                  - attr-endpoint: http-acceptor-throughput
+                    attr-name: http-connector-throughput
+                    attr-socket-binding: http
+                    param:
+                      attr-name: batch-delay
+                      attr-value: '50'
+                  in-vm-acceptor:
+                    attr-name: in-vm
+                    attr-server-id: '0'
+                    param:
+                      attr-name: buffer-pooling
+                      attr-value: 'false'
+                  in-vm-connector:
+                    attr-name: in-vm
+                    attr-server-id: '0'
+                    param:
+                      attr-name: buffer-pooling
+                      attr-value: 'false'
+                  jgroups-broadcast-group:
+                    attr-connectors: http-connector
+                    attr-jgroups-cluster: activemq-cluster
+                    attr-name: bg-group1
+                  jgroups-discovery-group:
+                    attr-jgroups-cluster: activemq-cluster
+                    attr-name: dg-group1
+                  jms-queue:
+                  - attr-entries: java:/jms/queue/ExpiryQueue
+                    attr-name: ExpiryQueue
+                  - attr-entries: java:/jms/queue/DLQ
+                    attr-name: DLQ
+                  pooled-connection-factory:
+                    attr-connectors: in-vm
+                    attr-entries: java:/JmsXA java:jboss/DefaultJMSConnectionFactory
+                    attr-name: activemq-ra
+                    attr-transaction: xa
+                  security-setting:
+                    attr-name: '#'
+                    role:
+                      attr-consume: 'true'
+                      attr-create-non-durable-queue: 'true'
+                      attr-delete-non-durable-queue: 'true'
+                      attr-name: guest
+                      attr-send: 'true'
+                  statistics:
+                    attr-enabled: ${wildfly.messaging-activemq.statistics-enabled:${wildfly.statistics-enabled:false}}
+              - attr-xmlns: urn:jboss:domain:modcluster:5.0
+                proxy:
+                  attr-advertise-socket: modcluster
+                  attr-listener: ajp
+                  attr-name: default
+                  dynamic-load-provider:
+                    load-metric:
+                      attr-type: cpu
+              - attr-xmlns: urn:jboss:domain:naming:2.0
+                remote-naming: null
+              - attr-xmlns: urn:jboss:domain:pojo:1.0
+              - attr-xmlns: urn:jboss:domain:remoting:4.0
+                http-connector:
+                  attr-connector-ref: default
+                  attr-name: http-remoting-connector
+                  attr-security-realm: ApplicationRealm
+              - attr-xmlns: urn:jboss:domain:request-controller:1.0
+              - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+              - attr-xmlns: urn:jboss:domain:sar:1.0
+              - attr-xmlns: urn:jboss:domain:security:2.0
+                security-domains:
+                  security-domain:
+                  - attr-cache-type: default
+                    attr-name: other
+                    authentication:
+                      login-module:
+                      - attr-code: Remoting
+                        attr-flag: optional
+                        module-option:
+                          attr-name: password-stacking
+                          attr-value: useFirstPass
+                      - attr-code: RealmDirect
+                        attr-flag: required
+                        module-option:
+                          attr-name: password-stacking
+                          attr-value: useFirstPass
+                  - attr-cache-type: default
+                    attr-name: jboss-web-policy
+                    authorization:
+                      policy-module:
+                        attr-code: Delegating
+                        attr-flag: required
+                  - attr-cache-type: default
+                    attr-name: jaspitest
+                    authentication-jaspi:
+                      auth-module:
+                        attr-code: Dummy
+                      login-module-stack:
+                        attr-name: dummy
+                        login-module:
+                          attr-code: Dummy
+                          attr-flag: optional
+                  - attr-cache-type: default
+                    attr-name: jboss-ejb-policy
+                    authorization:
+                      policy-module:
+                        attr-code: Delegating
+                        attr-flag: required
+              - attr-xmlns: urn:jboss:domain:security-manager:1.0
+                deployment-permissions:
+                  maximum-set:
+                    permission:
+                      attr-class: java.security.AllPermission
+              - attr-xmlns: urn:jboss:domain:singleton:1.0
+                singleton-policies:
+                  attr-default: default
+                  singleton-policy:
+                    attr-cache-container: server
+                    attr-name: default
+                    simple-election-policy: null
+              - attr-xmlns: urn:jboss:domain:transactions:6.0
+                coordinator-environment:
+                  attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+                core-environment:
+                  attr-node-identifier: ${jboss.tx.node.id:1}
+                  process-id:
+                    uuid: null
+                object-store:
+                  attr-path: tx-object-store
+                  attr-relative-to: jboss.server.data.dir
+                recovery-environment:
+                  attr-socket-binding: txn-recovery-environment
+                  attr-status-socket-binding: txn-status-manager
+              - attr-default-security-domain: other
+                attr-default-server: default-server
+                attr-default-servlet-container: default
+                attr-default-virtual-host: default-host
+                attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-xmlns: urn:jboss:domain:undertow:12.0
+                buffer-cache:
+                  attr-name: default
+                handlers:
+                  file:
+                    attr-name: welcome-content
+                    attr-path: ${jboss.home.dir}/welcome-content
+                server:
+                  ajp-listener:
+                    attr-name: ajp
+                    attr-socket-binding: ajp
+                  attr-name: default-server
+                  host:
+                    attr-alias: localhost
+                    attr-name: default-host
+                    http-invoker:
+                      attr-security-realm: ApplicationRealm
+                    location:
+                      attr-handler: welcome-content
+                      attr-name: /
+                  http-listener:
+                    attr-enable-http2: 'true'
+                    attr-name: default
+                    attr-redirect-socket: https
+                    attr-socket-binding: http
+                  https-listener:
+                    attr-enable-http2: 'true'
+                    attr-name: https
+                    attr-security-realm: ApplicationRealm
+                    attr-socket-binding: https
+                servlet-container:
+                  attr-name: default
+                  jsp-config: null
+                  websockets: null
+              - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-xmlns: urn:jboss:domain:webservices:2.0
+                client-config:
+                  attr-name: Standard-Client-Config
+                endpoint-config:
+                - attr-name: Standard-Endpoint-Config
+                - attr-name: Recording-Endpoint-Config
+                  pre-handler-chain:
+                    attr-name: recording-handlers
+                    attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                      ##SOAP12_HTTP_MTOM'
+                    handler:
+                      attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                      attr-name: RecordingHandler
+                wsdl-host: ${jboss.bind.address:127.0.0.1}
+              - attr-xmlns: urn:jboss:domain:weld:4.0
+            - attr-name: load-balancer
+              subsystem:
+              - attr-xmlns: urn:jboss:domain:logging:8.0
+                formatter:
+                - attr-name: PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                - attr-name: COLOR-PATTERN
+                  pattern-formatter:
+                    attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+                logger:
+                - attr-category: com.arjuna
+                  level:
+                    attr-name: WARN
+                - attr-category: io.jaegertracing.Configuration
+                  level:
+                    attr-name: WARN
+                - attr-category: org.jboss.as.config
+                  level:
+                    attr-name: DEBUG
+                - attr-category: sun.rmi
+                  level:
+                    attr-name: WARN
+                periodic-rotating-file-handler:
+                  append:
+                    attr-value: 'true'
+                  attr-autoflush: 'true'
+                  attr-name: FILE
+                  file:
+                    attr-path: server.log
+                    attr-relative-to: jboss.server.log.dir
+                  formatter:
+                    named-formatter:
+                      attr-name: PATTERN
+                  suffix:
+                    attr-value: .yyyy-MM-dd
+                root-logger:
+                  handlers:
+                    handler:
+                      attr-name: FILE
+                  level:
+                    attr-name: INFO
+              - attr-xmlns: urn:jboss:domain:io:3.0
+                buffer-pool:
+                  attr-name: default
+                worker:
+                  attr-name: default
+              - attr-default-server: default-server
+                attr-default-servlet-container: default
+                attr-default-virtual-host: default-host
+                attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-xmlns: urn:jboss:domain:undertow:12.0
+                buffer-cache:
+                  attr-name: default
+                filters:
+                  mod-cluster:
+                    attr-advertise-socket-binding: modcluster
+                    attr-enable-http2: 'true'
+                    attr-management-socket-binding: mcmp-management
+                    attr-max-retries: '3'
+                    attr-name: load-balancer
+                    single-affinity: null
+                server:
+                  attr-name: default-server
+                  host:
+                    attr-alias: localhost
+                    attr-name: default-host
+                    filter-ref:
+                      attr-name: load-balancer
+                  http-listener:
+                  - attr-enable-http2: 'true'
+                    attr-name: default
+                    attr-redirect-socket: https
+                    attr-socket-binding: http
+                  - attr-enable-http2: 'true'
+                    attr-name: management
+                    attr-socket-binding: mcmp-management
+                servlet-container:
+                  attr-name: default
+          server-groups:
+            server-group:
+            - attr-name: main-server-group
+              attr-profile: full-ha
+              jvm:
+                attr-name: default
+                heap:
+                  attr-max-size: 1000m
+                  attr-size: 1000m
+              socket-binding-group:
+                attr-ref: full-ha-sockets
+            - attr-name: second-server-group
+              attr-profile: full-ha
+              jvm:
+                attr-name: default
+                heap:
+                  attr-max-size: 1000m
+                  attr-size: 1000m
+              socket-binding-group:
+                attr-ref: full-ha-sockets
+          socket-binding-groups:
+            socket-binding-group:
+            - attr-default-interface: public
+              attr-name: standard-sockets
+              outbound-socket-binding:
+                attr-name: mail-smtp
+                remote-destination:
+                  attr-host: ${jboss.mail.server.host:localhost}
+                  attr-port: ${jboss.mail.server.port:25}
+              socket-binding:
+              - attr-name: ajp
+                attr-port: ${jboss.ajp.port:8009}
+              - attr-name: http
+                attr-port: ${jboss.http.port:8080}
+              - attr-name: https
+                attr-port: ${jboss.https.port:8443}
+              - attr-name: txn-recovery-environment
+                attr-port: '4712'
+              - attr-name: txn-status-manager
+                attr-port: '4713'
+            - attr-default-interface: public
+              attr-name: ha-sockets
+              outbound-socket-binding:
+                attr-name: mail-smtp
+                remote-destination:
+                  attr-host: ${jboss.mail.server.host:localhost}
+                  attr-port: ${jboss.mail.server.port:25}
+              socket-binding:
+              - attr-name: ajp
+                attr-port: ${jboss.ajp.port:8009}
+              - attr-name: http
+                attr-port: ${jboss.http.port:8080}
+              - attr-name: https
+                attr-port: ${jboss.https.port:8443}
+              - attr-interface: private
+                attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
+                attr-multicast-port: '45700'
+                attr-name: jgroups-mping
+              - attr-interface: private
+                attr-name: jgroups-tcp
+                attr-port: '7600'
+              - attr-interface: private
+                attr-name: jgroups-tcp-fd
+                attr-port: '57600'
+              - attr-interface: private
+                attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
+                attr-multicast-port: '45688'
+                attr-name: jgroups-udp
+                attr-port: '55200'
+              - attr-interface: private
+                attr-name: jgroups-udp-fd
+                attr-port: '54200'
+              - attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
+                attr-multicast-port: '23364'
+                attr-name: modcluster
+              - attr-name: txn-recovery-environment
+                attr-port: '4712'
+              - attr-name: txn-status-manager
+                attr-port: '4713'
+            - attr-default-interface: public
+              attr-name: full-sockets
+              outbound-socket-binding:
+                attr-name: mail-smtp
+                remote-destination:
+                  attr-host: ${jboss.mail.server.host:localhost}
+                  attr-port: ${jboss.mail.server.port:25}
+              socket-binding:
+              - attr-name: ajp
+                attr-port: ${jboss.ajp.port:8009}
+              - attr-name: http
+                attr-port: ${jboss.http.port:8080}
+              - attr-name: https
+                attr-port: ${jboss.https.port:8443}
+              - attr-interface: unsecure
+                attr-name: iiop
+                attr-port: '3528'
+              - attr-interface: unsecure
+                attr-name: iiop-ssl
+                attr-port: '3529'
+              - attr-name: txn-recovery-environment
+                attr-port: '4712'
+              - attr-name: txn-status-manager
+                attr-port: '4713'
+            - attr-default-interface: public
+              attr-name: full-ha-sockets
+              outbound-socket-binding:
+                attr-name: mail-smtp
+                remote-destination:
+                  attr-host: ${jboss.mail.server.host:localhost}
+                  attr-port: ${jboss.mail.server.port:25}
+              socket-binding:
+              - attr-name: ajp
+                attr-port: ${jboss.ajp.port:8009}
+              - attr-name: http
+                attr-port: ${jboss.http.port:8080}
+              - attr-name: https
+                attr-port: ${jboss.https.port:8443}
+              - attr-interface: unsecure
+                attr-name: iiop
+                attr-port: '3528'
+              - attr-interface: unsecure
+                attr-name: iiop-ssl
+                attr-port: '3529'
+              - attr-interface: private
+                attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
+                attr-multicast-port: '45700'
+                attr-name: jgroups-mping
+              - attr-interface: private
+                attr-name: jgroups-tcp
+                attr-port: '7600'
+              - attr-interface: private
+                attr-name: jgroups-tcp-fd
+                attr-port: '57600'
+              - attr-interface: private
+                attr-multicast-address: ${jboss.default.multicast.address:230.0.0.4}
+                attr-multicast-port: '45688'
+                attr-name: jgroups-udp
+                attr-port: '55200'
+              - attr-interface: private
+                attr-name: jgroups-udp-fd
+                attr-port: '54200'
+              - attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
+                attr-multicast-port: '23364'
+                attr-name: modcluster
+              - attr-name: txn-recovery-environment
+                attr-port: '4712'
+              - attr-name: txn-status-manager
+                attr-port: '4713'
+            - attr-default-interface: public
+              attr-name: load-balancer-sockets
+              socket-binding:
+              - attr-name: http
+                attr-port: ${jboss.http.port:8080}
+              - attr-name: https
+                attr-port: ${jboss.https.port:8443}
+              - attr-interface: private
+                attr-name: mcmp-management
+                attr-port: ${jboss.mcmp.port:8090}
+              - attr-interface: private
+                attr-multicast-address: ${jboss.modcluster.multicast.address:224.0.1.105}
+                attr-multicast-port: '23364'
+                attr-name: modcluster
+          system-properties:
+            property:
+              attr-name: java.net.preferIPv4Stack
+              attr-value: 'true'
+  Read host_xml_file:
+    expected_args:
+      delegate_reading: false
+      file_path: /opt/jboss/domain/configuration/host.xml
+      in_docker: true
+      parser: xml
+      parser_params: null
+    plugin_result:
+      failed: false
+      parsed:
+        host:
+          attr-name: nodo1-master
+          attr-xmlns: urn:jboss:domain:16.0
+          domain-controller:
+            local: null
+          extensions:
+            extension:
+            - attr-module: org.jboss.as.jmx
+            - attr-module: org.wildfly.extension.core-management
+            - attr-module: org.wildfly.extension.elytron
+          interfaces:
+            interface:
+            - attr-name: management
+              inet-address:
+                attr-value: ${jboss.bind.address.management:0.0.0.0}
+            - attr-name: public
+              inet-address:
+                attr-value: ${jboss.bind.address:0.0.0.0}
+          jvms:
+            jvm:
+              attr-name: default
+              heap:
+                attr-max-size: 256m
+                attr-size: 64m
+              jvm-options:
+                option:
+                - attr-value: -server
+                - attr-value: -XX:MetaspaceSize=96m
+                - attr-value: -XX:MaxMetaspaceSize=256m
+          management:
+            audit-log:
+              formatters:
+                json-formatter:
+                  attr-name: json-formatter
+              handlers:
+                file-handler:
+                - attr-formatter: json-formatter
+                  attr-name: host-file
+                  attr-path: audit-log.log
+                  attr-relative-to: jboss.domain.data.dir
+                - attr-formatter: json-formatter
+                  attr-name: server-file
+                  attr-path: audit-log.log
+                  attr-relative-to: jboss.server.data.dir
+              logger:
+                attr-enabled: 'false'
+                attr-log-boot: 'true'
+                attr-log-read-only: 'false'
+                handlers:
+                  handler:
+                    attr-name: host-file
+              server-logger:
+                attr-enabled: 'false'
+                attr-log-boot: 'true'
+                attr-log-read-only: 'false'
+                handlers:
+                  handler:
+                    attr-name: server-file
+            management-interfaces:
+              http-interface:
+                attr-security-realm: ManagementRealm
+                http-upgrade:
+                  attr-enabled: 'true'
+                socket:
+                  attr-interface: management
+                  attr-port: ${jboss.management.http.port:9990}
+              native-interface:
+                socket:
+                  attr-interface: management
+                  attr-port: ${jboss.management.native.port:9999}
+            security-realms:
+              security-realm:
+              - attr-name: ManagementRealm
+                authentication:
+                  local:
+                    attr-default-user: $local
+                    attr-skip-group-loading: 'true'
+                  properties:
+                    attr-path: mgmt-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+                authorization:
+                  attr-map-groups-to-roles: 'false'
+                  properties:
+                    attr-path: mgmt-groups.properties
+                    attr-relative-to: jboss.domain.config.dir
+              - attr-name: ApplicationRealm
+                authentication:
+                  local:
+                    attr-allowed-users: '*'
+                    attr-default-user: $local
+                    attr-skip-group-loading: 'true'
+                  properties:
+                    attr-path: application-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+                authorization:
+                  properties:
+                    attr-path: application-roles.properties
+                    attr-relative-to: jboss.domain.config.dir
+                server-identities:
+                  ssl:
+                    keystore:
+                      attr-alias: server
+                      attr-generate-self-signed-certificate-host: localhost
+                      attr-key-password: password
+                      attr-keystore-password: password
+                      attr-path: application.keystore
+                      attr-relative-to: jboss.domain.config.dir
+          profile:
+            subsystem:
+            - attr-xmlns: urn:jboss:domain:core-management:1.0
+            - attr-disallowed-providers: OracleUcrypto
+              attr-final-providers: combined-providers
+              attr-xmlns: urn:wildfly:elytron:13.0
+              audit-logging:
+                file-audit-log:
+                  attr-format: JSON
+                  attr-name: local-audit
+                  attr-path: audit.log
+                  attr-relative-to: jboss.domain.log.dir
+              http:
+                http-authentication-factory:
+                  attr-http-server-mechanism-factory: global
+                  attr-name: management-http-authentication
+                  attr-security-domain: ManagementDomain
+                  mechanism-configuration:
+                    mechanism:
+                      attr-mechanism-name: BASIC
+                      mechanism-realm:
+                        attr-realm-name: Management Realm
+                provider-http-server-mechanism-factory:
+                  attr-name: global
+              mappers:
+                constant-realm-mapper:
+                  attr-name: local
+                  attr-realm-name: local
+                constant-role-mapper:
+                  attr-name: super-user-mapper
+                  role:
+                    attr-name: SuperUser
+                simple-permission-mapper:
+                  attr-mapping-mode: first
+                  attr-name: default-permission-mapper
+                  permission-mapping:
+                  - permission-set:
+                      attr-name: default-permissions
+                    principal:
+                      attr-name: anonymous
+                  - attr-match-all: 'true'
+                    permission-set:
+                    - attr-name: login-permission
+                    - attr-name: default-permissions
+                simple-role-decoder:
+                  attr-attribute: groups
+                  attr-name: groups-to-roles
+              permission-sets:
+                permission-set:
+                - attr-name: login-permission
+                  permission:
+                    attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                - attr-name: default-permissions
+              providers:
+                aggregate-providers:
+                  attr-name: combined-providers
+                  providers:
+                  - attr-name: elytron
+                  - attr-name: openssl
+                provider-loader:
+                - attr-module: org.wildfly.security.elytron
+                  attr-name: elytron
+                - attr-module: org.wildfly.openssl
+                  attr-name: openssl
+              sasl:
+                configurable-sasl-server-factory:
+                  attr-name: configured
+                  attr-sasl-server-factory: elytron
+                  properties:
+                    property:
+                      attr-name: wildfly.sasl.local-user.default-user
+                      attr-value: $local
+                mechanism-provider-filtering-sasl-server-factory:
+                  attr-name: elytron
+                  attr-sasl-server-factory: global
+                  filters:
+                    filter:
+                      attr-provider-name: WildFlyElytron
+                provider-sasl-server-factory:
+                  attr-name: global
+                sasl-authentication-factory:
+                  attr-name: management-sasl-authentication
+                  attr-sasl-server-factory: configured
+                  attr-security-domain: ManagementDomain
+                  mechanism-configuration:
+                    mechanism:
+                    - attr-mechanism-name: JBOSS-LOCAL-USER
+                      attr-realm-mapper: local
+                    - attr-mechanism-name: DIGEST-MD5
+                      mechanism-realm:
+                        attr-realm-name: ManagementRealm
+              security-domains:
+                security-domain:
+                  attr-default-realm: ManagementRealm
+                  attr-name: ManagementDomain
+                  attr-permission-mapper: default-permission-mapper
+                  realm:
+                  - attr-name: ManagementRealm
+                    attr-role-decoder: groups-to-roles
+                  - attr-name: local
+                    attr-role-mapper: super-user-mapper
+              security-realms:
+                identity-realm:
+                  attr-identity: $local
+                  attr-name: local
+                properties-realm:
+                  attr-name: ManagementRealm
+                  groups-properties:
+                    attr-path: mgmt-groups.properties
+                    attr-relative-to: jboss.domain.config.dir
+                  users-properties:
+                    attr-digest-realm-name: ManagementRealm
+                    attr-path: mgmt-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+            - attr-xmlns: urn:jboss:domain:jmx:1.3
+              expose-expression-model: null
+              expose-resolved-model: null
+              remoting-connector: null
+          servers:
+            server:
+            - attr-auto-start: 'true'
+              attr-group: main-server-group
+              attr-name: nodo1-server1
+            - attr-auto-start: 'true'
+              attr-group: second-server-group
+              attr-name: nodo1-server2
+              jvm:
+                attr-name: default
+              socket-bindings:
+                attr-port-offset: '150'
+  Read logging_conf_file if accessible:
+    expected_args:
+      delegate_reading: false
+      file_path: /opt/jboss/domain/servers/nodo1-server1/data/logging.properties
+      in_docker: true
+      parser: null
+      parser_params: null
+    plugin_result:
+      content: '# Note this file has been generated and will be overwritten if a
+
+        # logging subsystem has been defined in the XML configuration.
+
+
+
+        # Additional loggers to configure (the root logger is always configured)
+
+        loggers=sun.rmi,org.jboss.as.config,io.jaegertracing.Configuration,com.arjuna
+
+
+        logger.level=INFO
+
+        logger.handlers=FILE
+
+
+        logger.sun.rmi.level=WARN
+
+        logger.sun.rmi.useParentHandlers=true
+
+
+        logger.org.jboss.as.config.level=DEBUG
+
+        logger.org.jboss.as.config.useParentHandlers=true
+
+
+        logger.io.jaegertracing.Configuration.level=WARN
+
+        logger.io.jaegertracing.Configuration.useParentHandlers=true
+
+
+        logger.com.arjuna.level=WARN
+
+        logger.com.arjuna.useParentHandlers=true
+
+
+        handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+
+        handler.FILE.level=ALL
+
+        handler.FILE.formatter=PATTERN
+
+        handler.FILE.properties=autoFlush,append,fileName,suffix
+
+        handler.FILE.constructorProperties=fileName,append
+
+        handler.FILE.autoFlush=true
+
+        handler.FILE.append=true
+
+        handler.FILE.fileName=/opt/jboss/domain/servers/nodo1-server1/log/server.log
+
+        handler.FILE.suffix=.yyyy-MM-dd
+
+
+        # Additional formatters to configure
+
+        formatters=COLOR-PATTERN
+
+
+
+        formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+
+        formatter.PATTERN.properties=pattern
+
+        formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
+
+
+        formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+
+        formatter.COLOR-PATTERN.properties=pattern
+
+        formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t)
+        %s%e%n'
+      failed: false
+  Read version file:
+    expected_args:
+      delegate_reading: false
+      file_path: /opt/jboss/version.txt
+      in_docker: true
+      parser: null
+      parser_params: null
+    plugin_result:
+      content: Red Hat JBoss Enterprise Application Platform - Version 7.4.0.GA
+      failed: false
+  Run entry regex:
+    calls:
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - run
+    - run
+    - run
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - run
+    - run
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  aether-api:
+  - arch: noarch
+    epoch: null
+    name: aether-api
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
+  aether-connector-wagon:
+  - arch: noarch
+    epoch: null
+    name: aether-connector-wagon
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
+  aether-impl:
+  - arch: noarch
+    epoch: null
+    name: aether-impl
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
+  aether-spi:
+  - arch: noarch
+    epoch: null
+    name: aether-spi
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
+  aether-util:
+  - arch: noarch
+    epoch: null
+    name: aether-util
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
+  alsa-lib:
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
+  aopalliance:
+  - arch: noarch
+    epoch: 0
+    name: aopalliance
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  apache-commons-cli:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-cli
+    release: 13.el7
+    source: rpm
+    version: '1.2'
+  apache-commons-codec:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-codec
+    release: 7.el7
+    source: rpm
+    version: '1.8'
+  apache-commons-io:
+  - arch: noarch
+    epoch: 1
+    name: apache-commons-io
+    release: 12.el7
+    source: rpm
+    version: '2.4'
+  apache-commons-lang:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-lang
+    release: 15.el7
+    source: rpm
+    version: '2.6'
+  apache-commons-logging:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
+  apache-commons-net:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-net
+    release: 8.el7.centos
+    source: rpm
+    version: '3.2'
+  apr:
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
+  apr-util:
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
+  atinject:
+  - arch: noarch
+    epoch: null
+    name: atinject
+    release: 13.20100611svn86.el7
+    source: rpm
+    version: '1'
+  atk:
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  avahi-libs:
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  avalon-framework:
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
+  avalon-logkit:
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 35.el7_9
+    source: rpm
+    version: 4.2.46
+  bc:
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
+  bcel:
+  - arch: noarch
+    epoch: 0
+    name: bcel
+    release: 18.el7
+    source: rpm
+    version: '5.2'
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 72.el7_9
+    source: rpm
+    version: 2021.2.50
+  cairo:
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
+  cal10n:
+  - arch: noarch
+    epoch: null
+    name: cal10n
+    release: 4.el7
+    source: rpm
+    version: 0.7.7
+  cdi-api:
+  - arch: noarch
+    epoch: null
+    name: cdi-api
+    release: 11.SP4.el7
+    source: rpm
+    version: '1.0'
+  centos-logos:
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
+  cglib:
+  - arch: noarch
+    epoch: null
+    name: cglib
+    release: 18.el7
+    source: rpm
+    version: '2.2'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 7.el7.centos.6
+    source: rpm
+    version: '19.4'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
+  copy-jdk-configs:
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
+  cups-libs:
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-gssapi:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-gssapi
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-plain:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-plain
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  dejavu-fonts-common:
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  dejavu-sans-fonts:
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 808
-    port: 68
-    protocol: udp
-    stime: Thu Jun 16 14:09:53 2022
-    user: root
-  - address: 0.0.0.0
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  easymock2:
+  - arch: noarch
+    epoch: null
+    name: easymock2
+    release: 12.el7
+    source: rpm
+    version: 2.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '14'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  felix-framework:
+  - arch: noarch
+    epoch: null
+    name: felix-framework
+    release: 5.el7
+    source: rpm
+    version: 4.2.1
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  geronimo-annotation:
+  - arch: noarch
+    epoch: null
+    name: geronimo-annotation
+    release: 15.el7
+    source: rpm
+    version: '1.0'
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  google-guice:
+  - arch: noarch
+    epoch: null
+    name: google-guice
+    release: 9.el7
+    source: rpm
+    version: 3.1.3
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 61b8bab7
+    source: rpm
+    version: 3a79bd29
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 5c4058fb
+    source: rpm
+    version: 5072e1f5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 5eb44ee6
+    source: rpm
+    version: a3219f7b
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 602c28d5
+    source: rpm
+    version: e2c63c11
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 5ced7aac
+    source: rpm
+    version: 90cfb1f5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  guava:
+  - arch: noarch
+    epoch: null
+    name: guava
+    release: 6.el7
+    source: rpm
+    version: '13.0'
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hamcrest:
+  - arch: noarch
+    epoch: 0
+    name: hamcrest
+    release: 6.el7
+    source: rpm
+    version: '1.3'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  httpcomponents-client:
+  - arch: noarch
+    epoch: null
+    name: httpcomponents-client
+    release: 5.el7_0
+    source: rpm
+    version: 4.2.5
+  httpcomponents-core:
+  - arch: noarch
+    epoch: null
+    name: httpcomponents-core
+    release: 6.el7
+    source: rpm
+    version: 4.2.4
+  httpd:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos.4
+    source: rpm
+    version: 2.4.6
+  httpd-tools:
+  - arch: x86_64
+    epoch: null
+    name: httpd-tools
+    release: 97.el7.centos.4
+    source: rpm
+    version: 2.4.6
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-commons-httpclient:
+  - arch: noarch
+    epoch: 1
+    name: jakarta-commons-httpclient
+    release: 16.el7_0
+    source: rpm
+    version: '3.1'
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-devel:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-devel
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  javassist:
+  - arch: noarch
+    epoch: null
+    name: javassist
+    release: 10.el7
+    source: rpm
+    version: 3.16.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  jboss-ejb-3.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-ejb-3.1-api
+    release: 10.el7
+    source: rpm
+    version: 1.0.2
+  jboss-el-2.2-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-el-2.2-api
+    release: 0.7.20120212git2fabd8.el7
+    source: rpm
+    version: 1.0.1
+  jboss-interceptors-1.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-interceptors-1.1-api
+    release: 0.9.20120319git49a904.el7
+    source: rpm
+    version: 1.0.2
+  jboss-jaxrpc-1.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-jaxrpc-1.1-api
+    release: 7.el7
+    source: rpm
+    version: 1.0.1
+  jboss-servlet-3.0-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-servlet-3.0-api
+    release: 9.el7
+    source: rpm
+    version: 1.0.1
+  jboss-transaction-1.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-transaction-1.1-api
+    release: 8.el7
+    source: rpm
+    version: 1.0.1
+  jline:
+  - arch: noarch
+    epoch: null
+    name: jline
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  jsch:
+  - arch: noarch
+    epoch: 0
+    name: jsch
+    release: 5.el7
+    source: rpm
+    version: 0.1.50
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  jsoup:
+  - arch: noarch
+    epoch: null
+    name: jsoup
+    release: 10.el7
+    source: rpm
+    version: 1.6.1
+  junit:
+  - arch: noarch
+    epoch: 0
+    name: junit
+    release: 8.el7
+    source: rpm
+    version: '4.11'
+  jzlib:
+  - arch: noarch
+    epoch: 0
+    name: jzlib
+    release: 6.el7
+    source: rpm
+    version: 1.1.1
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.49.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.3
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 135.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 18.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  maven:
+  - arch: noarch
+    epoch: null
+    name: maven
+    release: 17.el7
+    source: rpm
+    version: 3.0.5
+  maven-wagon:
+  - arch: noarch
+    epoch: 0
+    name: maven-wagon
+    release: 3.el7
+    source: rpm
+    version: '2.4'
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mongodb-database-tools:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-database-tools
+    release: '1'
+    source: rpm
+    version: 100.5.2
+  mongodb-org:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-database-tools-extra:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-database-tools-extra
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-mongos:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-mongos
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-server:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-server
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-shell:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-shell
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-tools:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-tools
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mysql-community-client:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-client
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-client-plugins:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-client-plugins
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-common:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-common
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-icu-data-files:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-icu-data-files
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-libs:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-libs
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-libs-compat:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-libs-compat
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-server:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-server
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql80-community-release:
+  - arch: noarch
+    epoch: null
+    name: mysql80-community-release
+    release: '3'
+    source: rpm
+    version: el8
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  nekohtml:
+  - arch: noarch
+    epoch: 0
+    name: nekohtml
+    release: 13.el7
+    source: rpm
+    version: 1.9.14
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7.2
+    source: rpm
+    version: 1.3.0
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  objectweb-asm:
+  - arch: noarch
+    epoch: 0
+    name: objectweb-asm
+    release: 9.el7
+    source: rpm
+    version: 3.3.1
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 25.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  packer:
+  - arch: x86_64
+    epoch: null
+    name: packer
+    release: '1'
+    source: rpm
+    version: 1.7.10
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  plexus-cipher:
+  - arch: noarch
+    epoch: null
+    name: plexus-cipher
+    release: 5.el7
+    source: rpm
+    version: '1.7'
+  plexus-classworlds:
+  - arch: noarch
+    epoch: null
+    name: plexus-classworlds
+    release: 8.el7
+    source: rpm
+    version: 2.4.2
+  plexus-component-api:
+  - arch: noarch
+    epoch: null
+    name: plexus-component-api
+    release: 0.16.alpha15.el7
+    source: rpm
+    version: '1.0'
+  plexus-containers-component-annotations:
+  - arch: noarch
+    epoch: null
+    name: plexus-containers-component-annotations
+    release: 14.el7
+    source: rpm
+    version: 1.5.5
+  plexus-containers-container-default:
+  - arch: noarch
+    epoch: null
+    name: plexus-containers-container-default
+    release: 14.el7
+    source: rpm
+    version: 1.5.5
+  plexus-interactivity:
+  - arch: noarch
+    epoch: 0
+    name: plexus-interactivity
+    release: 0.14.alpha6.el7
+    source: rpm
+    version: '1.0'
+  plexus-interpolation:
+  - arch: noarch
+    epoch: null
+    name: plexus-interpolation
+    release: 8.el7
+    source: rpm
+    version: '1.15'
+  plexus-sec-dispatcher:
+  - arch: noarch
+    epoch: null
+    name: plexus-sec-dispatcher
+    release: 13.el7
+    source: rpm
+    version: '1.4'
+  plexus-utils:
+  - arch: noarch
+    epoch: null
+    name: plexus-utils
+    release: 9.el7
+    source: rpm
+    version: 3.0.9
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 10.el7
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qdox:
+  - arch: noarch
+    epoch: 0
+    name: qdox
+    release: 10.el7
+    source: rpm
+    version: 1.12.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  regexp:
+  - arch: noarch
+    epoch: 0
+    name: regexp
+    release: 13.el7
+    source: rpm
+    version: '1.5'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 550
-    port: 111
-    protocol: udp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 566
-    port: 323
-    protocol: udp
-    stime: Thu Jun 16 14:09:49 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 550
-    port: 721
-    protocol: udp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: '::'
-    name: rpcbind
-    pid: 550
-    port: 111
-    protocol: udp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: ::1
-    name: chronyd
-    pid: 566
-    port: 323
-    protocol: udp
-    stime: Thu Jun 16 14:09:49 2022
-    user: chrony
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9.1
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  sisu-inject-bean:
+  - arch: noarch
+    epoch: null
+    name: sisu-inject-bean
+    release: 11.el7
+    source: rpm
+    version: 2.3.0
+  sisu-inject-plexus:
+  - arch: noarch
+    epoch: null
+    name: sisu-inject-plexus
+    release: 11.el7
+    source: rpm
+    version: 2.3.0
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slf4j:
+  - arch: noarch
+    epoch: 0
+    name: slf4j
+    release: 4.el7_4
+    source: rpm
+    version: 1.7.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.2
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 66.el7
+    source: rpm
+    version: '0.17'
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 24.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7_9.1
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xbean:
+  - arch: noarch
+    epoch: null
+    name: xbean
+    release: 6.el7
+    source: rpm
+    version: '3.13'
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '113'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '192'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '193'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '260'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '266'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '281'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '282'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '408'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '447'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '471'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '512'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '539'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '548'
+  ppid: '1'
+  user: polkitd
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '550'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '554'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '562'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '563'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '566'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H test-norm01 eth0
+  cwd: /sbin/
+  pid: '808'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '864'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '866'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/java -Xms64M -Xmx1G -Djava.util.logging.config.file=logging.properties
+    -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config
+    -Dcom.sun.management.jmxremote -Djava.awt.headless=true -Djava.io.tmpdir=/opt/apache-activemq-5.14.3//tmp
+    -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/:
+    -Dactivemq.home=/opt/apache-activemq-5.14.3/ -Dactivemq.base=/opt/apache-activemq-5.14.3/
+    -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf -Dactivemq.data=/opt/apache-activemq-5.14.3//data
+    -jar /opt/apache-activemq-5.14.3//bin/activemq.jar start'
+  cwd: /usr/bin/
+  pid: '967'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1100'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1106'
+  ppid: '1100'
+  user: postfix
+- cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '1147'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1148'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1159'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1181'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1182'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1183'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/mongod -f /etc/mongod.conf
+  cwd: /usr/bin/
+  pid: '1239'
+  ppid: '1'
+  user: mongod
+- cmdline: /usr/sbin/mysqld
+  cwd: /usr/sbin/
+  pid: '1535'
+  ppid: '1'
+  user: mysql
+- cmdline: ''
+  cwd: /
+  pid: '1993'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2191'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2192'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2193'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2194'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2195'
+  ppid: '866'
+  user: apache
+- cmdline: ''
+  cwd: /
+  pid: '3613'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '6346'
+  ppid: '1100'
+  user: postfix
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '12465'
+  ppid: '1159'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '12468'
+  ppid: '12465'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '12469'
+  ppid: '12468'
+  user: centos
+- cmdline: sudo su
+  cwd: /
+  pid: '12624'
+  ppid: '12469'
+  user: root
+- cmdline: su
+  cwd: /
+  pid: '12625'
+  ppid: '12624'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '12626'
+  ppid: '12625'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13638'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13894'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '14201'
+  ppid: '1159'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '14204'
+  ppid: '14201'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-fuaxmatzfqmqdqgdvmixffwrycdkvoch
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009536.0534809-88841-259616145208073/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '14357'
+  ppid: '14204'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-fuaxmatzfqmqdqgdvmixffwrycdkvoch
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009536.0534809-88841-259616145208073/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '14370'
+  ppid: '14357'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-fuaxmatzfqmqdqgdvmixffwrycdkvoch ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656009536.0534809-88841-259616145208073/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '14371'
+  ppid: '14370'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009536.0534809-88841-259616145208073/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '14372'
+  ppid: '14371'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17543'
+  ppid: '2'
+  user: root
+- cmdline: /bin/sh /opt/jboss/bin/domain.sh --domain-config=domain.xml --host-config=host.xml
+  cwd: /bin/
+  pid: '17678'
+  ppid: '1'
+  user: wildfly
+- cmdline: java -D[Process Controller] -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m
+    -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman
+    -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/process-controller.log
+    -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
+    -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.process-controller
+    -jboss-home /opt/jboss -jvm java -mp /opt/jboss/modules -- -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log
+    -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
+    -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true
+    -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -- -default-jvm
+    java --domain-config=domain.xml --host-config=host.xml
+  cwd: /
+  pid: '17764'
+  ppid: '17678'
+  user: wildfly
+- cmdline: java -D[Host Controller] -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log
+    -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
+    -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true
+    -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -jar /opt/jboss/jboss-modules.jar
+    -mp /opt/jboss/modules org.jboss.as.host-controller -mp /opt/jboss/modules --pc-address
+    127.0.0.1 --pc-port 42816 -default-jvm java --domain-config=domain.xml --host-config=host.xml
+    -Djboss.home.dir=/opt/jboss
+  cwd: /
+  pid: '17780'
+  ppid: '17764'
+  user: wildfly
+- cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/java
+    -D[Server:nodo1-server1] -D[pcid:1449119893] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m
+    -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true
+    -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo1-server1/log
+    -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo1-server1/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo1-server1/data
+    -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo1-server1/data/logging.properties
+    -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
+  cwd: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/
+  pid: '17878'
+  ppid: '17764'
+  user: wildfly
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '18901'
+  ppid: '866'
+  user: apache
+software_list:
+- cmd_regexp: org\.jboss\.Main|org\.jboss\.(?:Main|as\.(?:standalone|server))
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/jboss.yaml
+    name: Include JBoss specific plugins
+  name: JBoss Application Server
+  pkg_regexp: jboss
+  process_type: parent
+  return_children: false
+  return_packages: true
+  vars:
+    credentials:
+      management_password: password
+      management_user: admin
+    default_management_port: '9990'
+tcp_listen:
+- address: 0.0.0.0
+  name: java
+  pid: 17924
+  port: 8230
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: java
+  pid: 17780
+  port: 9990
+  protocol: tcp
+  stime: Thu Jun 23 09:01:15 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17878
+  port: 3528
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: java
+  pid: 17878
+  port: 8009
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: mongod
+  pid: 1239
+  port: 27017
+  protocol: tcp
+  stime: Thu Jun 16 14:10:00 2022
+  user: mongod
+- address: 0.0.0.0
+  name: java
+  pid: 17780
+  port: 9999
+  protocol: tcp
+  stime: Thu Jun 23 09:01:15 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: 0.0.0.0
+  name: java
+  pid: 17878
+  port: 8080
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: java
+  pid: 17924
+  port: 8593
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: sshd
+  pid: 1159
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 16 14:09:58 2022
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: 17878
+  port: 54200
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17924
+  port: 54201
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: master
+  pid: 1100
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 16 14:09:57 2022
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: 17878
+  port: 8443
+  protocol: tcp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17924
+  port: 3678
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: java
+  pid: 17924
+  port: 8159
+  protocol: tcp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17764
+  port: 42816
+  protocol: tcp
+  stime: Thu Jun 23 09:01:13 2022
+  user: wildfly
+- address: '::'
+  name: java
+  pid: 967
+  port: 5672
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 42825
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: mysqld
+  pid: 1535
+  port: 3306
+  protocol: tcp
+  stime: Thu Jun 16 14:10:11 2022
+  user: mysql
+- address: '::'
+  name: java
+  pid: 967
+  port: 61613
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 61614
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: '::'
+  name: java
+  pid: 967
+  port: 61616
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: httpd
+  pid: 866
+  port: 80
+  protocol: tcp
+  stime: Thu Jun 16 14:09:53 2022
+  user: root
+- address: '::'
+  name: httpd
+  pid: 866
+  port: 81
+  protocol: tcp
+  stime: Thu Jun 16 14:09:53 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1159
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 16 14:09:58 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1100
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 16 14:09:57 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 1883
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 8161
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+udp_listen:
+- address: 230.0.0.4
+  name: java
+  pid: 17924
+  port: 45688
+  protocol: udp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 230.0.0.4
+  name: java
+  pid: 17878
+  port: 45688
+  protocol: udp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 550
+  port: 721
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: 224.0.1.105
+  name: java
+  pid: 17924
+  port: 23364
+  protocol: udp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 224.0.1.105
+  name: java
+  pid: 17878
+  port: 23364
+  protocol: udp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17878
+  port: 55200
+  protocol: udp
+  stime: Thu Jun 23 09:01:29 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 17924
+  port: 55350
+  protocol: udp
+  stime: Thu Jun 23 09:01:35 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: dhclient
+  pid: 808
+  port: 68
+  protocol: udp
+  stime: Thu Jun 16 14:09:53 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 566
+  port: 323
+  protocol: udp
+  stime: Thu Jun 16 14:09:49 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 550
+  port: 721
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: '::'
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 566
+  port: 323
+  protocol: udp
+  stime: Thu Jun 16 14:09:49 2022
+  user: chrony

--- a/tests/unit/plugins/action/auto/resources/jboss/jboss7.4_domain-slave_centos7.6.yaml
+++ b/tests/unit/plugins/action/auto/resources/jboss/jboss7.4_domain-slave_centos7.6.yaml
@@ -1,126 +1,422 @@
+dockers:
+  containers: []
+expected_result:
+- bindings:
+  - address: 127.0.0.1
+    class: service
+    port: 3528
+    protocol: tcp
+  - address: 192.168.0.98
+    class: service
+    port: 8009
+    protocol: tcp
+  - address: 192.168.0.98
+    class: service
+    port: 8080
+    protocol: tcp
+  - address: 127.0.0.1
+    class: service
+    port: 54200
+    protocol: tcp
+  - address: 192.168.0.98
+    class: service
+    port: 8443
+    protocol: tcp
+  - address: 230.0.0.4
+    class: service
+    port: 45688
+    protocol: udp
+  - address: 224.0.1.105
+    class: service
+    port: 23364
+    protocol: udp
+  - address: 127.0.0.1
+    class: service
+    port: 55200
+    protocol: udp
+  - class: ajp
+    port: 8009
+  - class: http
+    port: 8080
+  - class: https
+    port: 8443
+  - class: iiop
+    port: 3528
+  - class: iiop_ssl
+    port: 3529
+  - class: jgroups_tcp
+    port: 7600
+  - class: jgroups_tcp_fd
+    port: 57600
+  - class: jgroups_udp_fd
+    port: 54200
+  - class: txn_recovery_environment
+    port: 4712
+  - class: txn_status_manager
+    port: 4713
+  - address: 192.168.0.130
+    class: domain controller
+    extra_data:
+      security_realm: ManagementRealm
+    port: 9999
+  - class: listener
+    port: 19990
+  configuration:
+    host_xml:
+      host:
+        attr-name: nodo2
+        attr-xmlns: urn:jboss:domain:16.0
+        domain-controller:
+          remote:
+            attr-host: ${jboss.domain.master.address:192.168.0.130}
+            attr-port: ${jboss.domain.master.port:9999}
+            attr-security-realm: ManagementRealm
+        extensions:
+          extension:
+          - attr-module: org.jboss.as.jmx
+          - attr-module: org.wildfly.extension.core-management
+          - attr-module: org.wildfly.extension.elytron
+        interfaces:
+          interface:
+          - attr-name: management
+            inet-address:
+              attr-value: ${jboss.bind.address.management:127.0.0.1}
+          - attr-name: public
+            inet-address:
+              attr-value: ${jboss.bind.address:192.168.0.98}
+        jvms:
+          jvm:
+            attr-name: default
+            heap:
+              attr-max-size: 256m
+              attr-size: 64m
+            jvm-options:
+              option:
+              - attr-value: -server
+              - attr-value: -XX:MetaspaceSize=96m
+              - attr-value: -XX:MaxMetaspaceSize=256m
+        management:
+          audit-log:
+            formatters:
+              json-formatter:
+                attr-name: json-formatter
+            handlers:
+              file-handler:
+              - attr-formatter: json-formatter
+                attr-name: host-file
+                attr-path: audit-log.log
+                attr-relative-to: jboss.domain.data.dir
+              - attr-formatter: json-formatter
+                attr-name: server-file
+                attr-path: audit-log.log
+                attr-relative-to: jboss.server.data.dir
+            logger:
+              attr-enabled: 'false'
+              attr-log-boot: 'true'
+              attr-log-read-only: 'false'
+              handlers:
+                handler:
+                  attr-name: host-file
+            server-logger:
+              attr-enabled: 'false'
+              attr-log-boot: 'true'
+              attr-log-read-only: 'false'
+              handlers:
+                handler:
+                  attr-name: server-file
+          management-interfaces:
+            http-interface:
+              attr-security-realm: ManagementRealm
+              http-upgrade:
+                attr-enabled: 'true'
+              socket:
+                attr-interface: management
+                attr-port: ${jboss.management.http.port:19990}
+          security-realms:
+            security-realm:
+            - attr-name: ManagementRealm
+              authentication:
+                local:
+                  attr-default-user: $local
+                  attr-skip-group-loading: 'true'
+                properties:
+                  attr-path: mgmt-users.properties
+                  attr-relative-to: jboss.domain.config.dir
+              authorization:
+                attr-map-groups-to-roles: 'false'
+                properties:
+                  attr-path: mgmt-groups.properties
+                  attr-relative-to: jboss.domain.config.dir
+              server-identities:
+                secret:
+                  attr-value: ZDR0NGQwcDMh
+            - attr-name: ApplicationRealm
+              authentication:
+                local:
+                  attr-allowed-users: '*'
+                  attr-default-user: $local
+                  attr-skip-group-loading: 'true'
+                properties:
+                  attr-path: application-users.properties
+                  attr-relative-to: jboss.domain.config.dir
+              authorization:
+                properties:
+                  attr-path: application-roles.properties
+                  attr-relative-to: jboss.domain.config.dir
+              server-identities:
+                ssl:
+                  keystore:
+                    attr-alias: server
+                    attr-generate-self-signed-certificate-host: localhost
+                    attr-key-password: password
+                    attr-keystore-password: password
+                    attr-path: application.keystore
+                    attr-relative-to: jboss.domain.config.dir
+        profile:
+          subsystem:
+          - attr-xmlns: urn:jboss:domain:core-management:1.0
+          - attr-disallowed-providers: OracleUcrypto
+            attr-final-providers: combined-providers
+            attr-xmlns: urn:wildfly:elytron:13.0
+            audit-logging:
+              file-audit-log:
+                attr-format: JSON
+                attr-name: local-audit
+                attr-path: audit.log
+                attr-relative-to: jboss.domain.log.dir
+            http:
+              http-authentication-factory:
+                attr-http-server-mechanism-factory: global
+                attr-name: management-http-authentication
+                attr-security-domain: ManagementDomain
+                mechanism-configuration:
+                  mechanism:
+                    attr-mechanism-name: BASIC
+                    mechanism-realm:
+                      attr-realm-name: Management Realm
+              provider-http-server-mechanism-factory:
+                attr-name: global
+            mappers:
+              constant-realm-mapper:
+                attr-name: local
+                attr-realm-name: local
+              constant-role-mapper:
+                attr-name: super-user-mapper
+                role:
+                  attr-name: SuperUser
+              simple-permission-mapper:
+                attr-mapping-mode: first
+                attr-name: default-permission-mapper
+                permission-mapping:
+                - permission-set:
+                    attr-name: default-permissions
+                  principal:
+                    attr-name: anonymous
+                - attr-match-all: 'true'
+                  permission-set:
+                  - attr-name: login-permission
+                  - attr-name: default-permissions
+              simple-role-decoder:
+                attr-attribute: groups
+                attr-name: groups-to-roles
+            permission-sets:
+              permission-set:
+              - attr-name: login-permission
+                permission:
+                  attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+              - attr-name: default-permissions
+            providers:
+              aggregate-providers:
+                attr-name: combined-providers
+                providers:
+                - attr-name: elytron
+                - attr-name: openssl
+              provider-loader:
+              - attr-module: org.wildfly.security.elytron
+                attr-name: elytron
+              - attr-module: org.wildfly.openssl
+                attr-name: openssl
+            sasl:
+              configurable-sasl-server-factory:
+                attr-name: configured
+                attr-sasl-server-factory: elytron
+                properties:
+                  property:
+                    attr-name: wildfly.sasl.local-user.default-user
+                    attr-value: $local
+              mechanism-provider-filtering-sasl-server-factory:
+                attr-name: elytron
+                attr-sasl-server-factory: global
+                filters:
+                  filter:
+                    attr-provider-name: WildFlyElytron
+              provider-sasl-server-factory:
+                attr-name: global
+              sasl-authentication-factory:
+                attr-name: management-sasl-authentication
+                attr-sasl-server-factory: configured
+                attr-security-domain: ManagementDomain
+                mechanism-configuration:
+                  mechanism:
+                  - attr-mechanism-name: JBOSS-LOCAL-USER
+                    attr-realm-mapper: local
+                  - attr-mechanism-name: DIGEST-MD5
+                    mechanism-realm:
+                      attr-realm-name: ManagementRealm
+            security-domains:
+              security-domain:
+                attr-default-realm: ManagementRealm
+                attr-name: ManagementDomain
+                attr-permission-mapper: default-permission-mapper
+                realm:
+                - attr-name: ManagementRealm
+                  attr-role-decoder: groups-to-roles
+                - attr-name: local
+                  attr-role-mapper: super-user-mapper
+            security-realms:
+              identity-realm:
+                attr-identity: $local
+                attr-name: local
+              properties-realm:
+                attr-name: ManagementRealm
+                groups-properties:
+                  attr-path: mgmt-groups.properties
+                  attr-relative-to: jboss.domain.config.dir
+                users-properties:
+                  attr-digest-realm-name: ManagementRealm
+                  attr-path: mgmt-users.properties
+                  attr-relative-to: jboss.domain.config.dir
+          - attr-xmlns: urn:jboss:domain:jmx:1.3
+            expose-expression-model: null
+            expose-resolved-model: null
+            remoting-connector: null
+        servers:
+          server:
+          - attr-auto-start: 'true'
+            attr-group: main-server-group
+            attr-name: nodo2-server1
+          - attr-auto-start: 'true'
+            attr-group: second-server-group
+            attr-name: nodo2-server2
+            jvm:
+              attr-name: default
+            socket-bindings:
+              attr-port-offset: '150'
+  discovery_time: '2022-06-23T20:30:41+02:00'
+  extra_data:
+    domain_role: slave
+    heap_initial_allocation_memory: 1000m
+    heap_max_memory: 1000m
+    mode: domain
+    server:
+      group: main-server-group
+      name: nodo2-server1
+      port_offset: 0
+      profile: full-ha
+  files:
+  - path: /opt/jboss/domain/servers/nodo2-server1/log
+    subtype: generic
+    type: log
+  - name: server.log
+    path: /opt/jboss/domain/servers/nodo2-server1/log
+    subtype: generic
+    type: log
+  - name: logging.properties
+    path: /opt/jboss/domain/servers/nodo2-server1/data
+    subtype: generic
+    type: log
+  - name: host.xml
+    path: /opt/jboss/domain/configuration
+    subtype: host
+    type: config
+  - name: domain.xml
+    path: /opt/jboss/domain/configuration
+    subtype: domain
+    type: config
+  - path: /opt/jboss
+    subtype: generic
+    type: data
+  listening_ports:
+  - 3528
+  - 8009
+  - 8080
+  - 8443
+  - 23364
+  - 45688
+  - 54200
+  - 55200
+  packages: []
+  process:
+    cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-1.el7_9.x86_64/jre/bin/java
+      -D[Server:nodo2-server1] -D[pcid:485084469] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m
+      -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true
+      -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo2-server1/log
+      -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo2-server1/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo2-server1/data
+      -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo2-server1/data/logging.properties
+      -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
+    cwd: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-1.el7_9.x86_64/jre/bin/
+    listening_ports:
+    - 3528
+    - 8009
+    - 8080
+    - 8443
+    - 23364
+    - 45688
+    - 54200
+    - 55200
+    pid: '24402'
+    ppid: '24331'
+    user: wildfly
+  type: JBoss Application Server
+  version:
+  - number: 7.4.0
+    type: file
 mocked_plugin_tasks:
-  "Run entry regex":
-    calls:
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - run
-      - run
-      - run
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - run
-      - run
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-  "Check if controller information is available":
+  Check if controller information is available:
     expected_exception:
-      message: "'NoneType' object is not iterable"
-  "Check if version file is accessible":
+      message: '''NoneType'' object is not iterable'
+  Check if domain_xml_file is accessible:
     expected_args:
-      path: "/opt/jboss/version.txt"
       follow: false
       get_attributes: true
       get_mime: true
       in_docker: true
+      path: /opt/jboss/domain/configuration/domain.xml
     plugin_result:
       failed: false
-  "Read version file":
+  Check if host_xml_file is accessible:
     expected_args:
-      delegate_reading: false
-      file_path: "/opt/jboss/version.txt"
-      in_docker: true
-      parser: null
-      parser_params: null
-    plugin_result:
-      failed: false
-      content: "Red Hat JBoss Enterprise Application Platform - Version 7.4.0.GA"
-  "Check if logging_conf_file is accessible":
-    expected_args:
-      path: "/opt/jboss/domain/servers/nodo2-server1/data/logging.properties"
       follow: false
       get_attributes: true
       get_mime: true
       in_docker: true
+      path: /opt/jboss/domain/configuration/host.xml
     plugin_result:
       failed: false
-  "Read logging_conf_file if accessible":
+  Check if logging_conf_file is accessible:
     expected_args:
-      delegate_reading: false
-      file_path: "/opt/jboss/domain/servers/nodo2-server1/data/logging.properties"
-      in_docker: true
-      parser: null
-      parser_params: null
-    plugin_result:
-      failed: false
-      content: |-
-        # Note this file has been generated and will be overwritten if a
-        # logging subsystem has been defined in the XML configuration.
-        
-        
-        # Additional loggers to configure (the root logger is always configured)
-        loggers=sun.rmi,org.jboss.as.config,io.jaegertracing.Configuration,com.arjuna
-        
-        logger.level=INFO
-        logger.handlers=FILE
-        
-        logger.sun.rmi.level=WARN
-        logger.sun.rmi.useParentHandlers=true
-        
-        logger.org.jboss.as.config.level=DEBUG
-        logger.org.jboss.as.config.useParentHandlers=true
-        
-        logger.io.jaegertracing.Configuration.level=WARN
-        logger.io.jaegertracing.Configuration.useParentHandlers=true
-        
-        logger.com.arjuna.level=WARN
-        logger.com.arjuna.useParentHandlers=true
-        
-        handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
-        handler.FILE.level=ALL
-        handler.FILE.formatter=PATTERN
-        handler.FILE.properties=autoFlush,append,fileName,suffix
-        handler.FILE.constructorProperties=fileName,append
-        handler.FILE.autoFlush=true
-        handler.FILE.append=true
-        handler.FILE.fileName=/opt/jboss/domain/servers/nodo2-server1/log/server.log
-        handler.FILE.suffix=.yyyy-MM-dd
-        
-        # Additional formatters to configure
-        formatters=COLOR-PATTERN
-        
-        
-        formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
-        formatter.PATTERN.properties=pattern
-        formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
-        
-        formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
-        formatter.COLOR-PATTERN.properties=pattern
-        formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
-
-
-  "Check if host_xml_file is accessible":
-    expected_args:
-      path: "/opt/jboss/domain/configuration/host.xml"
       follow: false
       get_attributes: true
       get_mime: true
       in_docker: true
+      path: /opt/jboss/domain/servers/nodo2-server1/data/logging.properties
     plugin_result:
       failed: false
-  "Read host_xml_file":
+  Check if version file is accessible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /opt/jboss/version.txt
+    plugin_result:
+      failed: false
+  Read host_xml_file:
     expected_args:
       delegate_reading: false
-      file_path: "/opt/jboss/domain/configuration/host.xml"
+      file_path: /opt/jboss/domain/configuration/host.xml
       in_docker: true
-      parser: "xml"
+      parser: xml
       parser_params: null
     plugin_result:
       failed: false
@@ -135,17 +431,17 @@ mocked_plugin_tasks:
               attr-security-realm: ManagementRealm
           extensions:
             extension:
-              - attr-module: org.jboss.as.jmx
-              - attr-module: org.wildfly.extension.core-management
-              - attr-module: org.wildfly.extension.elytron
+            - attr-module: org.jboss.as.jmx
+            - attr-module: org.wildfly.extension.core-management
+            - attr-module: org.wildfly.extension.elytron
           interfaces:
             interface:
-              - attr-name: management
-                inet-address:
-                  attr-value: ${jboss.bind.address.management:127.0.0.1}
-              - attr-name: public
-                inet-address:
-                  attr-value: ${jboss.bind.address:192.168.0.98}
+            - attr-name: management
+              inet-address:
+                attr-value: ${jboss.bind.address.management:127.0.0.1}
+            - attr-name: public
+              inet-address:
+                attr-value: ${jboss.bind.address:192.168.0.98}
           jvms:
             jvm:
               attr-name: default
@@ -154,9 +450,9 @@ mocked_plugin_tasks:
                 attr-size: 64m
               jvm-options:
                 option:
-                  - attr-value: -server
-                  - attr-value: -XX:MetaspaceSize=96m
-                  - attr-value: -XX:MaxMetaspaceSize=256m
+                - attr-value: -server
+                - attr-value: -XX:MetaspaceSize=96m
+                - attr-value: -XX:MaxMetaspaceSize=256m
           management:
             audit-log:
               formatters:
@@ -164,14 +460,14 @@ mocked_plugin_tasks:
                   attr-name: json-formatter
               handlers:
                 file-handler:
-                  - attr-formatter: json-formatter
-                    attr-name: host-file
-                    attr-path: audit-log.log
-                    attr-relative-to: jboss.domain.data.dir
-                  - attr-formatter: json-formatter
-                    attr-name: server-file
-                    attr-path: audit-log.log
-                    attr-relative-to: jboss.server.data.dir
+                - attr-formatter: json-formatter
+                  attr-name: host-file
+                  attr-path: audit-log.log
+                  attr-relative-to: jboss.domain.data.dir
+                - attr-formatter: json-formatter
+                  attr-name: server-file
+                  attr-path: audit-log.log
+                  attr-relative-to: jboss.server.data.dir
               logger:
                 attr-enabled: 'false'
                 attr-log-boot: 'true'
@@ -196,4502 +492,4340 @@ mocked_plugin_tasks:
                   attr-port: ${jboss.management.http.port:19990}
             security-realms:
               security-realm:
-                - attr-name: ManagementRealm
-                  authentication:
-                    local:
-                      attr-default-user: $local
-                      attr-skip-group-loading: 'true'
-                    properties:
-                      attr-path: mgmt-users.properties
+              - attr-name: ManagementRealm
+                authentication:
+                  local:
+                    attr-default-user: $local
+                    attr-skip-group-loading: 'true'
+                  properties:
+                    attr-path: mgmt-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+                authorization:
+                  attr-map-groups-to-roles: 'false'
+                  properties:
+                    attr-path: mgmt-groups.properties
+                    attr-relative-to: jboss.domain.config.dir
+                server-identities:
+                  secret:
+                    attr-value: ZDR0NGQwcDMh
+              - attr-name: ApplicationRealm
+                authentication:
+                  local:
+                    attr-allowed-users: '*'
+                    attr-default-user: $local
+                    attr-skip-group-loading: 'true'
+                  properties:
+                    attr-path: application-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+                authorization:
+                  properties:
+                    attr-path: application-roles.properties
+                    attr-relative-to: jboss.domain.config.dir
+                server-identities:
+                  ssl:
+                    keystore:
+                      attr-alias: server
+                      attr-generate-self-signed-certificate-host: localhost
+                      attr-key-password: password
+                      attr-keystore-password: password
+                      attr-path: application.keystore
                       attr-relative-to: jboss.domain.config.dir
-                  authorization:
-                    attr-map-groups-to-roles: 'false'
-                    properties:
-                      attr-path: mgmt-groups.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  server-identities:
-                    secret:
-                      attr-value: ZDR0NGQwcDMh
-                - attr-name: ApplicationRealm
-                  authentication:
-                    local:
-                      attr-allowed-users: '*'
-                      attr-default-user: $local
-                      attr-skip-group-loading: 'true'
-                    properties:
-                      attr-path: application-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  authorization:
-                    properties:
-                      attr-path: application-roles.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  server-identities:
-                    ssl:
-                      keystore:
-                        attr-alias: server
-                        attr-generate-self-signed-certificate-host: localhost
-                        attr-key-password: password
-                        attr-keystore-password: password
-                        attr-path: application.keystore
-                        attr-relative-to: jboss.domain.config.dir
           profile:
             subsystem:
-              - attr-xmlns: urn:jboss:domain:core-management:1.0
-              - attr-disallowed-providers: OracleUcrypto
-                attr-final-providers: combined-providers
-                attr-xmlns: urn:wildfly:elytron:13.0
-                audit-logging:
-                  file-audit-log:
-                    attr-format: JSON
-                    attr-name: local-audit
-                    attr-path: audit.log
-                    attr-relative-to: jboss.domain.log.dir
-                http:
-                  http-authentication-factory:
-                    attr-http-server-mechanism-factory: global
-                    attr-name: management-http-authentication
-                    attr-security-domain: ManagementDomain
-                    mechanism-configuration:
-                      mechanism:
-                        attr-mechanism-name: BASIC
-                        mechanism-realm:
-                          attr-realm-name: Management Realm
-                  provider-http-server-mechanism-factory:
-                    attr-name: global
-                mappers:
-                  constant-realm-mapper:
-                    attr-name: local
-                    attr-realm-name: local
-                  constant-role-mapper:
-                    attr-name: super-user-mapper
-                    role:
-                      attr-name: SuperUser
-                  simple-permission-mapper:
-                    attr-mapping-mode: first
-                    attr-name: default-permission-mapper
-                    permission-mapping:
-                      - permission-set:
-                          attr-name: default-permissions
-                        principal:
-                          attr-name: anonymous
-                      - attr-match-all: 'true'
-                        permission-set:
-                          - attr-name: login-permission
-                          - attr-name: default-permissions
-                  simple-role-decoder:
-                    attr-attribute: groups
-                    attr-name: groups-to-roles
-                permission-sets:
-                  permission-set:
+            - attr-xmlns: urn:jboss:domain:core-management:1.0
+            - attr-disallowed-providers: OracleUcrypto
+              attr-final-providers: combined-providers
+              attr-xmlns: urn:wildfly:elytron:13.0
+              audit-logging:
+                file-audit-log:
+                  attr-format: JSON
+                  attr-name: local-audit
+                  attr-path: audit.log
+                  attr-relative-to: jboss.domain.log.dir
+              http:
+                http-authentication-factory:
+                  attr-http-server-mechanism-factory: global
+                  attr-name: management-http-authentication
+                  attr-security-domain: ManagementDomain
+                  mechanism-configuration:
+                    mechanism:
+                      attr-mechanism-name: BASIC
+                      mechanism-realm:
+                        attr-realm-name: Management Realm
+                provider-http-server-mechanism-factory:
+                  attr-name: global
+              mappers:
+                constant-realm-mapper:
+                  attr-name: local
+                  attr-realm-name: local
+                constant-role-mapper:
+                  attr-name: super-user-mapper
+                  role:
+                    attr-name: SuperUser
+                simple-permission-mapper:
+                  attr-mapping-mode: first
+                  attr-name: default-permission-mapper
+                  permission-mapping:
+                  - permission-set:
+                      attr-name: default-permissions
+                    principal:
+                      attr-name: anonymous
+                  - attr-match-all: 'true'
+                    permission-set:
                     - attr-name: login-permission
-                      permission:
-                        attr-class-name: org.wildfly.security.auth.permission.LoginPermission
                     - attr-name: default-permissions
-                providers:
-                  aggregate-providers:
-                    attr-name: combined-providers
-                    providers:
-                      - attr-name: elytron
-                      - attr-name: openssl
-                  provider-loader:
-                    - attr-module: org.wildfly.security.elytron
-                      attr-name: elytron
-                    - attr-module: org.wildfly.openssl
-                      attr-name: openssl
-                sasl:
-                  configurable-sasl-server-factory:
-                    attr-name: configured
-                    attr-sasl-server-factory: elytron
-                    properties:
-                      property:
-                        attr-name: wildfly.sasl.local-user.default-user
-                        attr-value: $local
-                  mechanism-provider-filtering-sasl-server-factory:
-                    attr-name: elytron
-                    attr-sasl-server-factory: global
-                    filters:
-                      filter:
-                        attr-provider-name: WildFlyElytron
-                  provider-sasl-server-factory:
-                    attr-name: global
-                  sasl-authentication-factory:
-                    attr-name: management-sasl-authentication
-                    attr-sasl-server-factory: configured
-                    attr-security-domain: ManagementDomain
-                    mechanism-configuration:
-                      mechanism:
-                        - attr-mechanism-name: JBOSS-LOCAL-USER
-                          attr-realm-mapper: local
-                        - attr-mechanism-name: DIGEST-MD5
-                          mechanism-realm:
-                            attr-realm-name: ManagementRealm
-                security-domains:
-                  security-domain:
-                    attr-default-realm: ManagementRealm
-                    attr-name: ManagementDomain
-                    attr-permission-mapper: default-permission-mapper
-                    realm:
-                      - attr-name: ManagementRealm
-                        attr-role-decoder: groups-to-roles
-                      - attr-name: local
-                        attr-role-mapper: super-user-mapper
-                security-realms:
-                  identity-realm:
-                    attr-identity: $local
-                    attr-name: local
-                  properties-realm:
-                    attr-name: ManagementRealm
-                    groups-properties:
-                      attr-path: mgmt-groups.properties
-                      attr-relative-to: jboss.domain.config.dir
-                    users-properties:
-                      attr-digest-realm-name: ManagementRealm
-                      attr-path: mgmt-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-              - attr-xmlns: urn:jboss:domain:jmx:1.3
-                expose-expression-model: null
-                expose-resolved-model: null
-                remoting-connector: null
+                simple-role-decoder:
+                  attr-attribute: groups
+                  attr-name: groups-to-roles
+              permission-sets:
+                permission-set:
+                - attr-name: login-permission
+                  permission:
+                    attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                - attr-name: default-permissions
+              providers:
+                aggregate-providers:
+                  attr-name: combined-providers
+                  providers:
+                  - attr-name: elytron
+                  - attr-name: openssl
+                provider-loader:
+                - attr-module: org.wildfly.security.elytron
+                  attr-name: elytron
+                - attr-module: org.wildfly.openssl
+                  attr-name: openssl
+              sasl:
+                configurable-sasl-server-factory:
+                  attr-name: configured
+                  attr-sasl-server-factory: elytron
+                  properties:
+                    property:
+                      attr-name: wildfly.sasl.local-user.default-user
+                      attr-value: $local
+                mechanism-provider-filtering-sasl-server-factory:
+                  attr-name: elytron
+                  attr-sasl-server-factory: global
+                  filters:
+                    filter:
+                      attr-provider-name: WildFlyElytron
+                provider-sasl-server-factory:
+                  attr-name: global
+                sasl-authentication-factory:
+                  attr-name: management-sasl-authentication
+                  attr-sasl-server-factory: configured
+                  attr-security-domain: ManagementDomain
+                  mechanism-configuration:
+                    mechanism:
+                    - attr-mechanism-name: JBOSS-LOCAL-USER
+                      attr-realm-mapper: local
+                    - attr-mechanism-name: DIGEST-MD5
+                      mechanism-realm:
+                        attr-realm-name: ManagementRealm
+              security-domains:
+                security-domain:
+                  attr-default-realm: ManagementRealm
+                  attr-name: ManagementDomain
+                  attr-permission-mapper: default-permission-mapper
+                  realm:
+                  - attr-name: ManagementRealm
+                    attr-role-decoder: groups-to-roles
+                  - attr-name: local
+                    attr-role-mapper: super-user-mapper
+              security-realms:
+                identity-realm:
+                  attr-identity: $local
+                  attr-name: local
+                properties-realm:
+                  attr-name: ManagementRealm
+                  groups-properties:
+                    attr-path: mgmt-groups.properties
+                    attr-relative-to: jboss.domain.config.dir
+                  users-properties:
+                    attr-digest-realm-name: ManagementRealm
+                    attr-path: mgmt-users.properties
+                    attr-relative-to: jboss.domain.config.dir
+            - attr-xmlns: urn:jboss:domain:jmx:1.3
+              expose-expression-model: null
+              expose-resolved-model: null
+              remoting-connector: null
           servers:
             server:
-              - attr-auto-start: 'true'
-                attr-group: main-server-group
-                attr-name: nodo2-server1
-              - attr-auto-start: 'true'
-                attr-group: second-server-group
-                attr-name: nodo2-server2
-                jvm:
-                  attr-name: default
-                socket-bindings:
-                  attr-port-offset: '150'
-  "Check if domain_xml_file is accessible":
+            - attr-auto-start: 'true'
+              attr-group: main-server-group
+              attr-name: nodo2-server1
+            - attr-auto-start: 'true'
+              attr-group: second-server-group
+              attr-name: nodo2-server2
+              jvm:
+                attr-name: default
+              socket-bindings:
+                attr-port-offset: '150'
+  Read logging_conf_file if accessible:
     expected_args:
-      path: "/opt/jboss/domain/configuration/domain.xml"
-      follow: false
-      get_attributes: true
-      get_mime: true
+      delegate_reading: false
+      file_path: /opt/jboss/domain/servers/nodo2-server1/data/logging.properties
       in_docker: true
+      parser: null
+      parser_params: null
     plugin_result:
+      content: '# Note this file has been generated and will be overwritten if a
+
+        # logging subsystem has been defined in the XML configuration.
+
+
+
+        # Additional loggers to configure (the root logger is always configured)
+
+        loggers=sun.rmi,org.jboss.as.config,io.jaegertracing.Configuration,com.arjuna
+
+
+        logger.level=INFO
+
+        logger.handlers=FILE
+
+
+        logger.sun.rmi.level=WARN
+
+        logger.sun.rmi.useParentHandlers=true
+
+
+        logger.org.jboss.as.config.level=DEBUG
+
+        logger.org.jboss.as.config.useParentHandlers=true
+
+
+        logger.io.jaegertracing.Configuration.level=WARN
+
+        logger.io.jaegertracing.Configuration.useParentHandlers=true
+
+
+        logger.com.arjuna.level=WARN
+
+        logger.com.arjuna.useParentHandlers=true
+
+
+        handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+
+        handler.FILE.level=ALL
+
+        handler.FILE.formatter=PATTERN
+
+        handler.FILE.properties=autoFlush,append,fileName,suffix
+
+        handler.FILE.constructorProperties=fileName,append
+
+        handler.FILE.autoFlush=true
+
+        handler.FILE.append=true
+
+        handler.FILE.fileName=/opt/jboss/domain/servers/nodo2-server1/log/server.log
+
+        handler.FILE.suffix=.yyyy-MM-dd
+
+
+        # Additional formatters to configure
+
+        formatters=COLOR-PATTERN
+
+
+
+        formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+
+        formatter.PATTERN.properties=pattern
+
+        formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
+
+
+        formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+
+        formatter.COLOR-PATTERN.properties=pattern
+
+        formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t)
+        %s%e%n'
       failed: false
-  "Request information to the management server":
+  Read version file:
+    expected_args:
+      delegate_reading: false
+      file_path: /opt/jboss/version.txt
+      in_docker: true
+      parser: null
+      parser_params: null
+    plugin_result:
+      content: Red Hat JBoss Enterprise Application Platform - Version 7.4.0.GA
+      failed: false
+  Request information to the management server:
     calls:
-      - plugin_result:
-          failed: true
-      - plugin_result:
-          failed: false
-          json: {
-            "outcome": "success",
-            "result": {
-              "profile": "full-ha",
-              "graceful-startup": true,
-              "socket-binding-group": "full-ha-sockets",
-              "deployment-overlay": null,
-              "socket-binding-port-offset": 0,
-              "jvm": {
-                "default": null
-              },
-              "deployment": null,
-              "system-property": null,
-              "socket-binding-default-interface": null,
-              "management-subsystem-endpoint": false
-            }
-          }
-  "Request socket binding group information by its name":
+    - plugin_result:
+        failed: true
+    - plugin_result:
+        failed: false
+        json:
+          outcome: success
+          result:
+            deployment: null
+            deployment-overlay: null
+            graceful-startup: true
+            jvm:
+              default: null
+            management-subsystem-endpoint: false
+            profile: full-ha
+            socket-binding-default-interface: null
+            socket-binding-group: full-ha-sockets
+            socket-binding-port-offset: 0
+            system-property: null
+  Request socket binding group information by its name:
     plugin_result:
       failed: false
-      json: {
-        "outcome": "success",
-        "result": {
-          "default-interface": "public",
-          "name": "full-ha-sockets",
-          "socket-binding": {
-            "https": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "https",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": null,
-              "port": {
-                "EXPRESSION_VALUE": "${jboss.https.port:8443}"
-              }
-            },
-            "http": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "http",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": null,
-              "port": {
-                "EXPRESSION_VALUE": "${jboss.http.port:8080}"
-              }
-            },
-            "jgroups-tcp-fd": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "jgroups-tcp-fd",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": "private",
-              "port": 57600
-            },
-            "ajp": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "ajp",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": null,
-              "port": {
-                "EXPRESSION_VALUE": "${jboss.ajp.port:8009}"
-              }
-            },
-            "txn-recovery-environment": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "txn-recovery-environment",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": null,
-              "port": 4712
-            },
-            "jgroups-tcp": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "jgroups-tcp",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": "private",
-              "port": 7600
-            },
-            "modcluster": {
-              "multicast-port": 23364,
-              "client-mappings": null,
-              "name": "modcluster",
-              "multicast-address": {
-                "EXPRESSION_VALUE": "${jboss.modcluster.multicast.address:224.0.1.105}"
-              },
-              "fixed-port": false,
-              "interface": null,
-              "port": 0
-            },
-            "jgroups-udp-fd": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "jgroups-udp-fd",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": "private",
-              "port": 54200
-            },
-            "jgroups-udp": {
-              "multicast-port": 45688,
-              "client-mappings": null,
-              "name": "jgroups-udp",
-              "multicast-address": {
-                "EXPRESSION_VALUE": "${jboss.default.multicast.address:230.0.0.4}"
-              },
-              "fixed-port": false,
-              "interface": "private",
-              "port": 55200
-            },
-            "iiop-ssl": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "iiop-ssl",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": "unsecure",
-              "port": 3529
-            },
-            "txn-status-manager": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "txn-status-manager",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": null,
-              "port": 4713
-            },
-            "jgroups-mping": {
-              "multicast-port": 45700,
-              "client-mappings": null,
-              "name": "jgroups-mping",
-              "multicast-address": {
-                "EXPRESSION_VALUE": "${jboss.default.multicast.address:230.0.0.4}"
-              },
-              "fixed-port": false,
-              "interface": "private",
-              "port": 0
-            },
-            "iiop": {
-              "multicast-port": null,
-              "client-mappings": null,
-              "name": "iiop",
-              "multicast-address": null,
-              "fixed-port": false,
-              "interface": "unsecure",
-              "port": 3528
-            }
-          },
-          "local-destination-outbound-socket-binding": null,
-          "includes": null,
-          "remote-destination-outbound-socket-binding": {
-            "mail-smtp": {
-              "port": {
-                "EXPRESSION_VALUE": "${jboss.mail.server.port:25}"
-              },
-              "fixed-source-port": false,
-              "source-port": null,
-              "host": {
-                "EXPRESSION_VALUE": "${jboss.mail.server.host:localhost}"
-              },
-              "source-interface": null
-            }
-          }
-        }
-      }
-
-expected_result:
-  - bindings:
-      - address: 127.0.0.1
-        class: service
-        port: 3528
-        protocol: tcp
-      - address: 192.168.0.98
-        class: service
-        port: 8009
-        protocol: tcp
-      - address: 192.168.0.98
-        class: service
-        port: 8080
-        protocol: tcp
-      - address: 127.0.0.1
-        class: service
-        port: 54200
-        protocol: tcp
-      - address: 192.168.0.98
-        class: service
-        port: 8443
-        protocol: tcp
-      - address: 230.0.0.4
-        class: service
-        port: 45688
-        protocol: udp
-      - address: 224.0.1.105
-        class: service
-        port: 23364
-        protocol: udp
-      - address: 127.0.0.1
-        class: service
-        port: 55200
-        protocol: udp
-      - class: https
-        port: 8443
-      - class: http
-        port: 8080
-      - class: jgroups_tcp_fd
-        port: 57600
-      - class: ajp
-        port: 8009
-      - class: txn_recovery_environment
-        port: 4712
-      - class: jgroups_tcp
-        port: 7600
-      - class: jgroups_udp_fd
-        port: 54200
-      - class: iiop_ssl
-        port: 3529
-      - class: txn_status_manager
-        port: 4713
-      - class: iiop
-        port: 3528
-      - address: 192.168.0.130
-        class: domain controller
-        extra_data:
-          security_realm: ManagementRealm
-        port: 9999
-      - class: listener
-        port: 19990
-    configuration:
-      host_xml:
-        host:
-          attr-name: nodo2
-          attr-xmlns: urn:jboss:domain:16.0
-          domain-controller:
-            remote:
-              attr-host: ${jboss.domain.master.address:192.168.0.130}
-              attr-port: ${jboss.domain.master.port:9999}
-              attr-security-realm: ManagementRealm
-          extensions:
-            extension:
-              - attr-module: org.jboss.as.jmx
-              - attr-module: org.wildfly.extension.core-management
-              - attr-module: org.wildfly.extension.elytron
-          interfaces:
-            interface:
-              - attr-name: management
-                inet-address:
-                  attr-value: ${jboss.bind.address.management:127.0.0.1}
-              - attr-name: public
-                inet-address:
-                  attr-value: ${jboss.bind.address:192.168.0.98}
-          jvms:
-            jvm:
-              attr-name: default
-              heap:
-                attr-max-size: 256m
-                attr-size: 64m
-              jvm-options:
-                option:
-                  - attr-value: -server
-                  - attr-value: -XX:MetaspaceSize=96m
-                  - attr-value: -XX:MaxMetaspaceSize=256m
-          management:
-            audit-log:
-              formatters:
-                json-formatter:
-                  attr-name: json-formatter
-              handlers:
-                file-handler:
-                  - attr-formatter: json-formatter
-                    attr-name: host-file
-                    attr-path: audit-log.log
-                    attr-relative-to: jboss.domain.data.dir
-                  - attr-formatter: json-formatter
-                    attr-name: server-file
-                    attr-path: audit-log.log
-                    attr-relative-to: jboss.server.data.dir
-              logger:
-                attr-enabled: 'false'
-                attr-log-boot: 'true'
-                attr-log-read-only: 'false'
-                handlers:
-                  handler:
-                    attr-name: host-file
-              server-logger:
-                attr-enabled: 'false'
-                attr-log-boot: 'true'
-                attr-log-read-only: 'false'
-                handlers:
-                  handler:
-                    attr-name: server-file
-            management-interfaces:
-              http-interface:
-                attr-security-realm: ManagementRealm
-                http-upgrade:
-                  attr-enabled: 'true'
-                socket:
-                  attr-interface: management
-                  attr-port: ${jboss.management.http.port:19990}
-            security-realms:
-              security-realm:
-                - attr-name: ManagementRealm
-                  authentication:
-                    local:
-                      attr-default-user: $local
-                      attr-skip-group-loading: 'true'
-                    properties:
-                      attr-path: mgmt-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  authorization:
-                    attr-map-groups-to-roles: 'false'
-                    properties:
-                      attr-path: mgmt-groups.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  server-identities:
-                    secret:
-                      attr-value: ZDR0NGQwcDMh
-                - attr-name: ApplicationRealm
-                  authentication:
-                    local:
-                      attr-allowed-users: '*'
-                      attr-default-user: $local
-                      attr-skip-group-loading: 'true'
-                    properties:
-                      attr-path: application-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  authorization:
-                    properties:
-                      attr-path: application-roles.properties
-                      attr-relative-to: jboss.domain.config.dir
-                  server-identities:
-                    ssl:
-                      keystore:
-                        attr-alias: server
-                        attr-generate-self-signed-certificate-host: localhost
-                        attr-key-password: password
-                        attr-keystore-password: password
-                        attr-path: application.keystore
-                        attr-relative-to: jboss.domain.config.dir
-          profile:
-            subsystem:
-              - attr-xmlns: urn:jboss:domain:core-management:1.0
-              - attr-disallowed-providers: OracleUcrypto
-                attr-final-providers: combined-providers
-                attr-xmlns: urn:wildfly:elytron:13.0
-                audit-logging:
-                  file-audit-log:
-                    attr-format: JSON
-                    attr-name: local-audit
-                    attr-path: audit.log
-                    attr-relative-to: jboss.domain.log.dir
-                http:
-                  http-authentication-factory:
-                    attr-http-server-mechanism-factory: global
-                    attr-name: management-http-authentication
-                    attr-security-domain: ManagementDomain
-                    mechanism-configuration:
-                      mechanism:
-                        attr-mechanism-name: BASIC
-                        mechanism-realm:
-                          attr-realm-name: Management Realm
-                  provider-http-server-mechanism-factory:
-                    attr-name: global
-                mappers:
-                  constant-realm-mapper:
-                    attr-name: local
-                    attr-realm-name: local
-                  constant-role-mapper:
-                    attr-name: super-user-mapper
-                    role:
-                      attr-name: SuperUser
-                  simple-permission-mapper:
-                    attr-mapping-mode: first
-                    attr-name: default-permission-mapper
-                    permission-mapping:
-                      - permission-set:
-                          attr-name: default-permissions
-                        principal:
-                          attr-name: anonymous
-                      - attr-match-all: 'true'
-                        permission-set:
-                          - attr-name: login-permission
-                          - attr-name: default-permissions
-                  simple-role-decoder:
-                    attr-attribute: groups
-                    attr-name: groups-to-roles
-                permission-sets:
-                  permission-set:
-                    - attr-name: login-permission
-                      permission:
-                        attr-class-name: org.wildfly.security.auth.permission.LoginPermission
-                    - attr-name: default-permissions
-                providers:
-                  aggregate-providers:
-                    attr-name: combined-providers
-                    providers:
-                      - attr-name: elytron
-                      - attr-name: openssl
-                  provider-loader:
-                    - attr-module: org.wildfly.security.elytron
-                      attr-name: elytron
-                    - attr-module: org.wildfly.openssl
-                      attr-name: openssl
-                sasl:
-                  configurable-sasl-server-factory:
-                    attr-name: configured
-                    attr-sasl-server-factory: elytron
-                    properties:
-                      property:
-                        attr-name: wildfly.sasl.local-user.default-user
-                        attr-value: $local
-                  mechanism-provider-filtering-sasl-server-factory:
-                    attr-name: elytron
-                    attr-sasl-server-factory: global
-                    filters:
-                      filter:
-                        attr-provider-name: WildFlyElytron
-                  provider-sasl-server-factory:
-                    attr-name: global
-                  sasl-authentication-factory:
-                    attr-name: management-sasl-authentication
-                    attr-sasl-server-factory: configured
-                    attr-security-domain: ManagementDomain
-                    mechanism-configuration:
-                      mechanism:
-                        - attr-mechanism-name: JBOSS-LOCAL-USER
-                          attr-realm-mapper: local
-                        - attr-mechanism-name: DIGEST-MD5
-                          mechanism-realm:
-                            attr-realm-name: ManagementRealm
-                security-domains:
-                  security-domain:
-                    attr-default-realm: ManagementRealm
-                    attr-name: ManagementDomain
-                    attr-permission-mapper: default-permission-mapper
-                    realm:
-                      - attr-name: ManagementRealm
-                        attr-role-decoder: groups-to-roles
-                      - attr-name: local
-                        attr-role-mapper: super-user-mapper
-                security-realms:
-                  identity-realm:
-                    attr-identity: $local
-                    attr-name: local
-                  properties-realm:
-                    attr-name: ManagementRealm
-                    groups-properties:
-                      attr-path: mgmt-groups.properties
-                      attr-relative-to: jboss.domain.config.dir
-                    users-properties:
-                      attr-digest-realm-name: ManagementRealm
-                      attr-path: mgmt-users.properties
-                      attr-relative-to: jboss.domain.config.dir
-              - attr-xmlns: urn:jboss:domain:jmx:1.3
-                expose-expression-model: null
-                expose-resolved-model: null
-                remoting-connector: null
-          servers:
-            server:
-              - attr-auto-start: 'true'
-                attr-group: main-server-group
-                attr-name: nodo2-server1
-              - attr-auto-start: 'true'
-                attr-group: second-server-group
-                attr-name: nodo2-server2
-                jvm:
-                  attr-name: default
-                socket-bindings:
-                  attr-port-offset: '150'
-    discovery_time: '2022-06-23T20:30:41+02:00'
-    extra_data:
-      heap_initial_allocation_memory: 1000m
-      heap_max_memory: 1000m
-      domain_role: slave
-      server:
-        group: main-server-group
-        name: nodo2-server1
-        port_offset: 0
-        profile: full-ha
-      mode: domain
-    files:
-      - path: /opt/jboss/domain/servers/nodo2-server1/log
-        subtype: generic
-        type: log
-      - name: server.log
-        path: /opt/jboss/domain/servers/nodo2-server1/log
-        subtype: generic
-        type: log
-      - name: logging.properties
-        path: /opt/jboss/domain/servers/nodo2-server1/data
-        subtype: generic
-        type: log
-      - name: host.xml
-        path: /opt/jboss/domain/configuration
-        subtype: host
-        type: config
-      - name: domain.xml
-        path: /opt/jboss/domain/configuration
-        subtype: domain
-        type: config
-      - path: /opt/jboss
-        subtype: generic
-        type: data
-    listening_ports:
-      - 3528
-      - 8009
-      - 8080
-      - 8443
-      - 23364
-      - 45688
-      - 54200
-      - 55200
-    packages: [ ]
-    process:
-      cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-1.el7_9.x86_64/jre/bin/java -D[Server:nodo2-server1] -D[pcid:485084469] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo2-server1/log -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo2-server1/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo2-server1/data -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo2-server1/data/logging.properties -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
-      listening_ports:
-        - 3528
-        - 8009
-        - 8080
-        - 8443
-        - 23364
-        - 45688
-        - 54200
-        - 55200
-      pid: '24402'
-      ppid: '24331'
-      user: wildfly
-    type: JBoss Application Server
-    version:
-      - number: 7.4.0
-        type: file
-
-software_list:
-  - cmd_regexp: org\.jboss\.Main|org\.jboss\.(?:Main|as\.(?:standalone|server))
-    name: JBoss Application Server
-    pkg_regexp: jboss
-    process_type: parent
-    return_children: false
-    return_packages: true
-    vars:
-      credentials:
-        management_user: admin
-        management_password: password
-      default_management_port: '9990'
-    custom_tasks:
-      - name: Include JBoss specific plugins
-        include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/jboss.yaml"
-
-dockers:
-  containers: [ ]
+      json:
+        outcome: success
+        result:
+          default-interface: public
+          includes: null
+          local-destination-outbound-socket-binding: null
+          name: full-ha-sockets
+          remote-destination-outbound-socket-binding:
+            mail-smtp:
+              fixed-source-port: false
+              host:
+                EXPRESSION_VALUE: ${jboss.mail.server.host:localhost}
+              port:
+                EXPRESSION_VALUE: ${jboss.mail.server.port:25}
+              source-interface: null
+              source-port: null
+          socket-binding:
+            ajp:
+              client-mappings: null
+              fixed-port: false
+              interface: null
+              multicast-address: null
+              multicast-port: null
+              name: ajp
+              port:
+                EXPRESSION_VALUE: ${jboss.ajp.port:8009}
+            http:
+              client-mappings: null
+              fixed-port: false
+              interface: null
+              multicast-address: null
+              multicast-port: null
+              name: http
+              port:
+                EXPRESSION_VALUE: ${jboss.http.port:8080}
+            https:
+              client-mappings: null
+              fixed-port: false
+              interface: null
+              multicast-address: null
+              multicast-port: null
+              name: https
+              port:
+                EXPRESSION_VALUE: ${jboss.https.port:8443}
+            iiop:
+              client-mappings: null
+              fixed-port: false
+              interface: unsecure
+              multicast-address: null
+              multicast-port: null
+              name: iiop
+              port: 3528
+            iiop-ssl:
+              client-mappings: null
+              fixed-port: false
+              interface: unsecure
+              multicast-address: null
+              multicast-port: null
+              name: iiop-ssl
+              port: 3529
+            jgroups-mping:
+              client-mappings: null
+              fixed-port: false
+              interface: private
+              multicast-address:
+                EXPRESSION_VALUE: ${jboss.default.multicast.address:230.0.0.4}
+              multicast-port: 45700
+              name: jgroups-mping
+              port: 0
+            jgroups-tcp:
+              client-mappings: null
+              fixed-port: false
+              interface: private
+              multicast-address: null
+              multicast-port: null
+              name: jgroups-tcp
+              port: 7600
+            jgroups-tcp-fd:
+              client-mappings: null
+              fixed-port: false
+              interface: private
+              multicast-address: null
+              multicast-port: null
+              name: jgroups-tcp-fd
+              port: 57600
+            jgroups-udp:
+              client-mappings: null
+              fixed-port: false
+              interface: private
+              multicast-address:
+                EXPRESSION_VALUE: ${jboss.default.multicast.address:230.0.0.4}
+              multicast-port: 45688
+              name: jgroups-udp
+              port: 55200
+            jgroups-udp-fd:
+              client-mappings: null
+              fixed-port: false
+              interface: private
+              multicast-address: null
+              multicast-port: null
+              name: jgroups-udp-fd
+              port: 54200
+            modcluster:
+              client-mappings: null
+              fixed-port: false
+              interface: null
+              multicast-address:
+                EXPRESSION_VALUE: ${jboss.modcluster.multicast.address:224.0.1.105}
+              multicast-port: 23364
+              name: modcluster
+              port: 0
+            txn-recovery-environment:
+              client-mappings: null
+              fixed-port: false
+              interface: null
+              multicast-address: null
+              multicast-port: null
+              name: txn-recovery-environment
+              port: 4712
+            txn-status-manager:
+              client-mappings: null
+              fixed-port: false
+              interface: null
+              multicast-address: null
+              multicast-port: null
+              name: txn-status-manager
+              port: 4713
+  Run entry regex:
+    calls:
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - run
+    - run
+    - run
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - run
+    - run
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   atomic-registries:
-    - arch: x86_64
-      epoch: 1
-      name: atomic-registries
-      release: 33.gitb507039.el7_8
-      source: rpm
-      version: 1.22.1
+  - arch: x86_64
+    epoch: 1
+    name: atomic-registries
+    release: 33.gitb507039.el7_8
+    source: rpm
+    version: 1.22.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 35.el7_9
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 35.el7_9
+    source: rpm
+    version: 4.2.46
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 72.el7_9
-      source: rpm
-      version: 2021.2.50
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 72.el7_9
+    source: rpm
+    version: 2021.2.50
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   centos-indexhtml:
-    - arch: noarch
-      epoch: null
-      name: centos-indexhtml
-      release: 9.el7.centos
-      source: rpm
-      version: '7'
+  - arch: noarch
+    epoch: null
+    name: centos-indexhtml
+    release: 9.el7.centos
+    source: rpm
+    version: '7'
   centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 7.el7.centos.5
-      source: rpm
-      version: '19.4'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 7.el7.centos.5
+    source: rpm
+    version: '19.4'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
   container-storage-setup:
-    - arch: noarch
-      epoch: null
-      name: container-storage-setup
-      release: 2.git5eaf76c.el7
-      source: rpm
-      version: 0.11.0
+  - arch: noarch
+    epoch: null
+    name: container-storage-setup
+    release: 2.git5eaf76c.el7
+    source: rpm
+    version: 0.11.0
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.6.4
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.6.4
   containers-common:
-    - arch: x86_64
-      epoch: 1
-      name: containers-common
-      release: 11.el7_8
-      source: rpm
-      version: 0.1.40
+  - arch: x86_64
+    epoch: 1
+    name: containers-common
+    release: 11.el7_8
+    source: rpm
+    version: 0.1.40
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 3.el7_9.2
-      source: rpm
-      version: 0.8.5
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 3.el7_9.2
+    source: rpm
+    version: 0.8.5
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 20.10.16
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 20.10.16
-  docker-ce-rootless-extras:
-    - arch: x86_64
-      epoch: 0
-      name: docker-ce-rootless-extras
-      release: 3.el7
-      source: rpm
-      version: 20.10.16
-  docker-compose-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-compose-plugin
-      release: 3.el7
-      source: rpm
-      version: 2.5.0
-  docker-scan-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-scan-plugin
-      release: 3.el7
-      source: rpm
-      version: 0.17.0
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '14'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
-  fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gperftools-libs:
-    - arch: x86_64
-      epoch: null
-      name: gperftools-libs
-      release: 1.el7
-      source: rpm
-      version: 2.6.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  haproxy:
-    - arch: x86_64
-      epoch: null
-      name: haproxy
-      release: 9.el7_9.1
-      source: rpm
-      version: 1.5.18
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.312.b07
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.312.b07
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.49.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.49.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.49.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.3
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 135.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl:
-    - arch: x86_64
-      epoch: null
-      name: libnl
-      release: 3.el7
-      source: rpm
-      version: 1.1.4
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 13.el7_9
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7.2
-      source: rpm
-      version: 1.3.0
-  nginx:
-    - arch: x86_64
-      epoch: 1
-      name: nginx
-      release: 9.el7
-      source: rpm
-      version: 1.20.1
-  nginx-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: nginx-filesystem
-      release: 9.el7
-      source: rpm
-      version: 1.20.1
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  oci-register-machine:
-    - arch: x86_64
-      epoch: 1
-      name: oci-register-machine
-      release: 6.git2b44233.el7
-      source: rpm
-      version: '0'
-  oci-systemd-hook:
-    - arch: x86_64
-      epoch: 1
-      name: oci-systemd-hook
-      release: 1.git05e6923.el7_6
-      source: rpm
-      version: 0.2.0
-  oci-umount:
-    - arch: x86_64
-      epoch: 2
-      name: oci-umount
-      release: 3.el7
-      source: rpm
-      version: '2.5'
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 22.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 22.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 2.el7
-      source: rpm
-      version: 1.1.1k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-dateutil:
-    - arch: noarch
-      epoch: null
-      name: python-dateutil
-      release: 7.el7
-      source: rpm
-      version: '1.5'
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-dmidecode:
-    - arch: x86_64
-      epoch: null
-      name: python-dmidecode
-      release: 4.el7
-      source: rpm
-      version: 3.12.2
-  python-docker-py:
-    - arch: noarch
-      epoch: 1
-      name: python-docker-py
-      release: 11.el7
-      source: rpm
-      version: 1.10.6
-  python-docker-pycreds:
-    - arch: noarch
-      epoch: 1
-      name: python-docker-pycreds
-      release: 11.el7
-      source: rpm
-      version: 0.3.0
-  python-ethtool:
-    - arch: x86_64
-      epoch: null
-      name: python-ethtool
-      release: 8.el7
-      source: rpm
-      version: '0.8'
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-inotify:
-    - arch: noarch
-      epoch: null
-      name: python-inotify
-      release: 4.el7
-      source: rpm
-      version: 0.9.4
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.49.1.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pytoml:
-    - arch: noarch
-      epoch: null
-      name: python-pytoml
-      release: 1.git7dea353.el7
-      source: rpm
-      version: 0.1.14
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 10.el7
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-syspurpose:
-    - arch: x86_64
-      epoch: null
-      name: python-syspurpose
-      release: 1.el7.centos
-      source: rpm
-      version: 1.24.50
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python-websocket-client:
-    - arch: noarch
-      epoch: null
-      name: python-websocket-client
-      release: 3.git3c25814.el7
-      source: rpm
-      version: 0.56.0
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9.1
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  subscription-manager:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager
-      release: 1.el7.centos
-      source: rpm
-      version: 1.24.50
-  subscription-manager-rhsm:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm
-      release: 1.el7.centos
-      source: rpm
-      version: 1.24.50
-  subscription-manager-rhsm-certificates:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm-certificates
-      release: 1.el7.centos
-      source: rpm
-      version: 1.24.50
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.2
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  traceroute:
-    - arch: x86_64
-      epoch: 3
-      name: traceroute
-      release: 2.el7
-      source: rpm
-      version: 2.0.22
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 24.el7_9
-      source: rpm
-      version: '6.0'
-  usermode:
-    - arch: x86_64
-      epoch: null
-      name: usermode
-      release: 6.el7
-      source: rpm
-      version: '1.111'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7_9.1
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yajl:
-    - arch: x86_64
-      epoch: null
-      name: yajl
-      release: 4.el7
-      source: rpm
-      version: 2.0.4
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '110'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '195'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '196'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '266'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '271'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '274'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '294'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '295'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '413'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '445'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '453'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '472'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '522'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '529'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '532'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/rpcbind -w
-    pid: '563'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '564'
-    ppid: '1'
-    user: polkitd
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '569'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '576'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '584'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '595'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H test-norm02 eth0
-    pid: '820'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
-    pid: '876'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '881'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '884'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/rhsmcertd
-    pid: '890'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '996'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '998'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '999'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1004'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1005'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1006'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1099'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1117'
-    ppid: '1099'
-    user: postfix
-  - cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
-    pid: '1224'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '5861'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '6059'
-    ppid: '1099'
-    user: postfix
-  - cmdline: ''
-    pid: '9122'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10141'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11860'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '13575'
-    ppid: '999'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '13577'
-    ppid: '13575'
-    user: centos
-  - cmdline: ''
-    pid: '13929'
-    ppid: '2'
-    user: root
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-vwrcplerovznrglfinpkaqiqdzbkswzg ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009015.9312289-87684-17844613504461/AnsiballZ_process_facts.py' && sleep 0
-    pid: '13930'
-    ppid: '13577'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-vwrcplerovznrglfinpkaqiqdzbkswzg ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009015.9312289-87684-17844613504461/AnsiballZ_process_facts.py
-    pid: '13943'
-    ppid: '13930'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-vwrcplerovznrglfinpkaqiqdzbkswzg ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009015.9312289-87684-17844613504461/AnsiballZ_process_facts.py
-    pid: '13944'
-    ppid: '13943'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009015.9312289-87684-17844613504461/AnsiballZ_process_facts.py
-    pid: '13945'
-    ppid: '13944'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '20119'
-    ppid: '999'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '20121'
-    ppid: '20119'
-    user: centos
-  - cmdline: -bash
-    pid: '20122'
-    ppid: '20121'
-    user: centos
-  - cmdline: sudo su
-    pid: '20146'
-    ppid: '20122'
-    user: root
-  - cmdline: su
-    pid: '20147'
-    ppid: '20146'
-    user: root
-  - cmdline: bash
-    pid: '20148'
-    ppid: '20147'
-    user: root
-  - cmdline: /bin/sh /opt/jboss/bin/domain.sh --domain-config=domain.xml --host-config=host.xml
-    pid: '24245'
-    ppid: '1'
-    user: wildfly
-  - cmdline: java -D[Process Controller] -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/process-controller.log -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.process-controller -jboss-home /opt/jboss -jvm java -mp /opt/jboss/modules -- -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -- -default-jvm java --domain-config=domain.xml --host-config=host.xml
-    pid: '24331'
-    ppid: '24245'
-    user: wildfly
-  - cmdline: java -D[Host Controller] -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.host-controller -mp /opt/jboss/modules --pc-address 127.0.0.1 --pc-port 33253 -default-jvm java --domain-config=domain.xml --host-config=host.xml -Djboss.home.dir=/opt/jboss
-    pid: '24345'
-    ppid: '24331'
-    user: wildfly
-  - cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-1.el7_9.x86_64/jre/bin/java -D[Server:nodo2-server1] -D[pcid:485084469] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo2-server1/log -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo2-server1/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo2-server1/data -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo2-server1/data/logging.properties -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
-    pid: '24402'
-    ppid: '24331'
-    user: wildfly
-  - cmdline: ''
-    pid: '26424'
-    ppid: '2'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: java
-    pid: 24440
-    port: 3678
-    protocol: tcp
-    stime: Thu Jun 23 08:51:00 2022
-    user: wildfly
-  - address: 192.168.0.98
-    name: java
-    pid: 24440
-    port: 8159
-    protocol: tcp
-    stime: Thu Jun 23 08:51:00 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 24331
-    port: 33253
-    protocol: tcp
-    stime: Thu Jun 23 08:50:37 2022
-    user: wildfly
-  - address: 192.168.0.98
-    name: java
-    pid: 24440
-    port: 8230
-    protocol: tcp
-    stime: Thu Jun 23 08:51:00 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 24402
-    port: 3528
-    protocol: tcp
-    stime: Thu Jun 23 08:50:53 2022
-    user: wildfly
-  - address: 192.168.0.98
-    name: java
-    pid: 24402
-    port: 8009
-    protocol: tcp
-    stime: Thu Jun 23 08:50:53 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 563
-    port: 111
-    protocol: tcp
-    stime: Thu Jun 16 14:08:49 2022
-    user: rpc
-  - address: 192.168.0.98
-    name: java
-    pid: 24402
-    port: 8080
-    protocol: tcp
-    stime: Thu Jun 23 08:50:53 2022
-    user: wildfly
-  - address: 192.168.0.98
-    name: java
-    pid: 24440
-    port: 8593
-    protocol: tcp
-    stime: Thu Jun 23 08:51:00 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 24345
-    port: 19990
-    protocol: tcp
-    stime: Thu Jun 23 08:50:39 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: sshd
-    pid: 999
-    port: 22
-    protocol: tcp
-    stime: Thu Jun 16 14:09:08 2022
-    user: root
-  - address: 127.0.0.1
-    name: java
-    pid: 24402
-    port: 54200
-    protocol: tcp
-    stime: Thu Jun 23 08:50:53 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 24440
-    port: 54201
-    protocol: tcp
-    stime: Thu Jun 23 08:51:00 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: master
-    pid: 1099
-    port: 25
-    protocol: tcp
-    stime: Thu Jun 16 14:09:09 2022
-    user: root
-  - address: 192.168.0.98
-    name: java
-    pid: 24402
-    port: 8443
-    protocol: tcp
-    stime: Thu Jun 23 08:50:53 2022
-    user: wildfly
-  - address: '::'
-    name: rpcbind
-    pid: 563
-    port: 111
-    protocol: tcp
-    stime: Thu Jun 16 14:08:49 2022
-    user: rpc
-  - address: '::'
-    name: sshd
-    pid: 999
-    port: 22
-    protocol: tcp
-    stime: Thu Jun 16 14:09:08 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1099
-    port: 25
-    protocol: tcp
-    stime: Thu Jun 16 14:09:09 2022
-    user: root
-udp_listen:
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 595
-    port: 323
-    protocol: udp
-    stime: Thu Jun 16 14:08:50 2022
-    user: chrony
-  - address: 230.0.0.4
-    name: java
-    pid: 24440
-    port: 45688
-    protocol: udp
-    stime: Thu Jun 23 08:51:00 2022
-    user: wildfly
-  - address: 230.0.0.4
-    name: java
-    pid: 24402
-    port: 45688
-    protocol: udp
-    stime: Thu Jun 23 08:50:53 2022
-    user: wildfly
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 563
-    port: 734
-    protocol: udp
-    stime: Thu Jun 16 14:08:49 2022
-    user: rpc
-  - address: 224.0.1.105
-    name: java
-    pid: 24440
-    port: 23364
-    protocol: udp
-    stime: Thu Jun 23 08:51:00 2022
-    user: wildfly
-  - address: 224.0.1.105
-    name: java
-    pid: 24402
-    port: 23364
-    protocol: udp
-    stime: Thu Jun 23 08:50:53 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 24402
-    port: 55200
-    protocol: udp
-    stime: Thu Jun 23 08:50:53 2022
-    user: wildfly
-  - address: 127.0.0.1
-    name: java
-    pid: 24440
-    port: 55350
-    protocol: udp
-    stime: Thu Jun 23 08:51:00 2022
-    user: wildfly
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 820
-    port: 68
-    protocol: udp
-    stime: Thu Jun 16 14:09:00 2022
-    user: root
-  - address: 0.0.0.0
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 20.10.16
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 20.10.16
+  docker-ce-rootless-extras:
+  - arch: x86_64
+    epoch: 0
+    name: docker-ce-rootless-extras
+    release: 3.el7
+    source: rpm
+    version: 20.10.16
+  docker-compose-plugin:
+  - arch: x86_64
+    epoch: 0
+    name: docker-compose-plugin
+    release: 3.el7
+    source: rpm
+    version: 2.5.0
+  docker-scan-plugin:
+  - arch: x86_64
+    epoch: 0
+    name: docker-scan-plugin
+    release: 3.el7
+    source: rpm
+    version: 0.17.0
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '14'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  fuse-overlayfs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
+  fuse3-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gperftools-libs:
+  - arch: x86_64
+    epoch: null
+    name: gperftools-libs
+    release: 1.el7
+    source: rpm
+    version: 2.6.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  haproxy:
+  - arch: x86_64
+    epoch: null
+    name: haproxy
+    release: 9.el7_9.1
+    source: rpm
+    version: 1.5.18
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.312.b07
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.312.b07
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.49.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.49.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.49.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.3
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 135.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl:
+  - arch: x86_64
+    epoch: null
+    name: libnl
+    release: 3.el7
+    source: rpm
+    version: 1.1.4
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 13.el7_9
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7.2
+    source: rpm
+    version: 1.3.0
+  nginx:
+  - arch: x86_64
+    epoch: 1
+    name: nginx
+    release: 9.el7
+    source: rpm
+    version: 1.20.1
+  nginx-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: nginx-filesystem
+    release: 9.el7
+    source: rpm
+    version: 1.20.1
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  oci-register-machine:
+  - arch: x86_64
+    epoch: 1
+    name: oci-register-machine
+    release: 6.git2b44233.el7
+    source: rpm
+    version: '0'
+  oci-systemd-hook:
+  - arch: x86_64
+    epoch: 1
+    name: oci-systemd-hook
+    release: 1.git05e6923.el7_6
+    source: rpm
+    version: 0.2.0
+  oci-umount:
+  - arch: x86_64
+    epoch: 2
+    name: oci-umount
+    release: 3.el7
+    source: rpm
+    version: '2.5'
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 22.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 22.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 2.el7
+    source: rpm
+    version: 1.1.1k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-dateutil:
+  - arch: noarch
+    epoch: null
+    name: python-dateutil
+    release: 7.el7
+    source: rpm
+    version: '1.5'
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-dmidecode:
+  - arch: x86_64
+    epoch: null
+    name: python-dmidecode
+    release: 4.el7
+    source: rpm
+    version: 3.12.2
+  python-docker-py:
+  - arch: noarch
+    epoch: 1
+    name: python-docker-py
+    release: 11.el7
+    source: rpm
+    version: 1.10.6
+  python-docker-pycreds:
+  - arch: noarch
+    epoch: 1
+    name: python-docker-pycreds
+    release: 11.el7
+    source: rpm
+    version: 0.3.0
+  python-ethtool:
+  - arch: x86_64
+    epoch: null
+    name: python-ethtool
+    release: 8.el7
+    source: rpm
+    version: '0.8'
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-inotify:
+  - arch: noarch
+    epoch: null
+    name: python-inotify
+    release: 4.el7
+    source: rpm
+    version: 0.9.4
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.49.1.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pytoml:
+  - arch: noarch
+    epoch: null
+    name: python-pytoml
+    release: 1.git7dea353.el7
+    source: rpm
+    version: 0.1.14
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 10.el7
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-syspurpose:
+  - arch: x86_64
+    epoch: null
+    name: python-syspurpose
+    release: 1.el7.centos
+    source: rpm
+    version: 1.24.50
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python-websocket-client:
+  - arch: noarch
+    epoch: null
+    name: python-websocket-client
+    release: 3.git3c25814.el7
+    source: rpm
+    version: 0.56.0
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 563
-    port: 111
-    protocol: udp
-    stime: Thu Jun 16 14:08:49 2022
-    user: rpc
-  - address: ::1
-    name: chronyd
-    pid: 595
-    port: 323
-    protocol: udp
-    stime: Thu Jun 16 14:08:50 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 563
-    port: 734
-    protocol: udp
-    stime: Thu Jun 16 14:08:49 2022
-    user: rpc
-  - address: '::'
-    name: rpcbind
-    pid: 563
-    port: 111
-    protocol: udp
-    stime: Thu Jun 16 14:08:49 2022
-    user: rpc
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9.1
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  subscription-manager:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager
+    release: 1.el7.centos
+    source: rpm
+    version: 1.24.50
+  subscription-manager-rhsm:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm
+    release: 1.el7.centos
+    source: rpm
+    version: 1.24.50
+  subscription-manager-rhsm-certificates:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm-certificates
+    release: 1.el7.centos
+    source: rpm
+    version: 1.24.50
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.2
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  traceroute:
+  - arch: x86_64
+    epoch: 3
+    name: traceroute
+    release: 2.el7
+    source: rpm
+    version: 2.0.22
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 24.el7_9
+    source: rpm
+    version: '6.0'
+  usermode:
+  - arch: x86_64
+    epoch: null
+    name: usermode
+    release: 6.el7
+    source: rpm
+    version: '1.111'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7_9.1
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yajl:
+  - arch: x86_64
+    epoch: null
+    name: yajl
+    release: 4.el7
+    source: rpm
+    version: 2.0.4
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '110'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '195'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '196'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '266'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '271'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '295'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '413'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '445'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '453'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '472'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '522'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '529'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '532'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '563'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '564'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '569'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '576'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '584'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '595'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H test-norm02 eth0
+  cwd: /sbin/
+  pid: '820'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '876'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '881'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '884'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/rhsmcertd
+  cwd: /usr/bin/
+  pid: '890'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '996'
+  ppid: '1'
+  user: root
+- cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '998'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '999'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1004'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1005'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1006'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1099'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1117'
+  ppid: '1099'
+  user: postfix
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1224'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5861'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '6059'
+  ppid: '1099'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '9122'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10141'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11860'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '13575'
+  ppid: '999'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '13577'
+  ppid: '13575'
+  user: centos
+- cmdline: ''
+  cwd: /
+  pid: '13929'
+  ppid: '2'
+  user: root
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-vwrcplerovznrglfinpkaqiqdzbkswzg
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009015.9312289-87684-17844613504461/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '13930'
+  ppid: '13577'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-vwrcplerovznrglfinpkaqiqdzbkswzg
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009015.9312289-87684-17844613504461/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '13943'
+  ppid: '13930'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-vwrcplerovznrglfinpkaqiqdzbkswzg ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656009015.9312289-87684-17844613504461/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '13944'
+  ppid: '13943'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656009015.9312289-87684-17844613504461/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '13945'
+  ppid: '13944'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '20119'
+  ppid: '999'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '20121'
+  ppid: '20119'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '20122'
+  ppid: '20121'
+  user: centos
+- cmdline: sudo su
+  cwd: /
+  pid: '20146'
+  ppid: '20122'
+  user: root
+- cmdline: su
+  cwd: /
+  pid: '20147'
+  ppid: '20146'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '20148'
+  ppid: '20147'
+  user: root
+- cmdline: /bin/sh /opt/jboss/bin/domain.sh --domain-config=domain.xml --host-config=host.xml
+  cwd: /bin/
+  pid: '24245'
+  ppid: '1'
+  user: wildfly
+- cmdline: java -D[Process Controller] -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m
+    -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman
+    -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/process-controller.log
+    -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
+    -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.process-controller
+    -jboss-home /opt/jboss -jvm java -mp /opt/jboss/modules -- -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log
+    -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
+    -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true
+    -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -- -default-jvm
+    java --domain-config=domain.xml --host-config=host.xml
+  cwd: /
+  pid: '24331'
+  ppid: '24245'
+  user: wildfly
+- cmdline: java -D[Host Controller] -Dorg.jboss.boot.log.file=/opt/jboss/domain/log/host-controller.log
+    -Dlogging.configuration=file:/opt/jboss/domain/configuration/logging.properties
+    -server -Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true
+    -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -jar /opt/jboss/jboss-modules.jar
+    -mp /opt/jboss/modules org.jboss.as.host-controller -mp /opt/jboss/modules --pc-address
+    127.0.0.1 --pc-port 33253 -default-jvm java --domain-config=domain.xml --host-config=host.xml
+    -Djboss.home.dir=/opt/jboss
+  cwd: /
+  pid: '24345'
+  ppid: '24331'
+  user: wildfly
+- cmdline: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-1.el7_9.x86_64/jre/bin/java
+    -D[Server:nodo2-server1] -D[pcid:485084469] -Xms1000m -Xmx1000m -server -XX:MetaspaceSize=96m
+    -XX:MaxMetaspaceSize=256m -Djava.awt.headless=true -Djava.net.preferIPv4Stack=true
+    -Djboss.home.dir=/opt/jboss -Djboss.modules.system.pkgs=org.jboss.byteman -Djboss.server.log.dir=/opt/jboss/domain/servers/nodo2-server1/log
+    -Djboss.server.temp.dir=/opt/jboss/domain/servers/nodo2-server1/tmp -Djboss.server.data.dir=/opt/jboss/domain/servers/nodo2-server1/data
+    -Dlogging.configuration=file:/opt/jboss/domain/servers/nodo2-server1/data/logging.properties
+    -jar /opt/jboss/jboss-modules.jar -mp /opt/jboss/modules org.jboss.as.server
+  cwd: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-1.el7_9.x86_64/jre/bin/
+  pid: '24402'
+  ppid: '24331'
+  user: wildfly
+- cmdline: ''
+  cwd: /
+  pid: '26424'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: org\.jboss\.Main|org\.jboss\.(?:Main|as\.(?:standalone|server))
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/jboss.yaml
+    name: Include JBoss specific plugins
+  name: JBoss Application Server
+  pkg_regexp: jboss
+  process_type: parent
+  return_children: false
+  return_packages: true
+  vars:
+    credentials:
+      management_password: password
+      management_user: admin
+    default_management_port: '9990'
+tcp_listen:
+- address: 127.0.0.1
+  name: java
+  pid: 24440
+  port: 3678
+  protocol: tcp
+  stime: Thu Jun 23 08:51:00 2022
+  user: wildfly
+- address: 192.168.0.98
+  name: java
+  pid: 24440
+  port: 8159
+  protocol: tcp
+  stime: Thu Jun 23 08:51:00 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 24331
+  port: 33253
+  protocol: tcp
+  stime: Thu Jun 23 08:50:37 2022
+  user: wildfly
+- address: 192.168.0.98
+  name: java
+  pid: 24440
+  port: 8230
+  protocol: tcp
+  stime: Thu Jun 23 08:51:00 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 24402
+  port: 3528
+  protocol: tcp
+  stime: Thu Jun 23 08:50:53 2022
+  user: wildfly
+- address: 192.168.0.98
+  name: java
+  pid: 24402
+  port: 8009
+  protocol: tcp
+  stime: Thu Jun 23 08:50:53 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 563
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 16 14:08:49 2022
+  user: rpc
+- address: 192.168.0.98
+  name: java
+  pid: 24402
+  port: 8080
+  protocol: tcp
+  stime: Thu Jun 23 08:50:53 2022
+  user: wildfly
+- address: 192.168.0.98
+  name: java
+  pid: 24440
+  port: 8593
+  protocol: tcp
+  stime: Thu Jun 23 08:51:00 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 24345
+  port: 19990
+  protocol: tcp
+  stime: Thu Jun 23 08:50:39 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: sshd
+  pid: 999
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 16 14:09:08 2022
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: 24402
+  port: 54200
+  protocol: tcp
+  stime: Thu Jun 23 08:50:53 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 24440
+  port: 54201
+  protocol: tcp
+  stime: Thu Jun 23 08:51:00 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: master
+  pid: 1099
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 16 14:09:09 2022
+  user: root
+- address: 192.168.0.98
+  name: java
+  pid: 24402
+  port: 8443
+  protocol: tcp
+  stime: Thu Jun 23 08:50:53 2022
+  user: wildfly
+- address: '::'
+  name: rpcbind
+  pid: 563
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 16 14:08:49 2022
+  user: rpc
+- address: '::'
+  name: sshd
+  pid: 999
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 16 14:09:08 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1099
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 16 14:09:09 2022
+  user: root
+udp_listen:
+- address: 127.0.0.1
+  name: chronyd
+  pid: 595
+  port: 323
+  protocol: udp
+  stime: Thu Jun 16 14:08:50 2022
+  user: chrony
+- address: 230.0.0.4
+  name: java
+  pid: 24440
+  port: 45688
+  protocol: udp
+  stime: Thu Jun 23 08:51:00 2022
+  user: wildfly
+- address: 230.0.0.4
+  name: java
+  pid: 24402
+  port: 45688
+  protocol: udp
+  stime: Thu Jun 23 08:50:53 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 563
+  port: 734
+  protocol: udp
+  stime: Thu Jun 16 14:08:49 2022
+  user: rpc
+- address: 224.0.1.105
+  name: java
+  pid: 24440
+  port: 23364
+  protocol: udp
+  stime: Thu Jun 23 08:51:00 2022
+  user: wildfly
+- address: 224.0.1.105
+  name: java
+  pid: 24402
+  port: 23364
+  protocol: udp
+  stime: Thu Jun 23 08:50:53 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 24402
+  port: 55200
+  protocol: udp
+  stime: Thu Jun 23 08:50:53 2022
+  user: wildfly
+- address: 127.0.0.1
+  name: java
+  pid: 24440
+  port: 55350
+  protocol: udp
+  stime: Thu Jun 23 08:51:00 2022
+  user: wildfly
+- address: 0.0.0.0
+  name: dhclient
+  pid: 820
+  port: 68
+  protocol: udp
+  stime: Thu Jun 16 14:09:00 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 563
+  port: 111
+  protocol: udp
+  stime: Thu Jun 16 14:08:49 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 595
+  port: 323
+  protocol: udp
+  stime: Thu Jun 16 14:08:50 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 563
+  port: 734
+  protocol: udp
+  stime: Thu Jun 16 14:08:49 2022
+  user: rpc
+- address: '::'
+  name: rpcbind
+  pid: 563
+  port: 111
+  protocol: udp
+  stime: Thu Jun 16 14:08:49 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/jboss/wildfly26.0.0_standalone_centos7.6.yaml
+++ b/tests/unit/plugins/action/auto/resources/jboss/wildfly26.0.0_standalone_centos7.6.yaml
@@ -1,1478 +1,1040 @@
+dockers:
+  containers: []
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 29990
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 28080
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 28443
+    protocol: tcp
+  - address: 0.0.0.0
+    class: binding_address
+  - class: ajp
+    port: 28009
+  - class: http
+    port: 28080
+  - class: https
+    port: 28443
+  - class: management_http
+    port: 29990
+  - class: management_https
+    port: 9993
+  - class: txn_recovery_environment
+    port: 4712
+  - class: txn_status_manager
+    port: 4713
+  - address: localhost
+    class: domain controller
+  configuration:
+    standalone_xml:
+      server:
+        attr-xmlns: urn:jboss:domain:19.0
+        extensions:
+          extension:
+          - attr-module: org.jboss.as.clustering.infinispan
+          - attr-module: org.jboss.as.connector
+          - attr-module: org.jboss.as.deployment-scanner
+          - attr-module: org.jboss.as.ee
+          - attr-module: org.jboss.as.ejb3
+          - attr-module: org.jboss.as.jaxrs
+          - attr-module: org.jboss.as.jdr
+          - attr-module: org.jboss.as.jmx
+          - attr-module: org.jboss.as.jpa
+          - attr-module: org.jboss.as.jsf
+          - attr-module: org.jboss.as.logging
+          - attr-module: org.jboss.as.mail
+          - attr-module: org.jboss.as.naming
+          - attr-module: org.jboss.as.pojo
+          - attr-module: org.jboss.as.remoting
+          - attr-module: org.jboss.as.sar
+          - attr-module: org.jboss.as.transactions
+          - attr-module: org.jboss.as.webservices
+          - attr-module: org.jboss.as.weld
+          - attr-module: org.wildfly.extension.batch.jberet
+          - attr-module: org.wildfly.extension.bean-validation
+          - attr-module: org.wildfly.extension.clustering.web
+          - attr-module: org.wildfly.extension.core-management
+          - attr-module: org.wildfly.extension.discovery
+          - attr-module: org.wildfly.extension.ee-security
+          - attr-module: org.wildfly.extension.elytron
+          - attr-module: org.wildfly.extension.elytron-oidc-client
+          - attr-module: org.wildfly.extension.health
+          - attr-module: org.wildfly.extension.io
+          - attr-module: org.wildfly.extension.metrics
+          - attr-module: org.wildfly.extension.microprofile.config-smallrye
+          - attr-module: org.wildfly.extension.microprofile.jwt-smallrye
+          - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+          - attr-module: org.wildfly.extension.request-controller
+          - attr-module: org.wildfly.extension.security.manager
+          - attr-module: org.wildfly.extension.undertow
+        interfaces:
+          interface:
+          - attr-name: management
+            inet-address:
+              attr-value: ${jboss.bind.address.management:127.0.0.1}
+          - attr-name: public
+            inet-address:
+              attr-value: ${jboss.bind.address:127.0.0.1}
+        management:
+          access-control:
+            attr-provider: simple
+            role-mapping:
+              role:
+                attr-name: SuperUser
+                include:
+                  user:
+                    attr-name: $local
+          audit-log:
+            formatters:
+              json-formatter:
+                attr-name: json-formatter
+            handlers:
+              file-handler:
+                attr-formatter: json-formatter
+                attr-name: file
+                attr-path: audit-log.log
+                attr-relative-to: jboss.server.data.dir
+            logger:
+              attr-enabled: 'false'
+              attr-log-boot: 'true'
+              attr-log-read-only: 'false'
+              handlers:
+                handler:
+                  attr-name: file
+          management-interfaces:
+            http-interface:
+              attr-http-authentication-factory: management-http-authentication
+              http-upgrade:
+                attr-enabled: 'true'
+                attr-sasl-authentication-factory: management-sasl-authentication
+              socket-binding:
+                attr-http: management-http
+        profile:
+          subsystem:
+          - attr-xmlns: urn:jboss:domain:logging:8.0
+            console-handler:
+              attr-name: CONSOLE
+              formatter:
+                named-formatter:
+                  attr-name: COLOR-PATTERN
+              level:
+                attr-name: INFO
+            formatter:
+            - attr-name: PATTERN
+              pattern-formatter:
+                attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+            - attr-name: COLOR-PATTERN
+              pattern-formatter:
+                attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+            logger:
+            - attr-category: com.arjuna
+              level:
+                attr-name: WARN
+            - attr-category: io.jaegertracing.Configuration
+              level:
+                attr-name: WARN
+            - attr-category: org.jboss.as.config
+              level:
+                attr-name: DEBUG
+            - attr-category: sun.rmi
+              level:
+                attr-name: WARN
+            periodic-rotating-file-handler:
+              append:
+                attr-value: 'true'
+              attr-autoflush: 'true'
+              attr-name: FILE
+              file:
+                attr-path: server.log
+                attr-relative-to: jboss.server.log.dir
+              formatter:
+                named-formatter:
+                  attr-name: PATTERN
+              suffix:
+                attr-value: .yyyy-MM-dd
+            root-logger:
+              handlers:
+                handler:
+                - attr-name: CONSOLE
+                - attr-name: FILE
+              level:
+                attr-name: INFO
+          - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+            default-job-repository:
+              attr-name: in-memory
+            default-thread-pool:
+              attr-name: batch
+            job-repository:
+              attr-name: in-memory
+              in-memory: null
+            thread-pool:
+              attr-name: batch
+              keepalive-time:
+                attr-time: '30'
+                attr-unit: seconds
+              max-threads:
+                attr-count: '10'
+          - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+          - attr-xmlns: urn:jboss:domain:core-management:1.0
+          - attr-xmlns: urn:jboss:domain:datasources:6.0
+            datasources:
+              datasource:
+                attr-enabled: 'true'
+                attr-jndi-name: java:jboss/datasources/ExampleDS
+                attr-pool-name: ExampleDS
+                attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                attr-use-java-context: 'true'
+                connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                driver: h2
+                security:
+                  password: sa
+                  user-name: sa
+              drivers:
+                driver:
+                  attr-module: com.h2database.h2
+                  attr-name: h2
+                  xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+          - attr-xmlns: urn:jboss:domain:deployment-scanner:2.0
+            deployment-scanner:
+              attr-path: deployments
+              attr-relative-to: jboss.server.base.dir
+              attr-runtime-failure-causes-rollback: ${jboss.deployment.scanner.rollback.on.failure:false}
+              attr-scan-interval: '5000'
+          - attr-xmlns: urn:jboss:domain:discovery:1.0
+          - attr-default-session-management: default
+            attr-default-single-sign-on-management: default
+            attr-xmlns: urn:jboss:domain:distributable-web:2.0
+            infinispan-session-management:
+              attr-cache-container: web
+              attr-granularity: SESSION
+              attr-name: default
+              local-affinity: null
+            infinispan-single-sign-on-management:
+              attr-cache: sso
+              attr-cache-container: web
+              attr-name: default
+            local-routing: null
+          - attr-xmlns: urn:jboss:domain:ee:6.0
+            concurrent:
+              context-services:
+                context-service:
+                  attr-jndi-name: java:jboss/ee/concurrency/context/default
+                  attr-name: default
+                  attr-use-transaction-setup-provider: 'true'
+              managed-executor-services:
+                managed-executor-service:
+                  attr-context-service: default
+                  attr-hung-task-termination-period: '0'
+                  attr-hung-task-threshold: '60000'
+                  attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                  attr-keepalive-time: '5000'
+                  attr-name: default
+              managed-scheduled-executor-services:
+                managed-scheduled-executor-service:
+                  attr-context-service: default
+                  attr-hung-task-termination-period: '0'
+                  attr-hung-task-threshold: '60000'
+                  attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                  attr-keepalive-time: '3000'
+                  attr-name: default
+              managed-thread-factories:
+                managed-thread-factory:
+                  attr-context-service: default
+                  attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                  attr-name: default
+            default-bindings:
+              attr-context-service: java:jboss/ee/concurrency/context/default
+              attr-datasource: java:jboss/datasources/ExampleDS
+              attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+              attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+              attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+            spec-descriptor-property-replacement: 'false'
+          - attr-xmlns: urn:jboss:domain:ee-security:1.0
+          - application-security-domains:
+              application-security-domain:
+                attr-name: other
+                attr-security-domain: ApplicationDomain
+            async:
+              attr-thread-pool-name: default
+            attr-xmlns: urn:jboss:domain:ejb3:9.0
+            caches:
+              cache:
+              - attr-name: simple
+              - attr-aliases: passivating clustered
+                attr-name: distributable
+                attr-passivation-store-ref: infinispan
+            default-missing-method-permissions-deny-access:
+              attr-value: 'true'
+            default-security-domain:
+              attr-value: other
+            log-system-exceptions:
+              attr-value: 'true'
+            passivation-stores:
+              passivation-store:
+                attr-cache-container: ejb
+                attr-max-size: '10000'
+                attr-name: infinispan
+            pools:
+              bean-instance-pools:
+                strict-max-pool:
+                - attr-derive-size: from-cpu-count
+                  attr-instance-acquisition-timeout: '5'
+                  attr-instance-acquisition-timeout-unit: MINUTES
+                  attr-name: mdb-strict-max-pool
+                - attr-derive-size: from-worker-pools
+                  attr-instance-acquisition-timeout: '5'
+                  attr-instance-acquisition-timeout-unit: MINUTES
+                  attr-name: slsb-strict-max-pool
+            remote:
+              attr-cluster: ejb
+              attr-connectors: http-remoting-connector
+              attr-thread-pool-name: default
+              channel-creation-options:
+                option:
+                  attr-name: MAX_OUTBOUND_MESSAGES
+                  attr-type: remoting
+                  attr-value: '1234'
+            session-bean:
+              singleton:
+                attr-default-access-timeout: '5000'
+              stateful:
+                attr-cache-ref: simple
+                attr-default-access-timeout: '5000'
+                attr-passivation-disabled-cache-ref: simple
+              stateless:
+                bean-instance-pool-ref:
+                  attr-pool-name: slsb-strict-max-pool
+            statistics:
+              attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+            thread-pools:
+              thread-pool:
+                attr-name: default
+                keepalive-time:
+                  attr-time: '60'
+                  attr-unit: seconds
+                max-threads:
+                  attr-count: '10'
+            timer-service:
+              attr-default-data-store: default-file-store
+              attr-thread-pool-name: default
+              data-stores:
+                file-data-store:
+                  attr-name: default-file-store
+                  attr-path: timer-service-data
+                  attr-relative-to: jboss.server.data.dir
+          - attr-disallowed-providers: OracleUcrypto
+            attr-final-providers: combined-providers
+            attr-xmlns: urn:wildfly:elytron:15.0
+            audit-logging:
+              file-audit-log:
+                attr-format: JSON
+                attr-name: local-audit
+                attr-path: audit.log
+                attr-relative-to: jboss.server.log.dir
+            http:
+              http-authentication-factory:
+              - attr-http-server-mechanism-factory: global
+                attr-name: management-http-authentication
+                attr-security-domain: ManagementDomain
+                mechanism-configuration:
+                  mechanism:
+                    attr-mechanism-name: DIGEST
+                    mechanism-realm:
+                      attr-realm-name: ManagementRealm
+              - attr-http-server-mechanism-factory: global
+                attr-name: application-http-authentication
+                attr-security-domain: ApplicationDomain
+                mechanism-configuration:
+                  mechanism:
+                    attr-mechanism-name: BASIC
+                    mechanism-realm:
+                      attr-realm-name: ApplicationRealm
+              provider-http-server-mechanism-factory:
+                attr-name: global
+            mappers:
+              constant-realm-mapper:
+                attr-name: local
+                attr-realm-name: local
+              constant-role-mapper:
+                attr-name: super-user-mapper
+                role:
+                  attr-name: SuperUser
+              simple-permission-mapper:
+                attr-mapping-mode: first
+                attr-name: default-permission-mapper
+                permission-mapping:
+                - permission-set:
+                    attr-name: default-permissions
+                  principal:
+                    attr-name: anonymous
+                - attr-match-all: 'true'
+                  permission-set:
+                  - attr-name: login-permission
+                  - attr-name: default-permissions
+              simple-role-decoder:
+                attr-attribute: groups
+                attr-name: groups-to-roles
+            permission-sets:
+              permission-set:
+              - attr-name: login-permission
+                permission:
+                  attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+              - attr-name: default-permissions
+                permission:
+                - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                  attr-module: org.wildfly.extension.batch.jberet
+                  attr-target-name: '*'
+                - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                  attr-module: org.wildfly.transaction.client
+                - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                  attr-module: org.jboss.ejb-client
+            providers:
+              aggregate-providers:
+                attr-name: combined-providers
+                providers:
+                - attr-name: elytron
+                - attr-name: openssl
+              provider-loader:
+              - attr-module: org.wildfly.security.elytron
+                attr-name: elytron
+              - attr-module: org.wildfly.openssl
+                attr-name: openssl
+            sasl:
+              configurable-sasl-server-factory:
+                attr-name: configured
+                attr-sasl-server-factory: elytron
+                properties:
+                  property:
+                  - attr-name: wildfly.sasl.local-user.default-user
+                    attr-value: $local
+                  - attr-name: wildfly.sasl.local-user.challenge-path
+                    attr-value: ${jboss.server.temp.dir}/auth
+              mechanism-provider-filtering-sasl-server-factory:
+                attr-name: elytron
+                attr-sasl-server-factory: global
+                filters:
+                  filter:
+                    attr-provider-name: WildFlyElytron
+              provider-sasl-server-factory:
+                attr-name: global
+              sasl-authentication-factory:
+              - attr-name: management-sasl-authentication
+                attr-sasl-server-factory: configured
+                attr-security-domain: ManagementDomain
+                mechanism-configuration:
+                  mechanism:
+                  - attr-mechanism-name: JBOSS-LOCAL-USER
+                    attr-realm-mapper: local
+                  - attr-mechanism-name: DIGEST-MD5
+                    mechanism-realm:
+                      attr-realm-name: ManagementRealm
+              - attr-name: application-sasl-authentication
+                attr-sasl-server-factory: configured
+                attr-security-domain: ApplicationDomain
+                mechanism-configuration:
+                  mechanism:
+                  - attr-mechanism-name: JBOSS-LOCAL-USER
+                    attr-realm-mapper: local
+                  - attr-mechanism-name: DIGEST-MD5
+                    mechanism-realm:
+                      attr-realm-name: ApplicationRealm
+            security-domains:
+              security-domain:
+              - attr-default-realm: ManagementRealm
+                attr-name: ManagementDomain
+                attr-permission-mapper: default-permission-mapper
+                realm:
+                - attr-name: ManagementRealm
+                  attr-role-decoder: groups-to-roles
+                - attr-name: local
+                  attr-role-mapper: super-user-mapper
+              - attr-default-realm: ApplicationRealm
+                attr-name: ApplicationDomain
+                attr-permission-mapper: default-permission-mapper
+                realm:
+                - attr-name: ApplicationRealm
+                  attr-role-decoder: groups-to-roles
+                - attr-name: local
+            security-realms:
+              identity-realm:
+                attr-identity: $local
+                attr-name: local
+              properties-realm:
+              - attr-name: ApplicationRealm
+                groups-properties:
+                  attr-path: application-roles.properties
+                  attr-relative-to: jboss.server.config.dir
+                users-properties:
+                  attr-digest-realm-name: ApplicationRealm
+                  attr-path: application-users.properties
+                  attr-relative-to: jboss.server.config.dir
+              - attr-name: ManagementRealm
+                groups-properties:
+                  attr-path: mgmt-groups.properties
+                  attr-relative-to: jboss.server.config.dir
+                users-properties:
+                  attr-digest-realm-name: ManagementRealm
+                  attr-path: mgmt-users.properties
+                  attr-relative-to: jboss.server.config.dir
+            tls:
+              key-managers:
+                key-manager:
+                  attr-generate-self-signed-certificate-host: localhost
+                  attr-key-store: applicationKS
+                  attr-name: applicationKM
+                  credential-reference:
+                    attr-clear-text: password
+              key-stores:
+                key-store:
+                  attr-name: applicationKS
+                  credential-reference:
+                    attr-clear-text: password
+                  file:
+                    attr-path: application.keystore
+                    attr-relative-to: jboss.server.config.dir
+                  implementation:
+                    attr-type: JKS
+              server-ssl-contexts:
+                server-ssl-context:
+                  attr-key-manager: applicationKM
+                  attr-name: applicationSSC
+          - attr-xmlns: urn:wildfly:elytron-oidc-client:1.0
+          - attr-security-enabled: 'false'
+            attr-xmlns: urn:wildfly:health:1.0
+          - attr-xmlns: urn:jboss:domain:infinispan:13.0
+            cache-container:
+            - attr-aliases: sfsb
+              attr-default-cache: passivation
+              attr-marshaller: PROTOSTREAM
+              attr-modules: org.wildfly.clustering.ejb.infinispan
+              attr-name: ejb
+              local-cache:
+                attr-name: passivation
+                expiration:
+                  attr-interval: '0'
+                file-store:
+                  attr-passivation: 'true'
+                  attr-purge: 'false'
+            - attr-default-cache: passivation
+              attr-marshaller: PROTOSTREAM
+              attr-modules: org.wildfly.clustering.web.infinispan
+              attr-name: web
+              local-cache:
+              - attr-name: passivation
+                expiration:
+                  attr-interval: '0'
+                file-store:
+                  attr-passivation: 'true'
+                  attr-purge: 'false'
+              - attr-name: sso
+                expiration:
+                  attr-interval: '0'
+            - attr-default-cache: default
+              attr-marshaller: PROTOSTREAM
+              attr-modules: org.wildfly.clustering.server
+              attr-name: server
+              local-cache:
+                attr-name: default
+                expiration:
+                  attr-interval: '0'
+            - attr-marshaller: JBOSS
+              attr-modules: org.infinispan.hibernate-cache
+              attr-name: hibernate
+              local-cache:
+              - attr-name: entity
+                expiration:
+                  attr-max-idle: '100000'
+                heap-memory:
+                  attr-size: '10000'
+              - attr-name: local-query
+                expiration:
+                  attr-max-idle: '100000'
+                heap-memory:
+                  attr-size: '10000'
+              - attr-name: timestamps
+                expiration:
+                  attr-interval: '0'
+              - attr-name: pending-puts
+                expiration:
+                  attr-max-idle: '60000'
+          - attr-xmlns: urn:jboss:domain:io:3.0
+            buffer-pool:
+              attr-name: default
+            worker:
+              attr-name: default
+          - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+          - archive-validation:
+              attr-enabled: 'true'
+              attr-fail-on-error: 'true'
+              attr-fail-on-warn: 'false'
+            attr-xmlns: urn:jboss:domain:jca:5.0
+            bean-validation:
+              attr-enabled: 'true'
+            cached-connection-manager: null
+            default-workmanager:
+              long-running-threads:
+                core-threads:
+                  attr-count: '50'
+                keepalive-time:
+                  attr-time: '10'
+                  attr-unit: seconds
+                max-threads:
+                  attr-count: '50'
+                queue-length:
+                  attr-count: '50'
+              short-running-threads:
+                core-threads:
+                  attr-count: '50'
+                keepalive-time:
+                  attr-time: '10'
+                  attr-unit: seconds
+                max-threads:
+                  attr-count: '50'
+                queue-length:
+                  attr-count: '50'
+          - attr-xmlns: urn:jboss:domain:jdr:1.0
+          - attr-xmlns: urn:jboss:domain:jmx:1.3
+            expose-expression-model: null
+            expose-resolved-model: null
+            remoting-connector: null
+          - attr-xmlns: urn:jboss:domain:jpa:1.1
+            jpa:
+              attr-default-extended-persistence-inheritance: DEEP
+          - attr-xmlns: urn:jboss:domain:jsf:1.1
+          - attr-xmlns: urn:jboss:domain:mail:4.0
+            mail-session:
+              attr-jndi-name: java:jboss/mail/Default
+              attr-name: default
+              smtp-server:
+                attr-outbound-socket-binding-ref: mail-smtp
+          - attr-exposed-subsystems: '*'
+            attr-prefix: ${wildfly.metrics.prefix:wildfly}
+            attr-security-enabled: 'false'
+            attr-xmlns: urn:wildfly:metrics:1.0
+          - attr-xmlns: urn:wildfly:microprofile-config-smallrye:1.0
+          - attr-xmlns: urn:wildfly:microprofile-jwt-smallrye:1.0
+          - attr-default-tracer: jaeger
+            attr-xmlns: urn:wildfly:microprofile-opentracing-smallrye:3.0
+            jaeger-tracer:
+              attr-name: jaeger
+              sampler-configuration:
+                attr-sampler-param: '1.0'
+                attr-sampler-type: const
+          - attr-xmlns: urn:jboss:domain:naming:2.0
+            remote-naming: null
+          - attr-xmlns: urn:jboss:domain:pojo:1.0
+          - attr-xmlns: urn:jboss:domain:remoting:4.0
+            http-connector:
+              attr-connector-ref: default
+              attr-name: http-remoting-connector
+              attr-sasl-authentication-factory: application-sasl-authentication
+          - attr-xmlns: urn:jboss:domain:request-controller:1.0
+          - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+          - attr-xmlns: urn:jboss:domain:sar:1.0
+          - attr-xmlns: urn:jboss:domain:security-manager:1.0
+            deployment-permissions:
+              maximum-set:
+                permission:
+                  attr-class: java.security.AllPermission
+          - attr-xmlns: urn:jboss:domain:transactions:6.0
+            coordinator-environment:
+              attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+            core-environment:
+              attr-node-identifier: ${jboss.tx.node.id:1}
+              process-id:
+                uuid: null
+            object-store:
+              attr-path: tx-object-store
+              attr-relative-to: jboss.server.data.dir
+            recovery-environment:
+              attr-socket-binding: txn-recovery-environment
+              attr-status-socket-binding: txn-status-manager
+          - application-security-domains:
+              application-security-domain:
+                attr-name: other
+                attr-security-domain: ApplicationDomain
+            attr-default-security-domain: other
+            attr-default-server: default-server
+            attr-default-servlet-container: default
+            attr-default-virtual-host: default-host
+            attr-instance-id: ${jboss.node.name}
+            attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+            attr-xmlns: urn:jboss:domain:undertow:12.0
+            buffer-cache:
+              attr-name: default
+            filters:
+              filter:
+                attr-class-name: io.undertow.server.handlers.RequestDumpingHandler
+                attr-module: io.undertow.core
+                attr-name: http-dumper
+            handlers:
+              file:
+                attr-name: welcome-content
+                attr-path: ${jboss.home.dir}/welcome-content
+            server:
+              attr-name: default-server
+              host:
+                access-log:
+                  attr-pattern: '%h %l %u %t "%r" %s %b "%{i,Referer}" "%{i,User-Agent}"
+                    Cookie: "%{i,COOKIE}" Set-Cookie: "%{o,SET-COOKIE}" SessionID:
+                    %S Thread: "%I" TimeTaken: %T'
+                attr-alias: localhost
+                attr-name: default-host
+                filter-ref:
+                  attr-name: http-dumper
+                http-invoker:
+                  attr-http-authentication-factory: application-http-authentication
+                location:
+                  attr-handler: welcome-content
+                  attr-name: /
+              http-listener:
+                attr-enable-http2: 'true'
+                attr-name: default
+                attr-record-request-start-time: 'true'
+                attr-redirect-socket: https
+                attr-socket-binding: http
+              https-listener:
+                attr-enable-http2: 'true'
+                attr-name: https
+                attr-socket-binding: https
+                attr-ssl-context: applicationSSC
+            servlet-container:
+              attr-name: default
+              jsp-config: null
+              websockets: null
+          - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+            attr-xmlns: urn:jboss:domain:webservices:2.0
+            client-config:
+              attr-name: Standard-Client-Config
+            endpoint-config:
+            - attr-name: Standard-Endpoint-Config
+            - attr-name: Recording-Endpoint-Config
+              pre-handler-chain:
+                attr-name: recording-handlers
+                attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                  ##SOAP12_HTTP_MTOM'
+                handler:
+                  attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                  attr-name: RecordingHandler
+            wsdl-host: ${jboss.bind.address:127.0.0.1}
+          - attr-xmlns: urn:jboss:domain:weld:4.0
+        socket-binding-group:
+          attr-default-interface: public
+          attr-name: standard-sockets
+          attr-port-offset: ${jboss.socket.binding.port-offset:0}
+          outbound-socket-binding:
+          - attr-name: infinispan-server-1
+            remote-destination:
+              attr-host: server1.example.com
+              attr-port: '11622'
+          - attr-name: mail-smtp
+            remote-destination:
+              attr-host: ${jboss.mail.server.host:localhost}
+              attr-port: ${jboss.mail.server.port:25}
+          socket-binding:
+          - attr-name: ajp
+            attr-port: ${jboss.ajp.port:28009}
+          - attr-name: http
+            attr-port: ${jboss.http.port:28080}
+          - attr-name: https
+            attr-port: ${jboss.https.port:28443}
+          - attr-interface: management
+            attr-name: management-http
+            attr-port: ${jboss.management.http.port:29990}
+          - attr-interface: management
+            attr-name: management-https
+            attr-port: ${jboss.management.https.port:9993}
+          - attr-name: txn-recovery-environment
+            attr-port: '4712'
+          - attr-name: txn-status-manager
+            attr-port: '4713'
+  discovery_time: '2022-06-23T20:55:14+02:00'
+  extra_data:
+    heap_initial_allocation_memory: 64m
+    heap_max_memory: 512m
+    mode: standalone
+    server:
+      name: jbossnode
+  files:
+  - name: server.log
+    path: /opt/wildfly/standalone/log
+    subtype: generic
+    type: log
+  - name: logging.properties
+    path: /opt/wildfly/standalone/configuration
+    subtype: generic
+    type: log
+  - path: /opt/wildfly/standalone
+    subtype: generic
+    type: data
+  - path: /opt/wildfly
+    subtype: generic
+    type: data
+  - path: /standalone.xml
+    subtype: generic
+    type: config
+  - name: standalone.xml
+    path: /opt/wildfly/standalone/configuration
+    subtype: xml
+    type: config
+  listening_ports:
+  - 28080
+  - 28443
+  - 29990
+  packages:
+  - arch: noarch
+    epoch: null
+    name: jboss-el-2.2-api
+    release: 0.7.20120212git2fabd8.el7
+    source: rpm
+    version: 1.0.1
+  - arch: noarch
+    epoch: null
+    name: jboss-jaxrpc-1.1-api
+    release: 7.el7
+    source: rpm
+    version: 1.0.1
+  - arch: noarch
+    epoch: null
+    name: jboss-servlet-3.0-api
+    release: 9.el7
+    source: rpm
+    version: 1.0.1
+  - arch: noarch
+    epoch: null
+    name: jboss-transaction-1.1-api
+    release: 8.el7
+    source: rpm
+    version: 1.0.1
+  - arch: noarch
+    epoch: null
+    name: jboss-ejb-3.1-api
+    release: 10.el7
+    source: rpm
+    version: 1.0.2
+  - arch: noarch
+    epoch: null
+    name: jboss-interceptors-1.1-api
+    release: 0.9.20120319git49a904.el7
+    source: rpm
+    version: 1.0.2
+  process:
+    cmdline: java -D[Standalone] -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m
+      -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman
+      -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/wildfly/standalone/log/server.log
+      -Dlogging.configuration=file:/opt/wildfly/standalone/configuration/logging.properties
+      -jar /opt/wildfly/jboss-modules.jar -mp /opt/wildfly/modules org.jboss.as.standalone
+      -Djboss.home.dir=/opt/wildfly -Djboss.server.base.dir=/opt/wildfly/standalone
+      -c standalone.xml -b 0.0.0.0 -bmanagement 0.0.0.0 -Djboss.node.name=jbossnode
+      -Djboss.bind.address=0.0.0.0
+    cwd: /
+    listening_ports:
+    - 28080
+    - 28443
+    - 29990
+    pid: '16804'
+    ppid: '16732'
+    user: root
+  type: JBoss Application Server
+  version:
+  - number: 1.0.1
+    type: package
+  - number: 1.0.2
+    type: package
+  - number: 26.0.0
+    type: file
 mocked_plugin_tasks:
-  "Run entry regex":
-    calls:
-      - run
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - run
-      - run
-      - run
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - run
-      - run
-      - run
-  "Check if version file is accessible":
+  Check if jboss_cmd is accessible:
     expected_args:
-      path: "/opt/wildfly/version.txt"
       follow: false
       get_attributes: true
       get_mime: true
       in_docker: true
+      path: /opt/wildfly/bin/standalone.sh
+    plugin_result:
+      failed: false
+  Check if logging_conf_file is accessible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /opt/wildfly/standalone/configuration/logging.properties
+    plugin_result:
+      failed: false
+  Check if standalone_xml_file is accessible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /opt/wildfly/standalone/configuration/standalone.xml
+    plugin_result:
+      failed: false
+  Check if version file is accessible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /opt/wildfly/version.txt
     plugin_result:
       failed: true
-  "Try to get version (2/6)":
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-  "Try to get version (3/6)":
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-  "Try to get version (4/6)":
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-  "Check if jboss_cmd is accessible":
-    expected_args:
-      path: "/opt/wildfly/bin/standalone.sh"
-      follow: false
-      get_attributes: true
-      get_mime: true
-      in_docker: true
-    plugin_result:
-      failed: false
-  "Run command if jboss_cmd is accessible":
-    expected_args:
-      argv: null
-      cmd: "/opt/wildfly/bin/standalone.sh -V"
-      in_docker: true
-    plugin_result:
-      failed: false
-      stdout: |-
-        =========================================================================
-
-          JBoss Bootstrap Environment
-        
-          JBOSS_HOME: /opt/wildfly
-        
-          JAVA: java
-        
-          JAVA_OPTS:  -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true 
-        
-        =========================================================================
-        
-        \u001b[0m00:31:53,215 INFO  [org.jboss.modules] (main) JBoss Modules version 2.0.0.Final
-        \u001b[0mWildFly Full 26.0.0.Final (WildFly Core 18.0.0.Final)
-  "Check if logging_conf_file is accessible":
-    expected_args:
-      path: "/opt/wildfly/standalone/configuration/logging.properties"
-      follow: false
-      get_attributes: true
-      get_mime: true
-      in_docker: true
-    plugin_result:
-      failed: false
-  "Read logging_conf_file if accessible":
+  Read logging_conf_file if accessible:
     expected_args:
       delegate_reading: false
-      file_path: "/opt/wildfly/standalone/configuration/logging.properties"
+      file_path: /opt/wildfly/standalone/configuration/logging.properties
       in_docker: true
       parser: null
       parser_params: null
     plugin_result:
-      failed: false
-      content: |-
-        # Note this file has been generated and will be overwritten if a
+      content: '# Note this file has been generated and will be overwritten if a
+
         # logging subsystem has been defined in the XML configuration.
 
 
+
         # Additional loggers to configure (the root logger is always configured)
+
         loggers=sun.rmi,io.jaegertracing.Configuration,org.jboss.as.config,com.arjuna
 
+
         logger.level=INFO
+
         logger.handlers=FILE,CONSOLE
 
+
         logger.sun.rmi.level=WARN
+
         logger.sun.rmi.useParentHandlers=true
 
+
         logger.io.jaegertracing.Configuration.level=WARN
+
         logger.io.jaegertracing.Configuration.useParentHandlers=true
 
+
         logger.org.jboss.as.config.level=DEBUG
+
         logger.org.jboss.as.config.useParentHandlers=true
 
+
         logger.com.arjuna.level=WARN
+
         logger.com.arjuna.useParentHandlers=true
 
+
         handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+
         handler.CONSOLE.level=INFO
+
         handler.CONSOLE.formatter=COLOR-PATTERN
+
         handler.CONSOLE.properties=autoFlush,target
+
         handler.CONSOLE.autoFlush=true
+
         handler.CONSOLE.target=SYSTEM_OUT
 
+
         handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+
         handler.FILE.level=ALL
+
         handler.FILE.formatter=PATTERN
+
         handler.FILE.properties=autoFlush,append,fileName,suffix
+
         handler.FILE.constructorProperties=fileName,append
+
         handler.FILE.autoFlush=true
+
         handler.FILE.append=true
+
         handler.FILE.fileName=/opt/wildfly/standalone/log/server.log
+
         handler.FILE.suffix=.yyyy-MM-dd
 
+
         formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+
         formatter.PATTERN.properties=pattern
+
         formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\\:mm\\:ss,SSS} %-5p [%c] (%t) %s%e%n
 
-        formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
-        formatter.COLOR-PATTERN.properties=pattern
-        formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\\:mm\\:ss,SSS} %-5p [%c] (%t) %s%e%n
 
-  "Check if standalone_xml_file is accessible":
-    expected_args:
-      path: "/opt/wildfly/standalone/configuration/standalone.xml"
-      follow: false
-      get_attributes: true
-      get_mime: true
-      in_docker: true
-    plugin_result:
+        formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+
+        formatter.COLOR-PATTERN.properties=pattern
+
+        formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\\:mm\\:ss,SSS} %-5p [%c] (%t)
+        %s%e%n'
       failed: false
-  "Read standalone_xml_file":
+  Read standalone_xml_file:
     expected_args:
       delegate_reading: false
-      file_path: "/opt/wildfly/standalone/configuration/standalone.xml"
+      file_path: /opt/wildfly/standalone/configuration/standalone.xml
       in_docker: true
-      parser: "xml"
+      parser: xml
       parser_params: null
     plugin_result:
       failed: false
-      parsed: {
-        "server": {
-          "attr-xmlns": "urn:jboss:domain:19.0",
-          "extensions": {
-            "extension": [
-              {
-                "attr-module": "org.jboss.as.clustering.infinispan"
-              },
-              {
-                "attr-module": "org.jboss.as.connector"
-              },
-              {
-                "attr-module": "org.jboss.as.deployment-scanner"
-              },
-              {
-                "attr-module": "org.jboss.as.ee"
-              },
-              {
-                "attr-module": "org.jboss.as.ejb3"
-              },
-              {
-                "attr-module": "org.jboss.as.jaxrs"
-              },
-              {
-                "attr-module": "org.jboss.as.jdr"
-              },
-              {
-                "attr-module": "org.jboss.as.jmx"
-              },
-              {
-                "attr-module": "org.jboss.as.jpa"
-              },
-              {
-                "attr-module": "org.jboss.as.jsf"
-              },
-              {
-                "attr-module": "org.jboss.as.logging"
-              },
-              {
-                "attr-module": "org.jboss.as.mail"
-              },
-              {
-                "attr-module": "org.jboss.as.naming"
-              },
-              {
-                "attr-module": "org.jboss.as.pojo"
-              },
-              {
-                "attr-module": "org.jboss.as.remoting"
-              },
-              {
-                "attr-module": "org.jboss.as.sar"
-              },
-              {
-                "attr-module": "org.jboss.as.transactions"
-              },
-              {
-                "attr-module": "org.jboss.as.webservices"
-              },
-              {
-                "attr-module": "org.jboss.as.weld"
-              },
-              {
-                "attr-module": "org.wildfly.extension.batch.jberet"
-              },
-              {
-                "attr-module": "org.wildfly.extension.bean-validation"
-              },
-              {
-                "attr-module": "org.wildfly.extension.clustering.web"
-              },
-              {
-                "attr-module": "org.wildfly.extension.core-management"
-              },
-              {
-                "attr-module": "org.wildfly.extension.discovery"
-              },
-              {
-                "attr-module": "org.wildfly.extension.ee-security"
-              },
-              {
-                "attr-module": "org.wildfly.extension.elytron"
-              },
-              {
-                "attr-module": "org.wildfly.extension.elytron-oidc-client"
-              },
-              {
-                "attr-module": "org.wildfly.extension.health"
-              },
-              {
-                "attr-module": "org.wildfly.extension.io"
-              },
-              {
-                "attr-module": "org.wildfly.extension.metrics"
-              },
-              {
-                "attr-module": "org.wildfly.extension.microprofile.config-smallrye"
-              },
-              {
-                "attr-module": "org.wildfly.extension.microprofile.jwt-smallrye"
-              },
-              {
-                "attr-module": "org.wildfly.extension.microprofile.opentracing-smallrye"
-              },
-              {
-                "attr-module": "org.wildfly.extension.request-controller"
-              },
-              {
-                "attr-module": "org.wildfly.extension.security.manager"
-              },
-              {
-                "attr-module": "org.wildfly.extension.undertow"
-              }
-            ]
-          },
-          "management": {
-            "audit-log": {
-              "formatters": {
-                "json-formatter": {
-                  "attr-name": "json-formatter"
-                }
-              },
-              "handlers": {
-                "file-handler": {
-                  "attr-name": "file",
-                  "attr-formatter": "json-formatter",
-                  "attr-path": "audit-log.log",
-                  "attr-relative-to": "jboss.server.data.dir"
-                }
-              },
-              "logger": {
-                "attr-log-boot": "true",
-                "attr-log-read-only": "false",
-                "attr-enabled": "false",
-                "handlers": {
-                  "handler": {
-                    "attr-name": "file"
-                  }
-                }
-              }
-            },
-            "management-interfaces": {
-              "http-interface": {
-                "attr-http-authentication-factory": "management-http-authentication",
-                "http-upgrade": {
-                  "attr-enabled": "true",
-                  "attr-sasl-authentication-factory": "management-sasl-authentication"
-                },
-                "socket-binding": {
-                  "attr-http": "management-http"
-                }
-              }
-            },
-            "access-control": {
-              "attr-provider": "simple",
-              "role-mapping": {
-                "role": {
-                  "attr-name": "SuperUser",
-                  "include": {
-                    "user": {
-                      "attr-name": "$local"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "profile": {
-            "subsystem": [
-              {
-                "attr-xmlns": "urn:jboss:domain:logging:8.0",
-                "console-handler": {
-                  "attr-name": "CONSOLE",
-                  "level": {
-                    "attr-name": "INFO"
-                  },
-                  "formatter": {
-                    "named-formatter": {
-                      "attr-name": "COLOR-PATTERN"
-                    }
-                  }
-                },
-                "periodic-rotating-file-handler": {
-                  "attr-name": "FILE",
-                  "attr-autoflush": "true",
-                  "formatter": {
-                    "named-formatter": {
-                      "attr-name": "PATTERN"
-                    }
-                  },
-                  "file": {
-                    "attr-relative-to": "jboss.server.log.dir",
-                    "attr-path": "server.log"
-                  },
-                  "suffix": {
-                    "attr-value": ".yyyy-MM-dd"
-                  },
-                  "append": {
-                    "attr-value": "true"
-                  }
-                },
-                "logger": [
-                  {
-                    "attr-category": "com.arjuna",
-                    "level": {
-                      "attr-name": "WARN"
-                    }
-                  },
-                  {
-                    "attr-category": "io.jaegertracing.Configuration",
-                    "level": {
-                      "attr-name": "WARN"
-                    }
-                  },
-                  {
-                    "attr-category": "org.jboss.as.config",
-                    "level": {
-                      "attr-name": "DEBUG"
-                    }
-                  },
-                  {
-                    "attr-category": "sun.rmi",
-                    "level": {
-                      "attr-name": "WARN"
-                    }
-                  }
-                ],
-                "root-logger": {
-                  "level": {
-                    "attr-name": "INFO"
-                  },
-                  "handlers": {
-                    "handler": [
-                      {
-                        "attr-name": "CONSOLE"
-                      },
-                      {
-                        "attr-name": "FILE"
-                      }
-                    ]
-                  }
-                },
-                "formatter": [
-                  {
-                    "attr-name": "PATTERN",
-                    "pattern-formatter": {
-                      "attr-pattern": "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"
-                    }
-                  },
-                  {
-                    "attr-name": "COLOR-PATTERN",
-                    "pattern-formatter": {
-                      "attr-pattern": "%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"
-                    }
-                  }
-                ]
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:batch-jberet:2.0",
-                "default-job-repository": {
-                  "attr-name": "in-memory"
-                },
-                "default-thread-pool": {
-                  "attr-name": "batch"
-                },
-                "job-repository": {
-                  "attr-name": "in-memory",
-                  "in-memory": null
-                },
-                "thread-pool": {
-                  "attr-name": "batch",
-                  "max-threads": {
-                    "attr-count": "10"
-                  },
-                  "keepalive-time": {
-                    "attr-time": "30",
-                    "attr-unit": "seconds"
-                  }
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:bean-validation:1.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:core-management:1.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:datasources:6.0",
-                "datasources": {
-                  "datasource": {
-                    "attr-jndi-name": "java:jboss/datasources/ExampleDS",
-                    "attr-pool-name": "ExampleDS",
-                    "attr-enabled": "true",
-                    "attr-use-java-context": "true",
-                    "attr-statistics-enabled": "${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}",
-                    "connection-url": "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
-                    "driver": "h2",
-                    "security": {
-                      "user-name": "sa",
-                      "password": "sa"
-                    }
-                  },
-                  "drivers": {
-                    "driver": {
-                      "attr-name": "h2",
-                      "attr-module": "com.h2database.h2",
-                      "xa-datasource-class": "org.h2.jdbcx.JdbcDataSource"
-                    }
-                  }
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:deployment-scanner:2.0",
-                "deployment-scanner": {
-                  "attr-path": "deployments",
-                  "attr-relative-to": "jboss.server.base.dir",
-                  "attr-scan-interval": "5000",
-                  "attr-runtime-failure-causes-rollback": "${jboss.deployment.scanner.rollback.on.failure:false}"
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:discovery:1.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:distributable-web:2.0",
-                "attr-default-session-management": "default",
-                "attr-default-single-sign-on-management": "default",
-                "infinispan-session-management": {
-                  "attr-name": "default",
-                  "attr-cache-container": "web",
-                  "attr-granularity": "SESSION",
-                  "local-affinity": null
-                },
-                "infinispan-single-sign-on-management": {
-                  "attr-name": "default",
-                  "attr-cache-container": "web",
-                  "attr-cache": "sso"
-                },
-                "local-routing": null
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:ee:6.0",
-                "spec-descriptor-property-replacement": "false",
-                "concurrent": {
-                  "context-services": {
-                    "context-service": {
-                      "attr-name": "default",
-                      "attr-jndi-name": "java:jboss/ee/concurrency/context/default",
-                      "attr-use-transaction-setup-provider": "true"
-                    }
-                  },
-                  "managed-thread-factories": {
-                    "managed-thread-factory": {
-                      "attr-name": "default",
-                      "attr-jndi-name": "java:jboss/ee/concurrency/factory/default",
-                      "attr-context-service": "default"
-                    }
-                  },
-                  "managed-executor-services": {
-                    "managed-executor-service": {
-                      "attr-name": "default",
-                      "attr-jndi-name": "java:jboss/ee/concurrency/executor/default",
-                      "attr-context-service": "default",
-                      "attr-hung-task-termination-period": "0",
-                      "attr-hung-task-threshold": "60000",
-                      "attr-keepalive-time": "5000"
-                    }
-                  },
-                  "managed-scheduled-executor-services": {
-                    "managed-scheduled-executor-service": {
-                      "attr-name": "default",
-                      "attr-jndi-name": "java:jboss/ee/concurrency/scheduler/default",
-                      "attr-context-service": "default",
-                      "attr-hung-task-termination-period": "0",
-                      "attr-hung-task-threshold": "60000",
-                      "attr-keepalive-time": "3000"
-                    }
-                  }
-                },
-                "default-bindings": {
-                  "attr-context-service": "java:jboss/ee/concurrency/context/default",
-                  "attr-datasource": "java:jboss/datasources/ExampleDS",
-                  "attr-managed-executor-service": "java:jboss/ee/concurrency/executor/default",
-                  "attr-managed-scheduled-executor-service": "java:jboss/ee/concurrency/scheduler/default",
-                  "attr-managed-thread-factory": "java:jboss/ee/concurrency/factory/default"
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:ee-security:1.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:ejb3:9.0",
-                "session-bean": {
-                  "stateless": {
-                    "bean-instance-pool-ref": {
-                      "attr-pool-name": "slsb-strict-max-pool"
-                    }
-                  },
-                  "stateful": {
-                    "attr-default-access-timeout": "5000",
-                    "attr-cache-ref": "simple",
-                    "attr-passivation-disabled-cache-ref": "simple"
-                  },
-                  "singleton": {
-                    "attr-default-access-timeout": "5000"
-                  }
-                },
-                "pools": {
-                  "bean-instance-pools": {
-                    "strict-max-pool": [
-                      {
-                        "attr-name": "mdb-strict-max-pool",
-                        "attr-derive-size": "from-cpu-count",
-                        "attr-instance-acquisition-timeout": "5",
-                        "attr-instance-acquisition-timeout-unit": "MINUTES"
-                      },
-                      {
-                        "attr-name": "slsb-strict-max-pool",
-                        "attr-derive-size": "from-worker-pools",
-                        "attr-instance-acquisition-timeout": "5",
-                        "attr-instance-acquisition-timeout-unit": "MINUTES"
-                      }
-                    ]
-                  }
-                },
-                "caches": {
-                  "cache": [
-                    {
-                      "attr-name": "simple"
-                    },
-                    {
-                      "attr-name": "distributable",
-                      "attr-passivation-store-ref": "infinispan",
-                      "attr-aliases": "passivating clustered"
-                    }
-                  ]
-                },
-                "passivation-stores": {
-                  "passivation-store": {
-                    "attr-name": "infinispan",
-                    "attr-cache-container": "ejb",
-                    "attr-max-size": "10000"
-                  }
-                },
-                "async": {
-                  "attr-thread-pool-name": "default"
-                },
-                "timer-service": {
-                  "attr-thread-pool-name": "default",
-                  "attr-default-data-store": "default-file-store",
-                  "data-stores": {
-                    "file-data-store": {
-                      "attr-name": "default-file-store",
-                      "attr-path": "timer-service-data",
-                      "attr-relative-to": "jboss.server.data.dir"
-                    }
-                  }
-                },
-                "remote": {
-                  "attr-cluster": "ejb",
-                  "attr-connectors": "http-remoting-connector",
-                  "attr-thread-pool-name": "default",
-                  "channel-creation-options": {
-                    "option": {
-                      "attr-name": "MAX_OUTBOUND_MESSAGES",
-                      "attr-value": "1234",
-                      "attr-type": "remoting"
-                    }
-                  }
-                },
-                "thread-pools": {
-                  "thread-pool": {
-                    "attr-name": "default",
-                    "max-threads": {
-                      "attr-count": "10"
-                    },
-                    "keepalive-time": {
-                      "attr-time": "60",
-                      "attr-unit": "seconds"
-                    }
-                  }
-                },
-                "default-security-domain": {
-                  "attr-value": "other"
-                },
-                "application-security-domains": {
-                  "application-security-domain": {
-                    "attr-name": "other",
-                    "attr-security-domain": "ApplicationDomain"
-                  }
-                },
-                "default-missing-method-permissions-deny-access": {
-                  "attr-value": "true"
-                },
-                "statistics": {
-                  "attr-enabled": "${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}"
-                },
-                "log-system-exceptions": {
-                  "attr-value": "true"
-                }
-              },
-              {
-                "attr-xmlns": "urn:wildfly:elytron:15.0",
-                "attr-final-providers": "combined-providers",
-                "attr-disallowed-providers": "OracleUcrypto",
-                "providers": {
-                  "aggregate-providers": {
-                    "attr-name": "combined-providers",
-                    "providers": [
-                      {
-                        "attr-name": "elytron"
-                      },
-                      {
-                        "attr-name": "openssl"
-                      }
-                    ]
-                  },
-                  "provider-loader": [
-                    {
-                      "attr-name": "elytron",
-                      "attr-module": "org.wildfly.security.elytron"
-                    },
-                    {
-                      "attr-name": "openssl",
-                      "attr-module": "org.wildfly.openssl"
-                    }
-                  ]
-                },
-                "audit-logging": {
-                  "file-audit-log": {
-                    "attr-name": "local-audit",
-                    "attr-path": "audit.log",
-                    "attr-relative-to": "jboss.server.log.dir",
-                    "attr-format": "JSON"
-                  }
-                },
-                "security-domains": {
-                  "security-domain": [
-                    {
-                      "attr-name": "ManagementDomain",
-                      "attr-default-realm": "ManagementRealm",
-                      "attr-permission-mapper": "default-permission-mapper",
-                      "realm": [
-                        {
-                          "attr-name": "ManagementRealm",
-                          "attr-role-decoder": "groups-to-roles"
-                        },
-                        {
-                          "attr-name": "local",
-                          "attr-role-mapper": "super-user-mapper"
-                        }
-                      ]
-                    },
-                    {
-                      "attr-name": "ApplicationDomain",
-                      "attr-default-realm": "ApplicationRealm",
-                      "attr-permission-mapper": "default-permission-mapper",
-                      "realm": [
-                        {
-                          "attr-name": "ApplicationRealm",
-                          "attr-role-decoder": "groups-to-roles"
-                        },
-                        {
-                          "attr-name": "local"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "security-realms": {
-                  "identity-realm": {
-                    "attr-name": "local",
-                    "attr-identity": "$local"
-                  },
-                  "properties-realm": [
-                    {
-                      "attr-name": "ApplicationRealm",
-                      "users-properties": {
-                        "attr-path": "application-users.properties",
-                        "attr-relative-to": "jboss.server.config.dir",
-                        "attr-digest-realm-name": "ApplicationRealm"
-                      },
-                      "groups-properties": {
-                        "attr-path": "application-roles.properties",
-                        "attr-relative-to": "jboss.server.config.dir"
-                      }
-                    },
-                    {
-                      "attr-name": "ManagementRealm",
-                      "users-properties": {
-                        "attr-path": "mgmt-users.properties",
-                        "attr-relative-to": "jboss.server.config.dir",
-                        "attr-digest-realm-name": "ManagementRealm"
-                      },
-                      "groups-properties": {
-                        "attr-path": "mgmt-groups.properties",
-                        "attr-relative-to": "jboss.server.config.dir"
-                      }
-                    }
-                  ]
-                },
-                "mappers": {
-                  "simple-permission-mapper": {
-                    "attr-name": "default-permission-mapper",
-                    "attr-mapping-mode": "first",
-                    "permission-mapping": [
-                      {
-                        "principal": {
-                          "attr-name": "anonymous"
-                        },
-                        "permission-set": {
-                          "attr-name": "default-permissions"
-                        }
-                      },
-                      {
-                        "attr-match-all": "true",
-                        "permission-set": [
-                          {
-                            "attr-name": "login-permission"
-                          },
-                          {
-                            "attr-name": "default-permissions"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  "constant-realm-mapper": {
-                    "attr-name": "local",
-                    "attr-realm-name": "local"
-                  },
-                  "simple-role-decoder": {
-                    "attr-name": "groups-to-roles",
-                    "attr-attribute": "groups"
-                  },
-                  "constant-role-mapper": {
-                    "attr-name": "super-user-mapper",
-                    "role": {
-                      "attr-name": "SuperUser"
-                    }
-                  }
-                },
-                "permission-sets": {
-                  "permission-set": [
-                    {
-                      "attr-name": "login-permission",
-                      "permission": {
-                        "attr-class-name": "org.wildfly.security.auth.permission.LoginPermission"
-                      }
-                    },
-                    {
-                      "attr-name": "default-permissions",
-                      "permission": [
-                        {
-                          "attr-class-name": "org.wildfly.extension.batch.jberet.deployment.BatchPermission",
-                          "attr-module": "org.wildfly.extension.batch.jberet",
-                          "attr-target-name": "*"
-                        },
-                        {
-                          "attr-class-name": "org.wildfly.transaction.client.RemoteTransactionPermission",
-                          "attr-module": "org.wildfly.transaction.client"
-                        },
-                        {
-                          "attr-class-name": "org.jboss.ejb.client.RemoteEJBPermission",
-                          "attr-module": "org.jboss.ejb-client"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "http": {
-                  "http-authentication-factory": [
-                    {
-                      "attr-name": "management-http-authentication",
-                      "attr-security-domain": "ManagementDomain",
-                      "attr-http-server-mechanism-factory": "global",
-                      "mechanism-configuration": {
-                        "mechanism": {
-                          "attr-mechanism-name": "DIGEST",
-                          "mechanism-realm": {
-                            "attr-realm-name": "ManagementRealm"
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "attr-name": "application-http-authentication",
-                      "attr-security-domain": "ApplicationDomain",
-                      "attr-http-server-mechanism-factory": "global",
-                      "mechanism-configuration": {
-                        "mechanism": {
-                          "attr-mechanism-name": "BASIC",
-                          "mechanism-realm": {
-                            "attr-realm-name": "ApplicationRealm"
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "provider-http-server-mechanism-factory": {
-                    "attr-name": "global"
-                  }
-                },
-                "sasl": {
-                  "sasl-authentication-factory": [
-                    {
-                      "attr-name": "management-sasl-authentication",
-                      "attr-sasl-server-factory": "configured",
-                      "attr-security-domain": "ManagementDomain",
-                      "mechanism-configuration": {
-                        "mechanism": [
-                          {
-                            "attr-mechanism-name": "JBOSS-LOCAL-USER",
-                            "attr-realm-mapper": "local"
-                          },
-                          {
-                            "attr-mechanism-name": "DIGEST-MD5",
-                            "mechanism-realm": {
-                              "attr-realm-name": "ManagementRealm"
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "attr-name": "application-sasl-authentication",
-                      "attr-sasl-server-factory": "configured",
-                      "attr-security-domain": "ApplicationDomain",
-                      "mechanism-configuration": {
-                        "mechanism": [
-                          {
-                            "attr-mechanism-name": "JBOSS-LOCAL-USER",
-                            "attr-realm-mapper": "local"
-                          },
-                          {
-                            "attr-mechanism-name": "DIGEST-MD5",
-                            "mechanism-realm": {
-                              "attr-realm-name": "ApplicationRealm"
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  ],
-                  "configurable-sasl-server-factory": {
-                    "attr-name": "configured",
-                    "attr-sasl-server-factory": "elytron",
-                    "properties": {
-                      "property": [
-                        {
-                          "attr-name": "wildfly.sasl.local-user.default-user",
-                          "attr-value": "$local"
-                        },
-                        {
-                          "attr-name": "wildfly.sasl.local-user.challenge-path",
-                          "attr-value": "${jboss.server.temp.dir}/auth"
-                        }
-                      ]
-                    }
-                  },
-                  "mechanism-provider-filtering-sasl-server-factory": {
-                    "attr-name": "elytron",
-                    "attr-sasl-server-factory": "global",
-                    "filters": {
-                      "filter": {
-                        "attr-provider-name": "WildFlyElytron"
-                      }
-                    }
-                  },
-                  "provider-sasl-server-factory": {
-                    "attr-name": "global"
-                  }
-                },
-                "tls": {
-                  "key-stores": {
-                    "key-store": {
-                      "attr-name": "applicationKS",
-                      "credential-reference": {
-                        "attr-clear-text": "password"
-                      },
-                      "implementation": {
-                        "attr-type": "JKS"
-                      },
-                      "file": {
-                        "attr-path": "application.keystore",
-                        "attr-relative-to": "jboss.server.config.dir"
-                      }
-                    }
-                  },
-                  "key-managers": {
-                    "key-manager": {
-                      "attr-name": "applicationKM",
-                      "attr-key-store": "applicationKS",
-                      "attr-generate-self-signed-certificate-host": "localhost",
-                      "credential-reference": {
-                        "attr-clear-text": "password"
-                      }
-                    }
-                  },
-                  "server-ssl-contexts": {
-                    "server-ssl-context": {
-                      "attr-name": "applicationSSC",
-                      "attr-key-manager": "applicationKM"
-                    }
-                  }
-                }
-              },
-              {
-                "attr-xmlns": "urn:wildfly:elytron-oidc-client:1.0"
-              },
-              {
-                "attr-xmlns": "urn:wildfly:health:1.0",
-                "attr-security-enabled": "false"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:infinispan:13.0",
-                "cache-container": [
-                  {
-                    "attr-name": "ejb",
-                    "attr-default-cache": "passivation",
-                    "attr-marshaller": "PROTOSTREAM",
-                    "attr-aliases": "sfsb",
-                    "attr-modules": "org.wildfly.clustering.ejb.infinispan",
-                    "local-cache": {
-                      "attr-name": "passivation",
-                      "expiration": {
-                        "attr-interval": "0"
-                      },
-                      "file-store": {
-                        "attr-passivation": "true",
-                        "attr-purge": "false"
-                      }
-                    }
-                  },
-                  {
-                    "attr-name": "web",
-                    "attr-default-cache": "passivation",
-                    "attr-marshaller": "PROTOSTREAM",
-                    "attr-modules": "org.wildfly.clustering.web.infinispan",
-                    "local-cache": [
-                      {
-                        "attr-name": "passivation",
-                        "expiration": {
-                          "attr-interval": "0"
-                        },
-                        "file-store": {
-                          "attr-passivation": "true",
-                          "attr-purge": "false"
-                        }
-                      },
-                      {
-                        "attr-name": "sso",
-                        "expiration": {
-                          "attr-interval": "0"
-                        }
-                      }
-                    ]
-                  },
-                  {
-                    "attr-name": "server",
-                    "attr-default-cache": "default",
-                    "attr-marshaller": "PROTOSTREAM",
-                    "attr-modules": "org.wildfly.clustering.server",
-                    "local-cache": {
-                      "attr-name": "default",
-                      "expiration": {
-                        "attr-interval": "0"
-                      }
-                    }
-                  },
-                  {
-                    "attr-name": "hibernate",
-                    "attr-marshaller": "JBOSS",
-                    "attr-modules": "org.infinispan.hibernate-cache",
-                    "local-cache": [
-                      {
-                        "attr-name": "entity",
-                        "heap-memory": {
-                          "attr-size": "10000"
-                        },
-                        "expiration": {
-                          "attr-max-idle": "100000"
-                        }
-                      },
-                      {
-                        "attr-name": "local-query",
-                        "heap-memory": {
-                          "attr-size": "10000"
-                        },
-                        "expiration": {
-                          "attr-max-idle": "100000"
-                        }
-                      },
-                      {
-                        "attr-name": "timestamps",
-                        "expiration": {
-                          "attr-interval": "0"
-                        }
-                      },
-                      {
-                        "attr-name": "pending-puts",
-                        "expiration": {
-                          "attr-max-idle": "60000"
-                        }
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:io:3.0",
-                "worker": {
-                  "attr-name": "default"
-                },
-                "buffer-pool": {
-                  "attr-name": "default"
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:jaxrs:2.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:jca:5.0",
-                "archive-validation": {
-                  "attr-enabled": "true",
-                  "attr-fail-on-error": "true",
-                  "attr-fail-on-warn": "false"
-                },
-                "bean-validation": {
-                  "attr-enabled": "true"
-                },
-                "default-workmanager": {
-                  "short-running-threads": {
-                    "core-threads": {
-                      "attr-count": "50"
-                    },
-                    "queue-length": {
-                      "attr-count": "50"
-                    },
-                    "max-threads": {
-                      "attr-count": "50"
-                    },
-                    "keepalive-time": {
-                      "attr-time": "10",
-                      "attr-unit": "seconds"
-                    }
-                  },
-                  "long-running-threads": {
-                    "core-threads": {
-                      "attr-count": "50"
-                    },
-                    "queue-length": {
-                      "attr-count": "50"
-                    },
-                    "max-threads": {
-                      "attr-count": "50"
-                    },
-                    "keepalive-time": {
-                      "attr-time": "10",
-                      "attr-unit": "seconds"
-                    }
-                  }
-                },
-                "cached-connection-manager": null
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:jdr:1.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:jmx:1.3",
-                "expose-resolved-model": null,
-                "expose-expression-model": null,
-                "remoting-connector": null
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:jpa:1.1",
-                "jpa": {
-                  "attr-default-extended-persistence-inheritance": "DEEP"
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:jsf:1.1"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:mail:4.0",
-                "mail-session": {
-                  "attr-name": "default",
-                  "attr-jndi-name": "java:jboss/mail/Default",
-                  "smtp-server": {
-                    "attr-outbound-socket-binding-ref": "mail-smtp"
-                  }
-                }
-              },
-              {
-                "attr-xmlns": "urn:wildfly:metrics:1.0",
-                "attr-security-enabled": "false",
-                "attr-exposed-subsystems": "*",
-                "attr-prefix": "${wildfly.metrics.prefix:wildfly}"
-              },
-              {
-                "attr-xmlns": "urn:wildfly:microprofile-config-smallrye:1.0"
-              },
-              {
-                "attr-xmlns": "urn:wildfly:microprofile-jwt-smallrye:1.0"
-              },
-              {
-                "attr-xmlns": "urn:wildfly:microprofile-opentracing-smallrye:3.0",
-                "attr-default-tracer": "jaeger",
-                "jaeger-tracer": {
-                  "attr-name": "jaeger",
-                  "sampler-configuration": {
-                    "attr-sampler-type": "const",
-                    "attr-sampler-param": "1.0"
-                  }
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:naming:2.0",
-                "remote-naming": null
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:pojo:1.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:remoting:4.0",
-                "http-connector": {
-                  "attr-name": "http-remoting-connector",
-                  "attr-connector-ref": "default",
-                  "attr-sasl-authentication-factory": "application-sasl-authentication"
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:request-controller:1.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:resource-adapters:6.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:sar:1.0"
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:security-manager:1.0",
-                "deployment-permissions": {
-                  "maximum-set": {
-                    "permission": {
-                      "attr-class": "java.security.AllPermission"
-                    }
-                  }
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:transactions:6.0",
-                "core-environment": {
-                  "attr-node-identifier": "${jboss.tx.node.id:1}",
-                  "process-id": {
-                    "uuid": null
-                  }
-                },
-                "recovery-environment": {
-                  "attr-socket-binding": "txn-recovery-environment",
-                  "attr-status-socket-binding": "txn-status-manager"
-                },
-                "coordinator-environment": {
-                  "attr-statistics-enabled": "${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}"
-                },
-                "object-store": {
-                  "attr-path": "tx-object-store",
-                  "attr-relative-to": "jboss.server.data.dir"
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:undertow:12.0",
-                "attr-default-server": "default-server",
-                "attr-default-virtual-host": "default-host",
-                "attr-default-servlet-container": "default",
-                "attr-instance-id": "${jboss.node.name}",
-                "attr-default-security-domain": "other",
-                "attr-statistics-enabled": "${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}",
-                "buffer-cache": {
-                  "attr-name": "default"
-                },
-                "server": {
-                  "attr-name": "default-server",
-                  "http-listener": {
-                    "attr-name": "default",
-                    "attr-socket-binding": "http",
-                    "attr-record-request-start-time": "true",
-                    "attr-redirect-socket": "https",
-                    "attr-enable-http2": "true"
-                  },
-                  "https-listener": {
-                    "attr-name": "https",
-                    "attr-socket-binding": "https",
-                    "attr-ssl-context": "applicationSSC",
-                    "attr-enable-http2": "true"
-                  },
-                  "host": {
-                    "attr-name": "default-host",
-                    "attr-alias": "localhost",
-                    "location": {
-                      "attr-name": "/",
-                      "attr-handler": "welcome-content"
-                    },
-                    "access-log": {
-                      "attr-pattern": "%h %l %u %t \"%r\" %s %b \"%{i,Referer}\" \"%{i,User-Agent}\" Cookie: \"%{i,COOKIE}\" Set-Cookie: \"%{o,SET-COOKIE}\" SessionID: %S Thread: \"%I\" TimeTaken: %T"
-                    },
-                    "filter-ref": {
-                      "attr-name": "http-dumper"
-                    },
-                    "http-invoker": {
-                      "attr-http-authentication-factory": "application-http-authentication"
-                    }
-                  }
-                },
-                "servlet-container": {
-                  "attr-name": "default",
-                  "jsp-config": null,
-                  "websockets": null
-                },
-                "handlers": {
-                  "file": {
-                    "attr-name": "welcome-content",
-                    "attr-path": "${jboss.home.dir}/welcome-content"
-                  }
-                },
-                "filters": {
-                  "filter": {
-                    "attr-name": "http-dumper",
-                    "attr-class-name": "io.undertow.server.handlers.RequestDumpingHandler",
-                    "attr-module": "io.undertow.core"
-                  }
-                },
-                "application-security-domains": {
-                  "application-security-domain": {
-                    "attr-name": "other",
-                    "attr-security-domain": "ApplicationDomain"
-                  }
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:webservices:2.0",
-                "attr-statistics-enabled": "${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}",
-                "wsdl-host": "${jboss.bind.address:127.0.0.1}",
-                "endpoint-config": [
-                  {
-                    "attr-name": "Standard-Endpoint-Config"
-                  },
-                  {
-                    "attr-name": "Recording-Endpoint-Config",
-                    "pre-handler-chain": {
-                      "attr-name": "recording-handlers",
-                      "attr-protocol-bindings": "##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM",
-                      "handler": {
-                        "attr-name": "RecordingHandler",
-                        "attr-class": "org.jboss.ws.common.invocation.RecordingServerHandler"
-                      }
-                    }
-                  }
-                ],
-                "client-config": {
-                  "attr-name": "Standard-Client-Config"
-                }
-              },
-              {
-                "attr-xmlns": "urn:jboss:domain:weld:4.0"
-              }
-            ]
-          },
-          "interfaces": {
-            "interface": [
-              {
-                "attr-name": "management",
-                "inet-address": {
-                  "attr-value": "${jboss.bind.address.management:127.0.0.1}"
-                }
-              },
-              {
-                "attr-name": "public",
-                "inet-address": {
-                  "attr-value": "${jboss.bind.address:127.0.0.1}"
-                }
-              }
-            ]
-          },
-          "socket-binding-group": {
-            "attr-name": "standard-sockets",
-            "attr-default-interface": "public",
-            "attr-port-offset": "${jboss.socket.binding.port-offset:0}",
-            "socket-binding": [
-              {
-                "attr-name": "ajp",
-                "attr-port": "${jboss.ajp.port:28009}"
-              },
-              {
-                "attr-name": "http",
-                "attr-port": "${jboss.http.port:28080}"
-              },
-              {
-                "attr-name": "https",
-                "attr-port": "${jboss.https.port:28443}"
-              },
-              {
-                "attr-name": "management-http",
-                "attr-interface": "management",
-                "attr-port": "${jboss.management.http.port:29990}"
-              },
-              {
-                "attr-name": "management-https",
-                "attr-interface": "management",
-                "attr-port": "${jboss.management.https.port:9993}"
-              },
-              {
-                "attr-name": "txn-recovery-environment",
-                "attr-port": "4712"
-              },
-              {
-                "attr-name": "txn-status-manager",
-                "attr-port": "4713"
-              }
-            ],
-            "outbound-socket-binding": [
-              {
-                "attr-name": "infinispan-server-1",
-                "remote-destination": {
-                  "attr-host": "server1.example.com",
-                  "attr-port": "11622"
-                }
-              },
-              {
-                "attr-name": "mail-smtp",
-                "remote-destination": {
-                  "attr-host": "${jboss.mail.server.host:localhost}",
-                  "attr-port": "${jboss.mail.server.port:25}"
-                }
-              }
-            ]
-          }
-        }
-      }
-
-expected_result:
-  - bindings:
-      - address: 0.0.0.0
-        class: service
-        port: 29990
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        port: 28080
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        port: 28443
-        protocol: tcp
-      - address: 0.0.0.0
-        class: binding_address
-      - class: ajp
-        port: 28009
-      - class: http
-        port: 28080
-      - class: https
-        port: 28443
-      - class: management_http
-        port: 29990
-      - class: management_https
-        port: 9993
-      - class: txn_recovery_environment
-        port: 4712
-      - class: txn_status_manager
-        port: 4713
-      - address: localhost
-        class: domain controller
-    configuration:
-      standalone_xml:
+      parsed:
         server:
           attr-xmlns: urn:jboss:domain:19.0
           extensions:
             extension:
-              - attr-module: org.jboss.as.clustering.infinispan
-              - attr-module: org.jboss.as.connector
-              - attr-module: org.jboss.as.deployment-scanner
-              - attr-module: org.jboss.as.ee
-              - attr-module: org.jboss.as.ejb3
-              - attr-module: org.jboss.as.jaxrs
-              - attr-module: org.jboss.as.jdr
-              - attr-module: org.jboss.as.jmx
-              - attr-module: org.jboss.as.jpa
-              - attr-module: org.jboss.as.jsf
-              - attr-module: org.jboss.as.logging
-              - attr-module: org.jboss.as.mail
-              - attr-module: org.jboss.as.naming
-              - attr-module: org.jboss.as.pojo
-              - attr-module: org.jboss.as.remoting
-              - attr-module: org.jboss.as.sar
-              - attr-module: org.jboss.as.transactions
-              - attr-module: org.jboss.as.webservices
-              - attr-module: org.jboss.as.weld
-              - attr-module: org.wildfly.extension.batch.jberet
-              - attr-module: org.wildfly.extension.bean-validation
-              - attr-module: org.wildfly.extension.clustering.web
-              - attr-module: org.wildfly.extension.core-management
-              - attr-module: org.wildfly.extension.discovery
-              - attr-module: org.wildfly.extension.ee-security
-              - attr-module: org.wildfly.extension.elytron
-              - attr-module: org.wildfly.extension.elytron-oidc-client
-              - attr-module: org.wildfly.extension.health
-              - attr-module: org.wildfly.extension.io
-              - attr-module: org.wildfly.extension.metrics
-              - attr-module: org.wildfly.extension.microprofile.config-smallrye
-              - attr-module: org.wildfly.extension.microprofile.jwt-smallrye
-              - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
-              - attr-module: org.wildfly.extension.request-controller
-              - attr-module: org.wildfly.extension.security.manager
-              - attr-module: org.wildfly.extension.undertow
+            - attr-module: org.jboss.as.clustering.infinispan
+            - attr-module: org.jboss.as.connector
+            - attr-module: org.jboss.as.deployment-scanner
+            - attr-module: org.jboss.as.ee
+            - attr-module: org.jboss.as.ejb3
+            - attr-module: org.jboss.as.jaxrs
+            - attr-module: org.jboss.as.jdr
+            - attr-module: org.jboss.as.jmx
+            - attr-module: org.jboss.as.jpa
+            - attr-module: org.jboss.as.jsf
+            - attr-module: org.jboss.as.logging
+            - attr-module: org.jboss.as.mail
+            - attr-module: org.jboss.as.naming
+            - attr-module: org.jboss.as.pojo
+            - attr-module: org.jboss.as.remoting
+            - attr-module: org.jboss.as.sar
+            - attr-module: org.jboss.as.transactions
+            - attr-module: org.jboss.as.webservices
+            - attr-module: org.jboss.as.weld
+            - attr-module: org.wildfly.extension.batch.jberet
+            - attr-module: org.wildfly.extension.bean-validation
+            - attr-module: org.wildfly.extension.clustering.web
+            - attr-module: org.wildfly.extension.core-management
+            - attr-module: org.wildfly.extension.discovery
+            - attr-module: org.wildfly.extension.ee-security
+            - attr-module: org.wildfly.extension.elytron
+            - attr-module: org.wildfly.extension.elytron-oidc-client
+            - attr-module: org.wildfly.extension.health
+            - attr-module: org.wildfly.extension.io
+            - attr-module: org.wildfly.extension.metrics
+            - attr-module: org.wildfly.extension.microprofile.config-smallrye
+            - attr-module: org.wildfly.extension.microprofile.jwt-smallrye
+            - attr-module: org.wildfly.extension.microprofile.opentracing-smallrye
+            - attr-module: org.wildfly.extension.request-controller
+            - attr-module: org.wildfly.extension.security.manager
+            - attr-module: org.wildfly.extension.undertow
           interfaces:
             interface:
-              - attr-name: management
-                inet-address:
-                  attr-value: ${jboss.bind.address.management:127.0.0.1}
-              - attr-name: public
-                inet-address:
-                  attr-value: ${jboss.bind.address:127.0.0.1}
+            - attr-name: management
+              inet-address:
+                attr-value: ${jboss.bind.address.management:127.0.0.1}
+            - attr-name: public
+              inet-address:
+                attr-value: ${jboss.bind.address:127.0.0.1}
           management:
             access-control:
               attr-provider: simple
@@ -1509,5079 +1071,5160 @@ expected_result:
                   attr-http: management-http
           profile:
             subsystem:
-              - attr-xmlns: urn:jboss:domain:logging:8.0
-                console-handler:
-                  attr-name: CONSOLE
-                  formatter:
-                    named-formatter:
-                      attr-name: COLOR-PATTERN
-                  level:
-                    attr-name: INFO
+            - attr-xmlns: urn:jboss:domain:logging:8.0
+              console-handler:
+                attr-name: CONSOLE
                 formatter:
-                  - attr-name: PATTERN
-                    pattern-formatter:
-                      attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                  - attr-name: COLOR-PATTERN
-                    pattern-formatter:
-                      attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
-                logger:
-                  - attr-category: com.arjuna
-                    level:
-                      attr-name: WARN
-                  - attr-category: io.jaegertracing.Configuration
-                    level:
-                      attr-name: WARN
-                  - attr-category: org.jboss.as.config
-                    level:
-                      attr-name: DEBUG
-                  - attr-category: sun.rmi
-                    level:
-                      attr-name: WARN
-                periodic-rotating-file-handler:
-                  append:
-                    attr-value: 'true'
-                  attr-autoflush: 'true'
-                  attr-name: FILE
-                  file:
-                    attr-path: server.log
-                    attr-relative-to: jboss.server.log.dir
-                  formatter:
-                    named-formatter:
-                      attr-name: PATTERN
-                  suffix:
-                    attr-value: .yyyy-MM-dd
-                root-logger:
-                  handlers:
-                    handler:
-                      - attr-name: CONSOLE
-                      - attr-name: FILE
-                  level:
-                    attr-name: INFO
-              - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
-                default-job-repository:
-                  attr-name: in-memory
-                default-thread-pool:
-                  attr-name: batch
-                job-repository:
-                  attr-name: in-memory
-                  in-memory: null
+                  named-formatter:
+                    attr-name: COLOR-PATTERN
+                level:
+                  attr-name: INFO
+              formatter:
+              - attr-name: PATTERN
+                pattern-formatter:
+                  attr-pattern: '%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              - attr-name: COLOR-PATTERN
+                pattern-formatter:
+                  attr-pattern: '%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n'
+              logger:
+              - attr-category: com.arjuna
+                level:
+                  attr-name: WARN
+              - attr-category: io.jaegertracing.Configuration
+                level:
+                  attr-name: WARN
+              - attr-category: org.jboss.as.config
+                level:
+                  attr-name: DEBUG
+              - attr-category: sun.rmi
+                level:
+                  attr-name: WARN
+              periodic-rotating-file-handler:
+                append:
+                  attr-value: 'true'
+                attr-autoflush: 'true'
+                attr-name: FILE
+                file:
+                  attr-path: server.log
+                  attr-relative-to: jboss.server.log.dir
+                formatter:
+                  named-formatter:
+                    attr-name: PATTERN
+                suffix:
+                  attr-value: .yyyy-MM-dd
+              root-logger:
+                handlers:
+                  handler:
+                  - attr-name: CONSOLE
+                  - attr-name: FILE
+                level:
+                  attr-name: INFO
+            - attr-xmlns: urn:jboss:domain:batch-jberet:2.0
+              default-job-repository:
+                attr-name: in-memory
+              default-thread-pool:
+                attr-name: batch
+              job-repository:
+                attr-name: in-memory
+                in-memory: null
+              thread-pool:
+                attr-name: batch
+                keepalive-time:
+                  attr-time: '30'
+                  attr-unit: seconds
+                max-threads:
+                  attr-count: '10'
+            - attr-xmlns: urn:jboss:domain:bean-validation:1.0
+            - attr-xmlns: urn:jboss:domain:core-management:1.0
+            - attr-xmlns: urn:jboss:domain:datasources:6.0
+              datasources:
+                datasource:
+                  attr-enabled: 'true'
+                  attr-jndi-name: java:jboss/datasources/ExampleDS
+                  attr-pool-name: ExampleDS
+                  attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
+                  attr-use-java-context: 'true'
+                  connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+                  driver: h2
+                  security:
+                    password: sa
+                    user-name: sa
+                drivers:
+                  driver:
+                    attr-module: com.h2database.h2
+                    attr-name: h2
+                    xa-datasource-class: org.h2.jdbcx.JdbcDataSource
+            - attr-xmlns: urn:jboss:domain:deployment-scanner:2.0
+              deployment-scanner:
+                attr-path: deployments
+                attr-relative-to: jboss.server.base.dir
+                attr-runtime-failure-causes-rollback: ${jboss.deployment.scanner.rollback.on.failure:false}
+                attr-scan-interval: '5000'
+            - attr-xmlns: urn:jboss:domain:discovery:1.0
+            - attr-default-session-management: default
+              attr-default-single-sign-on-management: default
+              attr-xmlns: urn:jboss:domain:distributable-web:2.0
+              infinispan-session-management:
+                attr-cache-container: web
+                attr-granularity: SESSION
+                attr-name: default
+                local-affinity: null
+              infinispan-single-sign-on-management:
+                attr-cache: sso
+                attr-cache-container: web
+                attr-name: default
+              local-routing: null
+            - attr-xmlns: urn:jboss:domain:ee:6.0
+              concurrent:
+                context-services:
+                  context-service:
+                    attr-jndi-name: java:jboss/ee/concurrency/context/default
+                    attr-name: default
+                    attr-use-transaction-setup-provider: 'true'
+                managed-executor-services:
+                  managed-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/executor/default
+                    attr-keepalive-time: '5000'
+                    attr-name: default
+                managed-scheduled-executor-services:
+                  managed-scheduled-executor-service:
+                    attr-context-service: default
+                    attr-hung-task-termination-period: '0'
+                    attr-hung-task-threshold: '60000'
+                    attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
+                    attr-keepalive-time: '3000'
+                    attr-name: default
+                managed-thread-factories:
+                  managed-thread-factory:
+                    attr-context-service: default
+                    attr-jndi-name: java:jboss/ee/concurrency/factory/default
+                    attr-name: default
+              default-bindings:
+                attr-context-service: java:jboss/ee/concurrency/context/default
+                attr-datasource: java:jboss/datasources/ExampleDS
+                attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
+                attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
+                attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
+              spec-descriptor-property-replacement: 'false'
+            - attr-xmlns: urn:jboss:domain:ee-security:1.0
+            - application-security-domains:
+                application-security-domain:
+                  attr-name: other
+                  attr-security-domain: ApplicationDomain
+              async:
+                attr-thread-pool-name: default
+              attr-xmlns: urn:jboss:domain:ejb3:9.0
+              caches:
+                cache:
+                - attr-name: simple
+                - attr-aliases: passivating clustered
+                  attr-name: distributable
+                  attr-passivation-store-ref: infinispan
+              default-missing-method-permissions-deny-access:
+                attr-value: 'true'
+              default-security-domain:
+                attr-value: other
+              log-system-exceptions:
+                attr-value: 'true'
+              passivation-stores:
+                passivation-store:
+                  attr-cache-container: ejb
+                  attr-max-size: '10000'
+                  attr-name: infinispan
+              pools:
+                bean-instance-pools:
+                  strict-max-pool:
+                  - attr-derive-size: from-cpu-count
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: mdb-strict-max-pool
+                  - attr-derive-size: from-worker-pools
+                    attr-instance-acquisition-timeout: '5'
+                    attr-instance-acquisition-timeout-unit: MINUTES
+                    attr-name: slsb-strict-max-pool
+              remote:
+                attr-cluster: ejb
+                attr-connectors: http-remoting-connector
+                attr-thread-pool-name: default
+                channel-creation-options:
+                  option:
+                    attr-name: MAX_OUTBOUND_MESSAGES
+                    attr-type: remoting
+                    attr-value: '1234'
+              session-bean:
+                singleton:
+                  attr-default-access-timeout: '5000'
+                stateful:
+                  attr-cache-ref: simple
+                  attr-default-access-timeout: '5000'
+                  attr-passivation-disabled-cache-ref: simple
+                stateless:
+                  bean-instance-pool-ref:
+                    attr-pool-name: slsb-strict-max-pool
+              statistics:
+                attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
+              thread-pools:
                 thread-pool:
-                  attr-name: batch
+                  attr-name: default
                   keepalive-time:
-                    attr-time: '30'
+                    attr-time: '60'
                     attr-unit: seconds
                   max-threads:
                     attr-count: '10'
-              - attr-xmlns: urn:jboss:domain:bean-validation:1.0
-              - attr-xmlns: urn:jboss:domain:core-management:1.0
-              - attr-xmlns: urn:jboss:domain:datasources:6.0
-                datasources:
-                  datasource:
-                    attr-enabled: 'true'
-                    attr-jndi-name: java:jboss/datasources/ExampleDS
-                    attr-pool-name: ExampleDS
-                    attr-statistics-enabled: ${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}
-                    attr-use-java-context: 'true'
-                    connection-url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-                    driver: h2
-                    security:
-                      password: sa
-                      user-name: sa
-                  drivers:
-                    driver:
-                      attr-module: com.h2database.h2
-                      attr-name: h2
-                      xa-datasource-class: org.h2.jdbcx.JdbcDataSource
-              - attr-xmlns: urn:jboss:domain:deployment-scanner:2.0
-                deployment-scanner:
-                  attr-path: deployments
-                  attr-relative-to: jboss.server.base.dir
-                  attr-runtime-failure-causes-rollback: ${jboss.deployment.scanner.rollback.on.failure:false}
-                  attr-scan-interval: '5000'
-              - attr-xmlns: urn:jboss:domain:discovery:1.0
-              - attr-default-session-management: default
-                attr-default-single-sign-on-management: default
-                attr-xmlns: urn:jboss:domain:distributable-web:2.0
-                infinispan-session-management:
-                  attr-cache-container: web
-                  attr-granularity: SESSION
-                  attr-name: default
-                  local-affinity: null
-                infinispan-single-sign-on-management:
-                  attr-cache: sso
-                  attr-cache-container: web
-                  attr-name: default
-                local-routing: null
-              - attr-xmlns: urn:jboss:domain:ee:6.0
-                concurrent:
-                  context-services:
-                    context-service:
-                      attr-jndi-name: java:jboss/ee/concurrency/context/default
-                      attr-name: default
-                      attr-use-transaction-setup-provider: 'true'
-                  managed-executor-services:
-                    managed-executor-service:
-                      attr-context-service: default
-                      attr-hung-task-termination-period: '0'
-                      attr-hung-task-threshold: '60000'
-                      attr-jndi-name: java:jboss/ee/concurrency/executor/default
-                      attr-keepalive-time: '5000'
-                      attr-name: default
-                  managed-scheduled-executor-services:
-                    managed-scheduled-executor-service:
-                      attr-context-service: default
-                      attr-hung-task-termination-period: '0'
-                      attr-hung-task-threshold: '60000'
-                      attr-jndi-name: java:jboss/ee/concurrency/scheduler/default
-                      attr-keepalive-time: '3000'
-                      attr-name: default
-                  managed-thread-factories:
-                    managed-thread-factory:
-                      attr-context-service: default
-                      attr-jndi-name: java:jboss/ee/concurrency/factory/default
-                      attr-name: default
-                default-bindings:
-                  attr-context-service: java:jboss/ee/concurrency/context/default
-                  attr-datasource: java:jboss/datasources/ExampleDS
-                  attr-managed-executor-service: java:jboss/ee/concurrency/executor/default
-                  attr-managed-scheduled-executor-service: java:jboss/ee/concurrency/scheduler/default
-                  attr-managed-thread-factory: java:jboss/ee/concurrency/factory/default
-                spec-descriptor-property-replacement: 'false'
-              - attr-xmlns: urn:jboss:domain:ee-security:1.0
-              - application-security-domains:
-                  application-security-domain:
-                    attr-name: other
-                    attr-security-domain: ApplicationDomain
-                async:
-                  attr-thread-pool-name: default
-                attr-xmlns: urn:jboss:domain:ejb3:9.0
-                caches:
-                  cache:
-                    - attr-name: simple
-                    - attr-aliases: passivating clustered
-                      attr-name: distributable
-                      attr-passivation-store-ref: infinispan
-                default-missing-method-permissions-deny-access:
-                  attr-value: 'true'
-                default-security-domain:
-                  attr-value: other
-                log-system-exceptions:
-                  attr-value: 'true'
-                passivation-stores:
-                  passivation-store:
-                    attr-cache-container: ejb
-                    attr-max-size: '10000'
-                    attr-name: infinispan
-                pools:
-                  bean-instance-pools:
-                    strict-max-pool:
-                      - attr-derive-size: from-cpu-count
-                        attr-instance-acquisition-timeout: '5'
-                        attr-instance-acquisition-timeout-unit: MINUTES
-                        attr-name: mdb-strict-max-pool
-                      - attr-derive-size: from-worker-pools
-                        attr-instance-acquisition-timeout: '5'
-                        attr-instance-acquisition-timeout-unit: MINUTES
-                        attr-name: slsb-strict-max-pool
-                remote:
-                  attr-cluster: ejb
-                  attr-connectors: http-remoting-connector
-                  attr-thread-pool-name: default
-                  channel-creation-options:
-                    option:
-                      attr-name: MAX_OUTBOUND_MESSAGES
-                      attr-type: remoting
-                      attr-value: '1234'
-                session-bean:
-                  singleton:
-                    attr-default-access-timeout: '5000'
-                  stateful:
-                    attr-cache-ref: simple
-                    attr-default-access-timeout: '5000'
-                    attr-passivation-disabled-cache-ref: simple
-                  stateless:
-                    bean-instance-pool-ref:
-                      attr-pool-name: slsb-strict-max-pool
-                statistics:
-                  attr-enabled: ${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}
-                thread-pools:
-                  thread-pool:
-                    attr-name: default
-                    keepalive-time:
-                      attr-time: '60'
-                      attr-unit: seconds
-                    max-threads:
-                      attr-count: '10'
-                timer-service:
-                  attr-default-data-store: default-file-store
-                  attr-thread-pool-name: default
-                  data-stores:
-                    file-data-store:
-                      attr-name: default-file-store
-                      attr-path: timer-service-data
-                      attr-relative-to: jboss.server.data.dir
-              - attr-disallowed-providers: OracleUcrypto
-                attr-final-providers: combined-providers
-                attr-xmlns: urn:wildfly:elytron:15.0
-                audit-logging:
-                  file-audit-log:
-                    attr-format: JSON
-                    attr-name: local-audit
-                    attr-path: audit.log
-                    attr-relative-to: jboss.server.log.dir
-                http:
-                  http-authentication-factory:
-                    - attr-http-server-mechanism-factory: global
-                      attr-name: management-http-authentication
-                      attr-security-domain: ManagementDomain
-                      mechanism-configuration:
-                        mechanism:
-                          attr-mechanism-name: DIGEST
-                          mechanism-realm:
-                            attr-realm-name: ManagementRealm
-                    - attr-http-server-mechanism-factory: global
-                      attr-name: application-http-authentication
-                      attr-security-domain: ApplicationDomain
-                      mechanism-configuration:
-                        mechanism:
-                          attr-mechanism-name: BASIC
-                          mechanism-realm:
-                            attr-realm-name: ApplicationRealm
-                  provider-http-server-mechanism-factory:
-                    attr-name: global
-                mappers:
-                  constant-realm-mapper:
-                    attr-name: local
-                    attr-realm-name: local
-                  constant-role-mapper:
-                    attr-name: super-user-mapper
-                    role:
-                      attr-name: SuperUser
-                  simple-permission-mapper:
-                    attr-mapping-mode: first
-                    attr-name: default-permission-mapper
-                    permission-mapping:
-                      - permission-set:
-                          attr-name: default-permissions
-                        principal:
-                          attr-name: anonymous
-                      - attr-match-all: 'true'
-                        permission-set:
-                          - attr-name: login-permission
-                          - attr-name: default-permissions
-                  simple-role-decoder:
-                    attr-attribute: groups
-                    attr-name: groups-to-roles
-                permission-sets:
-                  permission-set:
+              timer-service:
+                attr-default-data-store: default-file-store
+                attr-thread-pool-name: default
+                data-stores:
+                  file-data-store:
+                    attr-name: default-file-store
+                    attr-path: timer-service-data
+                    attr-relative-to: jboss.server.data.dir
+            - attr-disallowed-providers: OracleUcrypto
+              attr-final-providers: combined-providers
+              attr-xmlns: urn:wildfly:elytron:15.0
+              audit-logging:
+                file-audit-log:
+                  attr-format: JSON
+                  attr-name: local-audit
+                  attr-path: audit.log
+                  attr-relative-to: jboss.server.log.dir
+              http:
+                http-authentication-factory:
+                - attr-http-server-mechanism-factory: global
+                  attr-name: management-http-authentication
+                  attr-security-domain: ManagementDomain
+                  mechanism-configuration:
+                    mechanism:
+                      attr-mechanism-name: DIGEST
+                      mechanism-realm:
+                        attr-realm-name: ManagementRealm
+                - attr-http-server-mechanism-factory: global
+                  attr-name: application-http-authentication
+                  attr-security-domain: ApplicationDomain
+                  mechanism-configuration:
+                    mechanism:
+                      attr-mechanism-name: BASIC
+                      mechanism-realm:
+                        attr-realm-name: ApplicationRealm
+                provider-http-server-mechanism-factory:
+                  attr-name: global
+              mappers:
+                constant-realm-mapper:
+                  attr-name: local
+                  attr-realm-name: local
+                constant-role-mapper:
+                  attr-name: super-user-mapper
+                  role:
+                    attr-name: SuperUser
+                simple-permission-mapper:
+                  attr-mapping-mode: first
+                  attr-name: default-permission-mapper
+                  permission-mapping:
+                  - permission-set:
+                      attr-name: default-permissions
+                    principal:
+                      attr-name: anonymous
+                  - attr-match-all: 'true'
+                    permission-set:
                     - attr-name: login-permission
-                      permission:
-                        attr-class-name: org.wildfly.security.auth.permission.LoginPermission
                     - attr-name: default-permissions
-                      permission:
-                        - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
-                          attr-module: org.wildfly.extension.batch.jberet
-                          attr-target-name: '*'
-                        - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
-                          attr-module: org.wildfly.transaction.client
-                        - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
-                          attr-module: org.jboss.ejb-client
-                providers:
-                  aggregate-providers:
-                    attr-name: combined-providers
-                    providers:
-                      - attr-name: elytron
-                      - attr-name: openssl
-                  provider-loader:
-                    - attr-module: org.wildfly.security.elytron
-                      attr-name: elytron
-                    - attr-module: org.wildfly.openssl
-                      attr-name: openssl
-                sasl:
-                  configurable-sasl-server-factory:
-                    attr-name: configured
-                    attr-sasl-server-factory: elytron
-                    properties:
-                      property:
-                        - attr-name: wildfly.sasl.local-user.default-user
-                          attr-value: $local
-                        - attr-name: wildfly.sasl.local-user.challenge-path
-                          attr-value: ${jboss.server.temp.dir}/auth
-                  mechanism-provider-filtering-sasl-server-factory:
-                    attr-name: elytron
-                    attr-sasl-server-factory: global
-                    filters:
-                      filter:
-                        attr-provider-name: WildFlyElytron
-                  provider-sasl-server-factory:
-                    attr-name: global
-                  sasl-authentication-factory:
-                    - attr-name: management-sasl-authentication
-                      attr-sasl-server-factory: configured
-                      attr-security-domain: ManagementDomain
-                      mechanism-configuration:
-                        mechanism:
-                          - attr-mechanism-name: JBOSS-LOCAL-USER
-                            attr-realm-mapper: local
-                          - attr-mechanism-name: DIGEST-MD5
-                            mechanism-realm:
-                              attr-realm-name: ManagementRealm
-                    - attr-name: application-sasl-authentication
-                      attr-sasl-server-factory: configured
-                      attr-security-domain: ApplicationDomain
-                      mechanism-configuration:
-                        mechanism:
-                          - attr-mechanism-name: JBOSS-LOCAL-USER
-                            attr-realm-mapper: local
-                          - attr-mechanism-name: DIGEST-MD5
-                            mechanism-realm:
-                              attr-realm-name: ApplicationRealm
-                security-domains:
-                  security-domain:
-                    - attr-default-realm: ManagementRealm
-                      attr-name: ManagementDomain
-                      attr-permission-mapper: default-permission-mapper
-                      realm:
-                        - attr-name: ManagementRealm
-                          attr-role-decoder: groups-to-roles
-                        - attr-name: local
-                          attr-role-mapper: super-user-mapper
-                    - attr-default-realm: ApplicationRealm
-                      attr-name: ApplicationDomain
-                      attr-permission-mapper: default-permission-mapper
-                      realm:
-                        - attr-name: ApplicationRealm
-                          attr-role-decoder: groups-to-roles
-                        - attr-name: local
-                security-realms:
-                  identity-realm:
-                    attr-identity: $local
-                    attr-name: local
-                  properties-realm:
-                    - attr-name: ApplicationRealm
-                      groups-properties:
-                        attr-path: application-roles.properties
-                        attr-relative-to: jboss.server.config.dir
-                      users-properties:
-                        attr-digest-realm-name: ApplicationRealm
-                        attr-path: application-users.properties
-                        attr-relative-to: jboss.server.config.dir
-                    - attr-name: ManagementRealm
-                      groups-properties:
-                        attr-path: mgmt-groups.properties
-                        attr-relative-to: jboss.server.config.dir
-                      users-properties:
-                        attr-digest-realm-name: ManagementRealm
-                        attr-path: mgmt-users.properties
-                        attr-relative-to: jboss.server.config.dir
-                tls:
-                  key-managers:
-                    key-manager:
-                      attr-generate-self-signed-certificate-host: localhost
-                      attr-key-store: applicationKS
-                      attr-name: applicationKM
-                      credential-reference:
-                        attr-clear-text: password
-                  key-stores:
-                    key-store:
-                      attr-name: applicationKS
-                      credential-reference:
-                        attr-clear-text: password
-                      file:
-                        attr-path: application.keystore
-                        attr-relative-to: jboss.server.config.dir
-                      implementation:
-                        attr-type: JKS
-                  server-ssl-contexts:
-                    server-ssl-context:
-                      attr-key-manager: applicationKM
-                      attr-name: applicationSSC
-              - attr-xmlns: urn:wildfly:elytron-oidc-client:1.0
-              - attr-security-enabled: 'false'
-                attr-xmlns: urn:wildfly:health:1.0
-              - attr-xmlns: urn:jboss:domain:infinispan:13.0
-                cache-container:
-                  - attr-aliases: sfsb
-                    attr-default-cache: passivation
-                    attr-marshaller: PROTOSTREAM
-                    attr-modules: org.wildfly.clustering.ejb.infinispan
-                    attr-name: ejb
-                    local-cache:
-                      attr-name: passivation
-                      expiration:
-                        attr-interval: '0'
-                      file-store:
-                        attr-passivation: 'true'
-                        attr-purge: 'false'
-                  - attr-default-cache: passivation
-                    attr-marshaller: PROTOSTREAM
-                    attr-modules: org.wildfly.clustering.web.infinispan
-                    attr-name: web
-                    local-cache:
-                      - attr-name: passivation
-                        expiration:
-                          attr-interval: '0'
-                        file-store:
-                          attr-passivation: 'true'
-                          attr-purge: 'false'
-                      - attr-name: sso
-                        expiration:
-                          attr-interval: '0'
-                  - attr-default-cache: default
-                    attr-marshaller: PROTOSTREAM
-                    attr-modules: org.wildfly.clustering.server
-                    attr-name: server
-                    local-cache:
-                      attr-name: default
-                      expiration:
-                        attr-interval: '0'
-                  - attr-marshaller: JBOSS
-                    attr-modules: org.infinispan.hibernate-cache
-                    attr-name: hibernate
-                    local-cache:
-                      - attr-name: entity
-                        expiration:
-                          attr-max-idle: '100000'
-                        heap-memory:
-                          attr-size: '10000'
-                      - attr-name: local-query
-                        expiration:
-                          attr-max-idle: '100000'
-                        heap-memory:
-                          attr-size: '10000'
-                      - attr-name: timestamps
-                        expiration:
-                          attr-interval: '0'
-                      - attr-name: pending-puts
-                        expiration:
-                          attr-max-idle: '60000'
-              - attr-xmlns: urn:jboss:domain:io:3.0
-                buffer-pool:
+                simple-role-decoder:
+                  attr-attribute: groups
+                  attr-name: groups-to-roles
+              permission-sets:
+                permission-set:
+                - attr-name: login-permission
+                  permission:
+                    attr-class-name: org.wildfly.security.auth.permission.LoginPermission
+                - attr-name: default-permissions
+                  permission:
+                  - attr-class-name: org.wildfly.extension.batch.jberet.deployment.BatchPermission
+                    attr-module: org.wildfly.extension.batch.jberet
+                    attr-target-name: '*'
+                  - attr-class-name: org.wildfly.transaction.client.RemoteTransactionPermission
+                    attr-module: org.wildfly.transaction.client
+                  - attr-class-name: org.jboss.ejb.client.RemoteEJBPermission
+                    attr-module: org.jboss.ejb-client
+              providers:
+                aggregate-providers:
+                  attr-name: combined-providers
+                  providers:
+                  - attr-name: elytron
+                  - attr-name: openssl
+                provider-loader:
+                - attr-module: org.wildfly.security.elytron
+                  attr-name: elytron
+                - attr-module: org.wildfly.openssl
+                  attr-name: openssl
+              sasl:
+                configurable-sasl-server-factory:
+                  attr-name: configured
+                  attr-sasl-server-factory: elytron
+                  properties:
+                    property:
+                    - attr-name: wildfly.sasl.local-user.default-user
+                      attr-value: $local
+                    - attr-name: wildfly.sasl.local-user.challenge-path
+                      attr-value: ${jboss.server.temp.dir}/auth
+                mechanism-provider-filtering-sasl-server-factory:
+                  attr-name: elytron
+                  attr-sasl-server-factory: global
+                  filters:
+                    filter:
+                      attr-provider-name: WildFlyElytron
+                provider-sasl-server-factory:
+                  attr-name: global
+                sasl-authentication-factory:
+                - attr-name: management-sasl-authentication
+                  attr-sasl-server-factory: configured
+                  attr-security-domain: ManagementDomain
+                  mechanism-configuration:
+                    mechanism:
+                    - attr-mechanism-name: JBOSS-LOCAL-USER
+                      attr-realm-mapper: local
+                    - attr-mechanism-name: DIGEST-MD5
+                      mechanism-realm:
+                        attr-realm-name: ManagementRealm
+                - attr-name: application-sasl-authentication
+                  attr-sasl-server-factory: configured
+                  attr-security-domain: ApplicationDomain
+                  mechanism-configuration:
+                    mechanism:
+                    - attr-mechanism-name: JBOSS-LOCAL-USER
+                      attr-realm-mapper: local
+                    - attr-mechanism-name: DIGEST-MD5
+                      mechanism-realm:
+                        attr-realm-name: ApplicationRealm
+              security-domains:
+                security-domain:
+                - attr-default-realm: ManagementRealm
+                  attr-name: ManagementDomain
+                  attr-permission-mapper: default-permission-mapper
+                  realm:
+                  - attr-name: ManagementRealm
+                    attr-role-decoder: groups-to-roles
+                  - attr-name: local
+                    attr-role-mapper: super-user-mapper
+                - attr-default-realm: ApplicationRealm
+                  attr-name: ApplicationDomain
+                  attr-permission-mapper: default-permission-mapper
+                  realm:
+                  - attr-name: ApplicationRealm
+                    attr-role-decoder: groups-to-roles
+                  - attr-name: local
+              security-realms:
+                identity-realm:
+                  attr-identity: $local
+                  attr-name: local
+                properties-realm:
+                - attr-name: ApplicationRealm
+                  groups-properties:
+                    attr-path: application-roles.properties
+                    attr-relative-to: jboss.server.config.dir
+                  users-properties:
+                    attr-digest-realm-name: ApplicationRealm
+                    attr-path: application-users.properties
+                    attr-relative-to: jboss.server.config.dir
+                - attr-name: ManagementRealm
+                  groups-properties:
+                    attr-path: mgmt-groups.properties
+                    attr-relative-to: jboss.server.config.dir
+                  users-properties:
+                    attr-digest-realm-name: ManagementRealm
+                    attr-path: mgmt-users.properties
+                    attr-relative-to: jboss.server.config.dir
+              tls:
+                key-managers:
+                  key-manager:
+                    attr-generate-self-signed-certificate-host: localhost
+                    attr-key-store: applicationKS
+                    attr-name: applicationKM
+                    credential-reference:
+                      attr-clear-text: password
+                key-stores:
+                  key-store:
+                    attr-name: applicationKS
+                    credential-reference:
+                      attr-clear-text: password
+                    file:
+                      attr-path: application.keystore
+                      attr-relative-to: jboss.server.config.dir
+                    implementation:
+                      attr-type: JKS
+                server-ssl-contexts:
+                  server-ssl-context:
+                    attr-key-manager: applicationKM
+                    attr-name: applicationSSC
+            - attr-xmlns: urn:wildfly:elytron-oidc-client:1.0
+            - attr-security-enabled: 'false'
+              attr-xmlns: urn:wildfly:health:1.0
+            - attr-xmlns: urn:jboss:domain:infinispan:13.0
+              cache-container:
+              - attr-aliases: sfsb
+                attr-default-cache: passivation
+                attr-marshaller: PROTOSTREAM
+                attr-modules: org.wildfly.clustering.ejb.infinispan
+                attr-name: ejb
+                local-cache:
+                  attr-name: passivation
+                  expiration:
+                    attr-interval: '0'
+                  file-store:
+                    attr-passivation: 'true'
+                    attr-purge: 'false'
+              - attr-default-cache: passivation
+                attr-marshaller: PROTOSTREAM
+                attr-modules: org.wildfly.clustering.web.infinispan
+                attr-name: web
+                local-cache:
+                - attr-name: passivation
+                  expiration:
+                    attr-interval: '0'
+                  file-store:
+                    attr-passivation: 'true'
+                    attr-purge: 'false'
+                - attr-name: sso
+                  expiration:
+                    attr-interval: '0'
+              - attr-default-cache: default
+                attr-marshaller: PROTOSTREAM
+                attr-modules: org.wildfly.clustering.server
+                attr-name: server
+                local-cache:
                   attr-name: default
-                worker:
-                  attr-name: default
-              - attr-xmlns: urn:jboss:domain:jaxrs:2.0
-              - archive-validation:
-                  attr-enabled: 'true'
-                  attr-fail-on-error: 'true'
-                  attr-fail-on-warn: 'false'
-                attr-xmlns: urn:jboss:domain:jca:5.0
-                bean-validation:
-                  attr-enabled: 'true'
-                cached-connection-manager: null
-                default-workmanager:
-                  long-running-threads:
-                    core-threads:
-                      attr-count: '50'
-                    keepalive-time:
-                      attr-time: '10'
-                      attr-unit: seconds
-                    max-threads:
-                      attr-count: '50'
-                    queue-length:
-                      attr-count: '50'
-                  short-running-threads:
-                    core-threads:
-                      attr-count: '50'
-                    keepalive-time:
-                      attr-time: '10'
-                      attr-unit: seconds
-                    max-threads:
-                      attr-count: '50'
-                    queue-length:
-                      attr-count: '50'
-              - attr-xmlns: urn:jboss:domain:jdr:1.0
-              - attr-xmlns: urn:jboss:domain:jmx:1.3
-                expose-expression-model: null
-                expose-resolved-model: null
-                remoting-connector: null
-              - attr-xmlns: urn:jboss:domain:jpa:1.1
-                jpa:
-                  attr-default-extended-persistence-inheritance: DEEP
-              - attr-xmlns: urn:jboss:domain:jsf:1.1
-              - attr-xmlns: urn:jboss:domain:mail:4.0
-                mail-session:
-                  attr-jndi-name: java:jboss/mail/Default
-                  attr-name: default
-                  smtp-server:
-                    attr-outbound-socket-binding-ref: mail-smtp
-              - attr-exposed-subsystems: '*'
-                attr-prefix: ${wildfly.metrics.prefix:wildfly}
-                attr-security-enabled: 'false'
-                attr-xmlns: urn:wildfly:metrics:1.0
-              - attr-xmlns: urn:wildfly:microprofile-config-smallrye:1.0
-              - attr-xmlns: urn:wildfly:microprofile-jwt-smallrye:1.0
-              - attr-default-tracer: jaeger
-                attr-xmlns: urn:wildfly:microprofile-opentracing-smallrye:3.0
-                jaeger-tracer:
-                  attr-name: jaeger
-                  sampler-configuration:
-                    attr-sampler-param: '1.0'
-                    attr-sampler-type: const
-              - attr-xmlns: urn:jboss:domain:naming:2.0
-                remote-naming: null
-              - attr-xmlns: urn:jboss:domain:pojo:1.0
-              - attr-xmlns: urn:jboss:domain:remoting:4.0
-                http-connector:
-                  attr-connector-ref: default
-                  attr-name: http-remoting-connector
-                  attr-sasl-authentication-factory: application-sasl-authentication
-              - attr-xmlns: urn:jboss:domain:request-controller:1.0
-              - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
-              - attr-xmlns: urn:jboss:domain:sar:1.0
-              - attr-xmlns: urn:jboss:domain:security-manager:1.0
-                deployment-permissions:
-                  maximum-set:
-                    permission:
-                      attr-class: java.security.AllPermission
-              - attr-xmlns: urn:jboss:domain:transactions:6.0
-                coordinator-environment:
-                  attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
-                core-environment:
-                  attr-node-identifier: ${jboss.tx.node.id:1}
-                  process-id:
-                    uuid: null
-                object-store:
-                  attr-path: tx-object-store
-                  attr-relative-to: jboss.server.data.dir
-                recovery-environment:
-                  attr-socket-binding: txn-recovery-environment
-                  attr-status-socket-binding: txn-status-manager
-              - application-security-domains:
-                  application-security-domain:
-                    attr-name: other
-                    attr-security-domain: ApplicationDomain
-                attr-default-security-domain: other
-                attr-default-server: default-server
-                attr-default-servlet-container: default
-                attr-default-virtual-host: default-host
-                attr-instance-id: ${jboss.node.name}
-                attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
-                attr-xmlns: urn:jboss:domain:undertow:12.0
-                buffer-cache:
-                  attr-name: default
-                filters:
-                  filter:
-                    attr-class-name: io.undertow.server.handlers.RequestDumpingHandler
-                    attr-module: io.undertow.core
+                  expiration:
+                    attr-interval: '0'
+              - attr-marshaller: JBOSS
+                attr-modules: org.infinispan.hibernate-cache
+                attr-name: hibernate
+                local-cache:
+                - attr-name: entity
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                - attr-name: local-query
+                  expiration:
+                    attr-max-idle: '100000'
+                  heap-memory:
+                    attr-size: '10000'
+                - attr-name: timestamps
+                  expiration:
+                    attr-interval: '0'
+                - attr-name: pending-puts
+                  expiration:
+                    attr-max-idle: '60000'
+            - attr-xmlns: urn:jboss:domain:io:3.0
+              buffer-pool:
+                attr-name: default
+              worker:
+                attr-name: default
+            - attr-xmlns: urn:jboss:domain:jaxrs:2.0
+            - archive-validation:
+                attr-enabled: 'true'
+                attr-fail-on-error: 'true'
+                attr-fail-on-warn: 'false'
+              attr-xmlns: urn:jboss:domain:jca:5.0
+              bean-validation:
+                attr-enabled: 'true'
+              cached-connection-manager: null
+              default-workmanager:
+                long-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+                short-running-threads:
+                  core-threads:
+                    attr-count: '50'
+                  keepalive-time:
+                    attr-time: '10'
+                    attr-unit: seconds
+                  max-threads:
+                    attr-count: '50'
+                  queue-length:
+                    attr-count: '50'
+            - attr-xmlns: urn:jboss:domain:jdr:1.0
+            - attr-xmlns: urn:jboss:domain:jmx:1.3
+              expose-expression-model: null
+              expose-resolved-model: null
+              remoting-connector: null
+            - attr-xmlns: urn:jboss:domain:jpa:1.1
+              jpa:
+                attr-default-extended-persistence-inheritance: DEEP
+            - attr-xmlns: urn:jboss:domain:jsf:1.1
+            - attr-xmlns: urn:jboss:domain:mail:4.0
+              mail-session:
+                attr-jndi-name: java:jboss/mail/Default
+                attr-name: default
+                smtp-server:
+                  attr-outbound-socket-binding-ref: mail-smtp
+            - attr-exposed-subsystems: '*'
+              attr-prefix: ${wildfly.metrics.prefix:wildfly}
+              attr-security-enabled: 'false'
+              attr-xmlns: urn:wildfly:metrics:1.0
+            - attr-xmlns: urn:wildfly:microprofile-config-smallrye:1.0
+            - attr-xmlns: urn:wildfly:microprofile-jwt-smallrye:1.0
+            - attr-default-tracer: jaeger
+              attr-xmlns: urn:wildfly:microprofile-opentracing-smallrye:3.0
+              jaeger-tracer:
+                attr-name: jaeger
+                sampler-configuration:
+                  attr-sampler-param: '1.0'
+                  attr-sampler-type: const
+            - attr-xmlns: urn:jboss:domain:naming:2.0
+              remote-naming: null
+            - attr-xmlns: urn:jboss:domain:pojo:1.0
+            - attr-xmlns: urn:jboss:domain:remoting:4.0
+              http-connector:
+                attr-connector-ref: default
+                attr-name: http-remoting-connector
+                attr-sasl-authentication-factory: application-sasl-authentication
+            - attr-xmlns: urn:jboss:domain:request-controller:1.0
+            - attr-xmlns: urn:jboss:domain:resource-adapters:6.0
+            - attr-xmlns: urn:jboss:domain:sar:1.0
+            - attr-xmlns: urn:jboss:domain:security-manager:1.0
+              deployment-permissions:
+                maximum-set:
+                  permission:
+                    attr-class: java.security.AllPermission
+            - attr-xmlns: urn:jboss:domain:transactions:6.0
+              coordinator-environment:
+                attr-statistics-enabled: ${wildfly.transactions.statistics-enabled:${wildfly.statistics-enabled:false}}
+              core-environment:
+                attr-node-identifier: ${jboss.tx.node.id:1}
+                process-id:
+                  uuid: null
+              object-store:
+                attr-path: tx-object-store
+                attr-relative-to: jboss.server.data.dir
+              recovery-environment:
+                attr-socket-binding: txn-recovery-environment
+                attr-status-socket-binding: txn-status-manager
+            - application-security-domains:
+                application-security-domain:
+                  attr-name: other
+                  attr-security-domain: ApplicationDomain
+              attr-default-security-domain: other
+              attr-default-server: default-server
+              attr-default-servlet-container: default
+              attr-default-virtual-host: default-host
+              attr-instance-id: ${jboss.node.name}
+              attr-statistics-enabled: ${wildfly.undertow.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:undertow:12.0
+              buffer-cache:
+                attr-name: default
+              filters:
+                filter:
+                  attr-class-name: io.undertow.server.handlers.RequestDumpingHandler
+                  attr-module: io.undertow.core
+                  attr-name: http-dumper
+              handlers:
+                file:
+                  attr-name: welcome-content
+                  attr-path: ${jboss.home.dir}/welcome-content
+              server:
+                attr-name: default-server
+                host:
+                  access-log:
+                    attr-pattern: '%h %l %u %t "%r" %s %b "%{i,Referer}" "%{i,User-Agent}"
+                      Cookie: "%{i,COOKIE}" Set-Cookie: "%{o,SET-COOKIE}" SessionID:
+                      %S Thread: "%I" TimeTaken: %T'
+                  attr-alias: localhost
+                  attr-name: default-host
+                  filter-ref:
                     attr-name: http-dumper
-                handlers:
-                  file:
-                    attr-name: welcome-content
-                    attr-path: ${jboss.home.dir}/welcome-content
-                server:
-                  attr-name: default-server
-                  host:
-                    access-log:
-                      attr-pattern: '%h %l %u %t "%r" %s %b "%{i,Referer}" "%{i,User-Agent}" Cookie: "%{i,COOKIE}" Set-Cookie: "%{o,SET-COOKIE}" SessionID: %S Thread: "%I" TimeTaken: %T'
-                    attr-alias: localhost
-                    attr-name: default-host
-                    filter-ref:
-                      attr-name: http-dumper
-                    http-invoker:
-                      attr-http-authentication-factory: application-http-authentication
-                    location:
-                      attr-handler: welcome-content
-                      attr-name: /
-                  http-listener:
-                    attr-enable-http2: 'true'
-                    attr-name: default
-                    attr-record-request-start-time: 'true'
-                    attr-redirect-socket: https
-                    attr-socket-binding: http
-                  https-listener:
-                    attr-enable-http2: 'true'
-                    attr-name: https
-                    attr-socket-binding: https
-                    attr-ssl-context: applicationSSC
-                servlet-container:
+                  http-invoker:
+                    attr-http-authentication-factory: application-http-authentication
+                  location:
+                    attr-handler: welcome-content
+                    attr-name: /
+                http-listener:
+                  attr-enable-http2: 'true'
                   attr-name: default
-                  jsp-config: null
-                  websockets: null
-              - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
-                attr-xmlns: urn:jboss:domain:webservices:2.0
-                client-config:
-                  attr-name: Standard-Client-Config
-                endpoint-config:
-                  - attr-name: Standard-Endpoint-Config
-                  - attr-name: Recording-Endpoint-Config
-                    pre-handler-chain:
-                      attr-name: recording-handlers
-                      attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM'
-                      handler:
-                        attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
-                        attr-name: RecordingHandler
-                wsdl-host: ${jboss.bind.address:127.0.0.1}
-              - attr-xmlns: urn:jboss:domain:weld:4.0
+                  attr-record-request-start-time: 'true'
+                  attr-redirect-socket: https
+                  attr-socket-binding: http
+                https-listener:
+                  attr-enable-http2: 'true'
+                  attr-name: https
+                  attr-socket-binding: https
+                  attr-ssl-context: applicationSSC
+              servlet-container:
+                attr-name: default
+                jsp-config: null
+                websockets: null
+            - attr-statistics-enabled: ${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}
+              attr-xmlns: urn:jboss:domain:webservices:2.0
+              client-config:
+                attr-name: Standard-Client-Config
+              endpoint-config:
+              - attr-name: Standard-Endpoint-Config
+              - attr-name: Recording-Endpoint-Config
+                pre-handler-chain:
+                  attr-name: recording-handlers
+                  attr-protocol-bindings: '##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP
+                    ##SOAP12_HTTP_MTOM'
+                  handler:
+                    attr-class: org.jboss.ws.common.invocation.RecordingServerHandler
+                    attr-name: RecordingHandler
+              wsdl-host: ${jboss.bind.address:127.0.0.1}
+            - attr-xmlns: urn:jboss:domain:weld:4.0
           socket-binding-group:
             attr-default-interface: public
             attr-name: standard-sockets
             attr-port-offset: ${jboss.socket.binding.port-offset:0}
             outbound-socket-binding:
-              - attr-name: infinispan-server-1
-                remote-destination:
-                  attr-host: server1.example.com
-                  attr-port: '11622'
-              - attr-name: mail-smtp
-                remote-destination:
-                  attr-host: ${jboss.mail.server.host:localhost}
-                  attr-port: ${jboss.mail.server.port:25}
+            - attr-name: infinispan-server-1
+              remote-destination:
+                attr-host: server1.example.com
+                attr-port: '11622'
+            - attr-name: mail-smtp
+              remote-destination:
+                attr-host: ${jboss.mail.server.host:localhost}
+                attr-port: ${jboss.mail.server.port:25}
             socket-binding:
-              - attr-name: ajp
-                attr-port: ${jboss.ajp.port:28009}
-              - attr-name: http
-                attr-port: ${jboss.http.port:28080}
-              - attr-name: https
-                attr-port: ${jboss.https.port:28443}
-              - attr-interface: management
-                attr-name: management-http
-                attr-port: ${jboss.management.http.port:29990}
-              - attr-interface: management
-                attr-name: management-https
-                attr-port: ${jboss.management.https.port:9993}
-              - attr-name: txn-recovery-environment
-                attr-port: '4712'
-              - attr-name: txn-status-manager
-                attr-port: '4713'
-    discovery_time: '2022-06-23T20:55:14+02:00'
-    extra_data:
-      heap_initial_allocation_memory: 64m
-      heap_max_memory: 512m
-      server:
-        name: jbossnode
-      mode: standalone
-    files:
-      - name: server.log
-        path: /opt/wildfly/standalone/log
-        subtype: generic
-        type: log
-      - name: logging.properties
-        path: /opt/wildfly/standalone/configuration
-        subtype: generic
-        type: log
-      - path: /opt/wildfly/standalone
-        subtype: generic
-        type: data
-      - path: /opt/wildfly
-        subtype: generic
-        type: data
-      - path: standalone.xml
-        subtype: generic
-        type: config
-      - name: standalone.xml
-        path: /opt/wildfly/standalone/configuration
-        subtype: xml
-        type: config
-    listening_ports:
-      - 28080
-      - 28443
-      - 29990
-    packages:
-      - arch: noarch
-        epoch: null
-        name: jboss-el-2.2-api
-        release: 0.7.20120212git2fabd8.el7
-        source: rpm
-        version: 1.0.1
-      - arch: noarch
-        epoch: null
-        name: jboss-jaxrpc-1.1-api
-        release: 7.el7
-        source: rpm
-        version: 1.0.1
-      - arch: noarch
-        epoch: null
-        name: jboss-servlet-3.0-api
-        release: 9.el7
-        source: rpm
-        version: 1.0.1
-      - arch: noarch
-        epoch: null
-        name: jboss-transaction-1.1-api
-        release: 8.el7
-        source: rpm
-        version: 1.0.1
-      - arch: noarch
-        epoch: null
-        name: jboss-ejb-3.1-api
-        release: 10.el7
-        source: rpm
-        version: 1.0.2
-      - arch: noarch
-        epoch: null
-        name: jboss-interceptors-1.1-api
-        release: 0.9.20120319git49a904.el7
-        source: rpm
-        version: 1.0.2
-    process:
-      cmdline: java -D[Standalone] -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/wildfly/standalone/log/server.log -Dlogging.configuration=file:/opt/wildfly/standalone/configuration/logging.properties -jar /opt/wildfly/jboss-modules.jar -mp /opt/wildfly/modules org.jboss.as.standalone -Djboss.home.dir=/opt/wildfly -Djboss.server.base.dir=/opt/wildfly/standalone -c standalone.xml -b 0.0.0.0 -bmanagement 0.0.0.0 -Djboss.node.name=jbossnode -Djboss.bind.address=0.0.0.0
-      listening_ports:
-        - 28080
-        - 28443
-        - 29990
-      pid: '16804'
-      ppid: '16732'
-      user: root
-    type: JBoss Application Server
-    version:
-      - number: 1.0.1
-        type: package
-      - number: 1.0.2
-        type: package
-      - number: 26.0.0
-        type: file
-
-software_list:
-  - cmd_regexp: org\.jboss\.Main|org\.jboss\.(?:Main|as\.(?:standalone|server))
-    name: JBoss Application Server
-    pkg_regexp: jboss
-    process_type: parent
-    return_children: false
-    return_packages: true
-    vars:
-      credentials:
-        management_user: admin
-        management_password: password
-      default_management_port: '9990'
-    custom_tasks:
-      - name: Include JBoss specific plugins
-        include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/jboss.yaml"
-
-dockers:
-  containers: [ ]
+            - attr-name: ajp
+              attr-port: ${jboss.ajp.port:28009}
+            - attr-name: http
+              attr-port: ${jboss.http.port:28080}
+            - attr-name: https
+              attr-port: ${jboss.https.port:28443}
+            - attr-interface: management
+              attr-name: management-http
+              attr-port: ${jboss.management.http.port:29990}
+            - attr-interface: management
+              attr-name: management-https
+              attr-port: ${jboss.management.https.port:9993}
+            - attr-name: txn-recovery-environment
+              attr-port: '4712'
+            - attr-name: txn-status-manager
+              attr-port: '4713'
+  Run command if jboss_cmd is accessible:
+    expected_args:
+      argv: null
+      cmd: /opt/wildfly/bin/standalone.sh -V
+      in_docker: true
+    plugin_result:
+      failed: false
+      stdout: "=========================================================================\n\
+        \n  JBoss Bootstrap Environment\n\n  JBOSS_HOME: /opt/wildfly\n\n  JAVA: java\n\
+        \n  JAVA_OPTS:  -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m\
+        \ -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman\
+        \ -Djava.awt.headless=true \n\n=========================================================================\n\
+        \n\\u001b[0m00:31:53,215 INFO  [org.jboss.modules] (main) JBoss Modules version\
+        \ 2.0.0.Final\n\\u001b[0mWildFly Full 26.0.0.Final (WildFly Core 18.0.0.Final)"
+  Run entry regex:
+    calls:
+    - run
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - run
+    - run
+    - run
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - run
+    - run
+    - run
+  Try to get version (2/6):
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Try to get version (3/6):
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Try to get version (4/6):
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   aether-api:
-    - arch: noarch
-      epoch: null
-      name: aether-api
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-api
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   aether-connector-wagon:
-    - arch: noarch
-      epoch: null
-      name: aether-connector-wagon
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-connector-wagon
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   aether-impl:
-    - arch: noarch
-      epoch: null
-      name: aether-impl
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-impl
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   aether-spi:
-    - arch: noarch
-      epoch: null
-      name: aether-spi
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-spi
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   aether-util:
-    - arch: noarch
-      epoch: null
-      name: aether-util
-      release: 13.el7
-      source: rpm
-      version: 1.13.1
+  - arch: noarch
+    epoch: null
+    name: aether-util
+    release: 13.el7
+    source: rpm
+    version: 1.13.1
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   aopalliance:
-    - arch: noarch
-      epoch: 0
-      name: aopalliance
-      release: 8.el7
-      source: rpm
-      version: '1.0'
+  - arch: noarch
+    epoch: 0
+    name: aopalliance
+    release: 8.el7
+    source: rpm
+    version: '1.0'
   apache-commons-cli:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-cli
-      release: 13.el7
-      source: rpm
-      version: '1.2'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-cli
+    release: 13.el7
+    source: rpm
+    version: '1.2'
   apache-commons-codec:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-codec
-      release: 7.el7
-      source: rpm
-      version: '1.8'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-codec
+    release: 7.el7
+    source: rpm
+    version: '1.8'
   apache-commons-io:
-    - arch: noarch
-      epoch: 1
-      name: apache-commons-io
-      release: 12.el7
-      source: rpm
-      version: '2.4'
+  - arch: noarch
+    epoch: 1
+    name: apache-commons-io
+    release: 12.el7
+    source: rpm
+    version: '2.4'
   apache-commons-lang:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-lang
-      release: 15.el7
-      source: rpm
-      version: '2.6'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-lang
+    release: 15.el7
+    source: rpm
+    version: '2.6'
   apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
   apache-commons-net:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-net
-      release: 8.el7.centos
-      source: rpm
-      version: '3.2'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-net
+    release: 8.el7.centos
+    source: rpm
+    version: '3.2'
   apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   atinject:
-    - arch: noarch
-      epoch: null
-      name: atinject
-      release: 13.20100611svn86.el7
-      source: rpm
-      version: '1'
+  - arch: noarch
+    epoch: null
+    name: atinject
+    release: 13.20100611svn86.el7
+    source: rpm
+    version: '1'
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
   avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 35.el7_9
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 35.el7_9
+    source: rpm
+    version: 4.2.46
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bcel:
-    - arch: noarch
-      epoch: 0
-      name: bcel
-      release: 18.el7
-      source: rpm
-      version: '5.2'
+  - arch: noarch
+    epoch: 0
+    name: bcel
+    release: 18.el7
+    source: rpm
+    version: '5.2'
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 72.el7_9
-      source: rpm
-      version: 2021.2.50
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 72.el7_9
+    source: rpm
+    version: 2021.2.50
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   cal10n:
-    - arch: noarch
-      epoch: null
-      name: cal10n
-      release: 4.el7
-      source: rpm
-      version: 0.7.7
+  - arch: noarch
+    epoch: null
+    name: cal10n
+    release: 4.el7
+    source: rpm
+    version: 0.7.7
   cdi-api:
-    - arch: noarch
-      epoch: null
-      name: cdi-api
-      release: 11.SP4.el7
-      source: rpm
-      version: '1.0'
+  - arch: noarch
+    epoch: null
+    name: cdi-api
+    release: 11.SP4.el7
+    source: rpm
+    version: '1.0'
   centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
   cglib:
-    - arch: noarch
-      epoch: null
-      name: cglib
-      release: 18.el7
-      source: rpm
-      version: '2.2'
+  - arch: noarch
+    epoch: null
+    name: cglib
+    release: 18.el7
+    source: rpm
+    version: '2.2'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 7.el7.centos.6
-      source: rpm
-      version: '19.4'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 7.el7.centos.6
+    source: rpm
+    version: '19.4'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-gssapi:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-gssapi
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-gssapi
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-plain:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-plain
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-plain
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  easymock2:
-    - arch: noarch
-      epoch: null
-      name: easymock2
-      release: 12.el7
-      source: rpm
-      version: 2.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '14'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  felix-framework:
-    - arch: noarch
-      epoch: null
-      name: felix-framework
-      release: 5.el7
-      source: rpm
-      version: 4.2.1
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  geronimo-annotation:
-    - arch: noarch
-      epoch: null
-      name: geronimo-annotation
-      release: 15.el7
-      source: rpm
-      version: '1.0'
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  google-guice:
-    - arch: noarch
-      epoch: null
-      name: google-guice
-      release: 9.el7
-      source: rpm
-      version: 3.1.3
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 61b8bab7
-      source: rpm
-      version: 3a79bd29
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 5c4058fb
-      source: rpm
-      version: 5072e1f5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 5eb44ee6
-      source: rpm
-      version: a3219f7b
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 602c28d5
-      source: rpm
-      version: e2c63c11
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 5ced7aac
-      source: rpm
-      version: 90cfb1f5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  guava:
-    - arch: noarch
-      epoch: null
-      name: guava
-      release: 6.el7
-      source: rpm
-      version: '13.0'
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hamcrest:
-    - arch: noarch
-      epoch: 0
-      name: hamcrest
-      release: 6.el7
-      source: rpm
-      version: '1.3'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  httpcomponents-client:
-    - arch: noarch
-      epoch: null
-      name: httpcomponents-client
-      release: 5.el7_0
-      source: rpm
-      version: 4.2.5
-  httpcomponents-core:
-    - arch: noarch
-      epoch: null
-      name: httpcomponents-core
-      release: 6.el7
-      source: rpm
-      version: 4.2.4
-  httpd:
-    - arch: x86_64
-      epoch: null
-      name: httpd
-      release: 97.el7.centos.4
-      source: rpm
-      version: 2.4.6
-  httpd-tools:
-    - arch: x86_64
-      epoch: null
-      name: httpd-tools
-      release: 97.el7.centos.4
-      source: rpm
-      version: 2.4.6
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-commons-httpclient:
-    - arch: noarch
-      epoch: 1
-      name: jakarta-commons-httpclient
-      release: 16.el7_0
-      source: rpm
-      version: '3.1'
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-devel:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-devel
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  javassist:
-    - arch: noarch
-      epoch: null
-      name: javassist
-      release: 10.el7
-      source: rpm
-      version: 3.16.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  jboss-ejb-3.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-ejb-3.1-api
-      release: 10.el7
-      source: rpm
-      version: 1.0.2
-  jboss-el-2.2-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-el-2.2-api
-      release: 0.7.20120212git2fabd8.el7
-      source: rpm
-      version: 1.0.1
-  jboss-interceptors-1.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-interceptors-1.1-api
-      release: 0.9.20120319git49a904.el7
-      source: rpm
-      version: 1.0.2
-  jboss-jaxrpc-1.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-jaxrpc-1.1-api
-      release: 7.el7
-      source: rpm
-      version: 1.0.1
-  jboss-servlet-3.0-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-servlet-3.0-api
-      release: 9.el7
-      source: rpm
-      version: 1.0.1
-  jboss-transaction-1.1-api:
-    - arch: noarch
-      epoch: null
-      name: jboss-transaction-1.1-api
-      release: 8.el7
-      source: rpm
-      version: 1.0.1
-  jline:
-    - arch: noarch
-      epoch: null
-      name: jline
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  jsch:
-    - arch: noarch
-      epoch: 0
-      name: jsch
-      release: 5.el7
-      source: rpm
-      version: 0.1.50
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  jsoup:
-    - arch: noarch
-      epoch: null
-      name: jsoup
-      release: 10.el7
-      source: rpm
-      version: 1.6.1
-  junit:
-    - arch: noarch
-      epoch: 0
-      name: junit
-      release: 8.el7
-      source: rpm
-      version: '4.11'
-  jzlib:
-    - arch: noarch
-      epoch: 0
-      name: jzlib
-      release: 6.el7
-      source: rpm
-      version: 1.1.1
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.49.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.3
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 135.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 18.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  maven:
-    - arch: noarch
-      epoch: null
-      name: maven
-      release: 17.el7
-      source: rpm
-      version: 3.0.5
-  maven-wagon:
-    - arch: noarch
-      epoch: 0
-      name: maven-wagon
-      release: 3.el7
-      source: rpm
-      version: '2.4'
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mongodb-database-tools:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-database-tools
-      release: '1'
-      source: rpm
-      version: 100.5.2
-  mongodb-org:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-database-tools-extra:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-database-tools-extra
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-mongos:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-mongos
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-server:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-server
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-shell:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-shell
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mongodb-org-tools:
-    - arch: x86_64
-      epoch: null
-      name: mongodb-org-tools
-      release: 1.el7
-      source: rpm
-      version: 4.4.12
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mysql-community-client:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-client
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-client-plugins:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-client-plugins
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-common:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-common
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-icu-data-files:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-icu-data-files
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-libs:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-libs
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-libs-compat:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-libs-compat
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql-community-server:
-    - arch: x86_64
-      epoch: null
-      name: mysql-community-server
-      release: 1.el7
-      source: rpm
-      version: 8.0.28
-  mysql80-community-release:
-    - arch: noarch
-      epoch: null
-      name: mysql80-community-release
-      release: '3'
-      source: rpm
-      version: el8
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  nekohtml:
-    - arch: noarch
-      epoch: 0
-      name: nekohtml
-      release: 13.el7
-      source: rpm
-      version: 1.9.14
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7.2
-      source: rpm
-      version: 1.3.0
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  objectweb-asm:
-    - arch: noarch
-      epoch: 0
-      name: objectweb-asm
-      release: 9.el7
-      source: rpm
-      version: 3.3.1
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 25.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  packer:
-    - arch: x86_64
-      epoch: null
-      name: packer
-      release: '1'
-      source: rpm
-      version: 1.7.10
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  plexus-cipher:
-    - arch: noarch
-      epoch: null
-      name: plexus-cipher
-      release: 5.el7
-      source: rpm
-      version: '1.7'
-  plexus-classworlds:
-    - arch: noarch
-      epoch: null
-      name: plexus-classworlds
-      release: 8.el7
-      source: rpm
-      version: 2.4.2
-  plexus-component-api:
-    - arch: noarch
-      epoch: null
-      name: plexus-component-api
-      release: 0.16.alpha15.el7
-      source: rpm
-      version: '1.0'
-  plexus-containers-component-annotations:
-    - arch: noarch
-      epoch: null
-      name: plexus-containers-component-annotations
-      release: 14.el7
-      source: rpm
-      version: 1.5.5
-  plexus-containers-container-default:
-    - arch: noarch
-      epoch: null
-      name: plexus-containers-container-default
-      release: 14.el7
-      source: rpm
-      version: 1.5.5
-  plexus-interactivity:
-    - arch: noarch
-      epoch: 0
-      name: plexus-interactivity
-      release: 0.14.alpha6.el7
-      source: rpm
-      version: '1.0'
-  plexus-interpolation:
-    - arch: noarch
-      epoch: null
-      name: plexus-interpolation
-      release: 8.el7
-      source: rpm
-      version: '1.15'
-  plexus-sec-dispatcher:
-    - arch: noarch
-      epoch: null
-      name: plexus-sec-dispatcher
-      release: 13.el7
-      source: rpm
-      version: '1.4'
-  plexus-utils:
-    - arch: noarch
-      epoch: null
-      name: plexus-utils
-      release: 9.el7
-      source: rpm
-      version: 3.0.9
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 10.el7
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qdox:
-    - arch: noarch
-      epoch: 0
-      name: qdox
-      release: 10.el7
-      source: rpm
-      version: 1.12.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  regexp:
-    - arch: noarch
-      epoch: 0
-      name: regexp
-      release: 13.el7
-      source: rpm
-      version: '1.5'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9.1
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  sisu-inject-bean:
-    - arch: noarch
-      epoch: null
-      name: sisu-inject-bean
-      release: 11.el7
-      source: rpm
-      version: 2.3.0
-  sisu-inject-plexus:
-    - arch: noarch
-      epoch: null
-      name: sisu-inject-plexus
-      release: 11.el7
-      source: rpm
-      version: 2.3.0
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slf4j:
-    - arch: noarch
-      epoch: 0
-      name: slf4j
-      release: 4.el7_4
-      source: rpm
-      version: 1.7.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.2
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 66.el7
-      source: rpm
-      version: '0.17'
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 24.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7_9.1
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xbean:
-    - arch: noarch
-      epoch: null
-      name: xbean
-      release: 6.el7
-      source: rpm
-      version: '3.13'
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '113'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '192'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '193'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '260'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '266'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '267'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '281'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '282'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '283'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '408'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '447'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '471'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '512'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '539'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '548'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /sbin/rpcbind -w
-    pid: '550'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '554'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '562'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '563'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/sbin/chronyd
-    pid: '566'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H test-norm01 eth0
-    pid: '808'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '864'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '866'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/java -Xms64M -Xmx1G -Djava.util.logging.config.file=logging.properties -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config -Dcom.sun.management.jmxremote -Djava.awt.headless=true -Djava.io.tmpdir=/opt/apache-activemq-5.14.3//tmp -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/: -Dactivemq.home=/opt/apache-activemq-5.14.3/ -Dactivemq.base=/opt/apache-activemq-5.14.3/ -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf -Dactivemq.data=/opt/apache-activemq-5.14.3//data -jar /opt/apache-activemq-5.14.3//bin/activemq.jar start'
-    pid: '967'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1100'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1106'
-    ppid: '1100'
-    user: postfix
-  - cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '1147'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1148'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1159'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1181'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1182'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1183'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/mongod -f /etc/mongod.conf
-    pid: '1239'
-    ppid: '1'
-    user: mongod
-  - cmdline: /usr/sbin/mysqld
-    pid: '1535'
-    ppid: '1'
-    user: mysql
-  - cmdline: ''
-    pid: '1993'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2191'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2192'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2193'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2194'
-    ppid: '866'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '2195'
-    ppid: '866'
-    user: apache
-  - cmdline: ''
-    pid: '3613'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '6346'
-    ppid: '1100'
-    user: postfix
-  - cmdline: 'sshd: centos [priv]'
-    pid: '12465'
-    ppid: '1159'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '12468'
-    ppid: '12465'
-    user: centos
-  - cmdline: -bash
-    pid: '12469'
-    ppid: '12468'
-    user: centos
-  - cmdline: sudo su
-    pid: '12624'
-    ppid: '12469'
-    user: root
-  - cmdline: su
-    pid: '12625'
-    ppid: '12624'
-    user: root
-  - cmdline: bash
-    pid: '12626'
-    ppid: '12625'
-    user: root
-  - cmdline: ''
-    pid: '13638'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16252'
-    ppid: '2'
-    user: root
-  - cmdline: /bin/bash /opt/wildfly/bin/launch.sh standalone standalone.xml 0.0.0.0 0.0.0.0
-    pid: '16731'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh /opt/wildfly/bin/standalone.sh -c standalone.xml -b 0.0.0.0 -bmanagement 0.0.0.0 -Djboss.node.name=jbossnode -Djboss.bind.address=0.0.0.0
-    pid: '16732'
-    ppid: '16731'
-    user: root
-  - cmdline: java -D[Standalone] -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/wildfly/standalone/log/server.log -Dlogging.configuration=file:/opt/wildfly/standalone/configuration/logging.properties -jar /opt/wildfly/jboss-modules.jar -mp /opt/wildfly/modules org.jboss.as.standalone -Djboss.home.dir=/opt/wildfly -Djboss.server.base.dir=/opt/wildfly/standalone -c standalone.xml -b 0.0.0.0 -bmanagement 0.0.0.0 -Djboss.node.name=jbossnode -Djboss.bind.address=0.0.0.0
-    pid: '16804'
-    ppid: '16732'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '17035'
-    ppid: '1159'
-    user: root
-  - cmdline: 'sshd: centos@pts/2'
-    pid: '17037'
-    ppid: '17035'
-    user: centos
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-uogiasqvprujzcdjlsfyzkxrwqlshowe ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656010476.541192-90866-279307388845969/AnsiballZ_process_facts.py' && sleep 0
-    pid: '17194'
-    ppid: '17037'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-uogiasqvprujzcdjlsfyzkxrwqlshowe ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656010476.541192-90866-279307388845969/AnsiballZ_process_facts.py
-    pid: '17207'
-    ppid: '17194'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-uogiasqvprujzcdjlsfyzkxrwqlshowe ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656010476.541192-90866-279307388845969/AnsiballZ_process_facts.py
-    pid: '17209'
-    ppid: '17207'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656010476.541192-90866-279307388845969/AnsiballZ_process_facts.py
-    pid: '17210'
-    ppid: '17209'
-    user: root
-  - cmdline: ''
-    pid: '17543'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '18901'
-    ppid: '866'
-    user: apache
-tcp_listen:
-  - address: 0.0.0.0
-    name: java
-    pid: 16804
-    port: 29990
-    protocol: tcp
-    stime: Thu Jun 23 18:52:06 2022
-    user: root
-  - address: 0.0.0.0
-    name: mongod
-    pid: 1239
-    port: 27017
-    protocol: tcp
-    stime: Thu Jun 16 14:10:00 2022
-    user: mongod
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 550
-    port: 111
-    protocol: tcp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: 0.0.0.0
-    name: java
-    pid: 16804
-    port: 28080
-    protocol: tcp
-    stime: Thu Jun 23 18:52:06 2022
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1159
-    port: 22
-    protocol: tcp
-    stime: Thu Jun 16 14:09:58 2022
-    user: root
-  - address: 127.0.0.1
-    name: master
-    pid: 1100
-    port: 25
-    protocol: tcp
-    stime: Thu Jun 16 14:09:57 2022
-    user: root
-  - address: 0.0.0.0
-    name: java
-    pid: 16804
-    port: 28443
-    protocol: tcp
-    stime: Thu Jun 23 18:52:06 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 5672
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 42825
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: mysqld
-    pid: 1535
-    port: 3306
-    protocol: tcp
-    stime: Thu Jun 16 14:10:11 2022
-    user: mysql
-  - address: '::'
-    name: java
-    pid: 967
-    port: 61613
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 61614
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 550
-    port: 111
-    protocol: tcp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: '::'
-    name: java
-    pid: 967
-    port: 61616
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: httpd
-    pid: 866
-    port: 80
-    protocol: tcp
-    stime: Thu Jun 16 14:09:53 2022
-    user: root
-  - address: '::'
-    name: httpd
-    pid: 866
-    port: 81
-    protocol: tcp
-    stime: Thu Jun 16 14:09:53 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1159
-    port: 22
-    protocol: tcp
-    stime: Thu Jun 16 14:09:58 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1100
-    port: 25
-    protocol: tcp
-    stime: Thu Jun 16 14:09:57 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 1883
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 967
-    port: 8161
-    protocol: tcp
-    stime: Thu Jun 16 14:09:54 2022
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 808
-    port: 68
-    protocol: udp
-    stime: Thu Jun 16 14:09:53 2022
-    user: root
-  - address: 0.0.0.0
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  easymock2:
+  - arch: noarch
+    epoch: null
+    name: easymock2
+    release: 12.el7
+    source: rpm
+    version: 2.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '14'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  felix-framework:
+  - arch: noarch
+    epoch: null
+    name: felix-framework
+    release: 5.el7
+    source: rpm
+    version: 4.2.1
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  geronimo-annotation:
+  - arch: noarch
+    epoch: null
+    name: geronimo-annotation
+    release: 15.el7
+    source: rpm
+    version: '1.0'
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  google-guice:
+  - arch: noarch
+    epoch: null
+    name: google-guice
+    release: 9.el7
+    source: rpm
+    version: 3.1.3
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 61b8bab7
+    source: rpm
+    version: 3a79bd29
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 5c4058fb
+    source: rpm
+    version: 5072e1f5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 5eb44ee6
+    source: rpm
+    version: a3219f7b
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 602c28d5
+    source: rpm
+    version: e2c63c11
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 5ced7aac
+    source: rpm
+    version: 90cfb1f5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  guava:
+  - arch: noarch
+    epoch: null
+    name: guava
+    release: 6.el7
+    source: rpm
+    version: '13.0'
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hamcrest:
+  - arch: noarch
+    epoch: 0
+    name: hamcrest
+    release: 6.el7
+    source: rpm
+    version: '1.3'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  httpcomponents-client:
+  - arch: noarch
+    epoch: null
+    name: httpcomponents-client
+    release: 5.el7_0
+    source: rpm
+    version: 4.2.5
+  httpcomponents-core:
+  - arch: noarch
+    epoch: null
+    name: httpcomponents-core
+    release: 6.el7
+    source: rpm
+    version: 4.2.4
+  httpd:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos.4
+    source: rpm
+    version: 2.4.6
+  httpd-tools:
+  - arch: x86_64
+    epoch: null
+    name: httpd-tools
+    release: 97.el7.centos.4
+    source: rpm
+    version: 2.4.6
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-commons-httpclient:
+  - arch: noarch
+    epoch: 1
+    name: jakarta-commons-httpclient
+    release: 16.el7_0
+    source: rpm
+    version: '3.1'
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-devel:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-devel
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  javassist:
+  - arch: noarch
+    epoch: null
+    name: javassist
+    release: 10.el7
+    source: rpm
+    version: 3.16.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  jboss-ejb-3.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-ejb-3.1-api
+    release: 10.el7
+    source: rpm
+    version: 1.0.2
+  jboss-el-2.2-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-el-2.2-api
+    release: 0.7.20120212git2fabd8.el7
+    source: rpm
+    version: 1.0.1
+  jboss-interceptors-1.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-interceptors-1.1-api
+    release: 0.9.20120319git49a904.el7
+    source: rpm
+    version: 1.0.2
+  jboss-jaxrpc-1.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-jaxrpc-1.1-api
+    release: 7.el7
+    source: rpm
+    version: 1.0.1
+  jboss-servlet-3.0-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-servlet-3.0-api
+    release: 9.el7
+    source: rpm
+    version: 1.0.1
+  jboss-transaction-1.1-api:
+  - arch: noarch
+    epoch: null
+    name: jboss-transaction-1.1-api
+    release: 8.el7
+    source: rpm
+    version: 1.0.1
+  jline:
+  - arch: noarch
+    epoch: null
+    name: jline
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  jsch:
+  - arch: noarch
+    epoch: 0
+    name: jsch
+    release: 5.el7
+    source: rpm
+    version: 0.1.50
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  jsoup:
+  - arch: noarch
+    epoch: null
+    name: jsoup
+    release: 10.el7
+    source: rpm
+    version: 1.6.1
+  junit:
+  - arch: noarch
+    epoch: 0
+    name: junit
+    release: 8.el7
+    source: rpm
+    version: '4.11'
+  jzlib:
+  - arch: noarch
+    epoch: 0
+    name: jzlib
+    release: 6.el7
+    source: rpm
+    version: 1.1.1
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.49.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.3
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 135.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 18.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  maven:
+  - arch: noarch
+    epoch: null
+    name: maven
+    release: 17.el7
+    source: rpm
+    version: 3.0.5
+  maven-wagon:
+  - arch: noarch
+    epoch: 0
+    name: maven-wagon
+    release: 3.el7
+    source: rpm
+    version: '2.4'
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mongodb-database-tools:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-database-tools
+    release: '1'
+    source: rpm
+    version: 100.5.2
+  mongodb-org:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-database-tools-extra:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-database-tools-extra
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-mongos:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-mongos
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-server:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-server
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-shell:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-shell
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mongodb-org-tools:
+  - arch: x86_64
+    epoch: null
+    name: mongodb-org-tools
+    release: 1.el7
+    source: rpm
+    version: 4.4.12
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mysql-community-client:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-client
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-client-plugins:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-client-plugins
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-common:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-common
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-icu-data-files:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-icu-data-files
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-libs:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-libs
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-libs-compat:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-libs-compat
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql-community-server:
+  - arch: x86_64
+    epoch: null
+    name: mysql-community-server
+    release: 1.el7
+    source: rpm
+    version: 8.0.28
+  mysql80-community-release:
+  - arch: noarch
+    epoch: null
+    name: mysql80-community-release
+    release: '3'
+    source: rpm
+    version: el8
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  nekohtml:
+  - arch: noarch
+    epoch: 0
+    name: nekohtml
+    release: 13.el7
+    source: rpm
+    version: 1.9.14
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7.2
+    source: rpm
+    version: 1.3.0
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  objectweb-asm:
+  - arch: noarch
+    epoch: 0
+    name: objectweb-asm
+    release: 9.el7
+    source: rpm
+    version: 3.3.1
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 25.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  packer:
+  - arch: x86_64
+    epoch: null
+    name: packer
+    release: '1'
+    source: rpm
+    version: 1.7.10
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  plexus-cipher:
+  - arch: noarch
+    epoch: null
+    name: plexus-cipher
+    release: 5.el7
+    source: rpm
+    version: '1.7'
+  plexus-classworlds:
+  - arch: noarch
+    epoch: null
+    name: plexus-classworlds
+    release: 8.el7
+    source: rpm
+    version: 2.4.2
+  plexus-component-api:
+  - arch: noarch
+    epoch: null
+    name: plexus-component-api
+    release: 0.16.alpha15.el7
+    source: rpm
+    version: '1.0'
+  plexus-containers-component-annotations:
+  - arch: noarch
+    epoch: null
+    name: plexus-containers-component-annotations
+    release: 14.el7
+    source: rpm
+    version: 1.5.5
+  plexus-containers-container-default:
+  - arch: noarch
+    epoch: null
+    name: plexus-containers-container-default
+    release: 14.el7
+    source: rpm
+    version: 1.5.5
+  plexus-interactivity:
+  - arch: noarch
+    epoch: 0
+    name: plexus-interactivity
+    release: 0.14.alpha6.el7
+    source: rpm
+    version: '1.0'
+  plexus-interpolation:
+  - arch: noarch
+    epoch: null
+    name: plexus-interpolation
+    release: 8.el7
+    source: rpm
+    version: '1.15'
+  plexus-sec-dispatcher:
+  - arch: noarch
+    epoch: null
+    name: plexus-sec-dispatcher
+    release: 13.el7
+    source: rpm
+    version: '1.4'
+  plexus-utils:
+  - arch: noarch
+    epoch: null
+    name: plexus-utils
+    release: 9.el7
+    source: rpm
+    version: 3.0.9
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 10.el7
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qdox:
+  - arch: noarch
+    epoch: 0
+    name: qdox
+    release: 10.el7
+    source: rpm
+    version: 1.12.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  regexp:
+  - arch: noarch
+    epoch: 0
+    name: regexp
+    release: 13.el7
+    source: rpm
+    version: '1.5'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 550
-    port: 111
-    protocol: udp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 566
-    port: 323
-    protocol: udp
-    stime: Thu Jun 16 14:09:49 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 550
-    port: 721
-    protocol: udp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: '::'
-    name: rpcbind
-    pid: 550
-    port: 111
-    protocol: udp
-    stime: Thu Jun 16 14:09:45 2022
-    user: rpc
-  - address: ::1
-    name: chronyd
-    pid: 566
-    port: 323
-    protocol: udp
-    stime: Thu Jun 16 14:09:49 2022
-    user: chrony
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9.1
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  sisu-inject-bean:
+  - arch: noarch
+    epoch: null
+    name: sisu-inject-bean
+    release: 11.el7
+    source: rpm
+    version: 2.3.0
+  sisu-inject-plexus:
+  - arch: noarch
+    epoch: null
+    name: sisu-inject-plexus
+    release: 11.el7
+    source: rpm
+    version: 2.3.0
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slf4j:
+  - arch: noarch
+    epoch: 0
+    name: slf4j
+    release: 4.el7_4
+    source: rpm
+    version: 1.7.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.2
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 66.el7
+    source: rpm
+    version: '0.17'
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 24.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7_9.1
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xbean:
+  - arch: noarch
+    epoch: null
+    name: xbean
+    release: 6.el7
+    source: rpm
+    version: '3.13'
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '113'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '192'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '193'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '260'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '266'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '281'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '282'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '408'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '447'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '471'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '512'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '539'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '548'
+  ppid: '1'
+  user: polkitd
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '550'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '554'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '562'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '563'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '566'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H test-norm01 eth0
+  cwd: /sbin/
+  pid: '808'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '864'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '866'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/java -Xms64M -Xmx1G -Djava.util.logging.config.file=logging.properties
+    -Djava.security.auth.login.config=/opt/apache-activemq-5.14.3//conf/login.config
+    -Dcom.sun.management.jmxremote -Djava.awt.headless=true -Djava.io.tmpdir=/opt/apache-activemq-5.14.3//tmp
+    -Dactivemq.classpath=/opt/apache-activemq-5.14.3//conf:/opt/apache-activemq-5.14.3//../lib/:
+    -Dactivemq.home=/opt/apache-activemq-5.14.3/ -Dactivemq.base=/opt/apache-activemq-5.14.3/
+    -Dactivemq.conf=/opt/apache-activemq-5.14.3//conf -Dactivemq.data=/opt/apache-activemq-5.14.3//data
+    -jar /opt/apache-activemq-5.14.3//bin/activemq.jar start'
+  cwd: /usr/bin/
+  pid: '967'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1100'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1106'
+  ppid: '1100'
+  user: postfix
+- cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '1147'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1148'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1159'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1181'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1182'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1183'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/mongod -f /etc/mongod.conf
+  cwd: /usr/bin/
+  pid: '1239'
+  ppid: '1'
+  user: mongod
+- cmdline: /usr/sbin/mysqld
+  cwd: /usr/sbin/
+  pid: '1535'
+  ppid: '1'
+  user: mysql
+- cmdline: ''
+  cwd: /
+  pid: '1993'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2191'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2192'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2193'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2194'
+  ppid: '866'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '2195'
+  ppid: '866'
+  user: apache
+- cmdline: ''
+  cwd: /
+  pid: '3613'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '6346'
+  ppid: '1100'
+  user: postfix
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '12465'
+  ppid: '1159'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '12468'
+  ppid: '12465'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '12469'
+  ppid: '12468'
+  user: centos
+- cmdline: sudo su
+  cwd: /
+  pid: '12624'
+  ppid: '12469'
+  user: root
+- cmdline: su
+  cwd: /
+  pid: '12625'
+  ppid: '12624'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '12626'
+  ppid: '12625'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13638'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16252'
+  ppid: '2'
+  user: root
+- cmdline: /bin/bash /opt/wildfly/bin/launch.sh standalone standalone.xml 0.0.0.0
+    0.0.0.0
+  cwd: /bin/
+  pid: '16731'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh /opt/wildfly/bin/standalone.sh -c standalone.xml -b 0.0.0.0 -bmanagement
+    0.0.0.0 -Djboss.node.name=jbossnode -Djboss.bind.address=0.0.0.0
+  cwd: /bin/
+  pid: '16732'
+  ppid: '16731'
+  user: root
+- cmdline: java -D[Standalone] -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m
+    -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman
+    -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/wildfly/standalone/log/server.log
+    -Dlogging.configuration=file:/opt/wildfly/standalone/configuration/logging.properties
+    -jar /opt/wildfly/jboss-modules.jar -mp /opt/wildfly/modules org.jboss.as.standalone
+    -Djboss.home.dir=/opt/wildfly -Djboss.server.base.dir=/opt/wildfly/standalone
+    -c standalone.xml -b 0.0.0.0 -bmanagement 0.0.0.0 -Djboss.node.name=jbossnode
+    -Djboss.bind.address=0.0.0.0
+  cwd: /
+  pid: '16804'
+  ppid: '16732'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '17035'
+  ppid: '1159'
+  user: root
+- cmdline: 'sshd: centos@pts/2'
+  cwd: /
+  pid: '17037'
+  ppid: '17035'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-uogiasqvprujzcdjlsfyzkxrwqlshowe
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656010476.541192-90866-279307388845969/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '17194'
+  ppid: '17037'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-uogiasqvprujzcdjlsfyzkxrwqlshowe
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656010476.541192-90866-279307388845969/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '17207'
+  ppid: '17194'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-uogiasqvprujzcdjlsfyzkxrwqlshowe ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656010476.541192-90866-279307388845969/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '17209'
+  ppid: '17207'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656010476.541192-90866-279307388845969/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '17210'
+  ppid: '17209'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17543'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '18901'
+  ppid: '866'
+  user: apache
+software_list:
+- cmd_regexp: org\.jboss\.Main|org\.jboss\.(?:Main|as\.(?:standalone|server))
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/jboss.yaml
+    name: Include JBoss specific plugins
+  name: JBoss Application Server
+  pkg_regexp: jboss
+  process_type: parent
+  return_children: false
+  return_packages: true
+  vars:
+    credentials:
+      management_password: password
+      management_user: admin
+    default_management_port: '9990'
+tcp_listen:
+- address: 0.0.0.0
+  name: java
+  pid: 16804
+  port: 29990
+  protocol: tcp
+  stime: Thu Jun 23 18:52:06 2022
+  user: root
+- address: 0.0.0.0
+  name: mongod
+  pid: 1239
+  port: 27017
+  protocol: tcp
+  stime: Thu Jun 16 14:10:00 2022
+  user: mongod
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: 0.0.0.0
+  name: java
+  pid: 16804
+  port: 28080
+  protocol: tcp
+  stime: Thu Jun 23 18:52:06 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1159
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 16 14:09:58 2022
+  user: root
+- address: 127.0.0.1
+  name: master
+  pid: 1100
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 16 14:09:57 2022
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: 16804
+  port: 28443
+  protocol: tcp
+  stime: Thu Jun 23 18:52:06 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 5672
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 42825
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: mysqld
+  pid: 1535
+  port: 3306
+  protocol: tcp
+  stime: Thu Jun 16 14:10:11 2022
+  user: mysql
+- address: '::'
+  name: java
+  pid: 967
+  port: 61613
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 61614
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: tcp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: '::'
+  name: java
+  pid: 967
+  port: 61616
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: httpd
+  pid: 866
+  port: 80
+  protocol: tcp
+  stime: Thu Jun 16 14:09:53 2022
+  user: root
+- address: '::'
+  name: httpd
+  pid: 866
+  port: 81
+  protocol: tcp
+  stime: Thu Jun 16 14:09:53 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1159
+  port: 22
+  protocol: tcp
+  stime: Thu Jun 16 14:09:58 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1100
+  port: 25
+  protocol: tcp
+  stime: Thu Jun 16 14:09:57 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 1883
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 967
+  port: 8161
+  protocol: tcp
+  stime: Thu Jun 16 14:09:54 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 808
+  port: 68
+  protocol: udp
+  stime: Thu Jun 16 14:09:53 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 566
+  port: 323
+  protocol: udp
+  stime: Thu Jun 16 14:09:49 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 550
+  port: 721
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: '::'
+  name: rpcbind
+  pid: 550
+  port: 111
+  protocol: udp
+  stime: Thu Jun 16 14:09:45 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 566
+  port: 323
+  protocol: udp
+  stime: Thu Jun 16 14:09:49 2022
+  user: chrony

--- a/tests/unit/plugins/action/auto/resources/keepalived/keepalived1.3.5_apache.yaml
+++ b/tests/unit/plugins/action/auto/resources/keepalived/keepalived1.3.5_apache.yaml
@@ -1,4401 +1,4489 @@
+dockers:
+  containers: []
+expected_result:
+- bindings: []
+  configuration:
+    global_defs:
+      notification_email:
+      - acassen@firewall.loc
+      - failover@firewall.loc
+      - sysadmin@firewall.loc
+      notification_email_from:
+      - Alexandre.Cassen@firewall.loc
+      smtp_connect_timeout: '30'
+      smtp_server: 192.168.200.1
+    vrrp_instance VI_1:
+      advert_int: '1'
+      interface: eth0
+      priority: '101'
+      state: MASTER
+      unicast_peer:
+        192.168.0.223: null
+      unicast_src_ip: 192.168.0.142
+      virtual_ipaddress:
+        192.168.0.100: null
+      virtual_router_id: '51'
+  discovery_time: '2022-06-10T13:34:54+02:00'
+  files:
+  - name: keepalived.conf
+    path: /etc/keepalived
+    subtype: generic
+    type: config
+  listening_ports: []
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 19.el7
+    source: rpm
+    version: 1.3.5
+  process:
+    cmdline: /usr/sbin/keepalived -D
+    cwd: /usr/sbin/
+    pid: '20808'
+    ppid: '1'
+    user: root
+  type: KeepAliveD
+  version:
+  - number: 1.3.5
+    type: package
+expected_tasks_calls:
+  Parse config file: 1
+  Read process environment: 1
+  Run stat for path: 1
 mocked_plugin_tasks:
-  Run stat for path:
+  Parse config file:
+    expected_args:
+      delegate_reading: true
+      file_path: /etc/keepalived/keepalived.conf
+      in_docker: true
+      parser: custom
+      parser_params:
+        module_args:
+          env_vars:
+            KEEPALIVED_OPTIONS: -D
+            LANG: en_US.UTF-8
+            PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+          parser: keepalived
+        module_name: file_parser
     number_of_calls: 1
     plugin_result:
       failed: false
-
+      parsed:
+        global_defs:
+          notification_email:
+            acassen@firewall.loc: null
+            failover@firewall.loc: null
+            sysadmin@firewall.loc: null
+          notification_email_from: Alexandre.Cassen@firewall.loc
+          smtp_connect_timeout: '30'
+          smtp_server: 192.168.200.1
+        vrrp_instance VI_1:
+          advert_int: '1'
+          interface: eth0
+          priority: '101'
+          state: MASTER
+          unicast_peer:
+            192.168.0.223: null
+          unicast_src_ip: 192.168.0.142
+          virtual_ipaddress:
+            192.168.0.100: null
+          virtual_router_id: '51'
   Read process environment:
     number_of_calls: 1
     plugin_result:
       failed: false
-      parsed: {
-        "LANG": "en_US.UTF-8",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
-        "KEEPALIVED_OPTIONS": "-D"
-      }
-
-
-  Parse config file:
+      parsed:
+        KEEPALIVED_OPTIONS: -D
+        LANG: en_US.UTF-8
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+  Run stat for path:
     number_of_calls: 1
-    expected_args: {
-        "delegate_reading": True,
-        "file_path": "/etc/keepalived/keepalived.conf",
-        "in_docker": True,
-        "parser": "custom",
-        "parser_params": {
-            "module_args": {
-                "env_vars": {
-                    "KEEPALIVED_OPTIONS": "-D",
-                    "LANG": "en_US.UTF-8",
-                    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
-                },
-                "parser": "keepalived"
-            },
-            "module_name": "file_parser"
-        }
-    }
     plugin_result:
       failed: false
-      parsed: {
-        "vrrp_instance VI_1": {
-            "advert_int": "1",
-            "unicast_peer": {
-                "192.168.0.223": null
-            },
-            "priority": "101",
-            "virtual_ipaddress": {
-                "192.168.0.100": null
-            },
-            "state": "MASTER",
-            "virtual_router_id": "51",
-            "unicast_src_ip": "192.168.0.142",
-            "interface": "eth0"
-        },
-        "global_defs": {
-            "notification_email_from": "Alexandre.Cassen@firewall.loc",
-            "notification_email": {
-                "sysadmin@firewall.loc": null,
-                "acassen@firewall.loc": null,
-                "failover@firewall.loc": null
-            },
-            "smtp_connect_timeout": "30",
-            "smtp_server": "192.168.200.1"
-        }
-    }
-
-expected_tasks_calls:
-  Run stat for path: 1
-  Read process environment: 1
-  Parse config file: 1
-
-expected_result:
-  - configuration:
-      global_defs:
-        notification_email:
-          - sysadmin@firewall.loc
-          - acassen@firewall.loc
-          - failover@firewall.loc
-        notification_email_from:
-          - Alexandre.Cassen@firewall.loc
-        smtp_connect_timeout: '30'
-        smtp_server: 192.168.200.1
-      vrrp_instance VI_1:
-        advert_int: '1'
-        interface: eth0
-        priority: '101'
-        state: MASTER
-        unicast_peer:
-          192.168.0.223: null
-        unicast_src_ip: 192.168.0.142
-        virtual_ipaddress:
-          192.168.0.100: null
-        virtual_router_id: '51'
-    bindings: [ ]
-    discovery_time: '2022-06-10T13:34:54+02:00'
-    files:
-      - name: keepalived.conf
-        path: /etc/keepalived
-        subtype: generic
-        type: config
-    listening_ports: [ ]
-    type: KeepAliveD
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: keepalived
-        release: 19.el7
-        source: rpm
-        version: 1.3.5
-    process:
-      cmdline: /usr/sbin/keepalived -D
-      pid: '20808'
-      ppid: '1'
-      user: root
-    version:
-      - number: 1.3.5
-        type: package
-        
-software_list:
-  - name: KeepAliveD
-    cmd_regexp: 'keepalived.*'
-    pkg_regexp: 'keepalived'
-    process_type: parent
-    return_children: false
-    return_packages: true
-    vars: {}
-    custom_tasks:
-      - name: Include keepalived specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/keepalived.yaml"
-          
-dockers:
-  containers: []
 packages:
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   apache-commons-collections:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-collections
-      release: 22.el7_2
-      source: rpm
-      version: 3.2.1
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
   apache-commons-daemon:
-    - arch: x86_64
-      epoch: null
-      name: apache-commons-daemon
-      release: 7.el7
-      source: rpm
-      version: 1.0.13
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
   apache-commons-dbcp:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-dbcp
-      release: 17.el7
-      source: rpm
-      version: '1.4'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
   apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
   apache-commons-pool:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-pool
-      release: 9.el7
-      source: rpm
-      version: '1.6'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
   apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-devel
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr-devel
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   apr-util-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-util-devel
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util-devel
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autoconf:
-    - arch: noarch
-      epoch: null
-      name: autoconf
-      release: 11.el7
-      source: rpm
-      version: '2.69'
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
   automake:
-    - arch: noarch
-      epoch: null
-      name: automake
-      release: 3.el7
-      source: rpm
-      version: 1.13.4
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
   avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 16.P2.el7_8.2
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 16.P2.el7_8.2
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 43.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 43.base.el7
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 76.el7_7
-      source: rpm
-      version: 2019.2.32
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 76.el7_7
+    source: rpm
+    version: 2019.2.32
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   centos-indexhtml:
-    - arch: noarch
-      epoch: null
-      name: centos-indexhtml
-      release: 9.el7.centos
-      source: rpm
-      version: '7'
+  - arch: noarch
+    epoch: null
+    name: centos-indexhtml
+    release: 9.el7.centos
+    source: rpm
+    version: '7'
   centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 8.2003.0.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 8.2003.0.el7.centos
+    source: rpm
+    version: '7'
   centos-release-scl-rh:
-    - arch: noarch
-      epoch: null
-      name: centos-release-scl-rh
-      release: 3.el7.centos
-      source: rpm
-      version: '2'
+  - arch: noarch
+    epoch: null
+    name: centos-release-scl-rh
+    release: 3.el7.centos
+    source: rpm
+    version: '2'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 6.el7.centos
-      source: rpm
-      version: '18.5'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 6.el7.centos
+    source: rpm
+    version: '18.5'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
   cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
   cyrus-sasl:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-devel:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-devel
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-devel
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
   devtoolset-7-binutils:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-binutils
-      release: 11.el7
-      source: rpm
-      version: '2.28'
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-binutils
+    release: 11.el7
+    source: rpm
+    version: '2.28'
   devtoolset-7-gcc:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
   devtoolset-7-gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc-c++
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc-c++
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
   devtoolset-7-libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-libstdc++-devel
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-libstdc++-devel
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
   devtoolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: '7.1'
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: '7.1'
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 3.el7
-      source: rpm
-      version: '3.2'
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dwz:
-    - arch: x86_64
-      epoch: null
-      name: dwz
-      release: 3.el7
-      source: rpm
-      version: '0.11'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  ecj:
-    - arch: x86_64
-      epoch: 1
-      name: ecj
-      release: 3.el7
-      source: rpm
-      version: 4.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  expat-devel:
-    - arch: x86_64
-      epoch: null
-      name: expat-devel
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  geronimo-jta:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jta
-      release: 17.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 5.el7
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gperftools-libs:
-    - arch: x86_64
-      epoch: null
-      name: gperftools-libs
-      release: 1.el7
-      source: rpm
-      version: 2.6.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 608c8351
-      source: rpm
-      version: 442df0f8
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 560cfc0a
-      source: rpm
-      version: f2ee9d55
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 28.el7
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  haproxy:
-    - arch: x86_64
-      epoch: null
-      name: haproxy
-      release: 9.el7_9.1
-      source: rpm
-      version: 1.5.18
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  httpd:
-    - arch: x86_64
-      epoch: null
-      name: httpd
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-devel:
-    - arch: x86_64
-      epoch: null
-      name: httpd-devel
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-tools:
-    - arch: x86_64
-      epoch: null
-      name: httpd-tools
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.5.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.49
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 25.el7_7.2
-      source: rpm
-      version: 4.11.0
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 34.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-taglibs-standard:
-    - arch: noarch
-      epoch: 0
-      name: jakarta-taglibs-standard
-      release: 14.el7_1
-      source: rpm
-      version: 1.1.2
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  keepalived:
-    - arch: x86_64
-      epoch: null
-      name: keepalived
-      release: 19.el7
-      source: rpm
-      version: 1.3.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.42.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 43.el7
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 131.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-devel:
-    - arch: x86_64
-      epoch: null
-      name: libdb-devel
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libedit-devel:
-    - arch: x86_64
-      epoch: null
-      name: libedit-devel
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libicu-devel:
-    - arch: x86_64
-      epoch: null
-      name: libicu-devel
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 3.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libtool:
-    - arch: x86_64
-      epoch: null
-      name: libtool
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  llvm-toolset-7-clang:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-clang-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang-libs
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-compiler-rt:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-compiler-rt
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-libomp:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-libomp
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-llvm-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-llvm-libs
-      release: 8.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-devel:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-devel
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-libs
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 16.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 14.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.65
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 61.el7
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-devel:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-devel
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.66.el7
-      source: rpm
-      version: 1.3.0
-  nginx:
-    - arch: x86_64
-      epoch: 1
-      name: nginx
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: nginx-filesystem
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-mod-stream:
-    - arch: x86_64
-      epoch: 1
-      name: nginx-mod-stream
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7
-      source: rpm
-      version: 4.21.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 4.el7_7
-      source: rpm
-      version: 3.44.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openldap-devel:
-    - arch: x86_64
-      epoch: null
-      name: openldap-devel
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Thread-Queue:
-    - arch: noarch
-      epoch: null
-      name: perl-Thread-Queue
-      release: 2.el7
-      source: rpm
-      version: '3.02'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: perl-srpm-macros
-      release: 8.el7
-      source: rpm
-      version: '1'
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pgdg-redhat-repo:
-    - arch: noarch
-      epoch: null
-      name: pgdg-redhat-repo
-      release: '24'
-      source: rpm
-      version: '42.0'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql11:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-contrib
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-devel:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-devel
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-libs
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-server
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 27.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-devel:
-    - arch: x86_64
-      epoch: null
-      name: python-devel
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 9.el7_8
-      source: rpm
-      version: 2.6.0
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python2-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python2-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-devel:
-    - arch: x86_64
-      epoch: null
-      name: python3-devel
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-rpm-generators:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-generators
-      release: 2.el7
-      source: rpm
-      version: '6'
-  python3-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redhat-rpm-config:
-    - arch: noarch
-      epoch: null
-      name: redhat-rpm-config
-      release: 88.el7.centos
-      source: rpm
-      version: 9.1.0
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 52.el7
-      source: rpm
-      version: 8.24.0
-  scl-utils:
-    - arch: x86_64
-      epoch: null
-      name: scl-utils
-      release: 19.el7
-      source: rpm
-      version: '20130529'
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 6.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 9.el7
-      source: rpm
-      version: 1.8.23
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  tomcat:
-    - arch: noarch
-      epoch: 0
-      name: tomcat
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-admin-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-admin-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-el-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-el-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-jsp-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-jsp-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-lib:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-lib
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 8.el7
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019c
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021a
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 20.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 167.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  zip:
-    - arch: x86_64
-      epoch: null
-      name: zip
-      release: 11.el7
-      source: rpm
-      version: '3.0'
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '50'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '65'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '197'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '198'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '274'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '275'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '276'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '277'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '279'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '294'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '295'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '297'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '298'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '299'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '412'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '444'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '466'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '469'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '511'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '513'
-    ppid: '1'
-    user: dbus
-  - cmdline: ''
-    pid: '514'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '556'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '559'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '564'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '566'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '567'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '581'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/rpcbind -w
-    pid: '582'
-    ppid: '1'
-    user: rpc
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H loadbalancer-2 eth0
-    pid: '830'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/lib/jvm/jre/bin/java
-      -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
-      -classpath
-      /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
-      -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat
-      -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp
-      -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      org.apache.catalina.startup.Bootstrap start
-    pid: '887'
-    ppid: '1'
-    user: tomcat
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '888'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '889'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p
-      /run/haproxy.pid
-    pid: '891'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-    pid: '896'
-    ppid: '891'
-    user: haproxy
-  - cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-    pid: '905'
-    ppid: '896'
-    user: haproxy
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1074'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1077'
-    ppid: '1074'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1079'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1083'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1089'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1090'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1092'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: master process /usr/sbin/nginx'
-    pid: '1151'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '1156'
-    ppid: '1151'
-    user: nginx
-  - cmdline: 'nginx: worker process'
-    pid: '1157'
-    ppid: '1151'
-    user: nginx
-  - cmdline: ''
-    pid: '1521'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '2521'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '2661'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6596'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '7586'
-    ppid: '1079'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '7588'
-    ppid: '7586'
-    user: centos
-  - cmdline: '-bash'
-    pid: '7589'
-    ppid: '7588'
-    user: centos
-  - cmdline: 'sshd: centos [priv]'
-    pid: '9099'
-    ppid: '1079'
-    user: root
-  - cmdline: 'sshd: centos@pts/2'
-    pid: '9101'
-    ppid: '9099'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-utaajrqatiwrmgxhrrdlenblpwnrkjvb ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654860880.8045018-31931-35862285958789/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '9249'
-    ppid: '9101'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-utaajrqatiwrmgxhrrdlenblpwnrkjvb ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654860880.8045018-31931-35862285958789/AnsiballZ_process_facts.py
-    pid: '9262'
-    ppid: '9249'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-utaajrqatiwrmgxhrrdlenblpwnrkjvb ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654860880.8045018-31931-35862285958789/AnsiballZ_process_facts.py
-    pid: '9263'
-    ppid: '9262'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654860880.8045018-31931-35862285958789/AnsiballZ_process_facts.py
-    pid: '9264'
-    ppid: '9263'
-    user: root
-  - cmdline: ''
-    pid: '9607'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '9928'
-    ppid: '1079'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '9930'
-    ppid: '9928'
-    user: centos
-  - cmdline: '-bash'
-    pid: '9931'
-    ppid: '9930'
-    user: centos
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20808'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20809'
-    ppid: '20808'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20810'
-    ppid: '20808'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21138'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21139'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21140'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21141'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '21142'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
-    pid: '21221'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: logger'
-    pid: '21223'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: checkpointer'
-    pid: '21225'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: background writer'
-    pid: '21226'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: walwriter'
-    pid: '21227'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '21228'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: stats collector'
-    pid: '21229'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '21230'
-    ppid: '21221'
-    user: postgres
-  - cmdline: pickup -l -t unix -u
-    pid: '25049'
-    ppid: '1074'
-    user: postfix
-  - cmdline: ''
-    pid: '25070'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27662'
-    ppid: '2'
-    user: root
-
-tcp_listen:
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 1151
-    port: 81
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:54 2022'
-    user: root
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 1151
-    port: 82
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:54 2022'
-    user: root
-  - address: 0.0.0.0
-    name: haproxy
-    pid: 905
-    port: 83
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: haproxy
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1079
-    port: 22
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:53 2022'
-    user: root
-  - address: 127.0.0.1
-    name: postmaster
-    pid: 21221
-    port: 5432
-    protocol: tcp
-    stime: 'Thu Apr 28 13:53:52 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1074
-    port: 25
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:53 2022'
-    user: root
-  - address: 0.0.0.0
-    name: haproxy
-    pid: 905
-    port: 5000
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: haproxy
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: '::'
-    name: java
-    pid: 887
-    port: 8080
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: tomcat
-  - address: '::'
-    name: httpd
-    pid: 889
-    port: 80
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: root
-  - address: '::'
-    name: 'nginx:'
-    pid: 1151
-    port: 81
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:54 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1079
-    port: 22
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:53 2022'
-    user: root
-  - address: '::1'
-    name: postmaster
-    pid: 21221
-    port: 5432
-    protocol: tcp
-    stime: 'Thu Apr 28 13:53:52 2022'
-    user: postgres
-  - address: '::1'
-    name: master
-    pid: 1074
-    port: 25
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:53 2022'
-    user: root
-  - address: 127.0.0.1
-    name: java
-    pid: 887
-    port: 8005
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 887
-    port: 8009
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: tomcat
-udp_listen:
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 830
-    port: 68
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: root
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 581
-    port: 323
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 3.el7
+    source: rpm
+    version: '3.2'
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dwz:
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  expat-devel:
+  - arch: x86_64
+    epoch: null
+    name: expat-devel
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 5.el7
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gperftools-libs:
+  - arch: x86_64
+    epoch: null
+    name: gperftools-libs
+    release: 1.el7
+    source: rpm
+    version: 2.6.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 560cfc0a
+    source: rpm
+    version: f2ee9d55
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 28.el7
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  haproxy:
+  - arch: x86_64
+    epoch: null
     name: haproxy
-    pid: 896
-    port: 49899
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: haproxy
-  - address: 0.0.0.0
+    release: 9.el7_9.1
+    source: rpm
+    version: 1.5.18
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  httpd:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-devel:
+  - arch: x86_64
+    epoch: null
+    name: httpd-devel
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-tools:
+  - arch: x86_64
+    epoch: null
+    name: httpd-tools
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.5.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.49
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 25.el7_7.2
+    source: rpm
+    version: 4.11.0
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 34.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  keepalived:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 19.el7
+    source: rpm
+    version: 1.3.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.42.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 43.el7
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 131.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-devel:
+  - arch: x86_64
+    epoch: null
+    name: libdb-devel
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libedit-devel:
+  - arch: x86_64
+    epoch: null
+    name: libedit-devel
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libicu-devel:
+  - arch: x86_64
+    epoch: null
+    name: libicu-devel
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 3.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libtool:
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  llvm-toolset-7-clang:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-clang-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang-libs
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-compiler-rt:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-compiler-rt
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-libomp:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-libomp
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-llvm-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-llvm-libs
+    release: 8.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-runtime:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-devel:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-devel
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-libs
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 16.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 14.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.65
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 61.el7
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-devel:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-devel
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.66.el7
+    source: rpm
+    version: 1.3.0
+  nginx:
+  - arch: x86_64
+    epoch: 1
+    name: nginx
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: nginx-filesystem
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-mod-stream:
+  - arch: x86_64
+    epoch: 1
+    name: nginx-mod-stream
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7
+    source: rpm
+    version: 4.21.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 4.el7_7
+    source: rpm
+    version: 3.44.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openldap-devel:
+  - arch: x86_64
+    epoch: null
+    name: openldap-devel
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Thread-Queue:
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pgdg-redhat-repo:
+  - arch: noarch
+    epoch: null
+    name: pgdg-redhat-repo
+    release: '24'
+    source: rpm
+    version: '42.0'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql11:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-devel:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-devel
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 27.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-devel:
+  - arch: x86_64
+    epoch: null
+    name: python-devel
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 9.el7_8
+    source: rpm
+    version: 2.6.0
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python2-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python2-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 582
-    port: 750
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 581
-    port: 323
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 750
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 52.el7
+    source: rpm
+    version: 8.24.0
+  scl-utils:
+  - arch: x86_64
+    epoch: null
+    name: scl-utils
+    release: 19.el7
+    source: rpm
+    version: '20130529'
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 6.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 9.el7
+    source: rpm
+    version: 1.8.23
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 8.el7
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019c
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 20.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 167.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '197'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '198'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '275'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '276'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '277'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '279'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '295'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '297'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '412'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '444'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '466'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '469'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '511'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '513'
+  ppid: '1'
+  user: dbus
+- cmdline: ''
+  cwd: /
+  pid: '514'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '556'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '559'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '564'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '566'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '567'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '581'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '582'
+  ppid: '1'
+  user: rpc
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H loadbalancer-2 eth0
+  cwd: /sbin/
+  pid: '830'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+    -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+    -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+    -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+    start
+  cwd: /usr/lib/jvm/jre/bin/
+  pid: '887'
+  ppid: '1'
+  user: tomcat
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '888'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '889'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
+  cwd: /usr/sbin/
+  pid: '891'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '896'
+  ppid: '891'
+  user: haproxy
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '905'
+  ppid: '896'
+  user: haproxy
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1074'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1077'
+  ppid: '1074'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1079'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1083'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1089'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1090'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1092'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: master process /usr/sbin/nginx'
+  cwd: /
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1156'
+  ppid: '1151'
+  user: nginx
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1157'
+  ppid: '1151'
+  user: nginx
+- cmdline: ''
+  cwd: /
+  pid: '1521'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2521'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2661'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6596'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '7586'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '7588'
+  ppid: '7586'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '7589'
+  ppid: '7588'
+  user: centos
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '9099'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@pts/2'
+  cwd: /
+  pid: '9101'
+  ppid: '9099'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-utaajrqatiwrmgxhrrdlenblpwnrkjvb
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654860880.8045018-31931-35862285958789/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '9249'
+  ppid: '9101'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-utaajrqatiwrmgxhrrdlenblpwnrkjvb
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654860880.8045018-31931-35862285958789/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '9262'
+  ppid: '9249'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-utaajrqatiwrmgxhrrdlenblpwnrkjvb ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1654860880.8045018-31931-35862285958789/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '9263'
+  ppid: '9262'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654860880.8045018-31931-35862285958789/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '9264'
+  ppid: '9263'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9607'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '9928'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '9930'
+  ppid: '9928'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '9931'
+  ppid: '9930'
+  user: centos
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20808'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20809'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20810'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21138'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21139'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21140'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21141'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '21142'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
+  cwd: /usr/pgsql-11/bin/
+  pid: '21221'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: logger'
+  cwd: /
+  pid: '21223'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '21225'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '21226'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '21227'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '21228'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '21229'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '21230'
+  ppid: '21221'
+  user: postgres
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '25049'
+  ppid: '1074'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '25070'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27662'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: keepalived.*
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/keepalived.yaml'
+    name: Include keepalived specific plugins
+  name: KeepAliveD
+  pkg_regexp: keepalived
+  process_type: parent
+  return_children: false
+  return_packages: true
+  vars: {}
+tcp_listen:
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 82
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 83
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 5000
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: java
+  pid: 887
+  port: 8080
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: httpd
+  pid: 889
+  port: 80
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: '::'
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: ::1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: ::1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: 887
+  port: 8005
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 887
+  port: 8009
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 830
+  port: 68
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: 0.0.0.0
+  name: haproxy
+  pid: 896
+  port: 49899
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/logstash/logstash7.4.2_centos7.6_docker.yaml
+++ b/tests/unit/plugins/action/auto/resources/logstash/logstash7.4.2_centos7.6_docker.yaml
@@ -1,4028 +1,4162 @@
-expected_result:
-  - discovery_time: '2022-07-05T09:45:46+02:00'
-    bindings:
-      - address: '::'
-        class: service
-        port: 5055
-        protocol: tcp
-      - address: '::'
-        class: service
-        port: 9600
-        protocol: tcp
-    docker:
-      exposed_ports:
-        5044/tcp: { }
-        9600/tcp: { }
-      id: 1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
-      image: nexusregistry.opensolutions.cloud/logstash:7.4.2_iometrics-1
-      name: /logstash
-      network_mode: 'host'
-      port_bindings: { }
-    listening_ports:
-      - 5055
-      - 9600
-    packages: [ ]
-    process:
-      cmdline: /bin/java -Xms2048m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djruby.compile.invokedynamic=true -Djruby.jit.threshold=0 -Djruby.regexp.interruptible=true -Djava.security.egd=file:/dev/urandom -Dlog4j2.isThreadContextMapInheritable=true -Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ -cp /usr/share/logstash/logstash-core/lib/jars/animal-sniffer-annotations-1.14.jar:/usr/share/logstash/logstash-core/lib/jars/commons-codec-1.11.jar:/usr/share/logstash/logstash-core/lib/jars/commons-compiler-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/error_prone_annotations-2.0.18.jar:/usr/share/logstash/logstash-core/lib/jars/google-java-format-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/gradle-license-report-0.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/guava-22.0.jar:/usr/share/logstash/logstash-core/lib/jars/j2objc-annotations-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-annotations-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-core-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-databind-2.9.9.3.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-dataformat-cbor-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/janino-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/javassist-3.24.0-GA.jar:/usr/share/logstash/logstash-core/lib/jars/jruby-complete-9.2.8.0.jar:/usr/share/logstash/logstash-core/lib/jars/jsr305-1.3.9.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-api-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-core-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-slf4j-impl-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/logstash-core.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.commands-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.contenttype-3.4.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.expressions-3.4.300.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.filesystem-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.jobs-3.5.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.resources-3.7.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.runtime-3.7.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.app-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.common-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.preferences-3.4.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.registry-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.jdt.core-3.10.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.osgi-3.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.text-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/reflections-0.9.11.jar:/usr/share/logstash/logstash-core/lib/jars/slf4j-api-1.7.25.jar org.logstash.Logstash
-      listening_ports:
-        - 5055
-        - 9600
-      pid: '7056'
-      ppid: '6923'
-      user: centos
-    type: Logstash
-    version:
-      - number: 7.4.2_iometrics-1
-        type: docker
-
-software_list:
-  - name: Logstash
-    cmd_regexp: org\.logstash\.Logstash
-    pkg_regexp: logstash
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - -c
-        - python ./listener.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - -c
-          - python ./listener.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
-          - PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
-        Hostname: indexer01.novalocal
-        Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.1.0-c165633
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /config: { }
-        WorkingDir: ''
-      Created: '2022-06-01T16:32:15.591995742Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521-init/diff:/var/lib/docker/overlay2/48af681efdc26a18db1f454929c8a9008b0c59035b43be3a8ad58e211a309a85/diff:/var/lib/docker/overlay2/c703bb1c40fe2d0178aae8f123e88241c3c6928e189d7ef47a9aaad609439655/diff:/var/lib/docker/overlay2/f0b32c9349991844490375e72f6a025c9d162a7edac7a4e585d295a66f01e782/diff:/var/lib/docker/overlay2/1ed8f7cae0ab8d14f1db25dc40bdc50d71a5ef5555cd05970f9b7ba08b7d7c61/diff:/var/lib/docker/overlay2/5cf6c028fe2b081fdcbda31e8e9133b89a79eccf663de59530b61a61692e97c6/diff:/var/lib/docker/overlay2/8311c64009b57db6fb231a3ca4ca41218abdc03e6b771602908e1a3bff032b13/diff:/var/lib/docker/overlay2/1009cd354b76d65ca194ab211a8ee1209c930aba645d667f0f2de93e7777fef8/diff:/var/lib/docker/overlay2/c7eb8b0108c5013dca78bf4a9eebf3ea41552d7f047664c842ef3f9ec0930f46/diff
-          MergedDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/merged
-          UpperDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/diff
-          WorkDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/redis-cleaner:/config:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hostname
-      HostsPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hosts
-      Id: 17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
-      Image: sha256:f4b8014dcf496e8a2dbc8786835825926dbd8db6a8ab8be9d012139a3e59e851
-      LogPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /config
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis-cleaner
-          Type: bind
-      Name: /iometrics-cmdb-redis-cleaner
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 42a46173b8a6a29b240d5e11e26f5142d483daac2b3a9ff7d463656952f656c4
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
-        Ports: { }
-        SandboxID: 35eeca78d95001ee58384d24c44d5c7cb0774fa1d3ccf65135245c3e115b8c64
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 28025
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-01T16:32:15.934702372Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /usr/local/bin/docker-entrypoint
-        Env:
-          - LOGSTASH_KEYSTORE_PASS=secur3it
-          - PATH=/usr/share/logstash/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - ELASTIC_CONTAINER=true
-          - LANG=en_US.UTF-8
-          - LC_ALL=en_US.UTF-8
-        ExposedPorts:
-          5044/tcp: { }
-          9600/tcp: { }
-        Hostname: indexer01.novalocal
-        Image: nexusregistry.opensolutions.cloud/logstash:7.4.2_iometrics-1
-        Labels:
-          license: Elastic License
-          org.label-schema.build-date: '20190801'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: logstash
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.url: https://www.elastic.co/products/logstash
-          org.label-schema.vcs-url: https://github.com/elastic/logstash
-          org.label-schema.vendor: Elastic
-          org.label-schema.version: 7.4.2
-          os_container_type: logstash
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: logstash
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /usr/share/logstash/config/jvm.options: { }
-          /usr/share/logstash/config/logstash.keystore: { }
-          /usr/share/logstash/config/logstash.yml: { }
-          /usr/share/logstash/config/pipelines.yml: { }
-          /usr/share/logstash/config/ssl: { }
-          /usr/share/logstash/libs: { }
-          /usr/share/logstash/pipelines: { }
-          /usr/share/logstash/scripts: { }
-          /var/lib/logstash/spool: { }
-        WorkingDir: /usr/share/logstash
-      Created: '2021-09-08T15:34:37.283512426Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23-init/diff:/var/lib/docker/overlay2/c0b64f0d978f9438dfbff80ce43ea262a8c3fada60512ae10e10cedf6155f2e5/diff:/var/lib/docker/overlay2/cecec1371061521c9c470de506604b84f0c7115e8afc98364cda87b4dee22fde/diff:/var/lib/docker/overlay2/34ed4ad551160a52e601b1d18bf370daad0f239bc6e77227b16b4c782a0eca06/diff:/var/lib/docker/overlay2/6df2c0f7c377aa12d60990c8c699892ab1b13be249c0c6fb6fbb98fe05480dc6/diff:/var/lib/docker/overlay2/85645c13b8a4234107187513bda39ca87750c745d01739d812905125684a5376/diff:/var/lib/docker/overlay2/571aeec40700310388bbeb8bd6167ff0a4e2e2df9e6c6e0288c409d334f54ca1/diff:/var/lib/docker/overlay2/de0534dca03a3dedda930c1ad97d22dd942c75b9616ab879972f07665838f08c/diff:/var/lib/docker/overlay2/7e8ced8ae7353db588e6473b42bfdc1d316dc47ac5f494dcc3e6d4f7e57da3e3/diff:/var/lib/docker/overlay2/001f9147b6ab66d62b1fbceaf77a9793a753a60559353c6327c50a0e49bc1231/diff:/var/lib/docker/overlay2/5516c130cfbb3f233c5b214316cdd11908b3bda15770c25496f2aa59b8849253/diff:/var/lib/docker/overlay2/68d49fb7cd2f845a36bf22bba766c721fe67274d7f5d0e6e1091071fc01f4fff/diff:/var/lib/docker/overlay2/e1d95b6fcae995ab60f12b75f6fcbeabecc2b02d02bb8ab225e5a55485adc03c/diff:/var/lib/docker/overlay2/09e21e4e8434de7e2800bfdc86f4dbbe999bc89186b7c099e58a58f13b083672/diff:/var/lib/docker/overlay2/7f3df92947c65debb3de8c0ecd1d556e90b355bc3af0163bc8a9862e8f869dac/diff:/var/lib/docker/overlay2/46b9ba93c62b5e0bd35145b2327e060712a85cf1cdd263188c010d5e2554670b/diff:/var/lib/docker/overlay2/f2454d9a3b25399047feb41486803d43fcbb45a81dc710601d5950da79ac8030/diff:/var/lib/docker/overlay2/b27d3ae7aff2ac9754f1c56378012380a1e5c17896c0c71b4759bfcb10a7c40a/diff:/var/lib/docker/overlay2/75d6bdb58f70a62e6ea684d6d3b37652c8b72d9d4f86551e553c6cf6bb7326ab/diff:/var/lib/docker/overlay2/54689b9f778d0fb8970c658303b1f70fd60328cd888dc5b74326b29c57ef8105/diff:/var/lib/docker/overlay2/e6ac2cd447117ff53d3fa9439b80162af5eeb91d20567780a58fa542b04e2a38/diff:/var/lib/docker/overlay2/78435691d0b8543fbe89e1d88f9a7b5fa681432b9a271a097a1fdcae9cb5a9e5/diff:/var/lib/docker/overlay2/229ee1b3a56196e119210269fce872d0fe3fb56b6f87f86a770837a5fa5b1ac7/diff
-          MergedDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/merged
-          UpperDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/diff
-          WorkDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/logstash/ssl:/usr/share/logstash/config/ssl:rw
-          - /etc/localtime:/etc/localtime:rw
-          - /etc/logstash/logstash.yml:/usr/share/logstash/config/logstash.yml:rw
-          - /usr/share/logstash/libs:/usr/share/logstash/libs:rw
-          - /etc/logstash/scripts:/usr/share/logstash/scripts:rw
-          - /etc/logstash/pipelines:/usr/share/logstash/pipelines:rw
-          - /etc/logstash/jvm.options:/usr/share/logstash/config/jvm.options:rw
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/logstash/pipelines.yml:/usr/share/logstash/config/pipelines.yml:rw
-          - /etc/logstash/logstash.keystore:/usr/share/logstash/config/logstash.keystore:rw
-          - /var/lib/logstash/spool:/var/lib/logstash/spool:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/hostname
-      HostsPath: /etc/hosts
-      Id: 1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
-      Image: sha256:6dea016b06dec9bd6649861e6ff6f37fa4cc33f4af5a908d42756f1ff07e1e3a
-      LogPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /usr/share/logstash/config/logstash.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/logstash.yml
-          Type: bind
-        - Destination: /usr/share/logstash/scripts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/scripts
-          Type: bind
-        - Destination: /var/lib/logstash/spool
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/logstash/spool
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /usr/share/logstash/config/jvm.options
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/jvm.options
-          Type: bind
-        - Destination: /usr/share/logstash/config/logstash.keystore
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/logstash.keystore
-          Type: bind
-        - Destination: /usr/share/logstash/config/pipelines.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/pipelines.yml
-          Type: bind
-        - Destination: /usr/share/logstash/config/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/ssl
-          Type: bind
-        - Destination: /usr/share/logstash/libs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /usr/share/logstash/libs
-          Type: bind
-        - Destination: /usr/share/logstash/pipelines
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/pipelines
-          Type: bind
-      Name: /logstash
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: a05e3bedd671d506ea7c75121f96d6f15b58fb25d99f0a761d85522c4cb31c13
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
-        Ports: { }
-        SandboxID: b70e6ce41402ab5de2b13827be954a106a7d738478fee9bd07a2ca753971613b
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/local/bin/docker-entrypoint
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:40.665430732Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 7056
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:55:51.256169421Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - --port
-        - '6379'
-        - --tls-port
-        - '6378'
-        - --appendonly
-        - 'no'
-        - --maxmemory
-        - '0'
-        - --maxclients
-        - '10000'
-        - --bind
-        - 0.0.0.0
-        - --tls-auth-clients
-        - 'no'
-        - --tls-cert-file
-        - /data/ssl/redis.crt
-        - --tls-key-file
-        - /data/ssl/redis.pem
-        - --tls-ca-cert-file
-        - /data/ssl/redis_ca.crt
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - --port
-          - '6379'
-          - --tls-port
-          - '6378'
-          - --appendonly
-          - 'no'
-          - --maxmemory
-          - '0'
-          - --maxclients
-          - '10000'
-          - --bind
-          - 0.0.0.0
-          - --tls-auth-clients
-          - 'no'
-          - --tls-cert-file
-          - /data/ssl/redis.crt
-          - --tls-key-file
-          - /data/ssl/redis.pem
-          - --tls-ca-cert-file
-          - /data/ssl/redis_ca.crt
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.0.1
-          - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
-          - REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
-        ExposedPorts:
-          6379/tcp: { }
-        Hostname: indexer01.novalocal
-        Image: redis:6.0.1
-        Labels:
-          os_contianer_type: redis
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: { }
-          /data/ssl/: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-        WorkingDir: /data
-      Created: '2021-09-08T15:21:08.364900148Z'
-      Driver: overlay2
-      ExecIDs:
-        - 09b5dc8e88df78d954a04edbbfe509aa3a8873b17c434360f0994b166eb661e6
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671-init/diff:/var/lib/docker/overlay2/d729bad126881ac666c1ce86fd53b9fbb89dd31a32982fbe52d7b0348d00a7a5/diff:/var/lib/docker/overlay2/6147c7e4ffcac3df8515c47b85fb28fa9cb14e2eda1ae99024a0ad2d4d2f2564/diff:/var/lib/docker/overlay2/e65a456f02dd73ccbf8fcf90ad6c9cd2d090f59a8419916c39c5e3d2f1f4633e/diff:/var/lib/docker/overlay2/0d37d43d45e3912548e3578ac61ec6ae557a5b096629ca286fc5b07999ccae31/diff:/var/lib/docker/overlay2/2c5d5d7ffd6855efcf3a7788c2a72f12de032ac3d00ffa437e32113ae5706b4d/diff:/var/lib/docker/overlay2/ef4edd4aa9d123bae52ac92f708fb15264ac3036df51240db0e17b7ae280a06d/diff
-          MergedDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/merged
-          UpperDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/diff
-          WorkDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /var/lib/redis:/data:rw
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/localtime:/etc/localtime:rw
-          - /etc/redis/ssl/:/data/ssl/:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/hostname
-      HostsPath: /etc/hosts
-      Id: 9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
-      Image: sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c
-      LogPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/redis
-          Type: bind
-        - Destination: /data/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis/ssl
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-      Name: /redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: c124f14eba8e33d8dfbf7244d810451b50469d02c40f191ac28d6309b4c2fb20
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
-        Ports: { }
-        SandboxID: 12fa0db070f4558f5c022bb880897adb0e4a11662b3ec5143027e742a036611d
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:40.681971343Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 7054
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:55:50.844646575Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  keepalived:
-    - arch: x86_64
-      epoch: null
-      name: keepalived
-      release: 16.el7
-      source: rpm
-      version: 1.3.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-devel:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-devel
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsepol-devel:
-    - arch: x86_64
-      epoch: null
-      name: libsepol-devel
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mariadb-server:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-server
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 48.el7_8.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 48.el7_8.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcre-devel:
-    - arch: x86_64
-      epoch: null
-      name: pcre-devel
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
-  perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
-  perl-DBD-MySQL:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBD-MySQL
-      release: 6.el7
-      source: rpm
-      version: '4.023'
-  perl-DBI:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBI
-      release: 4.el7
-      source: rpm
-      version: '1.627'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
-  perl-Net-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-Daemon
-      release: 5.el7
-      source: rpm
-      version: '0.48'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-PlRPC:
-    - arch: noarch
-      epoch: null
-      name: perl-PlRPC
-      release: 14.el7
-      source: rpm
-      version: '0.2020'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  socat:
-    - arch: x86_64
-      epoch: null
-      name: socat
-      release: 2.el7
-      source: rpm
-      version: 1.7.3.2
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '40'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '93'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '301'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '306'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '377'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '393'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '477'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '541'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '673'
-    ppid: '1'
-    user: polkitd
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '704'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '720'
-    ppid: '1'
-    user: rpc
-  - cmdline: ''
-    pid: '721'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '724'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '731'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '743'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '747'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H indexer01 eth0
-    pid: '976'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
-    pid: '1037'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1038'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1042'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
-    pid: '1128'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1136'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1140'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1151'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1152'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1153'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '1290'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '1291'
-    ppid: '1290'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '1292'
-    ppid: '1290'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1346'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1348'
-    ppid: '1346'
-    user: postfix
-  - cmdline: pickup -l -t unix -u
-    pid: '5992'
-    ppid: '1346'
-    user: postfix
-  - cmdline: 'sshd: centos [priv]'
-    pid: '6355'
-    ppid: '1140'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '6357'
-    ppid: '6355'
-    user: centos
-  - cmdline: -bash
-    pid: '6358'
-    ppid: '6357'
-    user: centos
-  - cmdline: sudo su -
-    pid: '6377'
-    ppid: '6358'
-    user: root
-  - cmdline: su -
-    pid: '6378'
-    ppid: '6377'
-    user: root
-  - cmdline: -bash
-    pid: '6379'
-    ppid: '6378'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '6498'
-    ppid: '1140'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '6500'
-    ppid: '6498'
-    user: centos
-  - cmdline: -bash
-    pid: '6501'
-    ppid: '6500'
-    user: centos
-  - cmdline: sudo su
-    pid: '6520'
-    ppid: '6501'
-    user: root
-  - cmdline: su
-    pid: '6521'
-    ppid: '6520'
-    user: root
-  - cmdline: bash
-    pid: '6522'
-    ppid: '6521'
-    user: root
-  - cmdline: ''
-    pid: '6605'
-    ppid: '2'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '6905'
-    ppid: '1042'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '6923'
-    ppid: '1042'
-    user: root
-  - cmdline: redis-server 0.0.0.0:6379
-    pid: '7054'
-    ppid: '6905'
-    user: polkitd
-  - cmdline: /bin/java -Xms2048m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djruby.compile.invokedynamic=true -Djruby.jit.threshold=0 -Djruby.regexp.interruptible=true -Djava.security.egd=file:/dev/urandom -Dlog4j2.isThreadContextMapInheritable=true -Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ -cp /usr/share/logstash/logstash-core/lib/jars/animal-sniffer-annotations-1.14.jar:/usr/share/logstash/logstash-core/lib/jars/commons-codec-1.11.jar:/usr/share/logstash/logstash-core/lib/jars/commons-compiler-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/error_prone_annotations-2.0.18.jar:/usr/share/logstash/logstash-core/lib/jars/google-java-format-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/gradle-license-report-0.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/guava-22.0.jar:/usr/share/logstash/logstash-core/lib/jars/j2objc-annotations-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-annotations-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-core-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-databind-2.9.9.3.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-dataformat-cbor-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/janino-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/javassist-3.24.0-GA.jar:/usr/share/logstash/logstash-core/lib/jars/jruby-complete-9.2.8.0.jar:/usr/share/logstash/logstash-core/lib/jars/jsr305-1.3.9.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-api-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-core-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-slf4j-impl-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/logstash-core.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.commands-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.contenttype-3.4.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.expressions-3.4.300.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.filesystem-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.jobs-3.5.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.resources-3.7.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.runtime-3.7.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.app-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.common-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.preferences-3.4.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.registry-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.jdt.core-3.10.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.osgi-3.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.text-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/reflections-0.9.11.jar:/usr/share/logstash/logstash-core/lib/jars/slf4j-api-1.7.25.jar org.logstash.Logstash
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - python ./listener.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - python ./listener.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
+      Hostname: indexer01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.1.0-c165633
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /config: {}
+      WorkingDir: ''
+    Created: '2022-06-01T16:32:15.591995742Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521-init/diff:/var/lib/docker/overlay2/48af681efdc26a18db1f454929c8a9008b0c59035b43be3a8ad58e211a309a85/diff:/var/lib/docker/overlay2/c703bb1c40fe2d0178aae8f123e88241c3c6928e189d7ef47a9aaad609439655/diff:/var/lib/docker/overlay2/f0b32c9349991844490375e72f6a025c9d162a7edac7a4e585d295a66f01e782/diff:/var/lib/docker/overlay2/1ed8f7cae0ab8d14f1db25dc40bdc50d71a5ef5555cd05970f9b7ba08b7d7c61/diff:/var/lib/docker/overlay2/5cf6c028fe2b081fdcbda31e8e9133b89a79eccf663de59530b61a61692e97c6/diff:/var/lib/docker/overlay2/8311c64009b57db6fb231a3ca4ca41218abdc03e6b771602908e1a3bff032b13/diff:/var/lib/docker/overlay2/1009cd354b76d65ca194ab211a8ee1209c930aba645d667f0f2de93e7777fef8/diff:/var/lib/docker/overlay2/c7eb8b0108c5013dca78bf4a9eebf3ea41552d7f047664c842ef3f9ec0930f46/diff
+        MergedDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/merged
+        UpperDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/diff
+        WorkDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/redis-cleaner:/config:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hostname
+    HostsPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hosts
+    Id: 17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
+    Image: sha256:f4b8014dcf496e8a2dbc8786835825926dbd8db6a8ab8be9d012139a3e59e851
+    LogPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /config
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis-cleaner
+      Type: bind
+    Name: /iometrics-cmdb-redis-cleaner
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 42a46173b8a6a29b240d5e11e26f5142d483daac2b3a9ff7d463656952f656c4
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
+      Ports: {}
+      SandboxID: 35eeca78d95001ee58384d24c44d5c7cb0774fa1d3ccf65135245c3e115b8c64
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 28025
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-01T16:32:15.934702372Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /usr/local/bin/docker-entrypoint
+      Env:
+      - LOGSTASH_KEYSTORE_PASS=secur3it
+      - PATH=/usr/share/logstash/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - ELASTIC_CONTAINER=true
+      - LANG=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+      ExposedPorts:
+        5044/tcp: {}
+        9600/tcp: {}
+      Hostname: indexer01.novalocal
+      Image: nexusregistry.opensolutions.cloud/logstash:7.4.2_iometrics-1
+      Labels:
+        license: Elastic License
+        org.label-schema.build-date: '20190801'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: logstash
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.url: https://www.elastic.co/products/logstash
+        org.label-schema.vcs-url: https://github.com/elastic/logstash
+        org.label-schema.vendor: Elastic
+        org.label-schema.version: 7.4.2
+        os_container_type: logstash
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: logstash
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /usr/share/logstash/config/jvm.options: {}
+        /usr/share/logstash/config/logstash.keystore: {}
+        /usr/share/logstash/config/logstash.yml: {}
+        /usr/share/logstash/config/pipelines.yml: {}
+        /usr/share/logstash/config/ssl: {}
+        /usr/share/logstash/libs: {}
+        /usr/share/logstash/pipelines: {}
+        /usr/share/logstash/scripts: {}
+        /var/lib/logstash/spool: {}
+      WorkingDir: /usr/share/logstash
+    Created: '2021-09-08T15:34:37.283512426Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23-init/diff:/var/lib/docker/overlay2/c0b64f0d978f9438dfbff80ce43ea262a8c3fada60512ae10e10cedf6155f2e5/diff:/var/lib/docker/overlay2/cecec1371061521c9c470de506604b84f0c7115e8afc98364cda87b4dee22fde/diff:/var/lib/docker/overlay2/34ed4ad551160a52e601b1d18bf370daad0f239bc6e77227b16b4c782a0eca06/diff:/var/lib/docker/overlay2/6df2c0f7c377aa12d60990c8c699892ab1b13be249c0c6fb6fbb98fe05480dc6/diff:/var/lib/docker/overlay2/85645c13b8a4234107187513bda39ca87750c745d01739d812905125684a5376/diff:/var/lib/docker/overlay2/571aeec40700310388bbeb8bd6167ff0a4e2e2df9e6c6e0288c409d334f54ca1/diff:/var/lib/docker/overlay2/de0534dca03a3dedda930c1ad97d22dd942c75b9616ab879972f07665838f08c/diff:/var/lib/docker/overlay2/7e8ced8ae7353db588e6473b42bfdc1d316dc47ac5f494dcc3e6d4f7e57da3e3/diff:/var/lib/docker/overlay2/001f9147b6ab66d62b1fbceaf77a9793a753a60559353c6327c50a0e49bc1231/diff:/var/lib/docker/overlay2/5516c130cfbb3f233c5b214316cdd11908b3bda15770c25496f2aa59b8849253/diff:/var/lib/docker/overlay2/68d49fb7cd2f845a36bf22bba766c721fe67274d7f5d0e6e1091071fc01f4fff/diff:/var/lib/docker/overlay2/e1d95b6fcae995ab60f12b75f6fcbeabecc2b02d02bb8ab225e5a55485adc03c/diff:/var/lib/docker/overlay2/09e21e4e8434de7e2800bfdc86f4dbbe999bc89186b7c099e58a58f13b083672/diff:/var/lib/docker/overlay2/7f3df92947c65debb3de8c0ecd1d556e90b355bc3af0163bc8a9862e8f869dac/diff:/var/lib/docker/overlay2/46b9ba93c62b5e0bd35145b2327e060712a85cf1cdd263188c010d5e2554670b/diff:/var/lib/docker/overlay2/f2454d9a3b25399047feb41486803d43fcbb45a81dc710601d5950da79ac8030/diff:/var/lib/docker/overlay2/b27d3ae7aff2ac9754f1c56378012380a1e5c17896c0c71b4759bfcb10a7c40a/diff:/var/lib/docker/overlay2/75d6bdb58f70a62e6ea684d6d3b37652c8b72d9d4f86551e553c6cf6bb7326ab/diff:/var/lib/docker/overlay2/54689b9f778d0fb8970c658303b1f70fd60328cd888dc5b74326b29c57ef8105/diff:/var/lib/docker/overlay2/e6ac2cd447117ff53d3fa9439b80162af5eeb91d20567780a58fa542b04e2a38/diff:/var/lib/docker/overlay2/78435691d0b8543fbe89e1d88f9a7b5fa681432b9a271a097a1fdcae9cb5a9e5/diff:/var/lib/docker/overlay2/229ee1b3a56196e119210269fce872d0fe3fb56b6f87f86a770837a5fa5b1ac7/diff
+        MergedDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/merged
+        UpperDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/diff
+        WorkDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/logstash/ssl:/usr/share/logstash/config/ssl:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/logstash/logstash.yml:/usr/share/logstash/config/logstash.yml:rw
+      - /usr/share/logstash/libs:/usr/share/logstash/libs:rw
+      - /etc/logstash/scripts:/usr/share/logstash/scripts:rw
+      - /etc/logstash/pipelines:/usr/share/logstash/pipelines:rw
+      - /etc/logstash/jvm.options:/usr/share/logstash/config/jvm.options:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/logstash/pipelines.yml:/usr/share/logstash/config/pipelines.yml:rw
+      - /etc/logstash/logstash.keystore:/usr/share/logstash/config/logstash.keystore:rw
+      - /var/lib/logstash/spool:/var/lib/logstash/spool:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/hostname
+    HostsPath: /etc/hosts
+    Id: 1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
+    Image: sha256:6dea016b06dec9bd6649861e6ff6f37fa4cc33f4af5a908d42756f1ff07e1e3a
+    LogPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /usr/share/logstash/config/logstash.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/logstash.yml
+      Type: bind
+    - Destination: /usr/share/logstash/scripts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/scripts
+      Type: bind
+    - Destination: /var/lib/logstash/spool
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/logstash/spool
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /usr/share/logstash/config/jvm.options
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/jvm.options
+      Type: bind
+    - Destination: /usr/share/logstash/config/logstash.keystore
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/logstash.keystore
+      Type: bind
+    - Destination: /usr/share/logstash/config/pipelines.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/pipelines.yml
+      Type: bind
+    - Destination: /usr/share/logstash/config/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/ssl
+      Type: bind
+    - Destination: /usr/share/logstash/libs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /usr/share/logstash/libs
+      Type: bind
+    - Destination: /usr/share/logstash/pipelines
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/pipelines
+      Type: bind
+    Name: /logstash
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: a05e3bedd671d506ea7c75121f96d6f15b58fb25d99f0a761d85522c4cb31c13
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
+      Ports: {}
+      SandboxID: b70e6ce41402ab5de2b13827be954a106a7d738478fee9bd07a2ca753971613b
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/local/bin/docker-entrypoint
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:40.665430732Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 7056
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:55:51.256169421Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --port
+    - '6379'
+    - --tls-port
+    - '6378'
+    - --appendonly
+    - 'no'
+    - --maxmemory
+    - '0'
+    - --maxclients
+    - '10000'
+    - --bind
+    - 0.0.0.0
+    - --tls-auth-clients
+    - 'no'
+    - --tls-cert-file
+    - /data/ssl/redis.crt
+    - --tls-key-file
+    - /data/ssl/redis.pem
+    - --tls-ca-cert-file
+    - /data/ssl/redis_ca.crt
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - --port
+      - '6379'
+      - --tls-port
+      - '6378'
+      - --appendonly
+      - 'no'
+      - --maxmemory
+      - '0'
+      - --maxclients
+      - '10000'
+      - --bind
+      - 0.0.0.0
+      - --tls-auth-clients
+      - 'no'
+      - --tls-cert-file
+      - /data/ssl/redis.crt
+      - --tls-key-file
+      - /data/ssl/redis.pem
+      - --tls-ca-cert-file
+      - /data/ssl/redis_ca.crt
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.0.1
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
+      - REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: indexer01.novalocal
+      Image: redis:6.0.1
+      Labels:
+        os_contianer_type: redis
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+        /data/ssl/: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+      WorkingDir: /data
+    Created: '2021-09-08T15:21:08.364900148Z'
+    Driver: overlay2
+    ExecIDs:
+    - 09b5dc8e88df78d954a04edbbfe509aa3a8873b17c434360f0994b166eb661e6
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671-init/diff:/var/lib/docker/overlay2/d729bad126881ac666c1ce86fd53b9fbb89dd31a32982fbe52d7b0348d00a7a5/diff:/var/lib/docker/overlay2/6147c7e4ffcac3df8515c47b85fb28fa9cb14e2eda1ae99024a0ad2d4d2f2564/diff:/var/lib/docker/overlay2/e65a456f02dd73ccbf8fcf90ad6c9cd2d090f59a8419916c39c5e3d2f1f4633e/diff:/var/lib/docker/overlay2/0d37d43d45e3912548e3578ac61ec6ae557a5b096629ca286fc5b07999ccae31/diff:/var/lib/docker/overlay2/2c5d5d7ffd6855efcf3a7788c2a72f12de032ac3d00ffa437e32113ae5706b4d/diff:/var/lib/docker/overlay2/ef4edd4aa9d123bae52ac92f708fb15264ac3036df51240db0e17b7ae280a06d/diff
+        MergedDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/merged
+        UpperDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/diff
+        WorkDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/redis:/data:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/redis/ssl/:/data/ssl/:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/hostname
+    HostsPath: /etc/hosts
+    Id: 9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
+    Image: sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c
+    LogPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/redis
+      Type: bind
+    - Destination: /data/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis/ssl
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    Name: /redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: c124f14eba8e33d8dfbf7244d810451b50469d02c40f191ac28d6309b4c2fb20
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
+      Ports: {}
+      SandboxID: 12fa0db070f4558f5c022bb880897adb0e4a11662b3ec5143027e742a036611d
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:40.681971343Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 7054
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:55:50.844646575Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 5055
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 9600
+    protocol: tcp
+  discovery_time: '2022-07-05T09:45:46+02:00'
+  docker:
+    exposed_ports:
+      5044/tcp: {}
+      9600/tcp: {}
+    id: 1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
+    image: nexusregistry.opensolutions.cloud/logstash:7.4.2_iometrics-1
+    name: /logstash
+    network_mode: host
+    port_bindings: {}
+  listening_ports:
+  - 5055
+  - 9600
+  packages: []
+  process:
+    cmdline: /bin/java -Xms2048m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75
+      -XX:+UseCMSInitiatingOccupancyOnly -Djava.awt.headless=true -Dfile.encoding=UTF-8
+      -Djruby.compile.invokedynamic=true -Djruby.jit.threshold=0 -Djruby.regexp.interruptible=true
+      -Djava.security.egd=file:/dev/urandom -Dlog4j2.isThreadContextMapInheritable=true
+      -Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ -cp /usr/share/logstash/logstash-core/lib/jars/animal-sniffer-annotations-1.14.jar:/usr/share/logstash/logstash-core/lib/jars/commons-codec-1.11.jar:/usr/share/logstash/logstash-core/lib/jars/commons-compiler-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/error_prone_annotations-2.0.18.jar:/usr/share/logstash/logstash-core/lib/jars/google-java-format-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/gradle-license-report-0.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/guava-22.0.jar:/usr/share/logstash/logstash-core/lib/jars/j2objc-annotations-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-annotations-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-core-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-databind-2.9.9.3.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-dataformat-cbor-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/janino-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/javassist-3.24.0-GA.jar:/usr/share/logstash/logstash-core/lib/jars/jruby-complete-9.2.8.0.jar:/usr/share/logstash/logstash-core/lib/jars/jsr305-1.3.9.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-api-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-core-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-slf4j-impl-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/logstash-core.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.commands-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.contenttype-3.4.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.expressions-3.4.300.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.filesystem-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.jobs-3.5.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.resources-3.7.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.runtime-3.7.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.app-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.common-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.preferences-3.4.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.registry-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.jdt.core-3.10.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.osgi-3.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.text-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/reflections-0.9.11.jar:/usr/share/logstash/logstash-core/lib/jars/slf4j-api-1.7.25.jar
+      org.logstash.Logstash
+    cwd: /bin/
+    listening_ports:
+    - 5055
+    - 9600
     pid: '7056'
     ppid: '6923'
     user: centos
-  - cmdline: /usr/bin/docker start -a redis
-    pid: '7301'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a logstash
-    pid: '7302'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '7584'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7955'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '7971'
-    ppid: '1140'
-    user: root
-  - cmdline: 'sshd: centos@pts/2'
-    pid: '7973'
-    ppid: '7971'
-    user: centos
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1657007123
-    pid: '8083'
-    ppid: '1037'
-    user: root
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-utaajcbxxlcfngbglianirsgvhllmmtp ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007126.999418-41414-239517244210040/AnsiballZ_process_facts.py' && sleep 0
-    pid: '8177'
-    ppid: '7973'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-utaajcbxxlcfngbglianirsgvhllmmtp ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007126.999418-41414-239517244210040/AnsiballZ_process_facts.py
-    pid: '8192'
-    ppid: '8177'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-utaajcbxxlcfngbglianirsgvhllmmtp ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007126.999418-41414-239517244210040/AnsiballZ_process_facts.py
-    pid: '8193'
-    ppid: '8192'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007126.999418-41414-239517244210040/AnsiballZ_process_facts.py
-    pid: '8194'
-    ppid: '8193'
-    user: root
-  - cmdline: ''
-    pid: '19599'
-    ppid: '2'
-    user: root
-  - cmdline: bash
-    pid: '24140'
-    ppid: '6905'
-    user: root
-  - cmdline: ''
-    pid: '26607'
-    ppid: '2'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '28010'
-    ppid: '1042'
-    user: root
-  - cmdline: /bin/sh -c python ./listener.py
-    pid: '28025'
-    ppid: '28010'
-    user: root
-  - cmdline: python ./listener.py
-    pid: '28039'
-    ppid: '28025'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1346
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:54:56 2022
-    user: root
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 7054
-    port: 6378
-    protocol: tcp
-    stime: Tue Apr 26 15:55:48 2022
-    user: polkitd
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 7054
-    port: 6379
-    protocol: tcp
-    stime: Tue Apr 26 15:55:48 2022
-    user: polkitd
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:54:05 2022
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1140
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:54:48 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1346
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:54:56 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 7056
-    port: 5055
-    protocol: tcp
-    stime: Tue Apr 26 15:55:48 2022
-    user: centos
-  - address: '::'
-    name: java
-    pid: 7056
-    port: 9600
-    protocol: tcp
-    stime: Tue Apr 26 15:55:48 2022
-    user: centos
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:54:05 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1140
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:54:48 2022
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: Logstash
+  version:
+  - number: 7.4.2_iometrics-1
+    type: docker
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 976
-    port: 68
-    protocol: udp
-    stime: Tue Apr 26 15:54:43 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:54:05 2022
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 743
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:54:30 2022
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  keepalived:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 16.el7
+    source: rpm
+    version: 1.3.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-devel:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-devel
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsepol-devel:
+  - arch: x86_64
+    epoch: null
+    name: libsepol-devel
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mariadb-server:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-server
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 48.el7_8.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 48.el7_8.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcre-devel:
+  - arch: x86_64
+    epoch: null
+    name: pcre-devel
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Compress-Raw-Bzip2:
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
+  perl-Compress-Raw-Zlib:
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
+  perl-DBD-MySQL:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBD-MySQL
+    release: 6.el7
+    source: rpm
+    version: '4.023'
+  perl-DBI:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBI
+    release: 4.el7
+    source: rpm
+    version: '1.627'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-IO-Compress:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
+  perl-Net-Daemon:
+  - arch: noarch
+    epoch: null
+    name: perl-Net-Daemon
+    release: 5.el7
+    source: rpm
+    version: '0.48'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-PlRPC:
+  - arch: noarch
+    epoch: null
+    name: perl-PlRPC
+    release: 14.el7
+    source: rpm
+    version: '0.2020'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 720
-    port: 837
-    protocol: udp
-    stime: Tue Apr 26 15:54:29 2022
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  socat:
+  - arch: x86_64
+    epoch: null
+    name: socat
+    release: 2.el7
+    source: rpm
+    version: 1.7.3.2
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:54:05 2022
-    user: root
-  - address: ::1
-    name: chronyd
-    pid: 743
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:54:30 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 720
-    port: 837
-    protocol: udp
-    stime: Tue Apr 26 15:54:29 2022
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '40'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '93'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '301'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '306'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '377'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '393'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '477'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '541'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '673'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '704'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '720'
+  ppid: '1'
+  user: rpc
+- cmdline: ''
+  cwd: /
+  pid: '721'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '724'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '731'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '743'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '747'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H indexer01 eth0
+  cwd: /sbin/
+  pid: '976'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1037'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1038'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1042'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1128'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1136'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1140'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1152'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1153'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '1290'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '1291'
+  ppid: '1290'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '1292'
+  ppid: '1290'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1346'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1348'
+  ppid: '1346'
+  user: postfix
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '5992'
+  ppid: '1346'
+  user: postfix
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '6355'
+  ppid: '1140'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '6357'
+  ppid: '6355'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '6358'
+  ppid: '6357'
+  user: centos
+- cmdline: sudo su -
+  cwd: /
+  pid: '6377'
+  ppid: '6358'
+  user: root
+- cmdline: su -
+  cwd: /
+  pid: '6378'
+  ppid: '6377'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '6379'
+  ppid: '6378'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '6498'
+  ppid: '1140'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '6500'
+  ppid: '6498'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '6501'
+  ppid: '6500'
+  user: centos
+- cmdline: sudo su
+  cwd: /
+  pid: '6520'
+  ppid: '6501'
+  user: root
+- cmdline: su
+  cwd: /
+  pid: '6521'
+  ppid: '6520'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '6522'
+  ppid: '6521'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6605'
+  ppid: '2'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '6905'
+  ppid: '1042'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '6923'
+  ppid: '1042'
+  user: root
+- cmdline: redis-server 0.0.0.0:6379
+  cwd: /
+  pid: '7054'
+  ppid: '6905'
+  user: polkitd
+- cmdline: /bin/java -Xms2048m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75
+    -XX:+UseCMSInitiatingOccupancyOnly -Djava.awt.headless=true -Dfile.encoding=UTF-8
+    -Djruby.compile.invokedynamic=true -Djruby.jit.threshold=0 -Djruby.regexp.interruptible=true
+    -Djava.security.egd=file:/dev/urandom -Dlog4j2.isThreadContextMapInheritable=true
+    -Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ -cp /usr/share/logstash/logstash-core/lib/jars/animal-sniffer-annotations-1.14.jar:/usr/share/logstash/logstash-core/lib/jars/commons-codec-1.11.jar:/usr/share/logstash/logstash-core/lib/jars/commons-compiler-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/error_prone_annotations-2.0.18.jar:/usr/share/logstash/logstash-core/lib/jars/google-java-format-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/gradle-license-report-0.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/guava-22.0.jar:/usr/share/logstash/logstash-core/lib/jars/j2objc-annotations-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-annotations-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-core-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-databind-2.9.9.3.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-dataformat-cbor-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/janino-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/javassist-3.24.0-GA.jar:/usr/share/logstash/logstash-core/lib/jars/jruby-complete-9.2.8.0.jar:/usr/share/logstash/logstash-core/lib/jars/jsr305-1.3.9.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-api-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-core-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-slf4j-impl-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/logstash-core.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.commands-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.contenttype-3.4.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.expressions-3.4.300.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.filesystem-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.jobs-3.5.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.resources-3.7.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.runtime-3.7.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.app-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.common-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.preferences-3.4.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.registry-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.jdt.core-3.10.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.osgi-3.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.text-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/reflections-0.9.11.jar:/usr/share/logstash/logstash-core/lib/jars/slf4j-api-1.7.25.jar
+    org.logstash.Logstash
+  cwd: /bin/
+  pid: '7056'
+  ppid: '6923'
+  user: centos
+- cmdline: /usr/bin/docker start -a redis
+  cwd: /usr/bin/
+  pid: '7301'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a logstash
+  cwd: /usr/bin/
+  pid: '7302'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7584'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7955'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '7971'
+  ppid: '1140'
+  user: root
+- cmdline: 'sshd: centos@pts/2'
+  cwd: /
+  pid: '7973'
+  ppid: '7971'
+  user: centos
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1657007123
+  cwd: /usr/lib64/sa/
+  pid: '8083'
+  ppid: '1037'
+  user: root
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-utaajcbxxlcfngbglianirsgvhllmmtp
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007126.999418-41414-239517244210040/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '8177'
+  ppid: '7973'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-utaajcbxxlcfngbglianirsgvhllmmtp
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007126.999418-41414-239517244210040/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '8192'
+  ppid: '8177'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-utaajcbxxlcfngbglianirsgvhllmmtp ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1657007126.999418-41414-239517244210040/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '8193'
+  ppid: '8192'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007126.999418-41414-239517244210040/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '8194'
+  ppid: '8193'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19599'
+  ppid: '2'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '24140'
+  ppid: '6905'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26607'
+  ppid: '2'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '28010'
+  ppid: '1042'
+  user: root
+- cmdline: /bin/sh -c python ./listener.py
+  cwd: /bin/
+  pid: '28025'
+  ppid: '28010'
+  user: root
+- cmdline: python ./listener.py
+  cwd: /
+  pid: '28039'
+  ppid: '28025'
+  user: root
+software_list:
+- cmd_regexp: org\.logstash\.Logstash
+  name: Logstash
+  pkg_regexp: logstash
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1346
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:54:56 2022
+  user: root
+- address: 0.0.0.0
+  name: redis-server
+  pid: 7054
+  port: 6378
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: polkitd
+- address: 0.0.0.0
+  name: redis-server
+  pid: 7054
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: polkitd
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1140
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:54:48 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1346
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:54:56 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 7056
+  port: 5055
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: centos
+- address: '::'
+  name: java
+  pid: 7056
+  port: 9600
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: centos
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1140
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:54:48 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 976
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:54:43 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 743
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:30 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 720
+  port: 837
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 743
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:30 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 720
+  port: 837
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/mariadb/mariadb10.5_centos7.yaml
+++ b/tests/unit/plugins/action/auto/resources/mariadb/mariadb10.5_centos7.yaml
@@ -1,250 +1,1320 @@
-task_vars:
-  mariadb_monitor_users_info:
-    - username: user_a
-      password: password_a
-    - username: user_b
-      password: password_b
-  ansible_facts:
-    all_ipv4_addresses:
-      - 192.168.1.1
-      - 192.168.64.34
-
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - /usr/local/bin/docker-entrypoint.sh
+    - catalina.sh
+    - run
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - catalina.sh
+      - run
+      Domainname: ''
+      Entrypoint:
+      - /bin/sh
+      - -c
+      - /usr/local/bin/docker-entrypoint.sh
+      Env:
+      - LANG=C.UTF-8
+      - CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
+      - POSTGRES_PORT=5432
+      - CMDBUILD_DUMP=empty.dump.xz
+      - POSTGRES_HOST=192.168.64.34
+      - POSTGRES_PASS=the_password
+      - JAVA_OPTS=-Xmx7876m -Xms3846m
+      - POSTGRES_DB=cmdbuild_r2u2
+      - PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - TZ=Europe/Madrid
+      - POSTGRES_APP_USER=datadope
+      - POSTGRES_APP_PASSWORD=the_password
+      - POSTGRES_USER=datadope
+      - JAVA_HOME=/usr/local/openjdk-17
+      - JAVA_VERSION=17.0.2
+      - CATALINA_HOME=/usr/local/tomcat
+      - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
+      - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
+      - GPG_KEYS=48F8E69F6390C9F25CFEDCD268248959359E722B A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
+        DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
+      - TOMCAT_MAJOR=9
+      - TOMCAT_VERSION=9.0.60
+      - TOMCAT_SHA512=a4d43ac45f76e29d3dea23a2712c7570a11419aad7a1af2d1533454709c020b59666c7f9e063a77120224e0cbd4020cac06ca596dda7057cacb9a8a7e6d73eea
+      - APM_JAR_URL=https://nexus.opensolutions.cloud/repository/datadope-public/elastic-apm/elastic-apm-agent-1.28.1.jar
+      ExposedPorts:
+        8080/tcp: {}
+        8443/tcp: {}
+      Hostname: localhost
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.5.3
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: tomcat
+      Volumes: null
+      WorkingDir: /usr/local/tomcat
+    Created: '2022-03-25T12:04:52.930305974Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794-init/diff:/var/lib/docker/overlay2/0ca2f0e4b67ae95aef370146269b3fb10e55a6859d278f2997e8b84ff9122875/diff:/var/lib/docker/overlay2/308c2efd326216c0efe94e857b82520af6ab116a978811106d99e49ddf15fc1b/diff:/var/lib/docker/overlay2/c0610b1db247b6b1804c3b992e3f89f1ff75375a3b9c395de68e7dd6f0c5af41/diff:/var/lib/docker/overlay2/b49fa08f0f5246651d4fc001af50b8fc4f316d3add326329766d389a5b8597e1/diff:/var/lib/docker/overlay2/30067671d40d8ef3df665781083700fdb08887c64131c247ff8210714dd2d7a8/diff:/var/lib/docker/overlay2/acec1c4357e89e939adefb7160deb62f2e3dd2fb8e2b89c50a84d7e807b27220/diff:/var/lib/docker/overlay2/348d6cd50875127305d1c94e3d700856d51fc4a33a7c735163a54451c6fc3791/diff:/var/lib/docker/overlay2/b2dbb49865766b5568101566c79fdb955744097af5e48de46fc508b6de374d4a/diff:/var/lib/docker/overlay2/679f2167259fbc9d27c7bc3b9c872e59655afc90478754d2774935f005c62a2d/diff:/var/lib/docker/overlay2/1e770257e07955a14878870e1146a4954ff84e3a9a13f439b617d5a93316369b/diff:/var/lib/docker/overlay2/f4ddf2e6b8e7240af6c8026059475c51e762150436d2e78369347e31154144af/diff:/var/lib/docker/overlay2/10a54c98f41b6862c3ffb03a07cc1b23d517b5fce34238706646aa8949467afb/diff:/var/lib/docker/overlay2/f8c4e742a18bbeeaff6a7f3e99d59e12186868fbd68718b9adf44213e51fe1fc/diff:/var/lib/docker/overlay2/eaeac3feaa55318680b5311656bb14d685c03b356403ea6109fa7b1f16e63189/diff:/var/lib/docker/overlay2/5179e1277d7830285af10f6cd4bd09708b36dfe341288a6dcd68c7896718bb75/diff:/var/lib/docker/overlay2/8562f678e444a225812e39cdf950838f4ee626f1264ce3eac883dcc27bb165d2/diff:/var/lib/docker/overlay2/0f25f2ae977f5674027aac8cdd9cf2e07456a422fb88425fde7d3026f1f8ecdc/diff:/var/lib/docker/overlay2/997ff03392129602e78b3f0e6b5879ec656d11d8c3fa536f5577b0e540b40173/diff:/var/lib/docker/overlay2/994f47ca80b9c00cfabf4d1dcff4992f6b0c1647d89589dd5f31fdaa1bf6340f/diff:/var/lib/docker/overlay2/359f2d072fad20815db5e37ab4284e6c3376233db3163033fe04ba8b1153b443/diff:/var/lib/docker/overlay2/8a3f7b2f222926cdf88d12cd34fed89094bd049498fc78b1ddf625ce837f3760/diff:/var/lib/docker/overlay2/6daf829f7b4e94d9cba1f56aeab10d06a317241ee7aa01217ef88d2676fefce8/diff
+        MergedDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/merged
+        UpperDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/diff
+        WorkDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:ro
+      - /etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw
+      - /var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: []
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: []
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: bridge
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/hostname
+    HostsPath: /etc/hosts
+    Id: 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
+    Image: sha256:eb3e461a2b2785cb353346a408a9e43b7f0fb86bb8a9a592ada57ca4c52e3bfd
+    LogPath: /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /usr/local/tomcat/certs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics-cmdbuild/certs
+      Type: bind
+    - Destination: /usr/local/tomcat/logs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/iometrics-cmdbuild
+      Type: bind
+    Name: /iometrics-cmdbuild
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 5fb50fd979f12f7678c60474664f0350d32f6ff6dff61fa277c8aaeae6a7a93b
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 5fb50fd979f12f7678c60474664f0350d32f6ff6dff61fa277c8aaeae6a7a93b
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: e245cfe31a9637868b704e96aa6cbd268c001dc02bc3d706b7a2abb2276532ff
+      Ports:
+        8080/tcp: null
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      SandboxID: 24da94b8470d1a3e540d42a9b4e730e406e95e18f0a15f8aaf95405b113062b8
+      SandboxKey: /var/run/docker/netns/24da94b8470d
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-06-22T07:28:04.254622989Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 90702
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-22T08:01:19.112762511Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - ./start_cmdb_gateway.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - ./start_cmdb_gateway.sh
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.5
+      - CMDB_GATEWAY_CONFIG_FILE=config/cmdb_gateway.yaml
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - PYTHON_PIP_VERSION=20.2.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
+      - PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      Hostname: oss-devel-cmdb
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-gateway:0.18.0
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: /app
+    Created: '2021-12-16T13:40:54.11945545Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9-init/diff:/var/lib/docker/overlay2/f28f032f19b8e36176d7f5c3c3280960a1f0b2d030b1461fde6f85608b268fb7/diff:/var/lib/docker/overlay2/c812399fd0157a9db6cd588828f224d26a076ebaa05397d46399616d7491559b/diff:/var/lib/docker/overlay2/04dc77fa805a06bb44c58399ae78a7ab110bc9d714c346b0df5a7e5b349ae16c/diff:/var/lib/docker/overlay2/4c9d61501d1130eeaea40e3c6e8c58e3790995f474c04c2bb10c904a71431edb/diff:/var/lib/docker/overlay2/4993b8fafd5a9d9a6023eaf5d25fe51a2fabcb3dbee5ea7549ec9420497d57e5/diff:/var/lib/docker/overlay2/d6460864d519c5967a63083553d16607e9e209a7eab0d4c098a649aaa0cdf0f2/diff:/var/lib/docker/overlay2/70210d890e6f91fbea58cad88a3fce3e126382bc7b33645fc961fdb8faa8542f/diff:/var/lib/docker/overlay2/ca78aa40f8918ea045999b7270f6fd9704cb0cdb7540c93b5b2608c336057ab5/diff:/var/lib/docker/overlay2/a6183d5cdfd1c5842b63dc840de2a5ef55eb86dcd92872076825f6ae35fa240a/diff:/var/lib/docker/overlay2/b46ed7aa9054a838c1438c581e9d770be0a97cf687a962a532c5096af8f4714b/diff:/var/lib/docker/overlay2/46919684c7f455b8be1662fbc502637c471f5ea2fe53e4ea3edceadc8a28b14f/diff:/var/lib/docker/overlay2/764a651bc4126949119711643715095b4394c88d62b64f6c83a1720378145f0b/diff:/var/lib/docker/overlay2/9f37cd3fc4a2444f9ab442262e3f41cc348cee444f14100f61a487031cfe07f5/diff:/var/lib/docker/overlay2/47b0f955a1643f1d46055c3aeaa3a2ffdd59ccb1f5f14e89dcf603db8463b81b/diff:/var/lib/docker/overlay2/f3aa2fa503c8e7277a423cd85d1d8bdfd147fc867f5fab859a097188e0e6d004/diff
+        MergedDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/merged
+        UpperDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/diff
+        WorkDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/cmdb/config:/app/config:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: []
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: []
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: 'no'
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hostname
+    HostsPath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hosts
+    Id: da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
+    Image: sha256:af61c42a1772b373dbc30a6d3650af40d4e738a5d22959eccea5974946ada9fa
+    LogPath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/config
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/cmdb/config
+      Type: bind
+    Name: /iometrics-cmdb-gateway
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: b446b6007219a43a41e3772800df3501150674e500d3c82c5d55b0dbf0d2be45
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: 3ab9d1ec83de2a55dabf1c37436f60f360076bce9b6441e2ec7e5e283cb4c847
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-06-22T07:28:01.32208543Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 88553
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-22T07:28:01.764292527Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - python ./listener.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - python ./listener.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.5
+      - PYTHON_PIP_VERSION=20.2.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
+      - PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
+      Hostname: oss-devel-cmdb
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.0.1
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /config: {}
+      WorkingDir: ''
+    Created: '2021-05-25T10:08:10.097442624Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41-init/diff:/var/lib/docker/overlay2/ba78f066d9e46b0f7b41380a42ef0a747aa591e78992e40447ca78b8528de8ed/diff:/var/lib/docker/overlay2/3b784c7b5c126900be4badb31068a06fbfdfe15a2f15049ed151fb2a5a370659/diff:/var/lib/docker/overlay2/c6b744055dfca315c6446e3723460947b34efd1d75325b2caae502367afa3c2e/diff:/var/lib/docker/overlay2/a1a2492e64ab4e7a012e36e61ceabaf1d80bed24e72c2ae69d7172e35a3831de/diff:/var/lib/docker/overlay2/39a5edc9ab57849080990571d9a3f410b66a3bb04f12ca966d3f4a64e0cbbd8a/diff:/var/lib/docker/overlay2/0780a973dbea66c8f367c507554356a5d27303cd0a1d8b5396e7b0aa392b6149/diff:/var/lib/docker/overlay2/e1f23af492edda46763c05b32bcfe283f83fdd27460a55cf1a5dcf437a0e0ae7/diff:/var/lib/docker/overlay2/9f8debce0febecd5e1c4e50351a37d422b1b60f3826ddfd9dadc1961fe3e007f/diff
+        MergedDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/merged
+        UpperDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/diff
+        WorkDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/redis-cleaner:/config:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hostname
+    HostsPath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hosts
+    Id: 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
+    Image: sha256:70c1ea6bb3f2e939311b21e6b49cd3cce10ffb2e21e8b5b431bd293421ca8472
+    LogPath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /config
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis-cleaner
+      Type: bind
+    Name: /iometrics-cmdb-redis-cleaner
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ed464b6f49997d37e646e04846527f61c970de6c91c3deb620c2c3c80fca0b96
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: 72ed345048dcc6240fabf7e33835c2a4fd99d59e7fa0972a4685872da6303113
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 34206
+      Restarting: false
+      Running: true
+      StartedAt: '2021-05-25T10:08:10.240751099Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --tls-port
+    - '6378'
+    - --appendonly
+    - 'no'
+    - --maxmemory
+    - '0'
+    - --maxclients
+    - '10000'
+    - --bind
+    - 0.0.0.0
+    - --requirepass
+    - the_password
+    - --tls-auth-clients
+    - 'no'
+    - --tls-cert-file
+    - /data/ssl/redis.crt
+    - --tls-key-file
+    - /data/ssl/redis.pem
+    - --tls-ca-cert-file
+    - /data/ssl/redis_ca.crt
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - --tls-port
+      - '6378'
+      - --appendonly
+      - 'no'
+      - --maxmemory
+      - '0'
+      - --maxclients
+      - '10000'
+      - --bind
+      - 0.0.0.0
+      - --requirepass
+      - the_password
+      - --tls-auth-clients
+      - 'no'
+      - --tls-cert-file
+      - /data/ssl/redis.crt
+      - --tls-key-file
+      - /data/ssl/redis.pem
+      - --tls-ca-cert-file
+      - /data/ssl/redis_ca.crt
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.0.1
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
+      - REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: oss-devel-cmdb
+      Image: redis:6.0.1
+      Labels:
+        os_contianer_type: redis
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+        /data/ssl/: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+      WorkingDir: /data
+    Created: '2021-05-25T09:00:32.257009145Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce-init/diff:/var/lib/docker/overlay2/895c1f99a736e2df91bfc2a00c7551e51fd433dde75de2279435ff47ea0e6b38/diff:/var/lib/docker/overlay2/a9841cfec194609a7ec73913c03ba7d4155bc5334e801da50362b4a928a3fe93/diff:/var/lib/docker/overlay2/d9cb4756a3d19486043c08cf2b9492aca7b6664e4914a64c4ae7d649510fb8fb/diff:/var/lib/docker/overlay2/348fb45e5b21b874e1972d7abf6267aedb49052fe240ff1ca65c31d01f0cd49e/diff:/var/lib/docker/overlay2/1f6d3088e9933dfa837efd70762bf9724143691931203267ec5ff24aa5dfe170/diff:/var/lib/docker/overlay2/c96ac52a498ef5b1c8f81d0d7ee4cb762e570fee584f3b41148aceca3a8664b5/diff
+        MergedDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/merged
+        UpperDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/diff
+        WorkDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/redis:/data:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/redis/ssl/:/data/ssl/:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/hostname
+    HostsPath: /etc/hosts
+    Id: b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
+    Image: sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c
+    LogPath: /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/redis
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /data/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis/ssl
+      Type: bind
+    Name: /redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: beb2a749121a2b11fd9bc6093b92eb8fd64c1abf38a38f39261bc633429fc566
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: 6b4a27d90042eb73469fe2c90437f604c16aade938163e14d93d88892703a15f
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 20064
+      Restarting: false
+      Running: true
+      StartedAt: '2021-05-25T09:00:32.529069205Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: oss-devel-cmdb
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2021-05-24T14:27:58.280498639Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098-init/diff:/var/lib/docker/overlay2/572d19da46f80f29256ff94ed86f500ede7764af796338b02e10f781d4387407/diff:/var/lib/docker/overlay2/16e7f7bacf68db89a426b0b90b68188ce3387cd01bad762550e49c926b5879d8/diff:/var/lib/docker/overlay2/26ea1b9023be5dfd133dd9e015e47da4265ab65445bb17899fcc275604d3754d/diff
+        MergedDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/merged
+        UpperDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/diff
+        WorkDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/hostname
+    HostsPath: /etc/hosts
+    Id: df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 29d2d1ebe738bc2b3d44373cd6019b50940e82931b720cfd949e7c08c8a110ea
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: c2fdaac80977cad0b65bf2e24939c5a22c6ad249d8db4aab83f390a0bb1305d6
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2021-05-24T14:56:41.686346314Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 23339
+      Restarting: false
+      Running: true
+      StartedAt: '2021-06-01T15:04:41.797753434Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 3306
+    protocol: tcp
+  - address: 127.0.0.1
+    class: service
+  discovery_time: '2022-06-24T12:09:03+02:00'
+  extra_data:
+    databases:
+    - mm360_v2
+    - mm360_v3
+    - mm360_v4
+    - mm360_v5
+    - mm360_v5b
+    - mm360_v6
+    - mm360_v6b
+    - mm360_v7
+    - mm360_v8
+    - mm360_v9
+    gather_slave: false
+  files:
+  - name: my.cnf
+    path: /etc
+    subtype: generic
+    type: config
+  - path: /usr/sbin/mariadbd
+    subtype: generic
+    type: binary
+  - path: /usr/bin/mariadb
+    subtype: client
+    type: binary
+  listening_ports:
+  - 3306
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-server
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
+  process:
+    cmdline: /usr/sbin/mariadbd
+    cwd: /usr/sbin/
+    listening_ports:
+    - 3306
+    pid: '73979'
+    ppid: '1'
+    user: mysql
+  type: MariaDB DatabaseServer
+  version:
+  - number: 10.5.10
+    type: active
+  - number: 10.5.10
+    type: package
 mocked_plugin_tasks:
-  Read process environment:
-      expected_args:
-        pid: "73979"
-      execute_module_result:
-        failed: false
-        encoding: plain
-        content: "
-          LANG=es_ES.UTF-8\0\
-          PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin\0\
-          _WSREP_START_POSITION=\0\
-          NOTIFY_SOCKET=/run/systemd/notify\0\
-          HOME=/var/lib/mysql\0\
-          LOGNAME=mysql\0\
-          USER=mysql\0\
-          SHELL=/sbin/nologin\0\
-        "
-  Port from cmdline:
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Data dir from cmdline:
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Bind address from cmdline:
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Defaults file from cmdline:
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
   Bin file from cmdline:
     expected_args:
       _bin_file: /usr/sbin/mariadbd
-
-  Socket from cmdline:
+  Bind address from cmdline:
     expected_exception:
-      message: "'NoneType' object is not iterable"
-
+      message: '''NoneType'' object is not iterable'
   Calculate bin file if not available:
     fail: Should not be called
-#  Execute which for server:
-#    expected_args:
-#      name: mariadbd
-#      paths:
-#        - /usr/local/sbin
-#        - /usr/local/bin
-#        - /usr/sbin
-#        - /usr/bin
-#    plugin_result:
-#      failed: false
-#      file:
-#        path: /usr/sbin/mariadbd
-
+  Data dir from cmdline:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Defaults file from cmdline:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Execute command to get version:
+    expected_args:
+      argv:
+      - /usr/sbin/mariadbd
+      - -V
+      cmd: null
+      in_docker: true
+    expected_attributes:
+      environment:
+        HOME: /var/lib/mysql
+        LANG: es_ES.UTF-8
+        LOGNAME: mysql
+        NOTIFY_SOCKET: /run/systemd/notify
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+        SHELL: /sbin/nologin
+        USER: mysql
+        _WSREP_START_POSITION: ''
+      register: result
+    plugin_result:
+      failed: false
+      stdout: mysqld  Ver 10.5.10-MariaDB for Linux on x86_64 (MariaDB Server)
   Execute which for client:
     expected_args:
-      name: mariadb
-      paths:
-        - /usr/local/sbin
-        - /usr/local/bin
-        - /usr/sbin
-        - /usr/bin
       hidden: false
       in_docker: true
+      name: mariadb
+      paths:
+      - /usr/local/sbin
+      - /usr/local/bin
+      - /usr/sbin
+      - /usr/bin
       windows_valid_extensions: null
     plugin_result:
       failed: false
       file:
         path: /usr/bin/mariadb
-
-  Execute command to get version:
-    expected_args:
-      argv:
-        - /usr/sbin/mariadbd
-        - -V
-      cmd: null
-      in_docker: true
-    expected_attributes:
-      register: result
-      environment:
-        LANG: es_ES.UTF-8
-        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-        _WSREP_START_POSITION: ''
-        NOTIFY_SOCKET: /run/systemd/notify
-        HOME: /var/lib/mysql
-        LOGNAME: mysql
-        USER: mysql
-        SHELL: /sbin/nologin
-    plugin_result:
-      failed: false
-      stdout: "mysqld  Ver 10.5.10-MariaDB for Linux on x86_64 (MariaDB Server)"
-
-  Run command to get databases:
-    calls:
-      - expected_args:
-          cmd: "/usr/bin/mariadb -P 3306 -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb -P 3306 --user=user_a -ppassword_a -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb -P 3306 --user=user_b -ppassword_b -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-
-  Run command to get slave status:
-    fail: should not be called
-
-  Run command to get databases with IPs:
-    calls:
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=192.168.1.1 -P 3306 -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=192.168.64.34 -P 3306 -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=127.0.0.1 -P 3306 -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=192.168.1.1 -P 3306 --user=user_a -ppassword_a -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=192.168.64.34 -P 3306 --user=user_a -ppassword_a -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=127.0.0.1 -P 3306 --user=user_a -ppassword_a -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=192.168.1.1 -P 3306 --user=user_b -ppassword_b -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=192.168.64.34 -P 3306 --user=user_b -ppassword_b -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: true
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=127.0.0.1 -P 3306 --user=user_b -ppassword_b -N -s -e 'show databases'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - information_schema
-            - mm360_v2
-            - mm360_v3
-            - mm360_v4
-            - mm360_v5
-            - mm360_v5b
-            - mm360_v6
-            - mm360_v6b
-            - mm360_v7
-            - mm360_v8
-            - mm360_v9
-            - mysql
-            - performance_schema
-            - test
-
-  Run command to get slave status with IPs:
-    calls:
-      - expected_args:
-          cmd: "/usr/bin/mariadb --host=127.0.0.1 -P 3306 --user=user_b -ppassword_b -N -s -e 'show slave status'"
-          in_docker: true
-          argv: null
-        plugin_result:
-          failed: false
-          stdout: ""
-
   Find dirs:
     failed: should not be called
-#    expected_args:
-#      ansible.builtin.find:
-#        paths: /var/lib/mysql
-#        recurse: no
-#        file_type: directory
-#        excludes:
-#          - information_schema
-#          - mysql
-#          - test
-#          - performance_schema
-#    plugin_result:
-#      failed: false
-#      files:
-#        - path: /var/lib/mysql/mm360_v2
-#        - path: /var/lib/mysql/mm360_v3
-#        - path: /var/lib/mysql/mm360_v4
-#        - path: /var/lib/mysql/mm360_v5
-#        - path: /var/lib/mysql/mm360_v5b
-#        - path: /var/lib/mysql/mm360_v6
-#        - path: /var/lib/mysql/mm360_v6b
-#        - path: /var/lib/mysql/mm360_v7
-#        - path: /var/lib/mysql/mm360_v8
-#        - path: /var/lib/mysql/mm360_v9
-
-expected_result:
-  - bindings:
-      - address: '::'
-        class: 'service'
-        port: 3306
-        protocol: 'tcp'
-      - address: 127.0.0.1
-        class: service
-    extra_data:
-      databases:
+  Port from cmdline:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Read process environment:
+    execute_module_result:
+      content: " LANG=es_ES.UTF-8\0PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin\0\
+        _WSREP_START_POSITION=\0NOTIFY_SOCKET=/run/systemd/notify\0HOME=/var/lib/mysql\0\
+        LOGNAME=mysql\0USER=mysql\0SHELL=/sbin/nologin\0"
+      encoding: plain
+      failed: false
+    expected_args:
+      pid: '73979'
+  Run command to get databases:
+    calls:
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb -P 3306 -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb -P 3306 --user=user_a -ppassword_a -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb -P 3306 --user=user_b -ppassword_b -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+  Run command to get databases with IPs:
+    calls:
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=192.168.1.1 -P 3306 -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=192.168.64.34 -P 3306 -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=127.0.0.1 -P 3306 -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=192.168.1.1 -P 3306 --user=user_a -ppassword_a
+          -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=192.168.64.34 -P 3306 --user=user_a -ppassword_a
+          -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=127.0.0.1 -P 3306 --user=user_a -ppassword_a
+          -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=192.168.1.1 -P 3306 --user=user_b -ppassword_b
+          -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=192.168.64.34 -P 3306 --user=user_b -ppassword_b
+          -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=127.0.0.1 -P 3306 --user=user_b -ppassword_b
+          -N -s -e 'show databases'
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - information_schema
         - mm360_v2
         - mm360_v3
         - mm360_v4
@@ -255,6573 +1325,5663 @@ expected_result:
         - mm360_v7
         - mm360_v8
         - mm360_v9
-      gather_slave: false
-    files:
-      - name: my.cnf
-        path: /etc
-        subtype: generic
-        type: config
-      - path: /usr/sbin/mariadbd
-        subtype: generic
-        type: binary
-      - path: /usr/bin/mariadb
-        subtype: client
-        type: binary
-    discovery_time: '2022-06-24T12:09:03+02:00'
-    listening_ports:
-      - 3306
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: MariaDB-server
-        release: 1.el7.centos
-        source: rpm
-        version: 10.5.10
-    process:
-      cmdline: /usr/sbin/mariadbd
-      listening_ports:
-        - 3306
-      pid: '73979'
-      ppid: '1'
-      user: mysql
-    type: MariaDB DatabaseServer
-    version:
-      - number: 10.5.10
-        type: active
-      - number: 10.5.10
-        type: package
-
-software_list:
-  - name: MariaDB DatabaseServer
-    cmd_regexp: '/mariadbd(\s|$)'
-    pkg_regexp: 'mariadb-serve'
-    process_type: parent
-    return_children: false
-    return_packages: true
-    vars:
-      ignore_databases:
-        - information_schema
         - mysql
-        - test
         - performance_schema
-      connect_with_users: "{{ mariadb_monitor_users_info 
-        | default(mysql_monitor_users_info 
-          | default([{'username': mariadb_monitor_user | default(mysql_monitor_user | default('mysql')), 
-                    'password': mariadb_monitor_pass | default(mysql_monitor_pass | default('mysql'))}])) }}"
-    custom_tasks:
-      - name: Include MariaDB specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/mysql_mariadb.yaml"
-        vars:
-          default_server_file: mariadbd
-          default_client_file: mariadb
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '50'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '54'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '55'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '65'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '66'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '78'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '81'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '83'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '98'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '136'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '283'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '298'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '299'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '302'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '305'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '306'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '308'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '309'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '310'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '311'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '312'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '313'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '315'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '316'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '318'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '319'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '321'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '322'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '324'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '325'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '326'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '327'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '328'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '329'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '330'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '331'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '332'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '333'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '334'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '335'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '347'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '348'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '349'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '350'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '351'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '352'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '353'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '354'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '355'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '356'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '357'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '358'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '359'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '360'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '361'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '362'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '363'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '364'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '405'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '406'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '420'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '427'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '428'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '429'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '430'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '431'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '432'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '433'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '434'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '435'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '436'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '437'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '438'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '518'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '552'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '607'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '608'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '611'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '612'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '613'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '614'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '615'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '623'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '682'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/VGAuthService -s
-    pid: '705'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/vmtoolsd
-    pid: '706'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '708'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '710'
-    ppid: '1'
-    user: polkitd
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '713'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/sbin/chronyd
-    pid: '719'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/NetworkManager --no-daemon
-    pid: '732'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '734'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '738'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '813'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f
-    pid: '999'
-    ppid: '1'
-    user: nrpe
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1002'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1004'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1005'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1186'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1207'
-    ppid: '1186'
-    user: postfix
-  - cmdline: ''
-    pid: '1467'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1489'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1498'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1521'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '2185'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '3002'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '18532'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d -address
-      /run/containerd/containerd.sock
-    pid: '20044'
-    ppid: '1'
-    user: root
-  - cmdline: 'redis-server 0.0.0.0:6379'
-    pid: '20064'
-    ppid: '20044'
-    user: polkitd
-  - cmdline: /usr/bin/docker start -a redis
-    pid: '20366'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb -address
-      /run/containerd/containerd.sock
-    pid: '23319'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '23339'
-    ppid: '23319'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '23356'
-    ppid: '23339'
-    user: '101'
-  - cmdline: /usr/bin/docker start -a nginx
-    pid: '23581'
-    ppid: '1'
-    user: root
-  - cmdline: SCREEN
-    pid: '24403'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/bash
-    pid: '24404'
-    ppid: '24403'
-    user: root
-  - cmdline: sudo -u postgres psql
-    pid: '28523'
-    ppid: '24404'
-    user: root
-  - cmdline: psql
-    pid: '28524'
-    ppid: '28523'
-    user: postgres
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00 -address
-      /run/containerd/containerd.sock
-    pid: '34186'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh -c python ./listener.py
-    pid: '34206'
-    ppid: '34186'
-    user: root
-  - cmdline: python ./listener.py
-    pid: '34220'
-    ppid: '34206'
-    user: root
-  - cmdline: ''
-    pid: '36887'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44629'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46732'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46733'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '46865'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/rpcbind -w
-    pid: '47374'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '47383'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '47397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47398'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/rpc.statd
-    pid: '47406'
-    ppid: '1'
-    user: rpcuser
-  - cmdline: /usr/sbin/rpc.idmapd
-    pid: '47408'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rpc.mountd
-    pid: '47410'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '47415'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47416'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47421'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47422'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47423'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47424'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47425'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47426'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47427'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47428'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52062'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '54568'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '55619'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56141'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56568'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59036'
-    ppid: '2'
-    user: root
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '60677'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '61265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61266'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61267'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61271'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '67217'
-    ppid: '2'
-    user: root
-  - cmdline: /opt/fireeye/bin/xagt -M DAEMON
-    pid: '69963'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT
-      --logfd 4
-    pid: '69987'
-    ppid: '69963'
-    user: root
-  - cmdline: ''
-    pid: '71100'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: root@pts/0'
-    pid: '71236'
-    ppid: '1005'
-    user: root
-  - cmdline: '-bash'
-    pid: '71238'
-    ppid: '71236'
-    user: root
-  - cmdline: /usr/sbin/mariadbd
-    pid: '73979'
-    ppid: '1'
-    user: mysql
-  - cmdline: ''
-    pid: '78889'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '88081'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-cmdb-gateway
-    pid: '88490'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42 -address
-      /run/containerd/containerd.sock
-    pid: '88533'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh -c ./start_cmdb_gateway.sh
-    pid: '88553'
-    ppid: '88533'
-    user: root
-  - cmdline: /bin/sh ./start_cmdb_gateway.sh
-    pid: '88569'
-    ppid: '88553'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '88571'
-    ppid: '88569'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '88575'
-    ppid: '88571'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '88576'
-    ppid: '88571'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '88577'
-    ppid: '88571'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '88578'
-    ppid: '88571'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '88579'
-    ppid: '88571'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '88580'
-    ppid: '88571'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '88581'
-    ppid: '88571'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '88582'
-    ppid: '88571'
-    user: root
-  - cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
-    pid: '88651'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: data: checkpointer process'
-    pid: '88655'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: writer process'
-    pid: '88656'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: wal writer process'
-    pid: '88657'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: autovacuum launcher process'
-    pid: '88658'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: stats collector process'
-    pid: '88659'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: bgworker: logical replication launcher'
-    pid: '88660'
-    ppid: '88651'
-    user: postgres
-  - cmdline: ''
-    pid: '90282'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '90400'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-cmdbuild
-    pid: '90640'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443
-      -container-ip 192.168.1.2 -container-port 8443
-    pid: '90666'
-    ppid: '60677'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187 -address
-      /run/containerd/containerd.sock
-    pid: '90683'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
-    pid: '90702'
-    ppid: '90683'
-    user: tomcat
-  - cmdline: >-
-      /usr/local/openjdk-17/bin/java
-      -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      -Xmx7876m -Xms3846m -Djdk.tls.ephemeralDHKeySize=2048
-      -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
-      -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
-      -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
-      -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar
-      -Delastic.apm.service_name=cmdb
-      -Delastic.apm.server_url=http://192.168.8.53:8200
-      -Delastic.apm.environment=dev -Delastic.apm.enabled=true
-      -Delastic.apm.profiling_inferred_spans_enabled=true
-      -Delastic.apm.profiling_inferred_spans_min_duration=250ms
-      -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
-      -Dignore.endorsed.dirs= -classpath
-      /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
-      -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat
-      -Djava.io.tmpdir=/usr/local/tomcat/temp
-      org.apache.catalina.startup.Bootstrap start
-    pid: '90741'
-    ppid: '90702'
-    user: tomcat
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50944) idle'
-    pid: '90926'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50946) idle'
-    pid: '90927'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50948) idle'
-    pid: '90928'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50950) idle'
-    pid: '90929'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50952) idle'
-    pid: '90930'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50954) idle'
-    pid: '90931'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50956) idle'
-    pid: '90932'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50958) idle'
-    pid: '90933'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50960) idle'
-    pid: '90934'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50962) idle'
-    pid: '90935'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50964) idle'
-    pid: '90936'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50966) idle'
-    pid: '90937'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50968) idle'
-    pid: '90938'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50970) idle'
-    pid: '90939'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50972) idle'
-    pid: '90940'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50974) idle'
-    pid: '90941'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50976) idle'
-    pid: '90942'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50978) idle'
-    pid: '90943'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50980) idle'
-    pid: '90944'
-    ppid: '88651'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50982) idle'
-    pid: '90945'
-    ppid: '88651'
-    user: postgres
-  - cmdline: ''
-    pid: '102105'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '114346'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '117135'
-    ppid: '1186'
-    user: postfix
-  - cmdline: 'sshd: root@pts/2'
-    pid: '122013'
-    ppid: '1005'
-    user: root
-  - cmdline: '-bash'
-    pid: '122015'
-    ppid: '122013'
-    user: root
-  - cmdline: ''
-    pid: '123676'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '124124'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '125140'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '125701'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '125820'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: root@pts/3'
-    pid: '126024'
-    ppid: '1005'
-    user: root
-  - cmdline: ''
-    pid: '126104'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-lmxpukhnqgizkpshldtsbmeytdvlzwbs ; /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1656065317.510032-51987-252936824205505/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '126182'
-    ppid: '126024'
-    user: root
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-lmxpukhnqgizkpshldtsbmeytdvlzwbs ; /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1656065317.510032-51987-252936824205505/AnsiballZ_process_facts.py
-    pid: '126193'
-    ppid: '126182'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-lmxpukhnqgizkpshldtsbmeytdvlzwbs ;
-      /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1656065317.510032-51987-252936824205505/AnsiballZ_process_facts.py
-    pid: '126195'
-    ppid: '126193'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1656065317.510032-51987-252936824205505/AnsiballZ_process_facts.py
-    pid: '126196'
-    ppid: '126195'
-    user: root
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - /usr/local/bin/docker-entrypoint.sh
-        - catalina.sh
-        - run
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - catalina.sh
-          - run
-        Domainname: ''
-        Entrypoint:
-          - /bin/sh
-          - '-c'
-          - /usr/local/bin/docker-entrypoint.sh
-        Env:
-          - LANG=C.UTF-8
-          - >-
-            CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
-          - POSTGRES_PORT=5432
-          - CMDBUILD_DUMP=empty.dump.xz
-          - POSTGRES_HOST=192.168.64.34
-          - POSTGRES_PASS=the_password
-          - JAVA_OPTS=-Xmx7876m -Xms3846m
-          - POSTGRES_DB=cmdbuild_r2u2
-          - >-
-            PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - TZ=Europe/Madrid
-          - POSTGRES_APP_USER=datadope
-          - POSTGRES_APP_PASSWORD=the_password
-          - POSTGRES_USER=datadope
-          - JAVA_HOME=/usr/local/openjdk-17
-          - JAVA_VERSION=17.0.2
-          - CATALINA_HOME=/usr/local/tomcat
-          - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
-          - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
-          - >-
-            GPG_KEYS=48F8E69F6390C9F25CFEDCD268248959359E722B
-            A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
-            DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
-          - TOMCAT_MAJOR=9
-          - TOMCAT_VERSION=9.0.60
-          - >-
-            TOMCAT_SHA512=a4d43ac45f76e29d3dea23a2712c7570a11419aad7a1af2d1533454709c020b59666c7f9e063a77120224e0cbd4020cac06ca596dda7057cacb9a8a7e6d73eea
-          - >-
-            APM_JAR_URL=https://nexus.opensolutions.cloud/repository/datadope-public/elastic-apm/elastic-apm-agent-1.28.1.jar
-        ExposedPorts:
-          8080/tcp: {}
-          8443/tcp: {}
-        Hostname: localhost
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.5.3'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: tomcat
-        Volumes: null
-        WorkingDir: /usr/local/tomcat
-      Created: '2022-03-25T12:04:52.930305974Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794-init/diff:/var/lib/docker/overlay2/0ca2f0e4b67ae95aef370146269b3fb10e55a6859d278f2997e8b84ff9122875/diff:/var/lib/docker/overlay2/308c2efd326216c0efe94e857b82520af6ab116a978811106d99e49ddf15fc1b/diff:/var/lib/docker/overlay2/c0610b1db247b6b1804c3b992e3f89f1ff75375a3b9c395de68e7dd6f0c5af41/diff:/var/lib/docker/overlay2/b49fa08f0f5246651d4fc001af50b8fc4f316d3add326329766d389a5b8597e1/diff:/var/lib/docker/overlay2/30067671d40d8ef3df665781083700fdb08887c64131c247ff8210714dd2d7a8/diff:/var/lib/docker/overlay2/acec1c4357e89e939adefb7160deb62f2e3dd2fb8e2b89c50a84d7e807b27220/diff:/var/lib/docker/overlay2/348d6cd50875127305d1c94e3d700856d51fc4a33a7c735163a54451c6fc3791/diff:/var/lib/docker/overlay2/b2dbb49865766b5568101566c79fdb955744097af5e48de46fc508b6de374d4a/diff:/var/lib/docker/overlay2/679f2167259fbc9d27c7bc3b9c872e59655afc90478754d2774935f005c62a2d/diff:/var/lib/docker/overlay2/1e770257e07955a14878870e1146a4954ff84e3a9a13f439b617d5a93316369b/diff:/var/lib/docker/overlay2/f4ddf2e6b8e7240af6c8026059475c51e762150436d2e78369347e31154144af/diff:/var/lib/docker/overlay2/10a54c98f41b6862c3ffb03a07cc1b23d517b5fce34238706646aa8949467afb/diff:/var/lib/docker/overlay2/f8c4e742a18bbeeaff6a7f3e99d59e12186868fbd68718b9adf44213e51fe1fc/diff:/var/lib/docker/overlay2/eaeac3feaa55318680b5311656bb14d685c03b356403ea6109fa7b1f16e63189/diff:/var/lib/docker/overlay2/5179e1277d7830285af10f6cd4bd09708b36dfe341288a6dcd68c7896718bb75/diff:/var/lib/docker/overlay2/8562f678e444a225812e39cdf950838f4ee626f1264ce3eac883dcc27bb165d2/diff:/var/lib/docker/overlay2/0f25f2ae977f5674027aac8cdd9cf2e07456a422fb88425fde7d3026f1f8ecdc/diff:/var/lib/docker/overlay2/997ff03392129602e78b3f0e6b5879ec656d11d8c3fa536f5577b0e540b40173/diff:/var/lib/docker/overlay2/994f47ca80b9c00cfabf4d1dcff4992f6b0c1647d89589dd5f31fdaa1bf6340f/diff:/var/lib/docker/overlay2/359f2d072fad20815db5e37ab4284e6c3376233db3163033fe04ba8b1153b443/diff:/var/lib/docker/overlay2/8a3f7b2f222926cdf88d12cd34fed89094bd049498fc78b1ddf625ce837f3760/diff:/var/lib/docker/overlay2/6daf829f7b4e94d9cba1f56aeab10d06a317241ee7aa01217ef88d2676fefce8/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw'
-          - '/var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: []
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: []
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: bridge
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/hostname
-      HostsPath: /etc/hosts
-      Id: 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
-      Image: 'sha256:eb3e461a2b2785cb353346a408a9e43b7f0fb86bb8a9a592ada57ca4c52e3bfd'
-      LogPath: >-
-        /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /usr/local/tomcat/certs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics-cmdbuild/certs
-          Type: bind
-        - Destination: /usr/local/tomcat/logs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/iometrics-cmdbuild
-          Type: bind
-      Name: /iometrics-cmdbuild
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 5fb50fd979f12f7678c60474664f0350d32f6ff6dff61fa277c8aaeae6a7a93b
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: '02:42:ac:11:00:02'
-        Networks:
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 5fb50fd979f12f7678c60474664f0350d32f6ff6dff61fa277c8aaeae6a7a93b
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:11:00:02'
-            NetworkID: e245cfe31a9637868b704e96aa6cbd268c001dc02bc3d706b7a2abb2276532ff
-        Ports:
-          8080/tcp: null
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        SandboxID: 24da94b8470d1a3e540d42a9b4e730e406e95e18f0a15f8aaf95405b113062b8
-        SandboxKey: /var/run/docker/netns/24da94b8470d
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-06-22T07:28:04.254622989Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 90702
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-22T08:01:19.112762511Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - ./start_cmdb_gateway.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - ./start_cmdb_gateway.sh
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.5
-          - CMDB_GATEWAY_CONFIG_FILE=config/cmdb_gateway.yaml
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - PYTHON_PIP_VERSION=20.2.2
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-        Hostname: oss-devel-cmdb
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdb-gateway:0.18.0'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: /app
-      Created: '2021-12-16T13:40:54.11945545Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9-init/diff:/var/lib/docker/overlay2/f28f032f19b8e36176d7f5c3c3280960a1f0b2d030b1461fde6f85608b268fb7/diff:/var/lib/docker/overlay2/c812399fd0157a9db6cd588828f224d26a076ebaa05397d46399616d7491559b/diff:/var/lib/docker/overlay2/04dc77fa805a06bb44c58399ae78a7ab110bc9d714c346b0df5a7e5b349ae16c/diff:/var/lib/docker/overlay2/4c9d61501d1130eeaea40e3c6e8c58e3790995f474c04c2bb10c904a71431edb/diff:/var/lib/docker/overlay2/4993b8fafd5a9d9a6023eaf5d25fe51a2fabcb3dbee5ea7549ec9420497d57e5/diff:/var/lib/docker/overlay2/d6460864d519c5967a63083553d16607e9e209a7eab0d4c098a649aaa0cdf0f2/diff:/var/lib/docker/overlay2/70210d890e6f91fbea58cad88a3fce3e126382bc7b33645fc961fdb8faa8542f/diff:/var/lib/docker/overlay2/ca78aa40f8918ea045999b7270f6fd9704cb0cdb7540c93b5b2608c336057ab5/diff:/var/lib/docker/overlay2/a6183d5cdfd1c5842b63dc840de2a5ef55eb86dcd92872076825f6ae35fa240a/diff:/var/lib/docker/overlay2/b46ed7aa9054a838c1438c581e9d770be0a97cf687a962a532c5096af8f4714b/diff:/var/lib/docker/overlay2/46919684c7f455b8be1662fbc502637c471f5ea2fe53e4ea3edceadc8a28b14f/diff:/var/lib/docker/overlay2/764a651bc4126949119711643715095b4394c88d62b64f6c83a1720378145f0b/diff:/var/lib/docker/overlay2/9f37cd3fc4a2444f9ab442262e3f41cc348cee444f14100f61a487031cfe07f5/diff:/var/lib/docker/overlay2/47b0f955a1643f1d46055c3aeaa3a2ffdd59ccb1f5f14e89dcf603db8463b81b/diff:/var/lib/docker/overlay2/f3aa2fa503c8e7277a423cd85d1d8bdfd147fc867f5fab859a097188e0e6d004/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/cmdb/config:/app/config:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: []
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: []
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: {}
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: {}
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: 'no'
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hosts
-      Id: da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
-      Image: 'sha256:af61c42a1772b373dbc30a6d3650af40d4e738a5d22959eccea5974946ada9fa'
-      LogPath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/config
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/cmdb/config
-          Type: bind
-      Name: /iometrics-cmdb-gateway
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: b446b6007219a43a41e3772800df3501150674e500d3c82c5d55b0dbf0d2be45
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: {}
-        SandboxID: 3ab9d1ec83de2a55dabf1c37436f60f360076bce9b6441e2ec7e5e283cb4c847
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-06-22T07:28:01.32208543Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 88553
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-22T07:28:01.764292527Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - python ./listener.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - python ./listener.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.5
-          - PYTHON_PIP_VERSION=20.2.2
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
-        Hostname: oss-devel-cmdb
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.0.1'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /config: {}
-        WorkingDir: ''
-      Created: '2021-05-25T10:08:10.097442624Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41-init/diff:/var/lib/docker/overlay2/ba78f066d9e46b0f7b41380a42ef0a747aa591e78992e40447ca78b8528de8ed/diff:/var/lib/docker/overlay2/3b784c7b5c126900be4badb31068a06fbfdfe15a2f15049ed151fb2a5a370659/diff:/var/lib/docker/overlay2/c6b744055dfca315c6446e3723460947b34efd1d75325b2caae502367afa3c2e/diff:/var/lib/docker/overlay2/a1a2492e64ab4e7a012e36e61ceabaf1d80bed24e72c2ae69d7172e35a3831de/diff:/var/lib/docker/overlay2/39a5edc9ab57849080990571d9a3f410b66a3bb04f12ca966d3f4a64e0cbbd8a/diff:/var/lib/docker/overlay2/0780a973dbea66c8f367c507554356a5d27303cd0a1d8b5396e7b0aa392b6149/diff:/var/lib/docker/overlay2/e1f23af492edda46763c05b32bcfe283f83fdd27460a55cf1a5dcf437a0e0ae7/diff:/var/lib/docker/overlay2/9f8debce0febecd5e1c4e50351a37d422b1b60f3826ddfd9dadc1961fe3e007f/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/redis-cleaner:/config:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hosts
-      Id: 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
-      Image: 'sha256:70c1ea6bb3f2e939311b21e6b49cd3cce10ffb2e21e8b5b431bd293421ca8472'
-      LogPath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /config
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis-cleaner
-          Type: bind
-      Name: /iometrics-cmdb-redis-cleaner
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ed464b6f49997d37e646e04846527f61c970de6c91c3deb620c2c3c80fca0b96
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: {}
-        SandboxID: 72ed345048dcc6240fabf7e33835c2a4fd99d59e7fa0972a4685872da6303113
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 34206
-        Restarting: false
-        Running: true
-        StartedAt: '2021-05-25T10:08:10.240751099Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '--tls-port'
-        - '6378'
-        - '--appendonly'
-        - 'no'
-        - '--maxmemory'
-        - '0'
-        - '--maxclients'
-        - '10000'
-        - '--bind'
-        - 0.0.0.0
-        - '--requirepass'
-        - the_password
-        - '--tls-auth-clients'
-        - 'no'
-        - '--tls-cert-file'
-        - /data/ssl/redis.crt
-        - '--tls-key-file'
-        - /data/ssl/redis.pem
-        - '--tls-ca-cert-file'
-        - /data/ssl/redis_ca.crt
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '--tls-port'
-          - '6378'
-          - '--appendonly'
-          - 'no'
-          - '--maxmemory'
-          - '0'
-          - '--maxclients'
-          - '10000'
-          - '--bind'
-          - 0.0.0.0
-          - '--requirepass'
-          - the_password
-          - '--tls-auth-clients'
-          - 'no'
-          - '--tls-cert-file'
-          - /data/ssl/redis.crt
-          - '--tls-key-file'
-          - /data/ssl/redis.pem
-          - '--tls-ca-cert-file'
-          - /data/ssl/redis_ca.crt
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.0.1
-          - >-
-            REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
-          - >-
-            REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
-        ExposedPorts:
-          6379/tcp: {}
-        Hostname: oss-devel-cmdb
-        Image: 'redis:6.0.1'
-        Labels:
-          os_contianer_type: redis
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: {}
-          /data/ssl/: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-        WorkingDir: /data
-      Created: '2021-05-25T09:00:32.257009145Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce-init/diff:/var/lib/docker/overlay2/895c1f99a736e2df91bfc2a00c7551e51fd433dde75de2279435ff47ea0e6b38/diff:/var/lib/docker/overlay2/a9841cfec194609a7ec73913c03ba7d4155bc5334e801da50362b4a928a3fe93/diff:/var/lib/docker/overlay2/d9cb4756a3d19486043c08cf2b9492aca7b6664e4914a64c4ae7d649510fb8fb/diff:/var/lib/docker/overlay2/348fb45e5b21b874e1972d7abf6267aedb49052fe240ff1ca65c31d01f0cd49e/diff:/var/lib/docker/overlay2/1f6d3088e9933dfa837efd70762bf9724143691931203267ec5ff24aa5dfe170/diff:/var/lib/docker/overlay2/c96ac52a498ef5b1c8f81d0d7ee4cb762e570fee584f3b41148aceca3a8664b5/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/redis:/data:rw'
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/redis/ssl/:/data/ssl/:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/hostname
-      HostsPath: /etc/hosts
-      Id: b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
-      Image: 'sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c'
-      LogPath: >-
-        /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/redis
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /data/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis/ssl
-          Type: bind
-      Name: /redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: beb2a749121a2b11fd9bc6093b92eb8fd64c1abf38a38f39261bc633429fc566
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: {}
-        SandboxID: 6b4a27d90042eb73469fe2c90437f604c16aade938163e14d93d88892703a15f
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 20064
-        Restarting: false
-        Running: true
-        StartedAt: '2021-05-25T09:00:32.529069205Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: oss-devel-cmdb
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2021-05-24T14:27:58.280498639Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098-init/diff:/var/lib/docker/overlay2/572d19da46f80f29256ff94ed86f500ede7764af796338b02e10f781d4387407/diff:/var/lib/docker/overlay2/16e7f7bacf68db89a426b0b90b68188ce3387cd01bad762550e49c926b5879d8/diff:/var/lib/docker/overlay2/26ea1b9023be5dfd133dd9e015e47da4265ab65445bb17899fcc275604d3754d/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/hostname
-      HostsPath: /etc/hosts
-      Id: df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 29d2d1ebe738bc2b3d44373cd6019b50940e82931b720cfd949e7c08c8a110ea
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: {}
-        SandboxID: c2fdaac80977cad0b65bf2e24939c5a22c6ad249d8db4aab83f390a0bb1305d6
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2021-05-24T14:56:41.686346314Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 23339
-        Restarting: false
-        Running: true
-        StartedAt: '2021-06-01T15:04:41.797753434Z'
-        Status: running
+        - test
+  Run command to get slave status:
+    fail: should not be called
+  Run command to get slave status with IPs:
+    calls:
+    - expected_args:
+        argv: null
+        cmd: /usr/bin/mariadb --host=127.0.0.1 -P 3306 --user=user_b -ppassword_b
+          -N -s -e 'show slave status'
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout: ''
+  Socket from cmdline:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   MariaDB-client:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-client
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-client
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
   MariaDB-common:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-common
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-common
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
   MariaDB-compat:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-compat
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-compat
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
   MariaDB-server:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-server
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-server
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
   NetworkManager:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
   NetworkManager-libnm:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-libnm
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-libnm
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
   NetworkManager-team:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-team
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-team
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
   NetworkManager-tui:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-tui
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-tui
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   aic94xx-firmware:
-    - arch: noarch
-      epoch: null
-      name: aic94xx-firmware
-      release: 6.el7
-      source: rpm
-      version: '30'
+  - arch: noarch
+    epoch: null
+    name: aic94xx-firmware
+    release: 6.el7
+    source: rpm
+    version: '30'
   alsa-firmware:
-    - arch: noarch
-      epoch: null
-      name: alsa-firmware
-      release: 2.el7
-      source: rpm
-      version: 1.0.28
+  - arch: noarch
+    epoch: null
+    name: alsa-firmware
+    release: 2.el7
+    source: rpm
+    version: 1.0.28
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   alsa-tools-firmware:
-    - arch: x86_64
-      epoch: null
-      name: alsa-tools-firmware
-      release: 1.el7
-      source: rpm
-      version: 1.1.0
+  - arch: x86_64
+    epoch: null
+    name: alsa-tools-firmware
+    release: 1.el7
+    source: rpm
+    version: 1.1.0
   apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autoconf:
-    - arch: noarch
-      epoch: null
-      name: autoconf
-      release: 11.el7
-      source: rpm
-      version: '2.69'
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
   automake:
-    - arch: noarch
-      epoch: null
-      name: automake
-      release: 3.el7
-      source: rpm
-      version: 1.13.4
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.5
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.5
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7
+    source: rpm
+    version: '2.27'
   biosdevname:
-    - arch: x86_64
-      epoch: null
-      name: biosdevname
-      release: 2.el7
-      source: rpm
-      version: 0.7.3
+  - arch: x86_64
+    epoch: null
+    name: biosdevname
+    release: 2.el7
+    source: rpm
+    version: 0.7.3
   bison:
-    - arch: x86_64
-      epoch: null
-      name: bison
-      release: 2.el7
-      source: rpm
-      version: 3.0.4
+  - arch: x86_64
+    epoch: null
+    name: bison
+    release: 2.el7
+    source: rpm
+    version: 3.0.4
   boost-date-time:
-    - arch: x86_64
-      epoch: null
-      name: boost-date-time
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
+  - arch: x86_64
+    epoch: null
+    name: boost-date-time
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
   boost-program-options:
-    - arch: x86_64
-      epoch: null
-      name: boost-program-options
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
+  - arch: x86_64
+    epoch: null
+    name: boost-program-options
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
   boost-system:
-    - arch: x86_64
-      epoch: null
-      name: boost-system
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
+  - arch: x86_64
+    epoch: null
+    name: boost-system
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
   boost-thread:
-    - arch: x86_64
-      epoch: null
-      name: boost-thread
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
+  - arch: x86_64
+    epoch: null
+    name: boost-thread
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   byacc:
-    - arch: x86_64
-      epoch: null
-      name: byacc
-      release: 3.el7
-      source: rpm
-      version: 1.9.20130304
+  - arch: x86_64
+    epoch: null
+    name: byacc
+    release: 3.el7
+    source: rpm
+    version: 1.9.20130304
   bzip2:
-    - arch: x86_64
-      epoch: null
-      name: bzip2
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   c-ares:
-    - arch: x86_64
-      epoch: null
-      name: c-ares
-      release: 3.el7
-      source: rpm
-      version: 1.10.0
+  - arch: x86_64
+    epoch: null
+    name: c-ares
+    release: 3.el7
+    source: rpm
+    version: 1.10.0
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_8
-      source: rpm
-      version: 2020.2.41
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_8
+    source: rpm
+    version: 2020.2.41
   centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.4.4
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.4.4
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cscope:
-    - arch: x86_64
-      epoch: null
-      name: cscope
-      release: 10.el7
-      source: rpm
-      version: '15.8'
+  - arch: x86_64
+    epoch: null
+    name: cscope
+    release: 10.el7
+    source: rpm
+    version: '15.8'
   ctags:
-    - arch: x86_64
-      epoch: null
-      name: ctags
-      release: 13.el7
-      source: rpm
-      version: '5.8'
+  - arch: x86_64
+    epoch: null
+    name: ctags
+    release: 13.el7
+    source: rpm
+    version: '5.8'
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 3.el7_9.2
-      source: rpm
-      version: 0.8.5
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 3.el7_9.2
+    source: rpm
+    version: 0.8.5
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
+  - arch: x86_64
+    epoch: 12
+    name: dhclient
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
   dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
   dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
   diffstat:
-    - arch: x86_64
-      epoch: null
-      name: diffstat
-      release: 4.el7
-      source: rpm
-      version: '1.57'
+  - arch: x86_64
+    epoch: null
+    name: diffstat
+    release: 4.el7
+    source: rpm
+    version: '1.57'
   diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
   dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
   docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
   docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
   docker-ce-rootless-extras:
-    - arch: x86_64
-      epoch: 0
-      name: docker-ce-rootless-extras
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
+  - arch: x86_64
+    epoch: 0
+    name: docker-ce-rootless-extras
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
   docker-scan-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-scan-plugin
-      release: 3.el7
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: 0
+    name: docker-scan-plugin
+    release: 3.el7
+    source: rpm
+    version: 0.7.0
   doxygen:
-    - arch: x86_64
-      epoch: 1
-      name: doxygen
-      release: 4.el7
-      source: rpm
-      version: 1.8.5
+  - arch: x86_64
+    epoch: 1
+    name: doxygen
+    release: 4.el7
+    source: rpm
+    version: 1.8.5
   dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
   dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
   dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
   dwz:
-    - arch: x86_64
-      epoch: null
-      name: dwz
-      release: 3.el7
-      source: rpm
-      version: '0.11'
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
   dyninst:
-    - arch: x86_64
-      epoch: null
-      name: dyninst
-      release: 3.el7
-      source: rpm
-      version: 9.3.1
+  - arch: x86_64
+    epoch: null
+    name: dyninst
+    release: 3.el7
+    source: rpm
+    version: 9.3.1
   e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   ebtables:
-    - arch: x86_64
-      epoch: null
-      name: ebtables
-      release: 16.el7
-      source: rpm
-      version: 2.0.10
+  - arch: x86_64
+    epoch: null
+    name: ebtables
+    release: 16.el7
+    source: rpm
+    version: 2.0.10
   efivar-libs:
-    - arch: x86_64
-      epoch: null
-      name: efivar-libs
-      release: 12.el7
-      source: rpm
-      version: '36'
+  - arch: x86_64
+    epoch: null
+    name: efivar-libs
+    release: 12.el7
+    source: rpm
+    version: '36'
   elfutils:
-    - arch: x86_64
-      epoch: null
-      name: elfutils
-      release: 5.el7
-      source: rpm
-      version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils
+    release: 5.el7
+    source: rpm
+    version: '0.176'
   elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
   elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
   elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
   emacs-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: emacs-filesystem
-      release: 23.el7
-      source: rpm
-      version: '24.3'
+  - arch: noarch
+    epoch: 1
+    name: emacs-filesystem
+    release: 23.el7
+    source: rpm
+    version: '24.3'
   epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '13'
-      source: rpm
-      version: '7'
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '13'
+    source: rpm
+    version: '7'
   ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
   expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
   file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
   file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
   filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
   findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
   fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
   fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
   firewalld:
-    - arch: noarch
-      epoch: null
-      name: firewalld
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
+  - arch: noarch
+    epoch: null
+    name: firewalld
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
   firewalld-filesystem:
-    - arch: noarch
-      epoch: null
-      name: firewalld-filesystem
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
+  - arch: noarch
+    epoch: null
+    name: firewalld-filesystem
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
   flex:
-    - arch: x86_64
-      epoch: null
-      name: flex
-      release: 6.el7
-      source: rpm
-      version: 2.5.37
+  - arch: x86_64
+    epoch: null
+    name: flex
+    release: 6.el7
+    source: rpm
+    version: 2.5.37
   freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
   fuse:
-    - arch: x86_64
-      epoch: null
-      name: fuse
-      release: 11.el7
-      source: rpm
-      version: 2.9.2
+  - arch: x86_64
+    epoch: null
+    name: fuse
+    release: 11.el7
+    source: rpm
+    version: 2.9.2
   fuse-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-libs
-      release: 11.el7
-      source: rpm
-      version: 2.9.2
+  - arch: x86_64
+    epoch: null
+    name: fuse-libs
+    release: 11.el7
+    source: rpm
+    version: 2.9.2
   fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
   fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
   fxload:
-    - arch: x86_64
-      epoch: null
-      name: fxload
-      release: 16.el7
-      source: rpm
-      version: '2002_04_11'
+  - arch: x86_64
+    epoch: null
+    name: fxload
+    release: 16.el7
+    source: rpm
+    version: '2002_04_11'
   galera-4:
-    - arch: x86_64
-      epoch: null
-      name: galera-4
-      release: 1.el7.centos
-      source: rpm
-      version: 26.4.8
+  - arch: x86_64
+    epoch: null
+    name: galera-4
+    release: 1.el7.centos
+    source: rpm
+    version: 26.4.8
   gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
   gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   gcc-gfortran:
-    - arch: x86_64
-      epoch: null
-      name: gcc-gfortran
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: gcc-gfortran
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   gdb:
-    - arch: x86_64
-      epoch: null
-      name: gdb
-      release: 120.el7
-      source: rpm
-      version: 7.6.1
+  - arch: x86_64
+    epoch: null
+    name: gdb
+    release: 120.el7
+    source: rpm
+    version: 7.6.1
   gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
   geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
   gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-common-devel:
-    - arch: noarch
-      epoch: null
-      name: gettext-common-devel
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: noarch
+    epoch: null
+    name: gettext-common-devel
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-devel:
-    - arch: x86_64
-      epoch: null
-      name: gettext-devel
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext-devel
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   git:
-    - arch: x86_64
-      epoch: null
-      name: git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
+  - arch: x86_64
+    epoch: null
+    name: git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
   glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 8.el7
-      source: rpm
-      version: 2.56.1
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 8.el7
+    source: rpm
+    version: 2.56.1
   glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
   glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
   glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
   glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
   gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
   gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
   gnutls:
-    - arch: x86_64
-      epoch: null
-      name: gnutls
-      release: 9.el7_6
-      source: rpm
-      version: 3.3.29
+  - arch: x86_64
+    epoch: null
+    name: gnutls
+    release: 9.el7_6
+    source: rpm
+    version: 3.3.29
   gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
   gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 511147a9
-      source: rpm
-      version: 1bb943db
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 608c8351
-      source: rpm
-      version: 442df0f8
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 511147a9
+    source: rpm
+    version: 1bb943db
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
   gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
   gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
   grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
   groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
   grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
   gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
   gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
   hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
   hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
   htop:
-    - arch: x86_64
-      epoch: null
-      name: htop
-      release: 3.el7
-      source: rpm
-      version: 2.2.0
+  - arch: x86_64
+    epoch: null
+    name: htop
+    release: 3.el7
+    source: rpm
+    version: 2.2.0
   hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
   indent:
-    - arch: x86_64
-      epoch: null
-      name: indent
-      release: 13.el7
-      source: rpm
-      version: 2.2.11
+  - arch: x86_64
+    epoch: null
+    name: indent
+    release: 13.el7
+    source: rpm
+    version: 2.2.11
   info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
   initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
   intltool:
-    - arch: noarch
-      epoch: null
-      name: intltool
-      release: 7.el7
-      source: rpm
-      version: 0.50.2
+  - arch: noarch
+    epoch: null
+    name: intltool
+    release: 7.el7
+    source: rpm
+    version: 0.50.2
   iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
   iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
   iprutils:
-    - arch: x86_64
-      epoch: null
-      name: iprutils
-      release: 3.el7_7
-      source: rpm
-      version: 2.4.17.1
+  - arch: x86_64
+    epoch: null
+    name: iprutils
+    release: 3.el7_7
+    source: rpm
+    version: 2.4.17.1
   ipset:
-    - arch: x86_64
-      epoch: null
-      name: ipset
-      release: 1.el7
-      source: rpm
-      version: '7.1'
+  - arch: x86_64
+    epoch: null
+    name: ipset
+    release: 1.el7
+    source: rpm
+    version: '7.1'
   ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
   iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
   iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
   irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
   ivtv-firmware:
-    - arch: noarch
-      epoch: 2
-      name: ivtv-firmware
-      release: 26.el7
-      source: rpm
-      version: '20080701'
+  - arch: noarch
+    epoch: 2
+    name: ivtv-firmware
+    release: 26.el7
+    source: rpm
+    version: '20080701'
   iwl100-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl100-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
+  - arch: noarch
+    epoch: null
+    name: iwl100-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
   iwl1000-firmware:
-    - arch: noarch
-      epoch: 1
-      name: iwl1000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
+  - arch: noarch
+    epoch: 1
+    name: iwl1000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
   iwl105-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl105-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl105-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl135-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl135-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl135-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl2000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl2000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl2030-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2030-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl2030-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl3160-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3160-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
+  - arch: noarch
+    epoch: null
+    name: iwl3160-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
   iwl3945-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3945-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 15.32.2.9
+  - arch: noarch
+    epoch: null
+    name: iwl3945-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 15.32.2.9
   iwl4965-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl4965-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 228.61.2.24
+  - arch: noarch
+    epoch: null
+    name: iwl4965-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 228.61.2.24
   iwl5000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.83.5.1_1
+  - arch: noarch
+    epoch: null
+    name: iwl5000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.83.5.1_1
   iwl5150-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5150-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.24.2.2
+  - arch: noarch
+    epoch: null
+    name: iwl5150-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.24.2.2
   iwl6000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 9.221.4.1
+  - arch: noarch
+    epoch: null
+    name: iwl6000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 9.221.4.1
   iwl6000g2a-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2a-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2a-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl6000g2b-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2b-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2b-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl6050-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6050-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 41.28.5.1
+  - arch: noarch
+    epoch: null
+    name: iwl6050-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 41.28.5.1
   iwl7260-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7260-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
+  - arch: noarch
+    epoch: null
+    name: iwl7260-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
   jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
   jnettop:
-    - arch: x86_64
-      epoch: null
-      name: jnettop
-      release: 16.el7
-      source: rpm
-      version: 0.13.0
+  - arch: x86_64
+    epoch: null
+    name: jnettop
+    release: 16.el7
+    source: rpm
+    version: 0.13.0
   json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
   kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
   kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
   kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
   kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.21.3.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 862.9.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.10.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.15.2.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.21.3.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 862.9.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.10.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.15.2.el7
+    source: rpm
+    version: 3.10.0
   kernel-debug-devel:
-    - arch: x86_64
-      epoch: null
-      name: kernel-debug-devel
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-debug-devel
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
   kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
   kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
   kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
   kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.2
-      source: rpm
-      version: 2.0.15
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.2
+    source: rpm
+    version: 2.0.15
   keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
   keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
   kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
   kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
   kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 134.el7_9
-      source: rpm
-      version: 0.4.9
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 134.el7_9
+    source: rpm
+    version: 0.4.9
   krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 50.el7
-      source: rpm
-      version: 1.15.1
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 50.el7
+    source: rpm
+    version: 1.15.1
   less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
   libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
   libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
   libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
   libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
   libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
   libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
   libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
   libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
   libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
   libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
   libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
   libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
   libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
   libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
   libdnet:
-    - arch: x86_64
-      epoch: null
-      name: libdnet
-      release: 13.1.el7
-      source: rpm
-      version: '1.12'
+  - arch: x86_64
+    epoch: null
+    name: libdnet
+    release: 13.1.el7
+    source: rpm
+    version: '1.12'
   libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
   libdwarf:
-    - arch: x86_64
-      epoch: null
-      name: libdwarf
-      release: 4.el7
-      source: rpm
-      version: '20130207'
+  - arch: x86_64
+    epoch: null
+    name: libdwarf
+    release: 4.el7
+    source: rpm
+    version: '20130207'
   libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
   libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
   libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
   libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
   libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
   libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
   libgfortran:
-    - arch: x86_64
-      epoch: null
-      name: libgfortran
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgfortran
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
   libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
   libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
   libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
   libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
   libmodman:
-    - arch: x86_64
-      epoch: null
-      name: libmodman
-      release: 8.el7
-      source: rpm
-      version: 2.0.1
+  - arch: x86_64
+    epoch: null
+    name: libmodman
+    release: 8.el7
+    source: rpm
+    version: 2.0.1
   libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
   libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
   libmspack:
-    - arch: x86_64
-      epoch: null
-      name: libmspack
-      release: 0.8.alpha.el7
-      source: rpm
-      version: '0.5'
+  - arch: x86_64
+    epoch: null
+    name: libmspack
+    release: 0.8.alpha.el7
+    source: rpm
+    version: '0.5'
   libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
   libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
   libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
   libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
   libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
   libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
   libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
   libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
   libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
   libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
   libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
   libproxy:
-    - arch: x86_64
-      epoch: null
-      name: libproxy
-      release: 11.el7
-      source: rpm
-      version: 0.4.11
+  - arch: x86_64
+    epoch: null
+    name: libproxy
+    release: 11.el7
+    source: rpm
+    version: 0.4.11
   libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
   libquadmath:
-    - arch: x86_64
-      epoch: null
-      name: libquadmath
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libquadmath
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libquadmath-devel:
-    - arch: x86_64
-      epoch: null
-      name: libquadmath-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libquadmath-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
   libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.4.1
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.4.1
   libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
   libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
   libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
   libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
   libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
   libsmi:
-    - arch: x86_64
-      epoch: null
-      name: libsmi
-      release: 13.el7
-      source: rpm
-      version: 0.4.8
+  - arch: x86_64
+    epoch: null
+    name: libsmi
+    release: 13.el7
+    source: rpm
+    version: 0.4.8
   libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
   libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
   libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
   libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
   libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
   libtool:
-    - arch: x86_64
-      epoch: null
-      name: libtool
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
   libtool-ltdl:
-    - arch: x86_64
-      epoch: null
-      name: libtool-ltdl
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
+  - arch: x86_64
+    epoch: null
+    name: libtool-ltdl
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
   libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
   libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
   libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
   libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
   libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
   libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
   libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7.5
-      source: rpm
-      version: 2.9.1
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.5
+    source: rpm
+    version: 2.9.1
   libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7.5
-      source: rpm
-      version: 2.9.1
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.5
+    source: rpm
+    version: 2.9.1
   libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
   linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
   lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
   logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
   lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
   lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
   lsscsi:
-    - arch: x86_64
-      epoch: null
-      name: lsscsi
-      release: 6.el7
-      source: rpm
-      version: '0.27'
+  - arch: x86_64
+    epoch: null
+    name: lsscsi
+    release: 6.el7
+    source: rpm
+    version: '0.27'
   lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
   lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
   lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
   lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
   lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
   m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
   make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
   man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
   microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.8.el7_9
-      source: rpm
-      version: '2.1'
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.8.el7_9
+    source: rpm
+    version: '2.1'
   mokutil:
-    - arch: x86_64
-      epoch: null
-      name: mokutil
-      release: 8.el7
-      source: rpm
-      version: '15'
+  - arch: x86_64
+    epoch: null
+    name: mokutil
+    release: 8.el7
+    source: rpm
+    version: '15'
   mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
   mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
   nagios-common:
-    - arch: x86_64
-      epoch: null
-      name: nagios-common
-      release: 4.el7
-      source: rpm
-      version: 4.4.6
+  - arch: x86_64
+    epoch: null
+    name: nagios-common
+    release: 4.el7
+    source: rpm
+    version: 4.4.6
   nagios-plugins:
-    - arch: x86_64
-      epoch: null
-      name: nagios-plugins
-      release: 2.el7
-      source: rpm
-      version: 2.3.3
+  - arch: x86_64
+    epoch: null
+    name: nagios-plugins
+    release: 2.el7
+    source: rpm
+    version: 2.3.3
   nagios-plugins-perl:
-    - arch: x86_64
-      epoch: null
-      name: nagios-plugins-perl
-      release: 2.el7
-      source: rpm
-      version: 2.3.3
+  - arch: x86_64
+    epoch: null
+    name: nagios-plugins-perl
+    release: 2.el7
+    source: rpm
+    version: 2.3.3
   nano:
-    - arch: x86_64
-      epoch: null
-      name: nano
-      release: 10.el7
-      source: rpm
-      version: 2.3.1
+  - arch: x86_64
+    epoch: null
+    name: nano
+    release: 10.el7
+    source: rpm
+    version: 2.3.1
   ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
   ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
   ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
   neon:
-    - arch: x86_64
-      epoch: null
-      name: neon
-      release: 4.el7
-      source: rpm
-      version: 0.30.0
+  - arch: x86_64
+    epoch: null
+    name: neon
+    release: 4.el7
+    source: rpm
+    version: 0.30.0
   net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
   netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 2.el7
-      source: rpm
-      version: '1.218'
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 2.el7
+    source: rpm
+    version: '1.218'
   nettle:
-    - arch: x86_64
-      epoch: null
-      name: nettle
-      release: 9.el7_9
-      source: rpm
-      version: 2.7.1
+  - arch: x86_64
+    epoch: null
+    name: nettle
+    release: 9.el7_9
+    source: rpm
+    version: 2.7.1
   newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
   newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
   nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7
-      source: rpm
-      version: 1.3.0
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7
+    source: rpm
+    version: 1.3.0
   nrpe:
-    - arch: x86_64
-      epoch: null
-      name: nrpe
-      release: 6.el7
-      source: rpm
-      version: 4.0.3
+  - arch: x86_64
+    epoch: null
+    name: nrpe
+    release: 6.el7
+    source: rpm
+    version: 4.0.3
   nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 2.el7_9
-      source: rpm
-      version: 4.25.0
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 2.el7_9
+    source: rpm
+    version: 4.25.0
   nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
   nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
   nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 6.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 6.el7_9
+    source: rpm
+    version: 3.53.1
   nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 6.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 6.el7_9
+    source: rpm
+    version: 3.53.1
   nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
   nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
   nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.53.1
   numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
   open-vm-tools:
-    - arch: x86_64
-      epoch: null
-      name: open-vm-tools
-      release: 3.el7_9.3
-      source: rpm
-      version: 11.0.5
+  - arch: x86_64
+    epoch: null
+    name: open-vm-tools
+    release: 3.el7_9.3
+    source: rpm
+    version: 11.0.5
   openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 23.el7_9
-      source: rpm
-      version: 2.4.44
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 23.el7_9
+    source: rpm
+    version: 2.4.44
   openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
   openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
   openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
   openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 21.el7_9
-      source: rpm
-      version: 1.0.2k
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 21.el7_9
+    source: rpm
+    version: 1.0.2k
   openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 21.el7_9
-      source: rpm
-      version: 1.0.2k
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 21.el7_9
+    source: rpm
+    version: 1.0.2k
   openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
   os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
   p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
   p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
   pakchois:
-    - arch: x86_64
-      epoch: null
-      name: pakchois
-      release: 10.el7
-      source: rpm
-      version: '0.4'
+  - arch: x86_64
+    epoch: null
+    name: pakchois
+    release: 10.el7
+    source: rpm
+    version: '0.4'
   pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
   parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
   passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
   patch:
-    - arch: x86_64
-      epoch: null
-      name: patch
-      release: 12.el7_7
-      source: rpm
-      version: 2.7.1
+  - arch: x86_64
+    epoch: null
+    name: patch
+    release: 12.el7_7
+    source: rpm
+    version: 2.7.1
   patchutils:
-    - arch: x86_64
-      epoch: null
-      name: patchutils
-      release: 5.el7_9
-      source: rpm
-      version: 0.3.3
+  - arch: x86_64
+    epoch: null
+    name: patchutils
+    release: 5.el7_9
+    source: rpm
+    version: 0.3.3
   pciutils:
-    - arch: x86_64
-      epoch: null
-      name: pciutils
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
+  - arch: x86_64
+    epoch: null
+    name: pciutils
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
   pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
   pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
   pcre2:
-    - arch: x86_64
-      epoch: null
-      name: pcre2
-      release: 2.el7
-      source: rpm
-      version: '10.23'
+  - arch: x86_64
+    epoch: null
+    name: pcre2
+    release: 2.el7
+    source: rpm
+    version: '10.23'
   perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
   perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
   perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
   perl-DBD-MySQL:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBD-MySQL
-      release: 6.el7
-      source: rpm
-      version: '4.023'
+  - arch: x86_64
+    epoch: null
+    name: perl-DBD-MySQL
+    release: 6.el7
+    source: rpm
+    version: '4.023'
   perl-DBI:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBI
-      release: 4.el7
-      source: rpm
-      version: '1.627'
+  - arch: x86_64
+    epoch: null
+    name: perl-DBI
+    release: 4.el7
+    source: rpm
+    version: '1.627'
   perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
   perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
   perl-Error:
-    - arch: noarch
-      epoch: 1
-      name: perl-Error
-      release: 2.el7
-      source: rpm
-      version: '0.17020'
+  - arch: noarch
+    epoch: 1
+    name: perl-Error
+    release: 2.el7
+    source: rpm
+    version: '0.17020'
   perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
   perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
   perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
   perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
   perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
   perl-Git:
-    - arch: noarch
-      epoch: null
-      name: perl-Git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
+  - arch: noarch
+    epoch: null
+    name: perl-Git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
   perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
   perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
   perl-Net-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-Daemon
-      release: 5.el7
-      source: rpm
-      version: '0.48'
+  - arch: noarch
+    epoch: null
+    name: perl-Net-Daemon
+    release: 5.el7
+    source: rpm
+    version: '0.48'
   perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
   perl-PlRPC:
-    - arch: noarch
-      epoch: null
-      name: perl-PlRPC
-      release: 14.el7
-      source: rpm
-      version: '0.2020'
+  - arch: noarch
+    epoch: null
+    name: perl-PlRPC
+    release: 14.el7
+    source: rpm
+    version: '0.2020'
   perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
   perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
   perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
   perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
   perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
   perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
   perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
   perl-Sys-Statistics-Linux:
-    - arch: noarch
-      epoch: null
-      name: perl-Sys-Statistics-Linux
-      release: 14.el7
-      source: rpm
-      version: '0.66'
+  - arch: noarch
+    epoch: null
+    name: perl-Sys-Statistics-Linux
+    release: 14.el7
+    source: rpm
+    version: '0.66'
   perl-TermReadKey:
-    - arch: x86_64
-      epoch: null
-      name: perl-TermReadKey
-      release: 20.el7
-      source: rpm
-      version: '2.30'
+  - arch: x86_64
+    epoch: null
+    name: perl-TermReadKey
+    release: 20.el7
+    source: rpm
+    version: '2.30'
   perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
   perl-Test-Simple:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Simple
-      release: 243.el7
-      source: rpm
-      version: '0.98'
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Simple
+    release: 243.el7
+    source: rpm
+    version: '0.98'
   perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
   perl-Thread-Queue:
-    - arch: noarch
-      epoch: null
-      name: perl-Thread-Queue
-      release: 2.el7
-      source: rpm
-      version: '3.02'
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
   perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
   perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
   perl-XML-Parser:
-    - arch: x86_64
-      epoch: null
-      name: perl-XML-Parser
-      release: 10.el7
-      source: rpm
-      version: '2.41'
+  - arch: x86_64
+    epoch: null
+    name: perl-XML-Parser
+    release: 10.el7
+    source: rpm
+    version: '2.41'
   perl-YAML-Syck:
-    - arch: x86_64
-      epoch: null
-      name: perl-YAML-Syck
-      release: 3.el7
-      source: rpm
-      version: '1.27'
+  - arch: x86_64
+    epoch: null
+    name: perl-YAML-Syck
+    release: 3.el7
+    source: rpm
+    version: '1.27'
   perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
   perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
   perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
   perl-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: perl-srpm-macros
-      release: 8.el7
-      source: rpm
-      version: '1'
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
   perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
   perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
   pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
   pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
   plymouth:
-    - arch: x86_64
-      epoch: null
-      name: plymouth
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
+  - arch: x86_64
+    epoch: null
+    name: plymouth
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
   plymouth-core-libs:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-core-libs
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
+  - arch: x86_64
+    epoch: null
+    name: plymouth-core-libs
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
   plymouth-scripts:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-scripts
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
+  - arch: x86_64
+    epoch: null
+    name: plymouth-scripts
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
   policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
   policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
   polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
   polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
   popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
   postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
   postgresql:
-    - arch: x86_64
-      epoch: null
-      name: postgresql
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
+  - arch: x86_64
+    epoch: null
+    name: postgresql
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
   postgresql-devel:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-devel
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
+  - arch: x86_64
+    epoch: null
+    name: postgresql-devel
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
   postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
   postgresql10:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
+  - arch: x86_64
+    epoch: null
+    name: postgresql10
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
   postgresql10-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-contrib
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
   postgresql10-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-libs
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
   postgresql10-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-server
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
   postgresql12:
-    - arch: x86_64
-      epoch: null
-      name: postgresql12
-      release: 2PGDG.rhel7
-      source: rpm
-      version: '12.2'
+  - arch: x86_64
+    epoch: null
+    name: postgresql12
+    release: 2PGDG.rhel7
+    source: rpm
+    version: '12.2'
   postgresql12-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql12-libs
-      release: 2PGDG.rhel7
-      source: rpm
-      version: '12.2'
+  - arch: x86_64
+    epoch: null
+    name: postgresql12-libs
+    release: 2PGDG.rhel7
+    source: rpm
+    version: '12.2'
   procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
   psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 17.el7
-      source: rpm
-      version: '22.20'
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 17.el7
+    source: rpm
+    version: '22.20'
   pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
   pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
   pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
   python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-firewall:
-    - arch: noarch
-      epoch: null
-      name: python-firewall
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  python-psycopg2:
-    - arch: x86_64
-      epoch: null
-      name: python-psycopg2
-      release: 1.rhel7
-      source: rpm
-      version: 2.7.5
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-slip:
-    - arch: noarch
-      epoch: null
-      name: python-slip
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-slip-dbus:
-    - arch: noarch
-      epoch: null
-      name: python-slip-dbus
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-devel:
-    - arch: x86_64
-      epoch: null
-      name: python3-devel
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-rpm-generators:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-generators
-      release: 2.el7
-      source: rpm
-      version: '6'
-  python3-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  rcs:
-    - arch: x86_64
-      epoch: null
-      name: rcs
-      release: 7.el7
-      source: rpm
-      version: 5.9.0
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redhat-rpm-config:
-    - arch: noarch
-      epoch: null
-      name: redhat-rpm-config
-      release: 88.el7.centos
-      source: rpm
-      version: 9.1.0
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-sign:
-    - arch: x86_64
-      epoch: null
-      name: rpm-sign
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  socat:
-    - arch: x86_64
-      epoch: null
-      name: socat
-      release: 2.el7
-      source: rpm
-      version: 1.7.3.2
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 6.el7
-      source: rpm
-      version: '4.24'
-  subversion:
-    - arch: x86_64
-      epoch: null
-      name: subversion
-      release: 16.el7
-      source: rpm
-      version: 1.7.14
-  subversion-libs:
-    - arch: x86_64
-      epoch: null
-      name: subversion-libs
-      release: 16.el7
-      source: rpm
-      version: 1.7.14
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.1
-      source: rpm
-      version: 1.8.23
-  swig:
-    - arch: x86_64
-      epoch: null
-      name: swig
-      release: 5.el7
-      source: rpm
-      version: 2.0.10
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemtap:
-    - arch: x86_64
-      epoch: null
-      name: systemtap
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-client:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-client
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-devel:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-devel
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-runtime:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-runtime
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 66.el7
-      source: rpm
-      version: '0.17'
-  traceroute:
-    - arch: x86_64
-      epoch: 3
-      name: traceroute
-      release: 2.el7
-      source: rpm
-      version: 2.0.22
-  trousers:
-    - arch: x86_64
-      epoch: null
-      name: trousers
-      release: 2.el7
-      source: rpm
-      version: 0.3.14
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021a
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  webtatic-release:
-    - arch: noarch
-      epoch: null
-      name: webtatic-release
-      release: '3'
-      source: rpm
-      version: '7'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wireshark:
-    - arch: x86_64
-      epoch: null
-      name: wireshark
-      release: 25.el7
-      source: rpm
-      version: 1.10.14
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xagt:
-    - arch: x86_64
-      epoch: null
-      name: xagt
-      release: 1.el7
-      source: rpm
-      version: 33.46.6
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xmlsec1:
-    - arch: x86_64
-      epoch: null
-      name: xmlsec1
-      release: 7.el7_4
-      source: rpm
-      version: 1.2.20
-  xmlsec1-openssl:
-    - arch: x86_64
-      epoch: null
-      name: xmlsec1-openssl
-      release: 7.el7_4
-      source: rpm
-      version: 1.2.20
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zip:
-    - arch: x86_64
-      epoch: null
-      name: zip
-      release: 11.el7
-      source: rpm
-      version: '3.0'
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-tcp_listen:
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1005
-    port: 22
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: 0.0.0.0
-    name: postmaster
-    pid: 88651
-    port: 5432
-    protocol: tcp
-    stime: 'Wed Jun 22 09:28:14 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1186
-    port: 25
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: 0.0.0.0
-    name: docker-proxy
-    pid: 90666
-    port: 8443
-    protocol: tcp
-    stime: 'Wed Jun 22 10:01:17 2022'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 46171
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 23339
-    port: 443
-    protocol: tcp
-    stime: 'Tue Jun  1 17:04:40 2021'
-    user: root
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: null
     name: python
-    pid: 88571
-    port: 8444
-    protocol: tcp
-    stime: 'Wed Jun 22 09:28:00 2022'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: nrpe
-    pid: 999
-    port: 5666
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: nrpe
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 20064
-    port: 6378
-    protocol: tcp
-    stime: 'Tue May 25 11:00:31 2021'
-    user: polkitd
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 20064
-    port: 6379
-    protocol: tcp
-    stime: 'Tue May 25 11:00:31 2021'
-    user: polkitd
-  - address: 0.0.0.0
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-firewall:
+  - arch: noarch
+    epoch: null
+    name: python-firewall
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  python-psycopg2:
+  - arch: x86_64
+    epoch: null
+    name: python-psycopg2
+    release: 1.rhel7
+    source: rpm
+    version: 2.7.5
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-slip:
+  - arch: noarch
+    epoch: null
+    name: python-slip
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-slip-dbus:
+  - arch: noarch
+    epoch: null
+    name: python-slip-dbus
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  rcs:
+  - arch: x86_64
+    epoch: null
+    name: rcs
+    release: 7.el7
+    source: rpm
+    version: 5.9.0
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 0.0.0.0
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: 0.0.0.0
-    name: rpc.statd
-    pid: 47406
-    port: 53648
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 23339
-    port: 80
-    protocol: tcp
-    stime: 'Tue Jun  1 17:04:40 2021'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1005
-    port: 22
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1186
-    port: 25
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 40957
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: nrpe
-    pid: 999
-    port: 5666
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: nrpe
-  - address: '::'
-    name: mariadbd
-    pid: 73979
-    port: 3306
-    protocol: tcp
-    stime: 'Tue May 25 15:30:13 2021'
-    user: mysql
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: '::'
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: '::'
-    name: rpc.statd
-    pid: 47406
-    port: 47601
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-sign:
+  - arch: x86_64
+    epoch: null
+    name: rpm-sign
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  socat:
+  - arch: x86_64
+    epoch: null
+    name: socat
+    release: 2.el7
+    source: rpm
+    version: 1.7.3.2
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 6.el7
+    source: rpm
+    version: '4.24'
+  subversion:
+  - arch: x86_64
+    epoch: null
+    name: subversion
+    release: 16.el7
+    source: rpm
+    version: 1.7.14
+  subversion-libs:
+  - arch: x86_64
+    epoch: null
+    name: subversion-libs
+    release: 16.el7
+    source: rpm
+    version: 1.7.14
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.1
+    source: rpm
+    version: 1.8.23
+  swig:
+  - arch: x86_64
+    epoch: null
+    name: swig
+    release: 5.el7
+    source: rpm
+    version: 2.0.10
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemtap:
+  - arch: x86_64
+    epoch: null
+    name: systemtap
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-client:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-client
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-devel:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-devel
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-runtime:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-runtime
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 66.el7
+    source: rpm
+    version: '0.17'
+  traceroute:
+  - arch: x86_64
+    epoch: 3
+    name: traceroute
+    release: 2.el7
+    source: rpm
+    version: 2.0.22
+  trousers:
+  - arch: x86_64
+    epoch: null
+    name: trousers
+    release: 2.el7
+    source: rpm
+    version: 0.3.14
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  webtatic-release:
+  - arch: noarch
+    epoch: null
+    name: webtatic-release
+    release: '3'
+    source: rpm
+    version: '7'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wireshark:
+  - arch: x86_64
+    epoch: null
+    name: wireshark
+    release: 25.el7
+    source: rpm
+    version: 1.10.14
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xagt:
+  - arch: x86_64
+    epoch: null
+    name: xagt
+    release: 1.el7
+    source: rpm
+    version: 33.46.6
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xmlsec1:
+  - arch: x86_64
+    epoch: null
+    name: xmlsec1
+    release: 7.el7_4
+    source: rpm
+    version: 1.2.20
+  xmlsec1-openssl:
+  - arch: x86_64
+    epoch: null
+    name: xmlsec1-openssl
+    release: 7.el7_4
+    source: rpm
+    version: 1.2.20
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '54'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '55'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '66'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '78'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '98'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '136'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '302'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '305'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '306'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '308'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '309'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '310'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '311'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '312'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '315'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '321'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '322'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '324'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '325'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '326'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '327'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '328'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '329'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '330'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '331'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '332'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '333'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '334'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '335'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '347'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '348'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '349'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '350'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '351'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '352'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '353'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '354'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '355'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '356'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '357'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '358'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '359'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '360'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '361'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '362'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '363'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '364'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '405'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '406'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '420'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '427'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '428'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '429'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '430'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '431'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '432'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '433'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '434'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '435'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '436'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '437'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '438'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '518'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '552'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '607'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '608'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '611'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '612'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '613'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '614'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '615'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '623'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '682'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/VGAuthService -s
+  cwd: /usr/bin/
+  pid: '705'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/vmtoolsd
+  cwd: /usr/bin/
+  pid: '706'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '708'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '710'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '713'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '719'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/NetworkManager --no-daemon
+  cwd: /usr/sbin/
+  pid: '732'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '734'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '738'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '813'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f
+  cwd: /usr/sbin/
+  pid: '999'
+  ppid: '1'
+  user: nrpe
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1002'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1004'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1005'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1186'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1207'
+  ppid: '1186'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '1467'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1489'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1498'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1521'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2185'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '3002'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18532'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '20044'
+  ppid: '1'
+  user: root
+- cmdline: redis-server 0.0.0.0:6379
+  cwd: /
+  pid: '20064'
+  ppid: '20044'
+  user: polkitd
+- cmdline: /usr/bin/docker start -a redis
+  cwd: /usr/bin/
+  pid: '20366'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '23319'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '23339'
+  ppid: '23319'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '23356'
+  ppid: '23339'
+  user: '101'
+- cmdline: /usr/bin/docker start -a nginx
+  cwd: /usr/bin/
+  pid: '23581'
+  ppid: '1'
+  user: root
+- cmdline: SCREEN
+  cwd: /
+  pid: '24403'
+  ppid: '1'
+  user: root
+- cmdline: /bin/bash
+  cwd: /bin/
+  pid: '24404'
+  ppid: '24403'
+  user: root
+- cmdline: sudo -u postgres psql
+  cwd: /
+  pid: '28523'
+  ppid: '24404'
+  user: root
+- cmdline: psql
+  cwd: /
+  pid: '28524'
+  ppid: '28523'
+  user: postgres
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '34186'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c python ./listener.py
+  cwd: /bin/
+  pid: '34206'
+  ppid: '34186'
+  user: root
+- cmdline: python ./listener.py
+  cwd: /
+  pid: '34220'
+  ppid: '34206'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36887'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44629'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46732'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46733'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '46865'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '47374'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '47383'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47398'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/rpc.statd
+  cwd: /usr/sbin/
+  pid: '47406'
+  ppid: '1'
+  user: rpcuser
+- cmdline: /usr/sbin/rpc.idmapd
+  cwd: /usr/sbin/
+  pid: '47408'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rpc.mountd
+  cwd: /usr/sbin/
+  pid: '47410'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47415'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47416'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47421'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47422'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47423'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47424'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47425'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47426'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47427'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47428'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52062'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '54568'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '55619'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56141'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56568'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59036'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '60677'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61266'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61271'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '67217'
+  ppid: '2'
+  user: root
+- cmdline: /opt/fireeye/bin/xagt -M DAEMON
+  cwd: /opt/fireeye/bin/
+  pid: '69963'
+  ppid: '1'
+  user: root
+- cmdline: /opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT --logfd
+    4
+  cwd: /opt/fireeye/bin/
+  pid: '69987'
+  ppid: '69963'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '71100'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: root@pts/0'
+  cwd: /
+  pid: '71236'
+  ppid: '1005'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '71238'
+  ppid: '71236'
+  user: root
+- cmdline: /usr/sbin/mariadbd
+  cwd: /usr/sbin/
+  pid: '73979'
+  ppid: '1'
+  user: mysql
+- cmdline: ''
+  cwd: /
+  pid: '78889'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '88081'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-cmdb-gateway
+  cwd: /usr/bin/
+  pid: '88490'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '88533'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c ./start_cmdb_gateway.sh
+  cwd: /bin/
+  pid: '88553'
+  ppid: '88533'
+  user: root
+- cmdline: /bin/sh ./start_cmdb_gateway.sh
+  cwd: /bin/
+  pid: '88569'
+  ppid: '88553'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '88571'
+  ppid: '88569'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '88575'
+  ppid: '88571'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '88576'
+  ppid: '88571'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '88577'
+  ppid: '88571'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '88578'
+  ppid: '88571'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '88579'
+  ppid: '88571'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '88580'
+  ppid: '88571'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '88581'
+  ppid: '88571'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '88582'
+  ppid: '88571'
+  user: root
+- cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
+  cwd: /usr/pgsql-10/bin/
+  pid: '88651'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: data: checkpointer process'
+  cwd: /
+  pid: '88655'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: writer process'
+  cwd: /
+  pid: '88656'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: wal writer process'
+  cwd: /
+  pid: '88657'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: autovacuum launcher process'
+  cwd: /
+  pid: '88658'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: stats collector process'
+  cwd: /
+  pid: '88659'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: bgworker: logical replication launcher'
+  cwd: /
+  pid: '88660'
+  ppid: '88651'
+  user: postgres
+- cmdline: ''
+  cwd: /
+  pid: '90282'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '90400'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-cmdbuild
+  cwd: /usr/bin/
+  pid: '90640'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 -container-ip
+    192.168.1.2 -container-port 8443
+  cwd: /usr/bin/
+  pid: '90666'
+  ppid: '60677'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '90683'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
+  cwd: /bin/
+  pid: '90702'
+  ppid: '90683'
+  user: tomcat
+- cmdline: /usr/local/openjdk-17/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx7876m -Xms3846m
+    -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+    -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
+    -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar -Delastic.apm.service_name=cmdb
+    -Delastic.apm.server_url=http://192.168.8.53:8200 -Delastic.apm.environment=dev
+    -Delastic.apm.enabled=true -Delastic.apm.profiling_inferred_spans_enabled=true
+    -Delastic.apm.profiling_inferred_spans_min_duration=250ms -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
+    -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
+    -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp
+    org.apache.catalina.startup.Bootstrap start
+  cwd: /usr/local/openjdk-17/bin/
+  pid: '90741'
+  ppid: '90702'
+  user: tomcat
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50944) idle'
+  cwd: /
+  pid: '90926'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50946) idle'
+  cwd: /
+  pid: '90927'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50948) idle'
+  cwd: /
+  pid: '90928'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50950) idle'
+  cwd: /
+  pid: '90929'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50952) idle'
+  cwd: /
+  pid: '90930'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50954) idle'
+  cwd: /
+  pid: '90931'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50956) idle'
+  cwd: /
+  pid: '90932'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50958) idle'
+  cwd: /
+  pid: '90933'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50960) idle'
+  cwd: /
+  pid: '90934'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50962) idle'
+  cwd: /
+  pid: '90935'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50964) idle'
+  cwd: /
+  pid: '90936'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50966) idle'
+  cwd: /
+  pid: '90937'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50968) idle'
+  cwd: /
+  pid: '90938'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50970) idle'
+  cwd: /
+  pid: '90939'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50972) idle'
+  cwd: /
+  pid: '90940'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50974) idle'
+  cwd: /
+  pid: '90941'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50976) idle'
+  cwd: /
+  pid: '90942'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50978) idle'
+  cwd: /
+  pid: '90943'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50980) idle'
+  cwd: /
+  pid: '90944'
+  ppid: '88651'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(50982) idle'
+  cwd: /
+  pid: '90945'
+  ppid: '88651'
+  user: postgres
+- cmdline: ''
+  cwd: /
+  pid: '102105'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '114346'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '117135'
+  ppid: '1186'
+  user: postfix
+- cmdline: 'sshd: root@pts/2'
+  cwd: /
+  pid: '122013'
+  ppid: '1005'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '122015'
+  ppid: '122013'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '123676'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '124124'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '125140'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '125701'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '125820'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: root@pts/3'
+  cwd: /
+  pid: '126024'
+  ppid: '1005'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '126104'
+  ppid: '2'
+  user: root
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-lmxpukhnqgizkpshldtsbmeytdvlzwbs
+    ; /usr/bin/python /root/.ansible/tmp/ansible-tmp-1656065317.510032-51987-252936824205505/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '126182'
+  ppid: '126024'
+  user: root
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-lmxpukhnqgizkpshldtsbmeytdvlzwbs
+    ; /usr/bin/python /root/.ansible/tmp/ansible-tmp-1656065317.510032-51987-252936824205505/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '126193'
+  ppid: '126182'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-lmxpukhnqgizkpshldtsbmeytdvlzwbs ; /usr/bin/python
+    /root/.ansible/tmp/ansible-tmp-1656065317.510032-51987-252936824205505/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '126195'
+  ppid: '126193'
+  user: root
+- cmdline: /usr/bin/python /root/.ansible/tmp/ansible-tmp-1656065317.510032-51987-252936824205505/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '126196'
+  ppid: '126195'
+  user: root
+software_list:
+- cmd_regexp: /mariadbd(\s|$)
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/mysql_mariadb.yaml'
+    name: Include MariaDB specific plugins
+    vars:
+      default_client_file: mariadb
+      default_server_file: mariadbd
+  name: MariaDB DatabaseServer
+  pkg_regexp: mariadb-serve
+  process_type: parent
+  return_children: false
+  return_packages: true
+  vars:
+    connect_with_users: '{{ mariadb_monitor_users_info | default(mysql_monitor_users_info
+      | default([{''username'': mariadb_monitor_user | default(mysql_monitor_user
+      | default(''mysql'')), ''password'': mariadb_monitor_pass | default(mysql_monitor_pass
+      | default(''mysql''))}])) }}'
+    ignore_databases:
+    - information_schema
+    - mysql
+    - test
+    - performance_schema
+task_vars:
+  ansible_facts:
+    all_ipv4_addresses:
+    - 192.168.1.1
+    - 192.168.64.34
+  mariadb_monitor_users_info:
+  - password: password_a
+    username: user_a
+  - password: password_b
+    username: user_b
+tcp_listen:
+- address: 0.0.0.0
+  name: sshd
+  pid: 1005
+  port: 22
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: 0.0.0.0
+  name: postmaster
+  pid: 88651
+  port: 5432
+  protocol: tcp
+  stime: Wed Jun 22 09:28:14 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1186
+  port: 25
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: 0.0.0.0
+  name: docker-proxy
+  pid: 90666
+  port: 8443
+  protocol: tcp
+  stime: Wed Jun 22 10:01:17 2022
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 46171
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 23339
+  port: 443
+  protocol: tcp
+  stime: Tue Jun  1 17:04:40 2021
+  user: root
+- address: 0.0.0.0
+  name: python
+  pid: 88571
+  port: 8444
+  protocol: tcp
+  stime: Wed Jun 22 09:28:00 2022
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: nrpe
+  pid: 999
+  port: 5666
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: nrpe
+- address: 0.0.0.0
+  name: redis-server
+  pid: 20064
+  port: 6378
+  protocol: tcp
+  stime: Tue May 25 11:00:31 2021
+  user: polkitd
+- address: 0.0.0.0
+  name: redis-server
+  pid: 20064
+  port: 6379
+  protocol: tcp
+  stime: Tue May 25 11:00:31 2021
+  user: polkitd
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: tcp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 0.0.0.0
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: 0.0.0.0
+  name: rpc.statd
+  pid: 47406
+  port: 53648
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 23339
+  port: 80
+  protocol: tcp
+  stime: Tue Jun  1 17:04:40 2021
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1005
+  port: 22
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: ::1
+  name: master
+  pid: 1186
+  port: 25
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: '::'
+  name: ''
+  pid: 0
+  port: 40957
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: '::'
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: '::'
+  name: nrpe
+  pid: 999
+  port: 5666
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: nrpe
+- address: '::'
+  name: mariadbd
+  pid: 73979
+  port: 3306
+  protocol: tcp
+  stime: Tue May 25 15:30:13 2021
+  user: mysql
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: tcp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: '::'
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: '::'
+  name: rpc.statd
+  pid: 47406
+  port: 47601
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
 udp_listen:
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 59970
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: rpc.statd
-    pid: 47406
-    port: 60822
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 719
-    port: 323
-    protocol: udp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 909
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 127.0.0.1
-    name: rpc.statd
-    pid: 47406
-    port: 942
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: '::'
-    name: rpc.statd
-    pid: 47406
-    port: 42219
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 42799
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 719
-    port: 323
-    protocol: udp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 909
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: udp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 59970
+  protocol: udp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: rpc.statd
+  pid: 47406
+  port: 60822
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 719
+  port: 323
+  protocol: udp
+  stime: Fri May 21 08:55:20 2021
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 909
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 127.0.0.1
+  name: rpc.statd
+  pid: 47406
+  port: 942
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: '::'
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: udp
+  stime: ''
+  user: ''
+- address: '::'
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: '::'
+  name: rpc.statd
+  pid: 47406
+  port: 42219
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: '::'
+  name: ''
+  pid: 0
+  port: 42799
+  protocol: udp
+  stime: ''
+  user: ''
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 719
+  port: 323
+  protocol: udp
+  stime: Fri May 21 08:55:20 2021
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 909
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/memcached/memcached1.6.6_centos7.6_docker.yaml
+++ b/tests/unit/plugins/action/auto/resources/memcached/memcached1.6.6_centos7.6_docker.yaml
@@ -1,5390 +1,5601 @@
-expected_result:
-  - bindings:
-      - address: '::'
-        class: 'service'
-        port: 11211
-        protocol: 'tcp'
-    discovery_time: '2022-07-05T09:47:23+02:00'
-    docker:
-      exposed_ports:
-        11211/tcp: { }
-      id: 1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
-      image: nexusregistry.opensolutions.cloud/monitorizacion/memcached:alpine
-      name: /awx_memcached
-      network_mode: 'default'
-      port_bindings:
-        '11211/tcp':
-          - 'HostIp': '0.0.0.0'
-            'HostPort': '11211'
-    listening_ports:
-      - 11211
-    packages: [ ]
-    process:
-      cmdline: memcached -s /var/run/memcached/memcached.sock -a 0666
-      listening_ports:
-        - 11211
-      pid: '8510'
-      ppid: '8484'
-      user: '11211'
-    type: Memcached
-    version:
-      - number: alpine
-        type: docker
-
-software_list:
-  - name: Memcached
-    cmd_regexp: ^memcached
-    pkg_regexp: ^memcached
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - run
-        - python3
-        - cli.py
-        - -c
-        - /app/etc/awx_cleaner_conf.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - -c
-          - /app/etc/awx_cleaner_conf.yml
-        Domainname: ''
-        Entrypoint:
-          - pipenv
-          - run
-          - python3
-          - cli.py
-        Env:
-          - AWX_CLEANER_PASSWORD=
-          - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=the_key
-          - PYTHON_VERSION=3.7.9
-          - PYTHON_PIP_VERSION=20.2.2
-          - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
-          - PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
-          - PYTHONUNBUFFERED=true
-        Hostname: awx01.novalocal
-        Image: nexusregistry.opensolutions.cloud/awx-cleaner:1.2.1
-        Labels:
-          maintainer: oromeu
-          os_contianer_type: awx_cleaner
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: { }
-        WorkingDir: /app
-      Created: '2021-10-18T11:45:16.316785262Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976-init/diff:/var/lib/docker/overlay2/22df782a1cbd5e34a3d5776753b2a807f00ba47e6013551e8b95f7e2ed93db35/diff:/var/lib/docker/overlay2/312b95522dd6921da5c2d5289fb7f32e63ceb5e10ba2143adbbc4c99d35023a9/diff:/var/lib/docker/overlay2/6300a0d70ac3252c87a6be17df77e286b97b4db13ba9be1526f70834f50875e1/diff:/var/lib/docker/overlay2/fd460f916e69c1b50a62212515f5b8bc8a8d29472da602c7c4cb37a16eb20137/diff:/var/lib/docker/overlay2/f1d776f54a392e59db855bf36785245f6d6774c0d16951e72d5ef172007b3fb9/diff:/var/lib/docker/overlay2/a68da68959434fd6261752e9e627f939d0d4b2b2ccbac7f32d663f915b67b07d/diff:/var/lib/docker/overlay2/6705a2fe1186389824def98c101d6b9b14b6d32e920c3c874e43208cb067f5f1/diff:/var/lib/docker/overlay2/2fe2d6a4cb1c5d9f55c98910a5ea422b2f8e7d8fefedefc8b1913aed66fe7ed2/diff:/var/lib/docker/overlay2/5fabbebbda1b3e287dc88fa6f41f6e1cb3e63553bb07ce5e0f945eea1bfe255d/diff:/var/lib/docker/overlay2/5d678a8dc7b4f4a16fd7a36e567ea771d528ac34407935769ebfd7e1bac68eb4/diff
-          MergedDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/merged
-          UpperDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/diff
-          WorkDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/iometrics:/app/etc:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/hostname
-      HostsPath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/hosts
-      Id: 19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941
-      Image: sha256:9e588379d3c89b34839fda2502e557249b103a4b22fd1b80c37097ad0488fdf6
-      LogPath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics
-          Type: bind
-      Name: /awx_cleaner
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 42bdb7f605a2864503abdfd91ff9feeefc9c51f05d2244721f8611afa6a33ed4
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 9f8b86b22be78ec095186dd5f8afda1a02d9c56c4e2bbb6a334825173f523943
-        Ports: { }
-        SandboxID: 2d16f1e23a19f0ef31933e4089f40ddff90fc591a0b35c0dd09bbd262d0739df
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: pipenv
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-06-15T07:12:59.538531845Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1639
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-15T07:12:59.976312521Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - --
-        - /bin/sh
-        - -c
-        - /usr/bin/launch_awx_task.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - -c
-          - /usr/bin/launch_awx_task.sh
-        Domainname: ''
-        Entrypoint:
-          - tini
-          - --
-        Env:
-          - TASK_HOSTNAME=awx_awx01_task_1
-          - DATABASE_PORT=5432
-          - DATABASE_NAME=awx
-          - AWX_QUEUE_NAME=runners
-          - AWX_ADMIN_USER=datadope
-          - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
-          - AWX_ADMIN_PASSWORD=the_password
-          - DATABASE_PASSWORD=the_password
-          - SECRET_KEY=the_key
-          - DATABASE_HOST=192.168.0.252
-          - DATABASE_USER=awx
-          - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=en_US.UTF-8
-          - LANGUAGE=en_US:en
-          - LC_ALL=en_US.UTF-8
-          - HOME=/home/awx
-        ExposedPorts:
-          8052/tcp: { }
-        Hostname: awx_awx01_task_1
-        Image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
-        Labels:
-          org.label-schema.build-date: '20200114'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: CentOS Base Image
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vendor: CentOS
-          org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
-          org.opencontainers.image.licenses: GPL-2.0-only
-          org.opencontainers.image.title: CentOS Base Image
-          org.opencontainers.image.vendor: CentOS
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: root
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/tower/SECRET_KEY: { }
-          /etc/tower/conf.d/credentials.py: { }
-          /etc/tower/conf.d/environment.sh: { }
-          /etc/ucmdb.auth: { }
-          /usr/bin/launch_awx_task.sh: { }
-          /var/lib/awx/projects: { }
-          /var/lib/awx/rsyslog/: { }
-          /var/lib/nginx: { }
-          /var/run/awx-rsyslog: { }
-          /var/run/memcached: { }
-          /var/run/redis: { }
-          /var/run/supervisor: { }
-        WorkingDir: /var/lib/awx
-      Created: '2021-10-18T11:44:59.182845248Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
-          MergedDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/merged
-          UpperDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/diff
-          WorkDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
-          - /etc/localtime:/etc/localtime:ro
-          - /var/run/awx_memcached:/var/run/memcached:rw
-          - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
-          - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
-          - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
-          - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
-          - /var/lib/awx/projects/awx01__runners__1:/var/lib/awx/projects:rw
-          - /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
-          - /etc/hosts:/etc/hosts:ro
-          - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
-          - /var/run/awx_supervisor:/var/run/supervisor:rw
-          - /var/run/awx_redis:/var/run/redis:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/hostname
-      HostsPath: /etc/hosts
-      Id: d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
-      Image: sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7
-      LogPath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/ucmdb.auth
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/ucmdb.auth
-          Type: bind
-        - Destination: /var/lib/awx/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/projects/awx01__runners__1
-          Type: bind
-        - Destination: /var/lib/awx/rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/lib/awx/rsyslog
-          Type: bind
-        - Destination: /var/run/supervisor
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_supervisor
-          Type: bind
-        - Destination: /etc/tower/conf.d/credentials.py
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/credentials.py
-          Type: bind
-        - Destination: /etc/tower/conf.d/environment.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/environment.sh
-          Type: bind
-        - Destination: /var/run/awx-rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_rsyslog
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /usr/bin/launch_awx_task.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/launch_awx_task.sh
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/tower/SECRET_KEY
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/SECRET_KEY
-          Type: bind
-        - Destination: /var/lib/nginx
-          Driver: local
-          Mode: ''
-          Name: 7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6/_data
-          Type: volume
-      Name: /awx_awx01_task_1
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          awx:
-            Aliases:
-              - d13b4e9fdb7e
-            DriverOpts: null
-            EndpointID: 85027b2a5efa749aa7c8e87269e8803be0c4f0b5a75520aff51ab68492f91a7d
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:12:00:02
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-        Ports:
-          8052/tcp: null
-        SandboxID: b952a5e659a2bad6bef04200378542419a1ab00bffee6fb12ffefdf90ea009eb
-        SandboxKey: /var/run/docker/netns/b952a5e659a2
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.691239226Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8441
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.062811086Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - --
-        - /bin/sh
-        - -c
-        - /usr/bin/launch_awx_task.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - -c
-          - /usr/bin/launch_awx_task.sh
-        Domainname: ''
-        Entrypoint:
-          - tini
-          - --
-        Env:
-          - TASK_HOSTNAME=awx_awx01_task_tower_1
-          - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
-          - DATABASE_NAME=awx
-          - AWX_QUEUE_NAME=tower
-          - AWX_ADMIN_USER=datadope
-          - AWX_HOSTNAME=awx01
-          - DATABASE_PORT=5432
-          - AWX_ADMIN_PASSWORD=the_password
-          - DATABASE_PASSWORD=the_password
-          - SECRET_KEY=the_key
-          - DATABASE_HOST=192.168.0.252
-          - DATABASE_USER=awx
-          - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=en_US.UTF-8
-          - LANGUAGE=en_US:en
-          - LC_ALL=en_US.UTF-8
-          - HOME=/home/awx
-        ExposedPorts:
-          8052/tcp: { }
-        Hostname: awx_awx01_task_tower_1
-        Image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
-        Labels:
-          org.label-schema.build-date: '20200114'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: CentOS Base Image
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vendor: CentOS
-          org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
-          org.opencontainers.image.licenses: GPL-2.0-only
-          org.opencontainers.image.title: CentOS Base Image
-          org.opencontainers.image.vendor: CentOS
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: root
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/tower/SECRET_KEY: { }
-          /etc/tower/conf.d/credentials.py: { }
-          /etc/tower/conf.d/environment.sh: { }
-          /etc/tower/iometrics: { }
-          /etc/ucmdb.auth: { }
-          /usr/bin/launch_awx_task.sh: { }
-          /var/lib/awx/projects: { }
-          /var/lib/awx/rsyslog/: { }
-          /var/lib/nginx: { }
-          /var/run/awx-rsyslog: { }
-          /var/run/memcached: { }
-          /var/run/redis: { }
-          /var/run/supervisor: { }
-          /var/tmp/projects: { }
-        WorkingDir: /var/lib/awx
-      Created: '2021-10-18T11:44:40.881348712Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
-          MergedDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/merged
-          UpperDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/diff
-          WorkDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
-          - /var/lib/awx/projects/awx01__tower_task__1:/var/lib/awx/projects:rw
-          - /etc/localtime:/etc/localtime:ro
-          - /var/run/awx_memcached:/var/run/memcached:rw
-          - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
-          - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
-          - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
-          - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
-          - /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
-          - /etc/hosts:/etc/hosts:ro
-          - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
-          - /var/lib/awx/var/tmp/projects:/var/tmp/projects:rw
-          - /var/run/awx_supervisor:/var/run/supervisor:rw
-          - /var/run/awx_redis:/var/run/redis:rw
-          - /var/lib/awx/etc/awx/iometrics:/etc/tower/iometrics:ro
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/hostname
-      HostsPath: /etc/hosts
-      Id: efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
-      Image: sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7
-      LogPath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/run/awx-rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_rsyslog
-          Type: bind
-        - Destination: /var/run/supervisor
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_supervisor
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/tower/conf.d/credentials.py
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/credentials.py
-          Type: bind
-        - Destination: /etc/tower/iometrics
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/iometrics
-          Type: bind
-        - Destination: /etc/ucmdb.auth
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/ucmdb.auth
-          Type: bind
-        - Destination: /var/lib/awx/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/projects/awx01__tower_task__1
-          Type: bind
-        - Destination: /etc/tower/conf.d/environment.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/environment.sh
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-        - Destination: /usr/bin/launch_awx_task.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/launch_awx_task.sh
-          Type: bind
-        - Destination: /var/lib/nginx
-          Driver: local
-          Mode: ''
-          Name: 8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e/_data
-          Type: volume
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/tower/SECRET_KEY
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/SECRET_KEY
-          Type: bind
-        - Destination: /var/lib/awx/rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/lib/awx/rsyslog
-          Type: bind
-        - Destination: /var/tmp/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/tmp/projects
-          Type: bind
-      Name: /awx_awx01_task_tower_1
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          awx:
-            Aliases:
-              - efdbe7e2ed56
-            DriverOpts: null
-            EndpointID: 793c5d8df433bbb806037f28add3fb99b4b1deb2a738cd38a8b3432dabec6683
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.3
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:12:00:03
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-        Ports:
-          8052/tcp: null
-        SandboxID: c8b6987031aa99ac901a2ec3ec5eff6490a8fc6163a78728e1e72c7b07ba5f36
-        SandboxKey: /var/run/docker/netns/c8b6987031aa
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.666814215Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8448
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.066062167Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - --
-        - /bin/sh
-        - -c
-        - /usr/bin/launch_awx.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - -c
-          - /usr/bin/launch_awx.sh
-        Domainname: ''
-        Entrypoint:
-          - tini
-          - --
-        Env:
-          - DATABASE_NAME=awx
-          - AWX_QUEUE_NAME=tower
-          - AWX_ADMIN_USER=datadope
-          - DATABASE_PORT=5432
-          - AWX_ADMIN_PASSWORD=the_password
-          - DATABASE_PASSWORD=the_password
-          - SECRET_KEY=the_key
-          - DATABASE_HOST=192.168.0.252
-          - DATABASE_USER=awx
-          - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=en_US.UTF-8
-          - LANGUAGE=en_US:en
-          - LC_ALL=en_US.UTF-8
-          - HOME=/home/awx
-        ExposedPorts:
-          8052/tcp: { }
-          8053/tcp: { }
-        Hostname: awx_web_tower_1
-        Image: nexusregistry.opensolutions.cloud/awx_web:11.2.0
-        Labels:
-          org.label-schema.build-date: '20200114'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: CentOS Base Image
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vendor: CentOS
-          org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
-          org.opencontainers.image.licenses: GPL-2.0-only
-          org.opencontainers.image.title: CentOS Base Image
-          org.opencontainers.image.vendor: CentOS
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: root
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/nginx/awxweb.pem: { }
-          /etc/nginx/nginx.conf: { }
-          /etc/tower/SECRET_KEY: { }
-          /etc/tower/conf.d/credentials.py: { }
-          /etc/tower/conf.d/environment.sh: { }
-          /etc/ucmdb.auth: { }
-          /var/lib/awx/projects: { }
-          /var/lib/awx/rsyslog/: { }
-          /var/lib/nginx: { }
-          /var/run/awx-rsyslog: { }
-          /var/run/memcached: { }
-          /var/run/redis: { }
-          /var/run/supervisor: { }
-        WorkingDir: /var/lib/awx
-      Created: '2021-10-18T10:22:23.792332427Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2-init/diff:/var/lib/docker/overlay2/3c13fb2448c4706f60677e56fabf13eee05734ec5a9766eee43659261dab90a3/diff:/var/lib/docker/overlay2/91b427dfbb443e5fd41e123d6b65806881f1527b05e897537808332da3c65afc/diff:/var/lib/docker/overlay2/37f36c6664c7d70bb927546ad358b46f72fa603c0511aab5625546c4fbaf4224/diff:/var/lib/docker/overlay2/cb747a616cd72b17e0277b27cd036ff79f061d2bf1ec49f6f7576a513ff1f454/diff:/var/lib/docker/overlay2/1f5a7c255f9d87a97f18408553cc5ea8a3e57b803d58d444684e77065992886c/diff:/var/lib/docker/overlay2/701b839302666be2d93bcec208db2b10bfc64f25b9dd3edbb4b6f5beeb0ff215/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
-          MergedDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/merged
-          UpperDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/diff
-          WorkDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
-          - /etc/localtime:/etc/localtime:ro
-          - /var/run/awx_memcached:/var/run/memcached:rw
-          - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
-          - /var/run/awx_supervisor:/var/run/supervisor:rw
-          - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
-          - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
-          - /var/lib/awx/etc/awx/nginx.conf:/etc/nginx/nginx.conf:ro
-          - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
-          - /etc/hosts:/etc/hosts:ro
-          - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
-          - /var/lib/awx/etc/awx/awxweb.pem:/etc/nginx/awxweb.pem:ro
-          - /var/lib/awx/projects/awx01__tower_web_1:/var/lib/awx/projects:rw
-          - /var/run/awx_redis:/var/run/redis:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths: null
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8052/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '80'
-          8053/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '443'
-        Privileged: true
-        PublishAllPorts: false
-        ReadonlyPaths: null
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt:
-          - label=disable
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/hostname
-      HostsPath: /etc/hosts
-      Id: b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
-      Image: sha256:71ea5e1b1b2f382bd0b0560464ea9c77dc30e396e8c6e9b8958b33b94416b708
-      LogPath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/tower/SECRET_KEY
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/SECRET_KEY
-          Type: bind
-        - Destination: /etc/tower/conf.d/environment.sh
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/environment.sh
-          Type: bind
-        - Destination: /var/run/supervisor
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_supervisor
-          Type: bind
-        - Destination: /etc/nginx/awxweb.pem
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/awxweb.pem
-          Type: bind
-        - Destination: /var/lib/awx/rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/var/lib/awx/rsyslog
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/tower/conf.d/credentials.py
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/credentials.py
-          Type: bind
-        - Destination: /etc/ucmdb.auth
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/ucmdb.auth
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx/nginx.conf
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /var/lib/awx/etc/awx/nginx.conf
-          Type: bind
-        - Destination: /var/lib/awx/projects
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/awx/projects/awx01__tower_web_1
-          Type: bind
-        - Destination: /var/lib/nginx
-          Driver: local
-          Mode: ''
-          Name: 9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd/_data
-          Type: volume
-        - Destination: /var/run/awx-rsyslog
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_rsyslog
-          Type: bind
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-      Name: /awx_web_tower_1
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          awx:
-            Aliases:
-              - awx_web
-              - b7972b752e85
-            DriverOpts: null
-            EndpointID: 68e96dfb1a48497323aabc5ffbad6da682bbd271778ed383ed3c9cbf86ddb732
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.4
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:12:00:04
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-        Ports:
-          8052/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '80'
-          8053/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '443'
-        SandboxID: 82cf34c71f29edf07f8bfba5e104fe5715f8195c1c5d6af30843be7315149a93
-        SandboxKey: /var/run/docker/netns/82cf34c71f29
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: tini
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.713044964Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8455
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.064174569Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - -s
-        - /var/run/memcached/memcached.sock
-        - -a
-        - '0666'
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - -s
-          - /var/run/memcached/memcached.sock
-          - -a
-          - '0666'
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - MEMCACHED_VERSION=1.6.6
-          - MEMCACHED_SHA1=d8895b12dc9fc82b389f1713e2c09cc6ca3d03e4
-        ExposedPorts:
-          11211/tcp: { }
-        Hostname: 1c624b0d7c73
-        Image: nexusregistry.opensolutions.cloud/monitorizacion/memcached:alpine
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: memcache
-        Volumes:
-          /etc/localtime: { }
-          /var/run/memcached: { }
-        WorkingDir: ''
-      Created: '2020-06-03T10:16:16.67286319Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d-init/diff:/var/lib/docker/overlay2/d8877c054116b5ee97ee53c893117c6fb2dfff8ecd5f7de53f12ae1a64c9e063/diff:/var/lib/docker/overlay2/09557cecc7a0ad7866cb864928e034e550f8e97703d629f1f16287ebc96056ca/diff:/var/lib/docker/overlay2/e26535172b18e8ba64dfeb361e9a74d224ba94487968fff19550ae35baa09f1b/diff:/var/lib/docker/overlay2/005ea37c98a59f97323add0a2222945ef78f4af4abc0478bfd68a0de5805ee3a/diff:/var/lib/docker/overlay2/7b303f0c79fd7aa2e61f9f75e0fd0cc48375e353dc577c2ddbc819d1d42e1144/diff:/var/lib/docker/overlay2/5e13e12e87f251e2cf30736940f53a5b2a922d1b8fbab5fdb529c204d56010e3/diff
-          MergedDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/merged
-          UpperDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/diff
-          WorkDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/localtime:/etc/localtime:rw
-          - /var/run/awx_memcached:/var/run/memcached:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths: null
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          11211/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '11211'
-        Privileged: true
-        PublishAllPorts: false
-        ReadonlyPaths: null
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt:
-          - label=disable
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hostname
-      HostsPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hosts
-      Id: 1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
-      Image: sha256:35acd9837d07e6369afd8683ae08f7da10de93ea5d50e74050abbdeece1e6754
-      LogPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/run/memcached
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_memcached
-          Type: bind
-      Name: /awx_memcached
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: 02:42:ac:11:00:02
-        Networks:
-          awx:
-            Aliases:
-              - memcached
-              - 1c624b0d7c73
-            DriverOpts: null
-            EndpointID: 1918e2a1786dc68318500c7bb707bd61536735c440afa195359d798150cd924e
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.5
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:12:00:05
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:11:00:02
-            NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
-        Ports:
-          11211/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '11211'
-        SandboxID: 6b1d0adc35d952fa492b943f4104aa574aa23454c9b23be2ff55da2e148d9879
-        SandboxKey: /var/run/docker/netns/6b1d0adc35d9
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.690727633Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8510
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:10.809715881Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - /usr/local/etc/redis/redis.conf
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /usr/local/etc/redis/redis.conf
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.0.4
-          - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.4.tar.gz
-          - REDIS_DOWNLOAD_SHA=3337005a1e0c3aa293c87c313467ea8ac11984921fab08807998ba765c9943de
-        ExposedPorts:
-          6379/tcp: { }
-        Hostname: 46897b6fb532
-        Image: nexusregistry.opensolutions.cloud/monitorizacion/redis:6.0.4
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: { }
-          /etc/localtime: { }
-          /usr/local/etc/redis/redis.conf: { }
-          /var/run/redis: { }
-        WorkingDir: /data
-      Created: '2020-06-03T10:08:34.836826924Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5-init/diff:/var/lib/docker/overlay2/f195086ba7e5c223584dc55602eabac57e67456493d3adcbaa39c5734cc1aed6/diff:/var/lib/docker/overlay2/69a5b254a5f5034b01f48dfca65e3a9350da9ef3d39afa86378af53f17773bbc/diff:/var/lib/docker/overlay2/e7bc5968d1154c270b86fc6c25dff4cc0cd6445fd93053648cc6f647d108ac5d/diff:/var/lib/docker/overlay2/5acabe980feecd71fcb74ff02e49f3b54ea1274abfcc2901ac6aaf29bc76c00f/diff:/var/lib/docker/overlay2/1943e56b8ae64a1d3392bb93a86e20b8240ee27400cbfbc0f859909ed75d1b1c/diff:/var/lib/docker/overlay2/7c53990c945f93e734234bf43cdb0ba2ecce49b3b66c9abe18f529aef297e1c3/diff
-          MergedDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/merged
-          UpperDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/diff
-          WorkDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/localtime:/etc/localtime:rw
-          - /var/run/awx_redis:/var/run/redis:rw
-          - /usr/local/etc/redis/redis.conf:/usr/local/etc/redis/redis.conf:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          6379/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '6379'
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hostname
-      HostsPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hosts
-      Id: 46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
-      Image: sha256:36304d3b4540c5143673b2cefaba583a0426b57c709b5a35363f96a3510058cd
-      LogPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/run/redis
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/awx_redis
-          Type: bind
-        - Destination: /data
-          Driver: local
-          Mode: ''
-          Name: 6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330/_data
-          Type: volume
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /usr/local/etc/redis/redis.conf
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /usr/local/etc/redis/redis.conf
-          Type: bind
-      Name: /awx_redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.3
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: 02:42:ac:11:00:03
-        Networks:
-          awx:
-            Aliases:
-              - redis
-              - 46897b6fb532
-            DriverOpts: null
-            EndpointID: 484b6930ad5e400adc2c0bd5d5c0072f63b82cb3d210d25dbdf2776e30583828
-            Gateway: 192.168.2.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.2.6
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:12:00:06
-            NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.3
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:11:00:03
-            NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
-        Ports:
-          6379/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '6379'
-        SandboxID: e3c098aa78f830407f21419ab0f92eccc5d1f533c2c37be76db60452521346cd
-        SandboxKey: /var/run/docker/netns/e3c098aa78f8
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:56.690312533Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 8576
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:11.070796868Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 16.P2.el7_8.6
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-devel:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-devel
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 2.el7
-      source: rpm
-      version: 0.8.5
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  git:
-    - arch: x86_64
-      epoch: null
-      name: git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 307.el7.1
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  htop:
-    - arch: x86_64
-      epoch: null
-      name: htop
-      release: 3.el7
-      source: rpm
-      version: 2.2.0
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1127.13.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs-devel:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs-devel
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-devel:
-    - arch: x86_64
-      epoch: null
-      name: krb5-devel
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcom_err-devel:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err-devel
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libffi-devel:
-    - arch: x86_64
-      epoch: null
-      name: libffi-devel
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libkadm5:
-    - arch: x86_64
-      epoch: null
-      name: libkadm5
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnet:
-    - arch: x86_64
-      epoch: null
-      name: libnet
-      release: 7.el7
-      source: rpm
-      version: 1.1.6
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-devel:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-devel
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsepol-devel:
-    - arch: x86_64
-      epoch: null
-      name: libsepol-devel
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-devel:
-    - arch: x86_64
-      epoch: null
-      name: libverto-devel
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 7.el7_8.2
-      source: rpm
-      version: 2.02.186
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 2.02.186
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  ngrep:
-    - arch: x86_64
-      epoch: null
-      name: ngrep
-      release: 1.1.20180101git9b59468.el7
-      source: rpm
-      version: '1.47'
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-devel:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-devel
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcre-devel:
-    - arch: x86_64
-      epoch: null
-      name: pcre-devel
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Error:
-    - arch: noarch
-      epoch: 1
-      name: perl-Error
-      release: 2.el7
-      source: rpm
-      version: '0.17020'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-Git:
-    - arch: noarch
-      epoch: null
-      name: perl-Git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-TermReadKey:
-    - arch: x86_64
-      epoch: null
-      name: perl-TermReadKey
-      release: 20.el7
-      source: rpm
-      version: '2.30'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 6.el7
-      source: rpm
-      version: '4.24'
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 65.el7_8
-      source: rpm
-      version: '0.17'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 1.el7
-      source: rpm
-      version: 3.2.11
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 1.el7
-      source: rpm
-      version: 4.0.19
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-  zlib-devel:
-    - arch: x86_64
-      epoch: null
-      name: zlib-devel
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '63'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '130'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '179'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '180'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '281'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '304'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '308'
-    ppid: '1096'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '310'
-    ppid: '308'
-    user: centos
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '347'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '426'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '443'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '452'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '560'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '561'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '588'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '617'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '619'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '621'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '624'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '629'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '639'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '646'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker stop -t 2 awx_cleaner
-    pid: '793'
-    ppid: '1'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '800'
-    ppid: '941'
-    user: root
-  - cmdline: /root/.local/share/virtualenvs/app-4PlAip0Q/bin/python3 cli.py -c /app/etc/awx_cleaner_conf.yml
-    pid: '818'
-    ppid: '800'
-    user: root
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H awx01 eth0
-    pid: '872'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-urjapbstdzvgooaybedidpwdoxjwzpjp ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007216.6064398-41717-246077302232703/AnsiballZ_process_facts.py' && sleep 0
-    pid: '884'
-    ppid: '310'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-urjapbstdzvgooaybedidpwdoxjwzpjp ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007216.6064398-41717-246077302232703/AnsiballZ_process_facts.py
-    pid: '899'
-    ppid: '884'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-urjapbstdzvgooaybedidpwdoxjwzpjp ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007216.6064398-41717-246077302232703/AnsiballZ_process_facts.py
-    pid: '900'
-    ppid: '899'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007216.6064398-41717-246077302232703/AnsiballZ_process_facts.py
-    pid: '901'
-    ppid: '900'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '931'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
-    pid: '933'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '941'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '950'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '953'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '954'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '955'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '956'
-    ppid: '950'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '957'
-    ppid: '950'
-    user: zabbix
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1034'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1036'
-    ppid: '1034'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1096'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/local/bin/vault server -config=/etc/vault.d/vault_main.hcl -log-level=info
-    pid: '1135'
-    ppid: '1'
-    user: vault
-  - cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
-    pid: '1136'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1137'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1139'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1140'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1154'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '1516'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '2295'
-    ppid: '1034'
-    user: postfix
-  - cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
-    pid: '2678'
-    ppid: '9043'
-    user: root
-  - cmdline: python3 /usr/bin/config-watcher
-    pid: '2745'
-    ppid: '2678'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '2747'
-    ppid: '2678'
-    user: root
-  - cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
-    pid: '2763'
-    ppid: '9045'
-    user: root
-  - cmdline: ''
-    pid: '2774'
-    ppid: '2'
-    user: root
-  - cmdline: python3 /usr/bin/config-watcher
-    pid: '2811'
-    ppid: '2763'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '2814'
-    ppid: '2763'
-    user: root
-  - cmdline: ''
-    pid: '3188'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '7003'
-    ppid: '26058'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '7506'
-    ppid: '19428'
-    user: root
-  - cmdline: ''
-    pid: '7551'
-    ppid: '26058'
-    user: root
-  - cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 443 -container-ip 192.168.2.4 -container-port 8053
-    pid: '7659'
-    ppid: '1136'
-    user: root
-  - cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 80 -container-ip 192.168.2.4 -container-port 8052
-    pid: '7676'
-    ppid: '1136'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '7706'
-    ppid: '2747'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '7811'
-    ppid: '2747'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '7814'
-    ppid: '2814'
-    user: root
-  - cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 11211 -container-ip 192.168.2.5 -container-port 11211
-    pid: '7816'
-    ppid: '1136'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '7850'
-    ppid: '2814'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '7851'
-    ppid: '2747'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '7877'
-    ppid: '941'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '7943'
-    ppid: '941'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '7965'
-    ppid: '2814'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '7966'
-    ppid: '2747'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
-    pid: '8027'
-    ppid: '2814'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8384'
-    ppid: '941'
-    user: root
-  - cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 6379 -container-ip 192.168.2.6 -container-port 6379
-    pid: '8401'
-    ppid: '1136'
-    user: root
-  - cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
-    pid: '8441'
-    ppid: '7877'
-    user: root
-  - cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
-    pid: '8448'
-    ppid: '7943'
-    user: root
-  - cmdline: tini -- /bin/sh -c /usr/bin/launch_awx.sh
-    pid: '8455'
-    ppid: '8384'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8484'
-    ppid: '941'
-    user: root
-  - cmdline: memcached -s /var/run/memcached/memcached.sock -a 0666
+  - AppArmorProfile: ''
+    Args:
+    - run
+    - python3
+    - cli.py
+    - -c
+    - /app/etc/awx_cleaner_conf.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/awx_cleaner_conf.yml
+      Domainname: ''
+      Entrypoint:
+      - pipenv
+      - run
+      - python3
+      - cli.py
+      Env:
+      - AWX_CLEANER_PASSWORD=
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=the_key
+      - PYTHON_VERSION=3.7.9
+      - PYTHON_PIP_VERSION=20.2.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
+      - PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
+      - PYTHONUNBUFFERED=true
+      Hostname: awx01.novalocal
+      Image: nexusregistry.opensolutions.cloud/awx-cleaner:1.2.1
+      Labels:
+        maintainer: oromeu
+        os_contianer_type: awx_cleaner
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2021-10-18T11:45:16.316785262Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976-init/diff:/var/lib/docker/overlay2/22df782a1cbd5e34a3d5776753b2a807f00ba47e6013551e8b95f7e2ed93db35/diff:/var/lib/docker/overlay2/312b95522dd6921da5c2d5289fb7f32e63ceb5e10ba2143adbbc4c99d35023a9/diff:/var/lib/docker/overlay2/6300a0d70ac3252c87a6be17df77e286b97b4db13ba9be1526f70834f50875e1/diff:/var/lib/docker/overlay2/fd460f916e69c1b50a62212515f5b8bc8a8d29472da602c7c4cb37a16eb20137/diff:/var/lib/docker/overlay2/f1d776f54a392e59db855bf36785245f6d6774c0d16951e72d5ef172007b3fb9/diff:/var/lib/docker/overlay2/a68da68959434fd6261752e9e627f939d0d4b2b2ccbac7f32d663f915b67b07d/diff:/var/lib/docker/overlay2/6705a2fe1186389824def98c101d6b9b14b6d32e920c3c874e43208cb067f5f1/diff:/var/lib/docker/overlay2/2fe2d6a4cb1c5d9f55c98910a5ea422b2f8e7d8fefedefc8b1913aed66fe7ed2/diff:/var/lib/docker/overlay2/5fabbebbda1b3e287dc88fa6f41f6e1cb3e63553bb07ce5e0f945eea1bfe255d/diff:/var/lib/docker/overlay2/5d678a8dc7b4f4a16fd7a36e567ea771d528ac34407935769ebfd7e1bac68eb4/diff
+        MergedDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/merged
+        UpperDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/diff
+        WorkDir: /var/lib/docker/overlay2/e49830f4db94b1901c2340bf8bc0b2988216015d7da332dd8c547f360b369976/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/hostname
+    HostsPath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/hosts
+    Id: 19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941
+    Image: sha256:9e588379d3c89b34839fda2502e557249b103a4b22fd1b80c37097ad0488fdf6
+    LogPath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics
+      Type: bind
+    Name: /awx_cleaner
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 42bdb7f605a2864503abdfd91ff9feeefc9c51f05d2244721f8611afa6a33ed4
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 9f8b86b22be78ec095186dd5f8afda1a02d9c56c4e2bbb6a334825173f523943
+      Ports: {}
+      SandboxID: 2d16f1e23a19f0ef31933e4089f40ddff90fc591a0b35c0dd09bbd262d0739df
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: pipenv
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-06-15T07:12:59.538531845Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1639
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-15T07:12:59.976312521Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /bin/sh
+    - -c
+    - /usr/bin/launch_awx_task.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - /usr/bin/launch_awx_task.sh
+      Domainname: ''
+      Entrypoint:
+      - tini
+      - --
+      Env:
+      - TASK_HOSTNAME=awx_awx01_task_1
+      - DATABASE_PORT=5432
+      - DATABASE_NAME=awx
+      - AWX_QUEUE_NAME=runners
+      - AWX_ADMIN_USER=datadope
+      - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
+      - AWX_ADMIN_PASSWORD=the_password
+      - DATABASE_PASSWORD=the_password
+      - SECRET_KEY=the_key
+      - DATABASE_HOST=192.168.0.252
+      - DATABASE_USER=awx
+      - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
+      - LC_ALL=en_US.UTF-8
+      - HOME=/home/awx
+      ExposedPorts:
+        8052/tcp: {}
+      Hostname: awx_awx01_task_1
+      Image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
+      Labels:
+        org.label-schema.build-date: '20200114'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: CentOS Base Image
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vendor: CentOS
+        org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
+        org.opencontainers.image.licenses: GPL-2.0-only
+        org.opencontainers.image.title: CentOS Base Image
+        org.opencontainers.image.vendor: CentOS
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: root
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/tower/SECRET_KEY: {}
+        /etc/tower/conf.d/credentials.py: {}
+        /etc/tower/conf.d/environment.sh: {}
+        /etc/ucmdb.auth: {}
+        /usr/bin/launch_awx_task.sh: {}
+        /var/lib/awx/projects: {}
+        /var/lib/awx/rsyslog/: {}
+        /var/lib/nginx: {}
+        /var/run/awx-rsyslog: {}
+        /var/run/memcached: {}
+        /var/run/redis: {}
+        /var/run/supervisor: {}
+      WorkingDir: /var/lib/awx
+    Created: '2021-10-18T11:44:59.182845248Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
+        MergedDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/merged
+        UpperDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/diff
+        WorkDir: /var/lib/docker/overlay2/defdf3defdfdf725bb85f1d5738f551354f59e099e584364064bf0c2a4bfa6ec/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
+      - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
+      - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
+      - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
+      - /var/lib/awx/projects/awx01__runners__1:/var/lib/awx/projects:rw
+      - /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
+      - /etc/hosts:/etc/hosts:ro
+      - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
+      - /var/run/awx_supervisor:/var/run/supervisor:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/hostname
+    HostsPath: /etc/hosts
+    Id: d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
+    Image: sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7
+    LogPath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/ucmdb.auth
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/ucmdb.auth
+      Type: bind
+    - Destination: /var/lib/awx/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/projects/awx01__runners__1
+      Type: bind
+    - Destination: /var/lib/awx/rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/lib/awx/rsyslog
+      Type: bind
+    - Destination: /var/run/supervisor
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_supervisor
+      Type: bind
+    - Destination: /etc/tower/conf.d/credentials.py
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/credentials.py
+      Type: bind
+    - Destination: /etc/tower/conf.d/environment.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/environment.sh
+      Type: bind
+    - Destination: /var/run/awx-rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_rsyslog
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /usr/bin/launch_awx_task.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/launch_awx_task.sh
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/tower/SECRET_KEY
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/SECRET_KEY
+      Type: bind
+    - Destination: /var/lib/nginx
+      Driver: local
+      Mode: ''
+      Name: 7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/7b4e06a7b610d5ee7e5c7c29b716c33b48e0f518460cc094ca98a4af44d1a2e6/_data
+      Type: volume
+    Name: /awx_awx01_task_1
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        awx:
+          Aliases:
+          - d13b4e9fdb7e
+          DriverOpts: null
+          EndpointID: 85027b2a5efa749aa7c8e87269e8803be0c4f0b5a75520aff51ab68492f91a7d
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:02
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+      Ports:
+        8052/tcp: null
+      SandboxID: b952a5e659a2bad6bef04200378542419a1ab00bffee6fb12ffefdf90ea009eb
+      SandboxKey: /var/run/docker/netns/b952a5e659a2
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.691239226Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8441
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.062811086Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /bin/sh
+    - -c
+    - /usr/bin/launch_awx_task.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - /usr/bin/launch_awx_task.sh
+      Domainname: ''
+      Entrypoint:
+      - tini
+      - --
+      Env:
+      - TASK_HOSTNAME=awx_awx01_task_tower_1
+      - SUPERVISOR_WEB_CONFIG_PATH=/supervisor.conf
+      - DATABASE_NAME=awx
+      - AWX_QUEUE_NAME=tower
+      - AWX_ADMIN_USER=datadope
+      - AWX_HOSTNAME=awx01
+      - DATABASE_PORT=5432
+      - AWX_ADMIN_PASSWORD=the_password
+      - DATABASE_PASSWORD=the_password
+      - SECRET_KEY=the_key
+      - DATABASE_HOST=192.168.0.252
+      - DATABASE_USER=awx
+      - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
+      - LC_ALL=en_US.UTF-8
+      - HOME=/home/awx
+      ExposedPorts:
+        8052/tcp: {}
+      Hostname: awx_awx01_task_tower_1
+      Image: nexusregistry.opensolutions.cloud/awx_task:11.2.0
+      Labels:
+        org.label-schema.build-date: '20200114'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: CentOS Base Image
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vendor: CentOS
+        org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
+        org.opencontainers.image.licenses: GPL-2.0-only
+        org.opencontainers.image.title: CentOS Base Image
+        org.opencontainers.image.vendor: CentOS
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: root
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/tower/SECRET_KEY: {}
+        /etc/tower/conf.d/credentials.py: {}
+        /etc/tower/conf.d/environment.sh: {}
+        /etc/tower/iometrics: {}
+        /etc/ucmdb.auth: {}
+        /usr/bin/launch_awx_task.sh: {}
+        /var/lib/awx/projects: {}
+        /var/lib/awx/rsyslog/: {}
+        /var/lib/nginx: {}
+        /var/run/awx-rsyslog: {}
+        /var/run/memcached: {}
+        /var/run/redis: {}
+        /var/run/supervisor: {}
+        /var/tmp/projects: {}
+      WorkingDir: /var/lib/awx
+    Created: '2021-10-18T11:44:40.881348712Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03-init/diff:/var/lib/docker/overlay2/b23549ee7ed7dcfaf3eb8596fd2cb34f5eb51e7577d69a8dfa94ed0b1474067d/diff:/var/lib/docker/overlay2/f93609fb9a3a8d8a0de081f23e7b805f9f5188a388e588ec940540f438f4dce2/diff:/var/lib/docker/overlay2/cf5856e52d62049241739dfcacb30211c3f7a3b6046aa41e0bb3c5dd8c9d687b/diff:/var/lib/docker/overlay2/f1599e137e7ad8b4a88a7a97c83ff93e42cb8c583835b5891d20202c37f21774/diff:/var/lib/docker/overlay2/5529f5c41aeedbc05296de547929ee5ba3db6b5c17ab3b87c2d5e541738c9f13/diff:/var/lib/docker/overlay2/9ff7b307750a97c99c1d76598f445383b46d9eddcf7e13a230b909208f85f6ab/diff:/var/lib/docker/overlay2/f4e2368978b0b44f1d00161145870151e40c04fedf30efb7894e0826ec9efbf2/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
+        MergedDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/merged
+        UpperDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/diff
+        WorkDir: /var/lib/docker/overlay2/ece7767cc90c9cc0adb8bb3b10aaada4b196dd0cba919da131dd8bbe354e0e03/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
+      - /var/lib/awx/projects/awx01__tower_task__1:/var/lib/awx/projects:rw
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
+      - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
+      - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
+      - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
+      - /var/lib/awx/etc/awx/launch_awx_task.sh:/usr/bin/launch_awx_task.sh:ro
+      - /etc/hosts:/etc/hosts:ro
+      - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
+      - /var/lib/awx/var/tmp/projects:/var/tmp/projects:rw
+      - /var/run/awx_supervisor:/var/run/supervisor:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      - /var/lib/awx/etc/awx/iometrics:/etc/tower/iometrics:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/hostname
+    HostsPath: /etc/hosts
+    Id: efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
+    Image: sha256:fddbce25ae2c6b1969efde4c0020a9a67318fe2cda38acaaa3d33e824169c3a7
+    LogPath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/run/awx-rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_rsyslog
+      Type: bind
+    - Destination: /var/run/supervisor
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_supervisor
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/tower/conf.d/credentials.py
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/credentials.py
+      Type: bind
+    - Destination: /etc/tower/iometrics
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/iometrics
+      Type: bind
+    - Destination: /etc/ucmdb.auth
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/ucmdb.auth
+      Type: bind
+    - Destination: /var/lib/awx/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/projects/awx01__tower_task__1
+      Type: bind
+    - Destination: /etc/tower/conf.d/environment.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/environment.sh
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    - Destination: /usr/bin/launch_awx_task.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/launch_awx_task.sh
+      Type: bind
+    - Destination: /var/lib/nginx
+      Driver: local
+      Mode: ''
+      Name: 8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/8a88a06d480fc318227949a54bce0299adb5359954f842bd7d4594455ed4b23e/_data
+      Type: volume
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/tower/SECRET_KEY
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/SECRET_KEY
+      Type: bind
+    - Destination: /var/lib/awx/rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/lib/awx/rsyslog
+      Type: bind
+    - Destination: /var/tmp/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/tmp/projects
+      Type: bind
+    Name: /awx_awx01_task_tower_1
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        awx:
+          Aliases:
+          - efdbe7e2ed56
+          DriverOpts: null
+          EndpointID: 793c5d8df433bbb806037f28add3fb99b4b1deb2a738cd38a8b3432dabec6683
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.3
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:03
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+      Ports:
+        8052/tcp: null
+      SandboxID: c8b6987031aa99ac901a2ec3ec5eff6490a8fc6163a78728e1e72c7b07ba5f36
+      SandboxKey: /var/run/docker/netns/c8b6987031aa
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.666814215Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8448
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.066062167Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --
+    - /bin/sh
+    - -c
+    - /usr/bin/launch_awx.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - /usr/bin/launch_awx.sh
+      Domainname: ''
+      Entrypoint:
+      - tini
+      - --
+      Env:
+      - DATABASE_NAME=awx
+      - AWX_QUEUE_NAME=tower
+      - AWX_ADMIN_USER=datadope
+      - DATABASE_PORT=5432
+      - AWX_ADMIN_PASSWORD=the_password
+      - DATABASE_PASSWORD=the_password
+      - SECRET_KEY=the_key
+      - DATABASE_HOST=192.168.0.252
+      - DATABASE_USER=awx
+      - PATH=/usr/pgsql-10/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US:en
+      - LC_ALL=en_US.UTF-8
+      - HOME=/home/awx
+      ExposedPorts:
+        8052/tcp: {}
+        8053/tcp: {}
+      Hostname: awx_web_tower_1
+      Image: nexusregistry.opensolutions.cloud/awx_web:11.2.0
+      Labels:
+        org.label-schema.build-date: '20200114'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: CentOS Base Image
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vendor: CentOS
+        org.opencontainers.image.created: '2020-01-14 00:00:00-08:00'
+        org.opencontainers.image.licenses: GPL-2.0-only
+        org.opencontainers.image.title: CentOS Base Image
+        org.opencontainers.image.vendor: CentOS
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: root
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx/awxweb.pem: {}
+        /etc/nginx/nginx.conf: {}
+        /etc/tower/SECRET_KEY: {}
+        /etc/tower/conf.d/credentials.py: {}
+        /etc/tower/conf.d/environment.sh: {}
+        /etc/ucmdb.auth: {}
+        /var/lib/awx/projects: {}
+        /var/lib/awx/rsyslog/: {}
+        /var/lib/nginx: {}
+        /var/run/awx-rsyslog: {}
+        /var/run/memcached: {}
+        /var/run/redis: {}
+        /var/run/supervisor: {}
+      WorkingDir: /var/lib/awx
+    Created: '2021-10-18T10:22:23.792332427Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2-init/diff:/var/lib/docker/overlay2/3c13fb2448c4706f60677e56fabf13eee05734ec5a9766eee43659261dab90a3/diff:/var/lib/docker/overlay2/91b427dfbb443e5fd41e123d6b65806881f1527b05e897537808332da3c65afc/diff:/var/lib/docker/overlay2/37f36c6664c7d70bb927546ad358b46f72fa603c0511aab5625546c4fbaf4224/diff:/var/lib/docker/overlay2/cb747a616cd72b17e0277b27cd036ff79f061d2bf1ec49f6f7576a513ff1f454/diff:/var/lib/docker/overlay2/1f5a7c255f9d87a97f18408553cc5ea8a3e57b803d58d444684e77065992886c/diff:/var/lib/docker/overlay2/701b839302666be2d93bcec208db2b10bfc64f25b9dd3edbb4b6f5beeb0ff215/diff:/var/lib/docker/overlay2/a54664b71c9f0a83480cb9e1fca4f8a5517fc7e091817c72125f35e8947dfa60/diff:/var/lib/docker/overlay2/483c7fa7cf486f1476680c9d6d45a9905c513f5f27a233a452b928bef1013cdc/diff:/var/lib/docker/overlay2/aeb2a6563786f5ccfc4f47fc55ffc46d24615a3702094687c78e00108423ccee/diff:/var/lib/docker/overlay2/9611815af3cb77ffec377d3a42c672b3980b9c54fddb62f55df7746fcc12c905/diff:/var/lib/docker/overlay2/af94324f0426ab6aa792c79b4c9254d10e5009f6c4100923ac35b6581cc6fd2f/diff:/var/lib/docker/overlay2/1f7e3ce8f42330eaf4d269f2d87b143b1dc1f48af45c0a9d00689025c2f35872/diff:/var/lib/docker/overlay2/199990ed919b721a59076eb126197cf669cd63924eac647438ab59ce92b1bf9e/diff:/var/lib/docker/overlay2/fb62f2045aceffe67b42ce9b27d434de5fde8b58be3952a7e3ffcefa25c71d3c/diff:/var/lib/docker/overlay2/f3c1bc9c0510c5d43c7e00cb20de5ac30bb95b5aef57a4dda60aac1873386e86/diff:/var/lib/docker/overlay2/3e9234599a3117d6643ef47028d5204162ecfe3bea8e7046aeb94afbdeb8f69a/diff:/var/lib/docker/overlay2/777599fafb38dd97d7ca0e0e91bcdc55cebad76dc6d7edd2528d56dde94f526c/diff:/var/lib/docker/overlay2/96ba916e958178fd0e7cff8c573a0ba47cf106c109918a14bf3df1d5c816eb0c/diff:/var/lib/docker/overlay2/4356c2e18f332511722a2a3b091742377089b071c47c8c51f38df695dadf9bb7/diff:/var/lib/docker/overlay2/964801238deecd4f34e8cf4103869fd6c8f9ecc2307e206271195352b42ada75/diff:/var/lib/docker/overlay2/70a7151e580907ea55f0639bac1bc8cd1fcbf118506182c24e428b29c257651d/diff:/var/lib/docker/overlay2/cec3a7edfd3520ef51d5743cae89d05cc6cbada24ee943a338d55b5eec165066/diff:/var/lib/docker/overlay2/c5a71a148031c9e5986c962e5fc7bffcc0b97eb9ae4747240c0f1b82bbe191d6/diff:/var/lib/docker/overlay2/217bbe9b6f8bd086be301901b25d3ad34fe91f84560bd98dc3f3392ef72f971f/diff:/var/lib/docker/overlay2/a7225439b2f4df096fdc2a6149c7577a219937a1205d3bad7b443ca7336c6093/diff:/var/lib/docker/overlay2/e829044362b5bf5fbe7b267891a537a8fc81773124c20f39cdb1b3d9a6cf0b83/diff:/var/lib/docker/overlay2/7e80ee7d06f833f22076038c80082204db77c8bb6fe17cd55df22d1812a377c4/diff:/var/lib/docker/overlay2/ec212fa5caeb2cf18ae990c890abb4291c9f8b9ccb965bb80f671f9407ac758f/diff:/var/lib/docker/overlay2/b9ab89549d5de5b3b826547f8c9877cda7056ea933df0584d3db29f23112a038/diff:/var/lib/docker/overlay2/13b85f085a42cd70f31993162de6e519814626fd6d2629ea9f5f9a790a2bc1b9/diff:/var/lib/docker/overlay2/0bc930183d0d39e63c3a526afb1a721cba5b20cacd824f0b5050853d827a5f62/diff
+        MergedDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/merged
+        UpperDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/diff
+        WorkDir: /var/lib/docker/overlay2/6ba53caa9412e7c242fda826971260932af2c054282b1ba179cf1436892867c2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/awx/ucmdb.auth:/etc/ucmdb.auth:ro
+      - /etc/localtime:/etc/localtime:ro
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      - /var/run/awx_rsyslog:/var/run/awx-rsyslog:rw
+      - /var/run/awx_supervisor:/var/run/supervisor:rw
+      - /var/lib/awx/etc/awx/environment.sh:/etc/tower/conf.d/environment.sh:ro
+      - /var/lib/awx/etc/awx/credentials.py:/etc/tower/conf.d/credentials.py:ro
+      - /var/lib/awx/etc/awx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - /var/lib/awx/var/lib/awx/rsyslog/:/var/lib/awx/rsyslog/:rw
+      - /etc/hosts:/etc/hosts:ro
+      - /var/lib/awx/etc/awx/SECRET_KEY:/etc/tower/SECRET_KEY:ro
+      - /var/lib/awx/etc/awx/awxweb.pem:/etc/nginx/awxweb.pem:ro
+      - /var/lib/awx/projects/awx01__tower_web_1:/var/lib/awx/projects:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths: null
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8052/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '80'
+        8053/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '443'
+      Privileged: true
+      PublishAllPorts: false
+      ReadonlyPaths: null
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt:
+      - label=disable
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/hostname
+    HostsPath: /etc/hosts
+    Id: b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
+    Image: sha256:71ea5e1b1b2f382bd0b0560464ea9c77dc30e396e8c6e9b8958b33b94416b708
+    LogPath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/tower/SECRET_KEY
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/SECRET_KEY
+      Type: bind
+    - Destination: /etc/tower/conf.d/environment.sh
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/environment.sh
+      Type: bind
+    - Destination: /var/run/supervisor
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_supervisor
+      Type: bind
+    - Destination: /etc/nginx/awxweb.pem
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/awxweb.pem
+      Type: bind
+    - Destination: /var/lib/awx/rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/var/lib/awx/rsyslog
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/tower/conf.d/credentials.py
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/credentials.py
+      Type: bind
+    - Destination: /etc/ucmdb.auth
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/ucmdb.auth
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx/nginx.conf
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /var/lib/awx/etc/awx/nginx.conf
+      Type: bind
+    - Destination: /var/lib/awx/projects
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/awx/projects/awx01__tower_web_1
+      Type: bind
+    - Destination: /var/lib/nginx
+      Driver: local
+      Mode: ''
+      Name: 9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/9470bff94649f06520c34aa385075a8f6af30b6b0be7fddf2d1031134558afdd/_data
+      Type: volume
+    - Destination: /var/run/awx-rsyslog
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_rsyslog
+      Type: bind
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    Name: /awx_web_tower_1
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        awx:
+          Aliases:
+          - awx_web
+          - b7972b752e85
+          DriverOpts: null
+          EndpointID: 68e96dfb1a48497323aabc5ffbad6da682bbd271778ed383ed3c9cbf86ddb732
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.4
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:04
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+      Ports:
+        8052/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '80'
+        8053/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '443'
+      SandboxID: 82cf34c71f29edf07f8bfba5e104fe5715f8195c1c5d6af30843be7315149a93
+      SandboxKey: /var/run/docker/netns/82cf34c71f29
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: tini
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.713044964Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8455
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.064174569Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -s
+    - /var/run/memcached/memcached.sock
+    - -a
+    - '0666'
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -s
+      - /var/run/memcached/memcached.sock
+      - -a
+      - '0666'
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - MEMCACHED_VERSION=1.6.6
+      - MEMCACHED_SHA1=d8895b12dc9fc82b389f1713e2c09cc6ca3d03e4
+      ExposedPorts:
+        11211/tcp: {}
+      Hostname: 1c624b0d7c73
+      Image: nexusregistry.opensolutions.cloud/monitorizacion/memcached:alpine
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: memcache
+      Volumes:
+        /etc/localtime: {}
+        /var/run/memcached: {}
+      WorkingDir: ''
+    Created: '2020-06-03T10:16:16.67286319Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d-init/diff:/var/lib/docker/overlay2/d8877c054116b5ee97ee53c893117c6fb2dfff8ecd5f7de53f12ae1a64c9e063/diff:/var/lib/docker/overlay2/09557cecc7a0ad7866cb864928e034e550f8e97703d629f1f16287ebc96056ca/diff:/var/lib/docker/overlay2/e26535172b18e8ba64dfeb361e9a74d224ba94487968fff19550ae35baa09f1b/diff:/var/lib/docker/overlay2/005ea37c98a59f97323add0a2222945ef78f4af4abc0478bfd68a0de5805ee3a/diff:/var/lib/docker/overlay2/7b303f0c79fd7aa2e61f9f75e0fd0cc48375e353dc577c2ddbc819d1d42e1144/diff:/var/lib/docker/overlay2/5e13e12e87f251e2cf30736940f53a5b2a922d1b8fbab5fdb529c204d56010e3/diff
+        MergedDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/merged
+        UpperDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/diff
+        WorkDir: /var/lib/docker/overlay2/3c5b4361d3080d45be34c8ee409d63c058c5a9f9855a9ea02eba8a818d03ba7d/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/localtime:/etc/localtime:rw
+      - /var/run/awx_memcached:/var/run/memcached:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths: null
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        11211/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '11211'
+      Privileged: true
+      PublishAllPorts: false
+      ReadonlyPaths: null
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt:
+      - label=disable
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hostname
+    HostsPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/hosts
+    Id: 1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
+    Image: sha256:35acd9837d07e6369afd8683ae08f7da10de93ea5d50e74050abbdeece1e6754
+    LogPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/run/memcached
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_memcached
+      Type: bind
+    Name: /awx_memcached
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        awx:
+          Aliases:
+          - memcached
+          - 1c624b0d7c73
+          DriverOpts: null
+          EndpointID: 1918e2a1786dc68318500c7bb707bd61536735c440afa195359d798150cd924e
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.5
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:05
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ac329891b5ae44c222ac7eb5063a1f36a59a9d8e99247b0a3eb89da0102d08ef
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
+      Ports:
+        11211/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '11211'
+      SandboxID: 6b1d0adc35d952fa492b943f4104aa574aa23454c9b23be2ff55da2e148d9879
+      SandboxKey: /var/run/docker/netns/6b1d0adc35d9
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.690727633Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8510
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:10.809715881Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - /usr/local/etc/redis/redis.conf
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /usr/local/etc/redis/redis.conf
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.0.4
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.4.tar.gz
+      - REDIS_DOWNLOAD_SHA=3337005a1e0c3aa293c87c313467ea8ac11984921fab08807998ba765c9943de
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: 46897b6fb532
+      Image: nexusregistry.opensolutions.cloud/monitorizacion/redis:6.0.4
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+        /etc/localtime: {}
+        /usr/local/etc/redis/redis.conf: {}
+        /var/run/redis: {}
+      WorkingDir: /data
+    Created: '2020-06-03T10:08:34.836826924Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5-init/diff:/var/lib/docker/overlay2/f195086ba7e5c223584dc55602eabac57e67456493d3adcbaa39c5734cc1aed6/diff:/var/lib/docker/overlay2/69a5b254a5f5034b01f48dfca65e3a9350da9ef3d39afa86378af53f17773bbc/diff:/var/lib/docker/overlay2/e7bc5968d1154c270b86fc6c25dff4cc0cd6445fd93053648cc6f647d108ac5d/diff:/var/lib/docker/overlay2/5acabe980feecd71fcb74ff02e49f3b54ea1274abfcc2901ac6aaf29bc76c00f/diff:/var/lib/docker/overlay2/1943e56b8ae64a1d3392bb93a86e20b8240ee27400cbfbc0f859909ed75d1b1c/diff:/var/lib/docker/overlay2/7c53990c945f93e734234bf43cdb0ba2ecce49b3b66c9abe18f529aef297e1c3/diff
+        MergedDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/merged
+        UpperDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/diff
+        WorkDir: /var/lib/docker/overlay2/8978be3eef4eec9d723f3924a805bf2c1039c5902960cd24dce692910dfa4fa5/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/localtime:/etc/localtime:rw
+      - /var/run/awx_redis:/var/run/redis:rw
+      - /usr/local/etc/redis/redis.conf:/usr/local/etc/redis/redis.conf:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        6379/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '6379'
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hostname
+    HostsPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/hosts
+    Id: 46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
+    Image: sha256:36304d3b4540c5143673b2cefaba583a0426b57c709b5a35363f96a3510058cd
+    LogPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/run/redis
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/awx_redis
+      Type: bind
+    - Destination: /data
+      Driver: local
+      Mode: ''
+      Name: 6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/6ac933cacde5b8d32c0d447657b68e4d02a3248005b4fc86e025153c6f9ab330/_data
+      Type: volume
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /usr/local/etc/redis/redis.conf
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /usr/local/etc/redis/redis.conf
+      Type: bind
+    Name: /awx_redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.3
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:03
+      Networks:
+        awx:
+          Aliases:
+          - redis
+          - 46897b6fb532
+          DriverOpts: null
+          EndpointID: 484b6930ad5e400adc2c0bd5d5c0072f63b82cb3d210d25dbdf2776e30583828
+          Gateway: 192.168.2.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.2.6
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:12:00:06
+          NetworkID: d207202eaca91f8df3dbdec520d729bc6c063be18798492130a6ec52ff2bdb6b
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 3053313cb8b88a3801de75ac95c9140899fd4cdbdaefb16447140a6347ece323
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.3
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:03
+          NetworkID: d9d7265c60bdb7ab76d9936a9201aeabb1a4ac0c24e1cb9685a4eee20d85669f
+      Ports:
+        6379/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '6379'
+      SandboxID: e3c098aa78f830407f21419ab0f92eccc5d1f533c2c37be76db60452521346cd
+      SandboxKey: /var/run/docker/netns/e3c098aa78f8
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:56.690312533Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 8576
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:11.070796868Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 11211
+    protocol: tcp
+  discovery_time: '2022-07-05T09:47:23+02:00'
+  docker:
+    exposed_ports:
+      11211/tcp: {}
+    id: 1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
+    image: nexusregistry.opensolutions.cloud/monitorizacion/memcached:alpine
+    name: /awx_memcached
+    network_mode: default
+    port_bindings:
+      11211/tcp:
+      - HostIp: 0.0.0.0
+        HostPort: '11211'
+  listening_ports:
+  - 11211
+  packages: []
+  process:
+    cmdline: memcached -s /var/run/memcached/memcached.sock -a 0666
+    cwd: /
+    listening_ports:
+    - 11211
     pid: '8510'
     ppid: '8484'
     user: '11211'
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '8531'
-    ppid: '941'
-    user: root
-  - cmdline: redis-server 127.0.0.1:0
-    pid: '8576'
-    ppid: '8531'
-    user: polkitd
-  - cmdline: 'sshd: centos [priv]'
-    pid: '8899'
-    ppid: '1096'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '8908'
-    ppid: '8899'
-    user: centos
-  - cmdline: -bash
-    pid: '8909'
-    ppid: '8908'
-    user: centos
-  - cmdline: sudo su
-    pid: '8986'
-    ppid: '8909'
-    user: root
-  - cmdline: su
-    pid: '8987'
-    ppid: '8986'
-    user: root
-  - cmdline: bash
-    pid: '8988'
-    ppid: '8987'
-    user: root
-  - cmdline: bash /usr/bin/launch_awx.sh
-    pid: '9042'
-    ppid: '8455'
-    user: root
-  - cmdline: bash /usr/bin/launch_awx_task.sh
-    pid: '9043'
-    ppid: '8448'
-    user: root
-  - cmdline: bash /usr/bin/launch_awx_task.sh
-    pid: '9045'
-    ppid: '8441'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_awx01_task_tower_1
-    pid: '9274'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_redis
-    pid: '9279'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_awx01_task_1
-    pid: '9285'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_memcached
-    pid: '9287'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a awx_web_tower_1
-    pid: '9288'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '11925'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14277'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '14279'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '15693'
-    ppid: '26058'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '15696'
-    ppid: '25981'
-    user: root
-  - cmdline: ''
-    pid: '15703'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16481'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '17180'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '18557'
-    ppid: '19428'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '19267'
-    ppid: '19428'
-    user: root
-  - cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor.conf
-    pid: '19383'
-    ppid: '9042'
-    user: root
-  - cmdline: python3 /usr/bin/config-watcher
-    pid: '19426'
-    ppid: '19383'
-    user: root
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '19427'
-    ppid: '19383'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '19428'
-    ppid: '19383'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /var/lib/awx/venv/awx/bin/daphne -b 127.0.0.1 -p 8051 --websocket_timeout -1 awx.asgi:channel_layer
-    pid: '19429'
-    ppid: '19383'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '19432'
-    ppid: '19427'
-    user: zabbix
-  - cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '19437'
-    ppid: '19428'
-    user: root
-  - cmdline: ''
-    pid: '21346'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '22288'
-    ppid: '26058'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '22289'
-    ppid: '25981'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_wsbroadcast
-    pid: '25923'
-    ppid: '19383'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '25981'
-    ppid: '2678'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '26058'
-    ppid: '2763'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '27319'
-    ppid: '26058'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '27324'
-    ppid: '25981'
-    user: root
-  - cmdline: rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
-    pid: '27383'
-    ppid: '19383'
-    user: root
-  - cmdline: ''
-    pid: '30189'
-    ppid: '2'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000 --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
-    pid: '31706'
-    ppid: '19428'
-    user: root
-  - cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
-    pid: '32204'
-    ppid: '26058'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1034
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:55:05 2022
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 950
-    port: 10050
-    protocol: tcp
-    stime: Tue Apr 26 15:55:03 2022
-    user: zabbix
-  - address: 192.168.0.145
-    name: vault
-    pid: 1135
-    port: 8200
-    protocol: tcp
-    stime: Tue Apr 26 15:55:12 2022
-    user: vault
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:54:27 2022
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1096
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:55:11 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1034
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:55:05 2022
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 7659
-    port: 443
-    protocol: tcp
-    stime: Tue Apr 26 15:56:05 2022
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 8401
-    port: 6379
-    protocol: tcp
-    stime: Tue Apr 26 15:56:07 2022
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 7816
-    port: 11211
-    protocol: tcp
-    stime: Tue Apr 26 15:56:06 2022
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:54:27 2022
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 7676
-    port: 80
-    protocol: tcp
-    stime: Tue Apr 26 15:56:05 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1096
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:55:11 2022
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: Memcached
+  version:
+  - number: alpine
+    type: docker
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 16.P2.el7_8.6
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-devel:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-devel
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-event:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-event-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-persistent-data:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 2.el7
+    source: rpm
+    version: 0.8.5
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 872
-    port: 68
-    protocol: udp
-    stime: Tue Apr 26 15:55:02 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:54:27 2022
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 639
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:54:49 2022
-    user: chrony
-  - address: 0.0.0.0
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  git:
+  - arch: x86_64
+    epoch: null
+    name: git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 307.el7.1
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  htop:
+  - arch: x86_64
+    epoch: null
+    name: htop
+    release: 3.el7
+    source: rpm
+    version: 2.2.0
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1127.13.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs-devel:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs-devel
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-devel:
+  - arch: x86_64
+    epoch: null
+    name: krb5-devel
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcom_err-devel:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err-devel
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libffi-devel:
+  - arch: x86_64
+    epoch: null
+    name: libffi-devel
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libkadm5:
+  - arch: x86_64
+    epoch: null
+    name: libkadm5
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnet:
+  - arch: x86_64
+    epoch: null
+    name: libnet
+    release: 7.el7
+    source: rpm
+    version: 1.1.6
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-devel:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-devel
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsepol-devel:
+  - arch: x86_64
+    epoch: null
+    name: libsepol-devel
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-devel:
+  - arch: x86_64
+    epoch: null
+    name: libverto-devel
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 7.el7_8.2
+    source: rpm
+    version: 2.02.186
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 2.02.186
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  ngrep:
+  - arch: x86_64
+    epoch: null
+    name: ngrep
+    release: 1.1.20180101git9b59468.el7
+    source: rpm
+    version: '1.47'
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-devel:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-devel
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcre-devel:
+  - arch: x86_64
+    epoch: null
+    name: pcre-devel
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Error:
+  - arch: noarch
+    epoch: 1
+    name: perl-Error
+    release: 2.el7
+    source: rpm
+    version: '0.17020'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-Git:
+  - arch: noarch
+    epoch: null
+    name: perl-Git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-TermReadKey:
+  - arch: x86_64
+    epoch: null
+    name: perl-TermReadKey
+    release: 20.el7
+    source: rpm
+    version: '2.30'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 619
-    port: 788
-    protocol: udp
-    stime: Tue Apr 26 15:54:47 2022
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 6.el7
+    source: rpm
+    version: '4.24'
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:54:27 2022
-    user: root
-  - address: ::1
-    name: chronyd
-    pid: 639
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:54:49 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 619
-    port: 788
-    protocol: udp
-    stime: Tue Apr 26 15:54:47 2022
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 65.el7_8
+    source: rpm
+    version: '0.17'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 1.el7
+    source: rpm
+    version: 3.2.11
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 1.el7
+    source: rpm
+    version: 4.0.19
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  zlib-devel:
+  - arch: x86_64
+    epoch: null
+    name: zlib-devel
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '130'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '179'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '180'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '281'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '304'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '308'
+  ppid: '1096'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '310'
+  ppid: '308'
+  user: centos
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '347'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '426'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '443'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '452'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '560'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '561'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '588'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '617'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '619'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '621'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '624'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '629'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '639'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '646'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker stop -t 2 awx_cleaner
+  cwd: /usr/bin/
+  pid: '793'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/19a137fbd68beb18810ab7c00d7b508c3687abd6d52e76b45217dc6960033941
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '800'
+  ppid: '941'
+  user: root
+- cmdline: /root/.local/share/virtualenvs/app-4PlAip0Q/bin/python3 cli.py -c /app/etc/awx_cleaner_conf.yml
+  cwd: /root/.local/share/virtualenvs/app-4PlAip0Q/bin/
+  pid: '818'
+  ppid: '800'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H awx01 eth0
+  cwd: /sbin/
+  pid: '872'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-urjapbstdzvgooaybedidpwdoxjwzpjp
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007216.6064398-41717-246077302232703/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '884'
+  ppid: '310'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-urjapbstdzvgooaybedidpwdoxjwzpjp
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007216.6064398-41717-246077302232703/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '899'
+  ppid: '884'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-urjapbstdzvgooaybedidpwdoxjwzpjp ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1657007216.6064398-41717-246077302232703/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '900'
+  ppid: '899'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657007216.6064398-41717-246077302232703/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '901'
+  ppid: '900'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '931'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '933'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '941'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '950'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '953'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '954'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '955'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '956'
+  ppid: '950'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '957'
+  ppid: '950'
+  user: zabbix
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1034'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1036'
+  ppid: '1034'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1096'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/bin/vault server -config=/etc/vault.d/vault_main.hcl -log-level=info
+  cwd: /usr/local/bin/
+  pid: '1135'
+  ppid: '1'
+  user: vault
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1136'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1137'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1139'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1140'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1154'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1516'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '2295'
+  ppid: '1034'
+  user: postfix
+- cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
+  cwd: /usr/bin/
+  pid: '2678'
+  ppid: '9043'
+  user: root
+- cmdline: python3 /usr/bin/config-watcher
+  cwd: /
+  pid: '2745'
+  ppid: '2678'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '2747'
+  ppid: '2678'
+  user: root
+- cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor_task.conf
+  cwd: /usr/bin/
+  pid: '2763'
+  ppid: '9045'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2774'
+  ppid: '2'
+  user: root
+- cmdline: python3 /usr/bin/config-watcher
+  cwd: /
+  pid: '2811'
+  ppid: '2763'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '2814'
+  ppid: '2763'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3188'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7003'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7506'
+  ppid: '19428'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7551'
+  ppid: '26058'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 443 -container-ip
+    192.168.2.4 -container-port 8053
+  cwd: /usr/bin/
+  pid: '7659'
+  ppid: '1136'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 80 -container-ip
+    192.168.2.4 -container-port 8052
+  cwd: /usr/bin/
+  pid: '7676'
+  ppid: '1136'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7706'
+  ppid: '2747'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7811'
+  ppid: '2747'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7814'
+  ppid: '2814'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 11211 -container-ip
+    192.168.2.5 -container-port 11211
+  cwd: /usr/bin/
+  pid: '7816'
+  ppid: '1136'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7850'
+  ppid: '2814'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7851'
+  ppid: '2747'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d13b4e9fdb7e5c33352ea65d9ee8ebd6001fd9870a0e88a9216e2467f9759126
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '7877'
+  ppid: '941'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/efdbe7e2ed56807203b71874430607277285651845b9c15627b2990fd82cd555
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '7943'
+  ppid: '941'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7965'
+  ppid: '2814'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '7966'
+  ppid: '2747'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_callback_receiver
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '8027'
+  ppid: '2814'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/b7972b752e8513b4921aa785c911547cd2cf821f5ed2374d02cf567fbd8e62a2
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8384'
+  ppid: '941'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 6379 -container-ip
+    192.168.2.6 -container-port 6379
+  cwd: /usr/bin/
+  pid: '8401'
+  ppid: '1136'
+  user: root
+- cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '8441'
+  ppid: '7877'
+  user: root
+- cmdline: tini -- /bin/sh -c /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '8448'
+  ppid: '7943'
+  user: root
+- cmdline: tini -- /bin/sh -c /usr/bin/launch_awx.sh
+  cwd: /
+  pid: '8455'
+  ppid: '8384'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1c624b0d7c73a03cf904369aca8783ed2784823862c281df7499f0246a142f64
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8484'
+  ppid: '941'
+  user: root
+- cmdline: memcached -s /var/run/memcached/memcached.sock -a 0666
+  cwd: /
+  pid: '8510'
+  ppid: '8484'
+  user: '11211'
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/46897b6fb5321f022e035cf0e03e6f17f4d331a10ee7af0e4a20212a1a0171cb
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '8531'
+  ppid: '941'
+  user: root
+- cmdline: redis-server 127.0.0.1:0
+  cwd: /
+  pid: '8576'
+  ppid: '8531'
+  user: polkitd
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '8899'
+  ppid: '1096'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '8908'
+  ppid: '8899'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '8909'
+  ppid: '8908'
+  user: centos
+- cmdline: sudo su
+  cwd: /
+  pid: '8986'
+  ppid: '8909'
+  user: root
+- cmdline: su
+  cwd: /
+  pid: '8987'
+  ppid: '8986'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '8988'
+  ppid: '8987'
+  user: root
+- cmdline: bash /usr/bin/launch_awx.sh
+  cwd: /
+  pid: '9042'
+  ppid: '8455'
+  user: root
+- cmdline: bash /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '9043'
+  ppid: '8448'
+  user: root
+- cmdline: bash /usr/bin/launch_awx_task.sh
+  cwd: /
+  pid: '9045'
+  ppid: '8441'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_awx01_task_tower_1
+  cwd: /usr/bin/
+  pid: '9274'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_redis
+  cwd: /usr/bin/
+  pid: '9279'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_awx01_task_1
+  cwd: /usr/bin/
+  pid: '9285'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_memcached
+  cwd: /usr/bin/
+  pid: '9287'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a awx_web_tower_1
+  cwd: /usr/bin/
+  pid: '9288'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11925'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14277'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '14279'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '15693'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '15696'
+  ppid: '25981'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15703'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16481'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '17180'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '18557'
+  ppid: '19428'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19267'
+  ppid: '19428'
+  user: root
+- cmdline: /usr/bin/python3.6 /usr/local/bin/supervisord -c /supervisor.conf
+  cwd: /usr/bin/
+  pid: '19383'
+  ppid: '9042'
+  user: root
+- cmdline: python3 /usr/bin/config-watcher
+  cwd: /
+  pid: '19426'
+  ppid: '19383'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '19427'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19428'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /var/lib/awx/venv/awx/bin/daphne -b 127.0.0.1
+    -p 8051 --websocket_timeout -1 awx.asgi:channel_layer
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19429'
+  ppid: '19383'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '19432'
+  ppid: '19427'
+  user: zabbix
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '19437'
+  ppid: '19428'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21346'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '22288'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '22289'
+  ppid: '25981'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_wsbroadcast
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '25923'
+  ppid: '19383'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '25981'
+  ppid: '2678'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '26058'
+  ppid: '2763'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '27319'
+  ppid: '26058'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '27324'
+  ppid: '25981'
+  user: root
+- cmdline: rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
+  cwd: /
+  pid: '27383'
+  ppid: '19383'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30189'
+  ppid: '2'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/uwsgi --socket 127.0.0.1:8050 --module=awx.wsgi:application
+    --vacuum --processes=5 --harakiri=120 --no-orphans --master --max-requests=1000
+    --master-fifo=/var/lib/awx/awxfifo --lazy-apps -b 32768
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '31706'
+  ppid: '19428'
+  user: root
+- cmdline: /var/lib/awx/venv/awx/bin/python3 /usr/bin/awx-manage run_dispatcher
+  cwd: /var/lib/awx/venv/awx/bin/
+  pid: '32204'
+  ppid: '26058'
+  user: root
+software_list:
+- cmd_regexp: ^memcached
+  name: Memcached
+  pkg_regexp: ^memcached
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1034
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:05 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 950
+  port: 10050
+  protocol: tcp
+  stime: Tue Apr 26 15:55:03 2022
+  user: zabbix
+- address: 192.168.0.145
+  name: vault
+  pid: 1135
+  port: 8200
+  protocol: tcp
+  stime: Tue Apr 26 15:55:12 2022
+  user: vault
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1096
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:11 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1034
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:05 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 7659
+  port: 443
+  protocol: tcp
+  stime: Tue Apr 26 15:56:05 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 8401
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 15:56:07 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 7816
+  port: 11211
+  protocol: tcp
+  stime: Tue Apr 26 15:56:06 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 7676
+  port: 80
+  protocol: tcp
+  stime: Tue Apr 26 15:56:05 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1096
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:11 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 872
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:02 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 639
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 619
+  port: 788
+  protocol: udp
+  stime: Tue Apr 26 15:54:47 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:27 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 639
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 619
+  port: 788
+  protocol: udp
+  stime: Tue Apr 26 15:54:47 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/mongodb/mongodb_test.yaml
+++ b/tests/unit/plugins/action/auto/resources/mongodb/mongodb_test.yaml
@@ -1,1251 +1,1208 @@
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 53314
-        protocol: 'tcp'
-    discovery_time: '2022-07-05T11:05:27+02:00'
-    listening_ports:
-      - 53314
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: mongo server
-        release: 18.el7
-        source: rpm
-        version: 1.2.7
-    process:
-      cmdline: /usr/bin/mongod -b config.yaml
-      listening_ports:
-        - 53314
-      pid: '121'
-      ppid: '0'
-      user: root
-    type: MongoDB
-    version:
-      - number: 1.2.7
-        type: package
-software_list:
-  - cmd_regexp: mongod
-    name: MongoDB
-    pkg_regexp: mongodb-org-server$
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: {}
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: 'sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25'
-      LogPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: []
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /var/lib/grafana: {}
-          /var/log/grafana: {}
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: {}
-          /var/lib/postgresql/data: {}
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: {}
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ''
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 5caafdd39f48c7b60da3b248f80071f3e9a9cdf13be2219cb4d3eb43366722d5
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 1
-        FinishedAt: '2022-07-05T09:05:26.165422683Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 0
-        Restarting: false
-        Running: false
-        StartedAt: '2022-07-05T09:05:24.774809862Z'
-        Status: exited
-packages:
-  mongodb-org-server:
-    - arch: x86_64
-      epoch: null
-      name: mongo server
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/bin/mongod -b config.yaml
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ''
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 5caafdd39f48c7b60da3b248f80071f3e9a9cdf13be2219cb4d3eb43366722d5
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 1
+      FinishedAt: '2022-07-05T09:05:26.165422683Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 0
+      Restarting: false
+      Running: false
+      StartedAt: '2022-07-05T09:05:24.774809862Z'
+      Status: exited
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 53314
+    protocol: tcp
+  discovery_time: '2022-07-05T11:05:27+02:00'
+  listening_ports:
+  - 53314
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: mongo server
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  process:
+    cmdline: /usr/bin/mongod -b config.yaml
+    cwd: /usr/bin/
+    listening_ports:
+    - 53314
     pid: '121'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
+  type: MongoDB
+  version:
+  - number: 1.2.7
+    type: package
+packages:
+  mongodb-org-server:
+  - arch: x86_64
+    epoch: null
+    name: mongo server
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/bin/mongod -b config.yaml
+  cwd: /usr/bin/
+  pid: '121'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: mongod
+  name: MongoDB
+  pkg_regexp: mongodb-org-server$
+  process_type: parent
+  return_children: false
+  return_packages: true
 tcp_listen:
-  - address: 0.0.0.0
-    name: port1
-    pid: 121
-    port: 53314
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: port2
-    pid: 122
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: port3
-    pid: 123
-    port: 52914
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port4
-    pid: 124
-    port: 53213
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port5
-    pid: 125
-    port: 52614
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
+- address: 0.0.0.0
+  name: port1
+  pid: 121
+  port: 53314
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: port2
+  pid: 122
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: port3
+  pid: 123
+  port: 52914
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port4
+  pid: 124
+  port: 53213
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port5
+  pid: 125
+  port: 52614
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
 udp_listen:
-  - address: 0.0.0.0
-    name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/mulesoft/mulesoftappserver_test.yaml
+++ b/tests/unit/plugins/action/auto/resources/mulesoft/mulesoftappserver_test.yaml
@@ -1,1485 +1,1441 @@
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 53314
-        protocol: 'tcp'
-    discovery_time: '2022-07-05T18:21:21+02:00'
-    listening_ports:
-      - 53314
-    process:
-      cmdline: /usr/lib/systemd/MuleContainerBootstrap -b config.yaml
-      listening_ports:
-        - 53314
-      pid: '121'
-      ppid: '0'
-      user: root
-    type: MuleSoft AppServer
-    version: [ ]
-
-software_list:
-  - cmd_regexp: MuleContainerBootstrap
-    name: MuleSoft AppServer
-    process_type: parent
-    return_children: false
-    return_packages: false
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: { }
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: 'sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25'
-      LogPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /var/lib/grafana: { }
-          /var/log/grafana: { }
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: { }
-          /var/lib/postgresql/data: { }
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/nginx: { }
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: { }
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 41646a2e4cefe3075ce860a5b43a7fd895356fab3f730fb2fbf31eab4b3b63b8
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 6be7362230495d2759721f5bb7d6cccdfc95270e72eb2f0ce0281b3576039ae4
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-05T16:21:19.700599103Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 21867
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-05T16:21:20.43263416Z'
-        Status: running
-processes:
-  - cmdline: /usr/lib/systemd/MuleContainerBootstrap -b config.yaml
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 41646a2e4cefe3075ce860a5b43a7fd895356fab3f730fb2fbf31eab4b3b63b8
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 6be7362230495d2759721f5bb7d6cccdfc95270e72eb2f0ce0281b3576039ae4
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-05T16:21:19.700599103Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 21867
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-05T16:21:20.43263416Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 53314
+    protocol: tcp
+  discovery_time: '2022-07-05T18:21:21+02:00'
+  listening_ports:
+  - 53314
+  process:
+    cmdline: /usr/lib/systemd/MuleContainerBootstrap -b config.yaml
+    cwd: /usr/lib/systemd/
+    listening_ports:
+    - 53314
     pid: '121'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
+  type: MuleSoft AppServer
+  version: []
 packages:
   freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
   gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
   gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
   gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
   glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
   glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
   glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
   gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
   gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
   gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
   gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
   gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
   gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
   grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
   groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
   grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
   gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
   gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
   hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
   hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
   hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
   info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
   iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
   iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
   iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
   iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+processes:
+- cmdline: /usr/lib/systemd/MuleContainerBootstrap -b config.yaml
+  cwd: /usr/lib/systemd/
+  pid: '121'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: MuleContainerBootstrap
+  name: MuleSoft AppServer
+  process_type: parent
+  return_children: false
+  return_packages: false
 tcp_listen:
-  - address: 0.0.0.0
-    name: port1
-    pid: 121
-    port: 53314
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: port2
-    pid: 122
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: port3
-    pid: 123
-    port: 52914
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port4
-    pid: 124
-    port: 53213
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port5
-    pid: 125
-    port: 52614
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
+- address: 0.0.0.0
+  name: port1
+  pid: 121
+  port: 53314
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: port2
+  pid: 122
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: port3
+  pid: 123
+  port: 52914
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port4
+  pid: 124
+  port: 53213
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port5
+  pid: 125
+  port: 52614
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
 udp_listen:
-  - address: 0.0.0.0
-    name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/mysql/centos7.yaml
+++ b/tests/unit/plugins/action/auto/resources/mysql/centos7.yaml
@@ -1,5336 +1,5598 @@
-software_list:
-  - name: MySQL DatabaseServer
-    cmd_regexp: /mysqld(\s|$)
-    pkg_regexp: mysql-serve
-    process_type: parent
-    return_children: false
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-    pid: '1'
-    ppid: '0'
-    user: 'root'
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: 'root'
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '50'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '53'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '54'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '55'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '57'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '58'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '65'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '66'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '68'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '76'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '78'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '79'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '81'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '83'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '98'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '136'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '283'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '298'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '299'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '302'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '305'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '306'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '308'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '309'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '310'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '311'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '312'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '313'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '315'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '316'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '318'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '319'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '321'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '322'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '324'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '325'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '326'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '327'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '328'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '329'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '330'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '331'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '332'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '333'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '334'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '335'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '347'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '348'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '349'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '350'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '351'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '352'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '353'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '354'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '355'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '356'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '357'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '358'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '359'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '360'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '361'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '362'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '363'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '364'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '405'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '406'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '420'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '427'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '428'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '429'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '430'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '431'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '432'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '433'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '434'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '435'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '436'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '437'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '438'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '518'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '552'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '607'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '608'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '611'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '612'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '613'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '614'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '615'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '623'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /sbin/auditd
-    pid: '682'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/bin/VGAuthService -s
-    pid: '705'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/bin/vmtoolsd
-    pid: '706'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '708'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '710'
-    ppid: '1'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '713'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/chronyd
-    pid: '719'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/NetworkManager --no-daemon
-    pid: '732'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '734'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/crond -n
-    pid: '738'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '813'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f
-    pid: '999'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1002'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1004'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1005'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1186'
-    ppid: '1'
-    user: 'root'
-  - cmdline: qmgr -l -t unix -u
-    pid: '1207'
-    ppid: '1186'
-    user: 'root'
-  - cmdline: ''
-    pid: '1467'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '1489'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '1498'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '1521'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '2185'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '3002'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '9403'
-    ppid: '2'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d -address
-      /run/containerd/containerd.sock
-    pid: '20044'
-    ppid: '1'
-    user: 'root'
-  - cmdline: 'redis-server 0.0.0.0:6379'
-    pid: '20064'
-    ppid: '20044'
-    user: 'root'
-  - cmdline: /usr/bin/docker start -a redis
-    pid: '20366'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '20383'
-    ppid: '2'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb -address
-      /run/containerd/containerd.sock
-    pid: '23319'
-    ppid: '1'
-    user: 'root'
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '23339'
-    ppid: '23319'
-    user: 'root'
-  - cmdline: 'nginx: worker process'
-    pid: '23356'
-    ppid: '23339'
-    user: 'root'
-  - cmdline: /usr/bin/docker start -a nginx
-    pid: '23581'
-    ppid: '1'
-    user: 'root'
-  - cmdline: SCREEN
-    pid: '24403'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /bin/bash
-    pid: '24404'
-    ppid: '24403'
-    user: 'root'
-  - cmdline: ''
-    pid: '25635'
-    ppid: '2'
-    user: 'root'
-  - cmdline: sudo -u postgres psql
-    pid: '28523'
-    ppid: '24404'
-    user: 'root'
-  - cmdline: psql
-    pid: '28524'
-    ppid: '28523'
-    user: 'root'
-  - cmdline: /usr/bin/docker start -a iometrics-cmdb-gateway
-    pid: '28556'
-    ppid: '1'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42 -address
-      /run/containerd/containerd.sock
-    pid: '28596'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /bin/sh -c ./start_cmdb_gateway.sh
-    pid: '28617'
-    ppid: '28596'
-    user: 'root'
-  - cmdline: /bin/sh ./start_cmdb_gateway.sh
-    pid: '28631'
-    ppid: '28617'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28633'
-    ppid: '28631'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28635'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28637'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28638'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28639'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28640'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28641'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28642'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28643'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
-    pid: '28694'
-    ppid: '1'
-    user: 'root'
-  - cmdline: 'postgres: data: checkpointer process'
-    pid: '28697'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: writer process'
-    pid: '28698'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: wal writer process'
-    pid: '28699'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: autovacuum launcher process'
-    pid: '28700'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: stats collector process'
-    pid: '28701'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: bgworker: logical replication launcher'
-    pid: '28702'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: /usr/bin/docker start -a iometrics-cmdbuild
-    pid: '30649'
-    ppid: '1'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443
-      -container-ip 192.168.1.2 -container-port 8443
-    pid: '30674'
-    ppid: '60677'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187 -address
-      /run/containerd/containerd.sock
-    pid: '30689'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
-    pid: '30709'
-    ppid: '30689'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/openjdk-17/bin/java
-      -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      -Xmx7876m -Xms3846m -Djdk.tls.ephemeralDHKeySize=2048
-      -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
-      -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
-      -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
-      -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar
-      -Delastic.apm.service_name=cmdb
-      -Delastic.apm.server_url=http://192.168.8.53:8200
-      -Delastic.apm.environment=dev -Delastic.apm.enabled=true
-      -Delastic.apm.profiling_inferred_spans_enabled=true
-      -Delastic.apm.profiling_inferred_spans_min_duration=250ms
-      -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
-      -Dignore.endorsed.dirs= -classpath
-      /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
-      -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat
-      -Djava.io.tmpdir=/usr/local/tomcat/temp
-      org.apache.catalina.startup.Bootstrap start
-    pid: '30748'
-    ppid: '30709'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42292) idle'
-    pid: '30959'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00 -address
-      /run/containerd/containerd.sock
-    pid: '34186'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /bin/sh -c python ./listener.py
-    pid: '34206'
-    ppid: '34186'
-    user: 'root'
-  - cmdline: python ./listener.py
-    pid: '34220'
-    ppid: '34206'
-    user: 'root'
-  - cmdline: ''
-    pid: '44075'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '45038'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '46732'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '46733'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '46865'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /sbin/rpcbind -w
-    pid: '47374'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '47383'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '47397'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47398'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/sbin/rpc.statd
-    pid: '47406'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/rpc.idmapd
-    pid: '47408'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/rpc.mountd
-    pid: '47410'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '47415'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47416'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47421'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47422'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47423'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47424'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47425'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47426'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47427'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47428'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '49443'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '50335'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/bin/containerd
-    pid: '54568'
-    ppid: '1'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33168) idle'
-    pid: '57218'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33436) idle'
-    pid: '58454'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33512) idle'
-    pid: '58550'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33562) idle'
-    pid: '58612'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33642) idle'
-    pid: '58724'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33660) idle'
-    pid: '58766'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33720) idle'
-    pid: '58872'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33738) idle'
-    pid: '58949'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33766) idle'
-    pid: '59000'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33772) idle'
-    pid: '59003'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33778) idle'
-    pid: '59006'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33782) idle'
-    pid: '59008'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33788) idle'
-    pid: '59017'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33790) idle'
-    pid: '59018'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: ''
-    pid: '59036'
-    ppid: '2'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33792) idle'
-    pid: '59049'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33796) idle'
-    pid: '59051'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33798) idle'
-    pid: '59052'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33804) idle'
-    pid: '59064'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33808) idle'
-    pid: '59071'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33810) idle'
-    pid: '59077'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '60677'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '61265'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61266'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61267'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61268'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61269'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61270'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61271'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61272'
-    ppid: '2'
-    user: 'root'
-  - cmdline: pickup -l -t unix -u
-    pid: '62178'
-    ppid: '1186'
-    user: 'root'
-  - cmdline: ''
-    pid: '63141'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '67115'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /opt/fireeye/bin/xagt -M DAEMON
-    pid: '69963'
-    ppid: '1'
-    user: 'root'
-  - cmdline: >-
-      /opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT
-      --logfd 4
-    pid: '69987'
-    ppid: '69963'
-    user: 'root'
-  - cmdline: 'sshd: root@pts/0'
-    pid: '71236'
-    ppid: '1005'
-    user: 'root'
-  - cmdline: '-bash'
-    pid: '71238'
-    ppid: '71236'
-    user: 'root'
-  - cmdline: ''
-    pid: '72571'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '73404'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/sbin/mysqld
-    pid: '73979'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '75161'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '76377'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '77796'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '78673'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '79907'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '80858'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '81582'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '83325'
-    ppid: '2'
-    user: 'root'
-  - cmdline: 'sshd: root@pts/2'
-    pid: '83787'
-    ppid: '1005'
-    user: 'root'
-  - cmdline: ''
-    pid: '83867'
-    ppid: '2'
-    user: 'root'
-  - cmdline: >-
-      /bin/sh -c /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1651076211.87958-95939-60303799464658/AnsiballZ_process_facts.py
-      && sleep 0
-    pid: '83946'
-    ppid: '83787'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1651076211.87958-95939-60303799464658/AnsiballZ_process_facts.py
-    pid: '83959'
-    ppid: '83946'
-    user: 'root'
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
-  MySQL-client:
-    - arch: x86_64
-      epoch: null
-      name: MySQL-client
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
-  MySQL-common:
-    - arch: x86_64
-      epoch: null
-      name: MySQL-common
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
-  MySQL-compat:
-    - arch: x86_64
-      epoch: null
-      name: MySQL-compat
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
-  MySQL-server:
-    - arch: x86_64
-      epoch: null
-      name: MySQL-server
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
-  NetworkManager:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
-  NetworkManager-libnm:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-libnm
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
-  NetworkManager-team:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-team
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
-  NetworkManager-tui:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-tui
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  aic94xx-firmware:
-    - arch: noarch
-      epoch: null
-      name: aic94xx-firmware
-      release: 6.el7
-      source: rpm
-      version: '30'
-  alsa-firmware:
-    - arch: noarch
-      epoch: null
-      name: alsa-firmware
-      release: 2.el7
-      source: rpm
-      version: 1.0.28
-  alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
-  alsa-tools-firmware:
-    - arch: x86_64
-      epoch: null
-      name: alsa-tools-firmware
-      release: 1.el7
-      source: rpm
-      version: 1.1.0
-  apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
-  apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autoconf:
-    - arch: noarch
-      epoch: null
-      name: autoconf
-      release: 11.el7
-      source: rpm
-      version: '2.69'
-  automake:
-    - arch: noarch
-      epoch: null
-      name: automake
-      release: 3.el7
-      source: rpm
-      version: 1.13.4
-  avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
-  bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.5
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7
-      source: rpm
-      version: '2.27'
-  biosdevname:
-    - arch: x86_64
-      epoch: null
-      name: biosdevname
-      release: 2.el7
-      source: rpm
-      version: 0.7.3
-  bison:
-    - arch: x86_64
-      epoch: null
-      name: bison
-      release: 2.el7
-      source: rpm
-      version: 3.0.4
-  boost-date-time:
-    - arch: x86_64
-      epoch: null
-      name: boost-date-time
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
-  boost-program-options:
-    - arch: x86_64
-      epoch: null
-      name: boost-program-options
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
-  boost-system:
-    - arch: x86_64
-      epoch: null
-      name: boost-system
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
-  boost-thread:
-    - arch: x86_64
-      epoch: null
-      name: boost-thread
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  byacc:
-    - arch: x86_64
-      epoch: null
-      name: byacc
-      release: 3.el7
-      source: rpm
-      version: 1.9.20130304
-  bzip2:
-    - arch: x86_64
-      epoch: null
-      name: bzip2
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  c-ares:
-    - arch: x86_64
-      epoch: null
-      name: c-ares
-      release: 3.el7
-      source: rpm
-      version: 1.10.0
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_8
-      source: rpm
-      version: 2020.2.41
-  centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.4.4
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
-  cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
-  cscope:
-    - arch: x86_64
-      epoch: null
-      name: cscope
-      release: 10.el7
-      source: rpm
-      version: '15.8'
-  ctags:
-    - arch: x86_64
-      epoch: null
-      name: ctags
-      release: 13.el7
-      source: rpm
-      version: '5.8'
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 3.el7_9.2
-      source: rpm
-      version: 0.8.5
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffstat:
-    - arch: x86_64
-      epoch: null
-      name: diffstat
-      release: 4.el7
-      source: rpm
-      version: '1.57'
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
-  docker-ce-rootless-extras:
-    - arch: x86_64
-      epoch: 0
-      name: docker-ce-rootless-extras
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
-  docker-scan-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-scan-plugin
-      release: 3.el7
-      source: rpm
-      version: 0.7.0
-  doxygen:
-    - arch: x86_64
-      epoch: 1
-      name: doxygen
-      release: 4.el7
-      source: rpm
-      version: 1.8.5
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dwz:
-    - arch: x86_64
-      epoch: null
-      name: dwz
-      release: 3.el7
-      source: rpm
-      version: '0.11'
-  dyninst:
-    - arch: x86_64
-      epoch: null
-      name: dyninst
-      release: 3.el7
-      source: rpm
-      version: 9.3.1
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  ebtables:
-    - arch: x86_64
-      epoch: null
-      name: ebtables
-      release: 16.el7
-      source: rpm
-      version: 2.0.10
-  efivar-libs:
-    - arch: x86_64
-      epoch: null
-      name: efivar-libs
-      release: 12.el7
-      source: rpm
-      version: '36'
-  elfutils:
-    - arch: x86_64
-      epoch: null
-      name: elfutils
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  emacs-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: emacs-filesystem
-      release: 23.el7
-      source: rpm
-      version: '24.3'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '13'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  firewalld:
-    - arch: noarch
-      epoch: null
-      name: firewalld
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
-  firewalld-filesystem:
-    - arch: noarch
-      epoch: null
-      name: firewalld-filesystem
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
-  flex:
-    - arch: x86_64
-      epoch: null
-      name: flex
-      release: 6.el7
-      source: rpm
-      version: 2.5.37
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fuse:
-    - arch: x86_64
-      epoch: null
-      name: fuse
-      release: 11.el7
-      source: rpm
-      version: 2.9.2
-  fuse-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-libs
-      release: 11.el7
-      source: rpm
-      version: 2.9.2
-  fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
-  fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
-  fxload:
-    - arch: x86_64
-      epoch: null
-      name: fxload
-      release: 16.el7
-      source: rpm
-      version: '2002_04_11'
-  galera-4:
-    - arch: x86_64
-      epoch: null
-      name: galera-4
-      release: 1.el7.centos
-      source: rpm
-      version: 26.4.8
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gcc-gfortran:
-    - arch: x86_64
-      epoch: null
-      name: gcc-gfortran
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gdb:
-    - arch: x86_64
-      epoch: null
-      name: gdb
-      release: 120.el7
-      source: rpm
-      version: 7.6.1
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-common-devel:
-    - arch: noarch
-      epoch: null
-      name: gettext-common-devel
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-devel:
-    - arch: x86_64
-      epoch: null
-      name: gettext-devel
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  git:
-    - arch: x86_64
-      epoch: null
-      name: git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 8.el7
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gnutls:
-    - arch: x86_64
-      epoch: null
-      name: gnutls
-      release: 9.el7_6
-      source: rpm
-      version: 3.3.29
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 511147a9
-      source: rpm
-      version: 1bb943db
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 608c8351
-      source: rpm
-      version: 442df0f8
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  htop:
-    - arch: x86_64
-      epoch: null
-      name: htop
-      release: 3.el7
-      source: rpm
-      version: 2.2.0
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  indent:
-    - arch: x86_64
-      epoch: null
-      name: indent
-      release: 13.el7
-      source: rpm
-      version: 2.2.11
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  intltool:
-    - arch: noarch
-      epoch: null
-      name: intltool
-      release: 7.el7
-      source: rpm
-      version: 0.50.2
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iprutils:
-    - arch: x86_64
-      epoch: null
-      name: iprutils
-      release: 3.el7_7
-      source: rpm
-      version: 2.4.17.1
-  ipset:
-    - arch: x86_64
-      epoch: null
-      name: ipset
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  ivtv-firmware:
-    - arch: noarch
-      epoch: 2
-      name: ivtv-firmware
-      release: 26.el7
-      source: rpm
-      version: '20080701'
-  iwl100-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl100-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
-  iwl1000-firmware:
-    - arch: noarch
-      epoch: 1
-      name: iwl1000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
-  iwl105-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl105-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl135-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl135-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl2000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl2030-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2030-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl3160-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3160-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
-  iwl3945-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3945-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 15.32.2.9
-  iwl4965-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl4965-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 228.61.2.24
-  iwl5000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.83.5.1_1
-  iwl5150-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5150-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.24.2.2
-  iwl6000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 9.221.4.1
-  iwl6000g2a-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2a-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl6000g2b-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2b-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl6050-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6050-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 41.28.5.1
-  iwl7260-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7260-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jnettop:
-    - arch: x86_64
-      epoch: null
-      name: jnettop
-      release: 16.el7
-      source: rpm
-      version: 0.13.0
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.21.3.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 862.9.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.10.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.15.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-debug-devel:
-    - arch: x86_64
-      epoch: null
-      name: kernel-debug-devel
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.2
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 134.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 50.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdnet:
-    - arch: x86_64
-      epoch: null
-      name: libdnet
-      release: 13.1.el7
-      source: rpm
-      version: '1.12'
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libdwarf:
-    - arch: x86_64
-      epoch: null
-      name: libdwarf
-      release: 4.el7
-      source: rpm
-      version: '20130207'
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgfortran:
-    - arch: x86_64
-      epoch: null
-      name: libgfortran
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmodman:
-    - arch: x86_64
-      epoch: null
-      name: libmodman
-      release: 8.el7
-      source: rpm
-      version: 2.0.1
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libmspack:
-    - arch: x86_64
-      epoch: null
-      name: libmspack
-      release: 0.8.alpha.el7
-      source: rpm
-      version: '0.5'
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libproxy:
-    - arch: x86_64
-      epoch: null
-      name: libproxy
-      release: 11.el7
-      source: rpm
-      version: 0.4.11
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libquadmath:
-    - arch: x86_64
-      epoch: null
-      name: libquadmath
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libquadmath-devel:
-    - arch: x86_64
-      epoch: null
-      name: libquadmath-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.4.1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libsmi:
-    - arch: x86_64
-      epoch: null
-      name: libsmi
-      release: 13.el7
-      source: rpm
-      version: 0.4.8
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libtool:
-    - arch: x86_64
-      epoch: null
-      name: libtool
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libtool-ltdl:
-    - arch: x86_64
-      epoch: null
-      name: libtool-ltdl
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7.5
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7.5
-      source: rpm
-      version: 2.9.1
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lsscsi:
-    - arch: x86_64
-      epoch: null
-      name: lsscsi
-      release: 6.el7
-      source: rpm
-      version: '0.27'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.8.el7_9
-      source: rpm
-      version: '2.1'
-  mokutil:
-    - arch: x86_64
-      epoch: null
-      name: mokutil
-      release: 8.el7
-      source: rpm
-      version: '15'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  nagios-common:
-    - arch: x86_64
-      epoch: null
-      name: nagios-common
-      release: 4.el7
-      source: rpm
-      version: 4.4.6
-  nagios-plugins:
-    - arch: x86_64
-      epoch: null
-      name: nagios-plugins
-      release: 2.el7
-      source: rpm
-      version: 2.3.3
-  nagios-plugins-perl:
-    - arch: x86_64
-      epoch: null
-      name: nagios-plugins-perl
-      release: 2.el7
-      source: rpm
-      version: 2.3.3
-  nano:
-    - arch: x86_64
-      epoch: null
-      name: nano
-      release: 10.el7
-      source: rpm
-      version: 2.3.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  neon:
-    - arch: x86_64
-      epoch: null
-      name: neon
-      release: 4.el7
-      source: rpm
-      version: 0.30.0
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 2.el7
-      source: rpm
-      version: '1.218'
-  nettle:
-    - arch: x86_64
-      epoch: null
-      name: nettle
-      release: 9.el7_9
-      source: rpm
-      version: 2.7.1
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7
-      source: rpm
-      version: 1.3.0
-  nrpe:
-    - arch: x86_64
-      epoch: null
-      name: nrpe
-      release: 6.el7
-      source: rpm
-      version: 4.0.3
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 2.el7_9
-      source: rpm
-      version: 4.25.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 6.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 6.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.53.1
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  open-vm-tools:
-    - arch: x86_64
-      epoch: null
-      name: open-vm-tools
-      release: 3.el7_9.3
-      source: rpm
-      version: 11.0.5
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 23.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 21.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 21.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pakchois:
-    - arch: x86_64
-      epoch: null
-      name: pakchois
-      release: 10.el7
-      source: rpm
-      version: '0.4'
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  patch:
-    - arch: x86_64
-      epoch: null
-      name: patch
-      release: 12.el7_7
-      source: rpm
-      version: 2.7.1
-  patchutils:
-    - arch: x86_64
-      epoch: null
-      name: patchutils
-      release: 5.el7_9
-      source: rpm
-      version: 0.3.3
-  pciutils:
-    - arch: x86_64
-      epoch: null
-      name: pciutils
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcre2:
-    - arch: x86_64
-      epoch: null
-      name: pcre2
-      release: 2.el7
-      source: rpm
-      version: '10.23'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
-  perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
-  perl-DBD-MySQL:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBD-MySQL
-      release: 6.el7
-      source: rpm
-      version: '4.023'
-  perl-DBI:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBI
-      release: 4.el7
-      source: rpm
-      version: '1.627'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Error:
-    - arch: noarch
-      epoch: 1
-      name: perl-Error
-      release: 2.el7
-      source: rpm
-      version: '0.17020'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-Git:
-    - arch: noarch
-      epoch: null
-      name: perl-Git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
-  perl-Net-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-Daemon
-      release: 5.el7
-      source: rpm
-      version: '0.48'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-PlRPC:
-    - arch: noarch
-      epoch: null
-      name: perl-PlRPC
-      release: 14.el7
-      source: rpm
-      version: '0.2020'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Sys-Statistics-Linux:
-    - arch: noarch
-      epoch: null
-      name: perl-Sys-Statistics-Linux
-      release: 14.el7
-      source: rpm
-      version: '0.66'
-  perl-TermReadKey:
-    - arch: x86_64
-      epoch: null
-      name: perl-TermReadKey
-      release: 20.el7
-      source: rpm
-      version: '2.30'
-  perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
-  perl-Test-Simple:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Simple
-      release: 243.el7
-      source: rpm
-      version: '0.98'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Thread-Queue:
-    - arch: noarch
-      epoch: null
-      name: perl-Thread-Queue
-      release: 2.el7
-      source: rpm
-      version: '3.02'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-XML-Parser:
-    - arch: x86_64
-      epoch: null
-      name: perl-XML-Parser
-      release: 10.el7
-      source: rpm
-      version: '2.41'
-  perl-YAML-Syck:
-    - arch: x86_64
-      epoch: null
-      name: perl-YAML-Syck
-      release: 3.el7
-      source: rpm
-      version: '1.27'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: perl-srpm-macros
-      release: 8.el7
-      source: rpm
-      version: '1'
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  plymouth:
-    - arch: x86_64
-      epoch: null
-      name: plymouth
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
-  plymouth-core-libs:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-core-libs
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
-  plymouth-scripts:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-scripts
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql:
-    - arch: x86_64
-      epoch: null
-      name: postgresql
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-devel:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-devel
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql10:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
-  postgresql10-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-contrib
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
-  postgresql10-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-libs
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
-  postgresql10-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-server
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 17.el7
-      source: rpm
-      version: '22.20'
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-firewall:
-    - arch: noarch
-      epoch: null
-      name: python-firewall
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  python-psycopg2:
-    - arch: x86_64
-      epoch: null
-      name: python-psycopg2
-      release: 1.rhel7
-      source: rpm
-      version: 2.7.5
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-slip:
-    - arch: noarch
-      epoch: null
-      name: python-slip
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-slip-dbus:
-    - arch: noarch
-      epoch: null
-      name: python-slip-dbus
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-devel:
-    - arch: x86_64
-      epoch: null
-      name: python3-devel
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-rpm-generators:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-generators
-      release: 2.el7
-      source: rpm
-      version: '6'
-  python3-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  rcs:
-    - arch: x86_64
-      epoch: null
-      name: rcs
-      release: 7.el7
-      source: rpm
-      version: 5.9.0
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redhat-rpm-config:
-    - arch: noarch
-      epoch: null
-      name: redhat-rpm-config
-      release: 88.el7.centos
-      source: rpm
-      version: 9.1.0
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-sign:
-    - arch: x86_64
-      epoch: null
-      name: rpm-sign
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  socat:
-    - arch: x86_64
-      epoch: null
-      name: socat
-      release: 2.el7
-      source: rpm
-      version: 1.7.3.2
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 6.el7
-      source: rpm
-      version: '4.24'
-  subversion:
-    - arch: x86_64
-      epoch: null
-      name: subversion
-      release: 16.el7
-      source: rpm
-      version: 1.7.14
-  subversion-libs:
-    - arch: x86_64
-      epoch: null
-      name: subversion-libs
-      release: 16.el7
-      source: rpm
-      version: 1.7.14
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.1
-      source: rpm
-      version: 1.8.23
-  swig:
-    - arch: x86_64
-      epoch: null
-      name: swig
-      release: 5.el7
-      source: rpm
-      version: 2.0.10
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemtap:
-    - arch: x86_64
-      epoch: null
-      name: systemtap
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-client:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-client
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-devel:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-devel
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-runtime:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-runtime
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 66.el7
-      source: rpm
-      version: '0.17'
-  traceroute:
-    - arch: x86_64
-      epoch: 3
-      name: traceroute
-      release: 2.el7
-      source: rpm
-      version: 2.0.22
-  trousers:
-    - arch: x86_64
-      epoch: null
-      name: trousers
-      release: 2.el7
-      source: rpm
-      version: 0.3.14
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021a
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  webtatic-release:
-    - arch: noarch
-      epoch: null
-      name: webtatic-release
-      release: '3'
-      source: rpm
-      version: '7'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wireshark:
-    - arch: x86_64
-      epoch: null
-      name: wireshark
-      release: 25.el7
-      source: rpm
-      version: 1.10.14
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xagt:
-    - arch: x86_64
-      epoch: null
-      name: xagt
-      release: 1.el7
-      source: rpm
-      version: 33.46.6
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xmlsec1:
-    - arch: x86_64
-      epoch: null
-      name: xmlsec1
-      release: 7.el7_4
-      source: rpm
-      version: 1.2.20
-  xmlsec1-openssl:
-    - arch: x86_64
-      epoch: null
-      name: xmlsec1-openssl
-      release: 7.el7_4
-      source: rpm
-      version: 1.2.20
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zip:
-    - arch: x86_64
-      epoch: null
-      name: zip
-      release: 11.el7
-      source: rpm
-      version: '3.0'
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-tcp_listen:
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1005
-    port: 22
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: 0.0.0.0
-    name: postmaster
-    pid: 28694
-    port: 5432
-    protocol: tcp
-    stime: 'Mon Apr 18 15:03:42 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1186
-    port: 25
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: 0.0.0.0
-    name: docker-proxy
-    pid: 30674
-    port: 8443
-    protocol: tcp
-    stime: 'Mon Apr 18 15:33:41 2022'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 46171
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 23339
-    port: 443
-    protocol: tcp
-    stime: 'Tue Jun  1 17:04:40 2021'
-    user: root
-  - address: 0.0.0.0
-    name: python
-    pid: 28633
-    port: 8444
-    protocol: tcp
-    stime: 'Mon Apr 18 15:03:28 2022'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: nrpe
-    pid: 999
-    port: 5666
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: nrpe
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 20064
-    port: 6378
-    protocol: tcp
-    stime: 'Tue May 25 11:00:31 2021'
-    user: polkitd
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 20064
-    port: 6379
-    protocol: tcp
-    stime: 'Tue May 25 11:00:31 2021'
-    user: polkitd
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 0.0.0.0
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: 0.0.0.0
-    name: rpc.statd
-    pid: 47406
-    port: 53648
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 23339
-    port: 80
-    protocol: tcp
-    stime: 'Tue Jun  1 17:04:40 2021'
-    user: root
+expected_result:
+- bindings:
   - address: '::'
-    name: sshd
-    pid: 1005
-    port: 22
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1186
-    port: 25
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 40957
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: nrpe
-    pid: 999
-    port: 5666
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: nrpe
-  - address: '::'
-    name: mysqld
-    pid: 73979
+    class: service
     port: 3306
     protocol: tcp
-    stime: 'Tue May 25 15:30:13 2021'
-    user: mysql
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: '::'
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: '::'
-    name: rpc.statd
-    pid: 47406
-    port: 47601
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-udp_listen:
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 59970
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: rpc.statd
-    pid: 47406
-    port: 60822
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 719
-    port: 323
-    protocol: udp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 909
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 127.0.0.1
-    name: rpc.statd
-    pid: 47406
-    port: 942
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: '::'
-    name: rpc.statd
-    pid: 47406
-    port: 42219
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 42799
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 719
-    port: 323
-    protocol: udp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 909
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-expected_result:
-  - bindings:
-     - address: '::'
-       class: 'service'
-       port: 3306
-       protocol: 'tcp'
-    type: MySQL DatabaseServer
-    discovery_time: '2022-05-26T18:00:00+02:00'
-    process:
-      cmdline: /usr/sbin/mysqld
-      listening_ports:
-        - 3306
-      pid: '73979'
-      ppid: '1'
-      user: 'root'
+  discovery_time: '2022-05-26T18:00:00+02:00'
+  listening_ports:
+  - 3306
+  process:
+    cmdline: /usr/sbin/mysqld
+    cwd: /usr/sbin/
     listening_ports:
-      - 3306
-    version:
-      - number: 10.5.10
-        type: package
+    - 3306
+    pid: '73979'
+    ppid: '1'
+    user: root
+  type: MySQL DatabaseServer
+  version:
+  - number: 10.5.10
+    type: package
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
+  MySQL-client:
+  - arch: x86_64
+    epoch: null
+    name: MySQL-client
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
+  MySQL-common:
+  - arch: x86_64
+    epoch: null
+    name: MySQL-common
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
+  MySQL-compat:
+  - arch: x86_64
+    epoch: null
+    name: MySQL-compat
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
+  MySQL-server:
+  - arch: x86_64
+    epoch: null
+    name: MySQL-server
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
+  NetworkManager:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
+  NetworkManager-libnm:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-libnm
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
+  NetworkManager-team:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-team
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
+  NetworkManager-tui:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-tui
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  aic94xx-firmware:
+  - arch: noarch
+    epoch: null
+    name: aic94xx-firmware
+    release: 6.el7
+    source: rpm
+    version: '30'
+  alsa-firmware:
+  - arch: noarch
+    epoch: null
+    name: alsa-firmware
+    release: 2.el7
+    source: rpm
+    version: 1.0.28
+  alsa-lib:
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
+  alsa-tools-firmware:
+  - arch: x86_64
+    epoch: null
+    name: alsa-tools-firmware
+    release: 1.el7
+    source: rpm
+    version: 1.1.0
+  apr:
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
+  apr-util:
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autoconf:
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
+  automake:
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
+  avahi-libs:
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
+  bc:
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.5
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7
+    source: rpm
+    version: '2.27'
+  biosdevname:
+  - arch: x86_64
+    epoch: null
+    name: biosdevname
+    release: 2.el7
+    source: rpm
+    version: 0.7.3
+  bison:
+  - arch: x86_64
+    epoch: null
+    name: bison
+    release: 2.el7
+    source: rpm
+    version: 3.0.4
+  boost-date-time:
+  - arch: x86_64
+    epoch: null
+    name: boost-date-time
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
+  boost-program-options:
+  - arch: x86_64
+    epoch: null
+    name: boost-program-options
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
+  boost-system:
+  - arch: x86_64
+    epoch: null
+    name: boost-system
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
+  boost-thread:
+  - arch: x86_64
+    epoch: null
+    name: boost-thread
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  byacc:
+  - arch: x86_64
+    epoch: null
+    name: byacc
+    release: 3.el7
+    source: rpm
+    version: 1.9.20130304
+  bzip2:
+  - arch: x86_64
+    epoch: null
+    name: bzip2
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  c-ares:
+  - arch: x86_64
+    epoch: null
+    name: c-ares
+    release: 3.el7
+    source: rpm
+    version: 1.10.0
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_8
+    source: rpm
+    version: 2020.2.41
+  centos-logos:
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.4.4
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
+  cscope:
+  - arch: x86_64
+    epoch: null
+    name: cscope
+    release: 10.el7
+    source: rpm
+    version: '15.8'
+  ctags:
+  - arch: x86_64
+    epoch: null
+    name: ctags
+    release: 13.el7
+    source: rpm
+    version: '5.8'
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  device-mapper-event:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  device-mapper-event-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  device-mapper-persistent-data:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 3.el7_9.2
+    source: rpm
+    version: 0.8.5
+  dhclient:
+  - arch: x86_64
+    epoch: 12
+    name: dhclient
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffstat:
+  - arch: x86_64
+    epoch: null
+    name: diffstat
+    release: 4.el7
+    source: rpm
+    version: '1.57'
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
+  docker-ce-rootless-extras:
+  - arch: x86_64
+    epoch: 0
+    name: docker-ce-rootless-extras
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
+  docker-scan-plugin:
+  - arch: x86_64
+    epoch: 0
+    name: docker-scan-plugin
+    release: 3.el7
+    source: rpm
+    version: 0.7.0
+  doxygen:
+  - arch: x86_64
+    epoch: 1
+    name: doxygen
+    release: 4.el7
+    source: rpm
+    version: 1.8.5
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dwz:
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
+  dyninst:
+  - arch: x86_64
+    epoch: null
+    name: dyninst
+    release: 3.el7
+    source: rpm
+    version: 9.3.1
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  ebtables:
+  - arch: x86_64
+    epoch: null
+    name: ebtables
+    release: 16.el7
+    source: rpm
+    version: 2.0.10
+  efivar-libs:
+  - arch: x86_64
+    epoch: null
+    name: efivar-libs
+    release: 12.el7
+    source: rpm
+    version: '36'
+  elfutils:
+  - arch: x86_64
+    epoch: null
+    name: elfutils
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  emacs-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: emacs-filesystem
+    release: 23.el7
+    source: rpm
+    version: '24.3'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '13'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  firewalld:
+  - arch: noarch
+    epoch: null
+    name: firewalld
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
+  firewalld-filesystem:
+  - arch: noarch
+    epoch: null
+    name: firewalld-filesystem
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
+  flex:
+  - arch: x86_64
+    epoch: null
+    name: flex
+    release: 6.el7
+    source: rpm
+    version: 2.5.37
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fuse:
+  - arch: x86_64
+    epoch: null
+    name: fuse
+    release: 11.el7
+    source: rpm
+    version: 2.9.2
+  fuse-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-libs
+    release: 11.el7
+    source: rpm
+    version: 2.9.2
+  fuse-overlayfs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
+  fuse3-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
+  fxload:
+  - arch: x86_64
+    epoch: null
+    name: fxload
+    release: 16.el7
+    source: rpm
+    version: '2002_04_11'
+  galera-4:
+  - arch: x86_64
+    epoch: null
+    name: galera-4
+    release: 1.el7.centos
+    source: rpm
+    version: 26.4.8
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-gfortran:
+  - arch: x86_64
+    epoch: null
+    name: gcc-gfortran
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gdb:
+  - arch: x86_64
+    epoch: null
+    name: gdb
+    release: 120.el7
+    source: rpm
+    version: 7.6.1
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-common-devel:
+  - arch: noarch
+    epoch: null
+    name: gettext-common-devel
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-devel:
+  - arch: x86_64
+    epoch: null
+    name: gettext-devel
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  git:
+  - arch: x86_64
+    epoch: null
+    name: git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 8.el7
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gnutls:
+  - arch: x86_64
+    epoch: null
+    name: gnutls
+    release: 9.el7_6
+    source: rpm
+    version: 3.3.29
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 511147a9
+    source: rpm
+    version: 1bb943db
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  htop:
+  - arch: x86_64
+    epoch: null
+    name: htop
+    release: 3.el7
+    source: rpm
+    version: 2.2.0
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  indent:
+  - arch: x86_64
+    epoch: null
+    name: indent
+    release: 13.el7
+    source: rpm
+    version: 2.2.11
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  intltool:
+  - arch: noarch
+    epoch: null
+    name: intltool
+    release: 7.el7
+    source: rpm
+    version: 0.50.2
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iprutils:
+  - arch: x86_64
+    epoch: null
+    name: iprutils
+    release: 3.el7_7
+    source: rpm
+    version: 2.4.17.1
+  ipset:
+  - arch: x86_64
+    epoch: null
+    name: ipset
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  ivtv-firmware:
+  - arch: noarch
+    epoch: 2
+    name: ivtv-firmware
+    release: 26.el7
+    source: rpm
+    version: '20080701'
+  iwl100-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl100-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
+  iwl1000-firmware:
+  - arch: noarch
+    epoch: 1
+    name: iwl1000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
+  iwl105-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl105-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl135-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl135-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl2000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl2000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl2030-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl2030-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl3160-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl3160-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
+  iwl3945-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl3945-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 15.32.2.9
+  iwl4965-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl4965-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 228.61.2.24
+  iwl5000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl5000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.83.5.1_1
+  iwl5150-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl5150-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.24.2.2
+  iwl6000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 9.221.4.1
+  iwl6000g2a-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2a-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl6000g2b-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2b-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl6050-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6050-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 41.28.5.1
+  iwl7260-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7260-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jnettop:
+  - arch: x86_64
+    epoch: null
+    name: jnettop
+    release: 16.el7
+    source: rpm
+    version: 0.13.0
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.21.3.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 862.9.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.10.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.15.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-debug-devel:
+  - arch: x86_64
+    epoch: null
+    name: kernel-debug-devel
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.2
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 134.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 50.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdnet:
+  - arch: x86_64
+    epoch: null
+    name: libdnet
+    release: 13.1.el7
+    source: rpm
+    version: '1.12'
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libdwarf:
+  - arch: x86_64
+    epoch: null
+    name: libdwarf
+    release: 4.el7
+    source: rpm
+    version: '20130207'
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgfortran:
+  - arch: x86_64
+    epoch: null
+    name: libgfortran
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmodman:
+  - arch: x86_64
+    epoch: null
+    name: libmodman
+    release: 8.el7
+    source: rpm
+    version: 2.0.1
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libmspack:
+  - arch: x86_64
+    epoch: null
+    name: libmspack
+    release: 0.8.alpha.el7
+    source: rpm
+    version: '0.5'
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libproxy:
+  - arch: x86_64
+    epoch: null
+    name: libproxy
+    release: 11.el7
+    source: rpm
+    version: 0.4.11
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libquadmath:
+  - arch: x86_64
+    epoch: null
+    name: libquadmath
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libquadmath-devel:
+  - arch: x86_64
+    epoch: null
+    name: libquadmath-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.4.1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libsmi:
+  - arch: x86_64
+    epoch: null
+    name: libsmi
+    release: 13.el7
+    source: rpm
+    version: 0.4.8
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libtool:
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libtool-ltdl:
+  - arch: x86_64
+    epoch: null
+    name: libtool-ltdl
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.5
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.5
+    source: rpm
+    version: 2.9.1
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lsscsi:
+  - arch: x86_64
+    epoch: null
+    name: lsscsi
+    release: 6.el7
+    source: rpm
+    version: '0.27'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.8.el7_9
+    source: rpm
+    version: '2.1'
+  mokutil:
+  - arch: x86_64
+    epoch: null
+    name: mokutil
+    release: 8.el7
+    source: rpm
+    version: '15'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  nagios-common:
+  - arch: x86_64
+    epoch: null
+    name: nagios-common
+    release: 4.el7
+    source: rpm
+    version: 4.4.6
+  nagios-plugins:
+  - arch: x86_64
+    epoch: null
+    name: nagios-plugins
+    release: 2.el7
+    source: rpm
+    version: 2.3.3
+  nagios-plugins-perl:
+  - arch: x86_64
+    epoch: null
+    name: nagios-plugins-perl
+    release: 2.el7
+    source: rpm
+    version: 2.3.3
+  nano:
+  - arch: x86_64
+    epoch: null
+    name: nano
+    release: 10.el7
+    source: rpm
+    version: 2.3.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  neon:
+  - arch: x86_64
+    epoch: null
+    name: neon
+    release: 4.el7
+    source: rpm
+    version: 0.30.0
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 2.el7
+    source: rpm
+    version: '1.218'
+  nettle:
+  - arch: x86_64
+    epoch: null
+    name: nettle
+    release: 9.el7_9
+    source: rpm
+    version: 2.7.1
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7
+    source: rpm
+    version: 1.3.0
+  nrpe:
+  - arch: x86_64
+    epoch: null
+    name: nrpe
+    release: 6.el7
+    source: rpm
+    version: 4.0.3
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 2.el7_9
+    source: rpm
+    version: 4.25.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 6.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 6.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.53.1
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  open-vm-tools:
+  - arch: x86_64
+    epoch: null
+    name: open-vm-tools
+    release: 3.el7_9.3
+    source: rpm
+    version: 11.0.5
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 23.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 21.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 21.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pakchois:
+  - arch: x86_64
+    epoch: null
+    name: pakchois
+    release: 10.el7
+    source: rpm
+    version: '0.4'
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  patch:
+  - arch: x86_64
+    epoch: null
+    name: patch
+    release: 12.el7_7
+    source: rpm
+    version: 2.7.1
+  patchutils:
+  - arch: x86_64
+    epoch: null
+    name: patchutils
+    release: 5.el7_9
+    source: rpm
+    version: 0.3.3
+  pciutils:
+  - arch: x86_64
+    epoch: null
+    name: pciutils
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcre2:
+  - arch: x86_64
+    epoch: null
+    name: pcre2
+    release: 2.el7
+    source: rpm
+    version: '10.23'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Compress-Raw-Bzip2:
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
+  perl-Compress-Raw-Zlib:
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
+  perl-DBD-MySQL:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBD-MySQL
+    release: 6.el7
+    source: rpm
+    version: '4.023'
+  perl-DBI:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBI
+    release: 4.el7
+    source: rpm
+    version: '1.627'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Error:
+  - arch: noarch
+    epoch: 1
+    name: perl-Error
+    release: 2.el7
+    source: rpm
+    version: '0.17020'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-Git:
+  - arch: noarch
+    epoch: null
+    name: perl-Git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-IO-Compress:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
+  perl-Net-Daemon:
+  - arch: noarch
+    epoch: null
+    name: perl-Net-Daemon
+    release: 5.el7
+    source: rpm
+    version: '0.48'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-PlRPC:
+  - arch: noarch
+    epoch: null
+    name: perl-PlRPC
+    release: 14.el7
+    source: rpm
+    version: '0.2020'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Sys-Statistics-Linux:
+  - arch: noarch
+    epoch: null
+    name: perl-Sys-Statistics-Linux
+    release: 14.el7
+    source: rpm
+    version: '0.66'
+  perl-TermReadKey:
+  - arch: x86_64
+    epoch: null
+    name: perl-TermReadKey
+    release: 20.el7
+    source: rpm
+    version: '2.30'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Test-Simple:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Simple
+    release: 243.el7
+    source: rpm
+    version: '0.98'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Thread-Queue:
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-XML-Parser:
+  - arch: x86_64
+    epoch: null
+    name: perl-XML-Parser
+    release: 10.el7
+    source: rpm
+    version: '2.41'
+  perl-YAML-Syck:
+  - arch: x86_64
+    epoch: null
+    name: perl-YAML-Syck
+    release: 3.el7
+    source: rpm
+    version: '1.27'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  plymouth:
+  - arch: x86_64
+    epoch: null
+    name: plymouth
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
+  plymouth-core-libs:
+  - arch: x86_64
+    epoch: null
+    name: plymouth-core-libs
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
+  plymouth-scripts:
+  - arch: x86_64
+    epoch: null
+    name: plymouth-scripts
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql:
+  - arch: x86_64
+    epoch: null
+    name: postgresql
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-devel:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-devel
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql10:
+  - arch: x86_64
+    epoch: null
+    name: postgresql10
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
+  postgresql10-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
+  postgresql10-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
+  postgresql10-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  psmisc:
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 17.el7
+    source: rpm
+    version: '22.20'
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-firewall:
+  - arch: noarch
+    epoch: null
+    name: python-firewall
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  python-psycopg2:
+  - arch: x86_64
+    epoch: null
+    name: python-psycopg2
+    release: 1.rhel7
+    source: rpm
+    version: 2.7.5
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-slip:
+  - arch: noarch
+    epoch: null
+    name: python-slip
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-slip-dbus:
+  - arch: noarch
+    epoch: null
+    name: python-slip-dbus
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  rcs:
+  - arch: x86_64
+    epoch: null
+    name: rcs
+    release: 7.el7
+    source: rpm
+    version: 5.9.0
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
+    name: rpcbind
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-sign:
+  - arch: x86_64
+    epoch: null
+    name: rpm-sign
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  socat:
+  - arch: x86_64
+    epoch: null
+    name: socat
+    release: 2.el7
+    source: rpm
+    version: 1.7.3.2
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 6.el7
+    source: rpm
+    version: '4.24'
+  subversion:
+  - arch: x86_64
+    epoch: null
+    name: subversion
+    release: 16.el7
+    source: rpm
+    version: 1.7.14
+  subversion-libs:
+  - arch: x86_64
+    epoch: null
+    name: subversion-libs
+    release: 16.el7
+    source: rpm
+    version: 1.7.14
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.1
+    source: rpm
+    version: 1.8.23
+  swig:
+  - arch: x86_64
+    epoch: null
+    name: swig
+    release: 5.el7
+    source: rpm
+    version: 2.0.10
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemtap:
+  - arch: x86_64
+    epoch: null
+    name: systemtap
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-client:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-client
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-devel:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-devel
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-runtime:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-runtime
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 66.el7
+    source: rpm
+    version: '0.17'
+  traceroute:
+  - arch: x86_64
+    epoch: 3
+    name: traceroute
+    release: 2.el7
+    source: rpm
+    version: 2.0.22
+  trousers:
+  - arch: x86_64
+    epoch: null
+    name: trousers
+    release: 2.el7
+    source: rpm
+    version: 0.3.14
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  webtatic-release:
+  - arch: noarch
+    epoch: null
+    name: webtatic-release
+    release: '3'
+    source: rpm
+    version: '7'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wireshark:
+  - arch: x86_64
+    epoch: null
+    name: wireshark
+    release: 25.el7
+    source: rpm
+    version: 1.10.14
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xagt:
+  - arch: x86_64
+    epoch: null
+    name: xagt
+    release: 1.el7
+    source: rpm
+    version: 33.46.6
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xmlsec1:
+  - arch: x86_64
+    epoch: null
+    name: xmlsec1
+    release: 7.el7_4
+    source: rpm
+    version: 1.2.20
+  xmlsec1-openssl:
+  - arch: x86_64
+    epoch: null
+    name: xmlsec1-openssl
+    release: 7.el7_4
+    source: rpm
+    version: 1.2.20
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '54'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '55'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '66'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '78'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '98'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '136'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '302'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '305'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '306'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '308'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '309'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '310'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '311'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '312'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '315'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '321'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '322'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '324'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '325'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '326'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '327'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '328'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '329'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '330'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '331'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '332'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '333'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '334'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '335'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '347'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '348'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '349'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '350'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '351'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '352'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '353'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '354'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '355'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '356'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '357'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '358'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '359'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '360'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '361'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '362'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '363'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '364'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '405'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '406'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '420'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '427'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '428'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '429'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '430'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '431'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '432'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '433'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '434'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '435'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '436'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '437'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '438'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '518'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '552'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '607'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '608'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '611'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '612'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '613'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '614'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '615'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '623'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '682'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/VGAuthService -s
+  cwd: /usr/bin/
+  pid: '705'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/vmtoolsd
+  cwd: /usr/bin/
+  pid: '706'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '708'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '710'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '713'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '719'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/NetworkManager --no-daemon
+  cwd: /usr/sbin/
+  pid: '732'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '734'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '738'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '813'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f
+  cwd: /usr/sbin/
+  pid: '999'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1002'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1004'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1005'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1186'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1207'
+  ppid: '1186'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1467'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1489'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1498'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1521'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2185'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '3002'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9403'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '20044'
+  ppid: '1'
+  user: root
+- cmdline: redis-server 0.0.0.0:6379
+  cwd: /
+  pid: '20064'
+  ppid: '20044'
+  user: root
+- cmdline: /usr/bin/docker start -a redis
+  cwd: /usr/bin/
+  pid: '20366'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20383'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '23319'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '23339'
+  ppid: '23319'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '23356'
+  ppid: '23339'
+  user: root
+- cmdline: /usr/bin/docker start -a nginx
+  cwd: /usr/bin/
+  pid: '23581'
+  ppid: '1'
+  user: root
+- cmdline: SCREEN
+  cwd: /
+  pid: '24403'
+  ppid: '1'
+  user: root
+- cmdline: /bin/bash
+  cwd: /bin/
+  pid: '24404'
+  ppid: '24403'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25635'
+  ppid: '2'
+  user: root
+- cmdline: sudo -u postgres psql
+  cwd: /
+  pid: '28523'
+  ppid: '24404'
+  user: root
+- cmdline: psql
+  cwd: /
+  pid: '28524'
+  ppid: '28523'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-cmdb-gateway
+  cwd: /usr/bin/
+  pid: '28556'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '28596'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c ./start_cmdb_gateway.sh
+  cwd: /bin/
+  pid: '28617'
+  ppid: '28596'
+  user: root
+- cmdline: /bin/sh ./start_cmdb_gateway.sh
+  cwd: /bin/
+  pid: '28631'
+  ppid: '28617'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28633'
+  ppid: '28631'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28635'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28637'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28638'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28639'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28640'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28641'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28642'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28643'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
+  cwd: /usr/pgsql-10/bin/
+  pid: '28694'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: data: checkpointer process'
+  cwd: /
+  pid: '28697'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: writer process'
+  cwd: /
+  pid: '28698'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: wal writer process'
+  cwd: /
+  pid: '28699'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: autovacuum launcher process'
+  cwd: /
+  pid: '28700'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: stats collector process'
+  cwd: /
+  pid: '28701'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: bgworker: logical replication launcher'
+  cwd: /
+  pid: '28702'
+  ppid: '28694'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-cmdbuild
+  cwd: /usr/bin/
+  pid: '30649'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 -container-ip
+    192.168.1.2 -container-port 8443
+  cwd: /usr/bin/
+  pid: '30674'
+  ppid: '60677'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '30689'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
+  cwd: /bin/
+  pid: '30709'
+  ppid: '30689'
+  user: root
+- cmdline: /usr/local/openjdk-17/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx7876m -Xms3846m
+    -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+    -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
+    -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar -Delastic.apm.service_name=cmdb
+    -Delastic.apm.server_url=http://192.168.8.53:8200 -Delastic.apm.environment=dev
+    -Delastic.apm.enabled=true -Delastic.apm.profiling_inferred_spans_enabled=true
+    -Delastic.apm.profiling_inferred_spans_min_duration=250ms -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
+    -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
+    -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp
+    org.apache.catalina.startup.Bootstrap start
+  cwd: /usr/local/openjdk-17/bin/
+  pid: '30748'
+  ppid: '30709'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42292) idle'
+  cwd: /
+  pid: '30959'
+  ppid: '28694'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '34186'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c python ./listener.py
+  cwd: /bin/
+  pid: '34206'
+  ppid: '34186'
+  user: root
+- cmdline: python ./listener.py
+  cwd: /
+  pid: '34220'
+  ppid: '34206'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44075'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45038'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46732'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46733'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '46865'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '47374'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '47383'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47398'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/rpc.statd
+  cwd: /usr/sbin/
+  pid: '47406'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rpc.idmapd
+  cwd: /usr/sbin/
+  pid: '47408'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rpc.mountd
+  cwd: /usr/sbin/
+  pid: '47410'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47415'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47416'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47421'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47422'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47423'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47424'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47425'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47426'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47427'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47428'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49443'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50335'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '54568'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33168) idle'
+  cwd: /
+  pid: '57218'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33436) idle'
+  cwd: /
+  pid: '58454'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33512) idle'
+  cwd: /
+  pid: '58550'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33562) idle'
+  cwd: /
+  pid: '58612'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33642) idle'
+  cwd: /
+  pid: '58724'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33660) idle'
+  cwd: /
+  pid: '58766'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33720) idle'
+  cwd: /
+  pid: '58872'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33738) idle'
+  cwd: /
+  pid: '58949'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33766) idle'
+  cwd: /
+  pid: '59000'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33772) idle'
+  cwd: /
+  pid: '59003'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33778) idle'
+  cwd: /
+  pid: '59006'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33782) idle'
+  cwd: /
+  pid: '59008'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33788) idle'
+  cwd: /
+  pid: '59017'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33790) idle'
+  cwd: /
+  pid: '59018'
+  ppid: '28694'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59036'
+  ppid: '2'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33792) idle'
+  cwd: /
+  pid: '59049'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33796) idle'
+  cwd: /
+  pid: '59051'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33798) idle'
+  cwd: /
+  pid: '59052'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33804) idle'
+  cwd: /
+  pid: '59064'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33808) idle'
+  cwd: /
+  pid: '59071'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33810) idle'
+  cwd: /
+  pid: '59077'
+  ppid: '28694'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '60677'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61266'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61271'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61272'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '62178'
+  ppid: '1186'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63141'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '67115'
+  ppid: '2'
+  user: root
+- cmdline: /opt/fireeye/bin/xagt -M DAEMON
+  cwd: /opt/fireeye/bin/
+  pid: '69963'
+  ppid: '1'
+  user: root
+- cmdline: /opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT --logfd
+    4
+  cwd: /opt/fireeye/bin/
+  pid: '69987'
+  ppid: '69963'
+  user: root
+- cmdline: 'sshd: root@pts/0'
+  cwd: /
+  pid: '71236'
+  ppid: '1005'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '71238'
+  ppid: '71236'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '72571'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '73404'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/mysqld
+  cwd: /usr/sbin/
+  pid: '73979'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '75161'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76377'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '77796'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '78673'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79907'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80858'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81582'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83325'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: root@pts/2'
+  cwd: /
+  pid: '83787'
+  ppid: '1005'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83867'
+  ppid: '2'
+  user: root
+- cmdline: /bin/sh -c /usr/bin/python /root/.ansible/tmp/ansible-tmp-1651076211.87958-95939-60303799464658/AnsiballZ_process_facts.py
+    && sleep 0
+  cwd: /bin/
+  pid: '83946'
+  ppid: '83787'
+  user: root
+- cmdline: /usr/bin/python /root/.ansible/tmp/ansible-tmp-1651076211.87958-95939-60303799464658/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '83959'
+  ppid: '83946'
+  user: root
+software_list:
+- cmd_regexp: /mysqld(\s|$)
+  name: MySQL DatabaseServer
+  pkg_regexp: mysql-serve
+  process_type: parent
+  return_children: false
+tcp_listen:
+- address: 0.0.0.0
+  name: sshd
+  pid: 1005
+  port: 22
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: 0.0.0.0
+  name: postmaster
+  pid: 28694
+  port: 5432
+  protocol: tcp
+  stime: Mon Apr 18 15:03:42 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1186
+  port: 25
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: 0.0.0.0
+  name: docker-proxy
+  pid: 30674
+  port: 8443
+  protocol: tcp
+  stime: Mon Apr 18 15:33:41 2022
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 46171
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 23339
+  port: 443
+  protocol: tcp
+  stime: Tue Jun  1 17:04:40 2021
+  user: root
+- address: 0.0.0.0
+  name: python
+  pid: 28633
+  port: 8444
+  protocol: tcp
+  stime: Mon Apr 18 15:03:28 2022
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: nrpe
+  pid: 999
+  port: 5666
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: nrpe
+- address: 0.0.0.0
+  name: redis-server
+  pid: 20064
+  port: 6378
+  protocol: tcp
+  stime: Tue May 25 11:00:31 2021
+  user: polkitd
+- address: 0.0.0.0
+  name: redis-server
+  pid: 20064
+  port: 6379
+  protocol: tcp
+  stime: Tue May 25 11:00:31 2021
+  user: polkitd
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: tcp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 0.0.0.0
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: 0.0.0.0
+  name: rpc.statd
+  pid: 47406
+  port: 53648
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 23339
+  port: 80
+  protocol: tcp
+  stime: Tue Jun  1 17:04:40 2021
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1005
+  port: 22
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: ::1
+  name: master
+  pid: 1186
+  port: 25
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: '::'
+  name: ''
+  pid: 0
+  port: 40957
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: '::'
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: '::'
+  name: nrpe
+  pid: 999
+  port: 5666
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: nrpe
+- address: '::'
+  name: mysqld
+  pid: 73979
+  port: 3306
+  protocol: tcp
+  stime: Tue May 25 15:30:13 2021
+  user: mysql
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: tcp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: '::'
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: '::'
+  name: rpc.statd
+  pid: 47406
+  port: 47601
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+udp_listen:
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: udp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 59970
+  protocol: udp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: rpc.statd
+  pid: 47406
+  port: 60822
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 719
+  port: 323
+  protocol: udp
+  stime: Fri May 21 08:55:20 2021
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 909
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 127.0.0.1
+  name: rpc.statd
+  pid: 47406
+  port: 942
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: '::'
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: udp
+  stime: ''
+  user: ''
+- address: '::'
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: '::'
+  name: rpc.statd
+  pid: 47406
+  port: 42219
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: '::'
+  name: ''
+  pid: 0
+  port: 42799
+  protocol: udp
+  stime: ''
+  user: ''
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 719
+  port: 323
+  protocol: udp
+  stime: Fri May 21 08:55:20 2021
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 909
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/nagiosNRPE/nagios_tests.yaml
+++ b/tests/unit/plugins/action/auto/resources/nagiosNRPE/nagios_tests.yaml
@@ -1,1038 +1,1006 @@
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 53314
-        protocol: 'tcp'
-    discovery_time: '2022-07-04T18:52:37+02:00'
-    listening_ports:
-      - 53314
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: NCSA nagios
-        release: 18.el7
-        source: rpm
-        version: 1.2.7
-    process:
-      cmdline: /usr/bin/nagios/nrpe -b config.yaml
-      listening_ports:
-        - 53314
-      pid: '121'
-      ppid: '0'
-      user: root
-    type: Nagios NRPE
-    version:
-      - number: 1.2.7
-        type: package
-software_list:
-  - cmd_regexp: nagios/nrpe
-    name: Nagios NRPE
-    pkg_regexp: nagios
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: {}
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: 'sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25'
-      LogPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: []
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /var/lib/grafana: {}
-          /var/log/grafana: {}
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: {}
-          /var/lib/postgresql/data: {}
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-packages:
-  NCSA nagios:
-    - arch: x86_64
-      epoch: null
-      name: NCSA nagios
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/bin/nagios/nrpe -b config.yaml
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 53314
+    protocol: tcp
+  discovery_time: '2022-07-04T18:52:37+02:00'
+  listening_ports:
+  - 53314
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: NCSA nagios
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  process:
+    cmdline: /usr/bin/nagios/nrpe -b config.yaml
+    cwd: /usr/bin/nagios/
+    listening_ports:
+    - 53314
     pid: '121'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
+  type: Nagios NRPE
+  version:
+  - number: 1.2.7
+    type: package
+packages:
+  NCSA nagios:
+  - arch: x86_64
+    epoch: null
+    name: NCSA nagios
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/bin/nagios/nrpe -b config.yaml
+  cwd: /usr/bin/nagios/
+  pid: '121'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: nagios/nrpe
+  name: Nagios NRPE
+  pkg_regexp: nagios
+  process_type: parent
+  return_children: false
+  return_packages: true
 tcp_listen:
-  - address: 0.0.0.0
-    name: port1
-    pid: 121
-    port: 53314
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: port2
-    pid: 122
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: port3
-    pid: 123
-    port: 52914
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port4
-    pid: 124
-    port: 53213
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port5
-    pid: 125
-    port: 52614
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
+- address: 0.0.0.0
+  name: port1
+  pid: 121
+  port: 53314
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: port2
+  pid: 122
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: port3
+  pid: 123
+  port: 52914
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port4
+  pid: 124
+  port: 53213
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port5
+  pid: 125
+  port: 52614
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
 udp_listen:
-  - address: 0.0.0.0
-    name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/nginx/nxing1.17.9_centos7.yaml
+++ b/tests/unit/plugins/action/auto/resources/nginx/nxing1.17.9_centos7.yaml
@@ -1,4950 +1,5075 @@
+dockers:
+  containers: []
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    extra_data:
+      protocol: http
+      status: '404'
+    port: 81
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    extra_data:
+      protocol: http
+      status: '200'
+    port: 82
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 81
+    protocol: tcp
+  configuration:
+    error_log: /var/log/nginx/error.log
+    events:
+      worker_connections: '1024'
+    http:
+      access_log: /var/log/nginx/access.log  main
+      default_type: application/octet-stream
+      keepalive_timeout: '65'
+      l: g
+      sendfile: 'on'
+      server:
+        error_page:
+        - 404 /404.html
+        - 500 502 503 504 /50x.html
+        listen:
+        - '81'
+        - '[::]:81'
+        location = /404.html: {}
+        location = /50x.html: {}
+        root: /usr/share/nginx/html
+        server_name: _
+      tcp_nodelay: 'on'
+      tcp_nopush: 'on'
+      types:
+        a:
+        - p
+        - p
+        - p
+        application/atom+xml: atom
+        application/java-archive: jar war ear
+        application/javascript: js
+        application/json: json
+        application/mac-binhex40: hqx
+        application/msword: doc
+        application/octet-stream:
+        - bin exe dll
+        - deb
+        - dmg
+        - iso img
+        - msi msp msm
+        application/pdf: pdf
+        application/postscript: ps eps ai
+        application/rss+xml: rss
+        application/rtf: rtf
+        application/vnd.apple.mpegurl: m3u8
+        application/vnd.google-earth.kml+xml: kml
+        application/vnd.google-earth.kmz: kmz
+        application/vnd.ms-excel: xls
+        application/vnd.ms-fontobject: eot
+        application/vnd.ms-powerpoint: ppt
+        application/vnd.oasis.opendocument.graphics: odg
+        application/vnd.oasis.opendocument.presentation: odp
+        application/vnd.oasis.opendocument.spreadsheet: ods
+        application/vnd.oasis.opendocument.text: odt
+        application/vnd.wap.wmlc: wmlc
+        application/x-7z-compressed: 7z
+        application/x-cocoa: cco
+        application/x-java-archive-diff: jardiff
+        application/x-java-jnlp-file: jnlp
+        application/x-makeself: run
+        application/x-perl: pl pm
+        application/x-pilot: prc pdb
+        application/x-rar-compressed: rar
+        application/x-redhat-package-manager: rpm
+        application/x-sea: sea
+        application/x-shockwave-flash: swf
+        application/x-stuffit: sit
+        application/x-tcl: tcl tk
+        application/x-x509-ca-cert: der pem crt
+        application/x-xpinstall: xpi
+        application/xhtml+xml: xhtml
+        application/xspf+xml: xspf
+        application/zip: zip
+        audio/midi: mid midi kar
+        audio/mpeg: mp3
+        audio/ogg: ogg
+        audio/x-m4a: m4a
+        audio/x-realaudio: ra
+        font/woff: woff
+        font/woff2: woff2
+        image/gif: gif
+        image/jpeg: jpeg jpg
+        image/png: png
+        image/svg+xml: svg svgz
+        image/tiff: tif tiff
+        image/vnd.wap.wbmp: wbmp
+        image/webp: webp
+        image/x-icon: ico
+        image/x-jng: jng
+        image/x-ms-bmp: bmp
+        text/css: css
+        text/html: html htm shtml
+        text/mathml: mml
+        text/plain: txt
+        text/vnd.sun.j2me.app-descriptor: jad
+        text/vnd.wap.wml: wml
+        text/x-component: htc
+        text/xml: xml
+        video/3gpp: 3gpp 3gp
+        video/mp2t: ts
+        video/mp4: mp4
+        video/mpeg: mpeg mpg
+        video/quicktime: mov
+        video/webm: webm
+        video/x-flv: flv
+        video/x-m4v: m4v
+        video/x-mng: mng
+        video/x-ms-asf: asx asf
+        video/x-ms-wmv: wmv
+        video/x-msvideo: avi
+      types_hash_max_size: '4096'
+    load_module: '"/usr/lib64/nginx/modules/ngx_stream_module.so"'
+    pid: /run/nginx.pid
+    stream:
+      access_log: /var/log/nginx/stream.log  basic  buffer=1k flush=5s
+      l: g
+      server:
+        listen: '82'
+        proxy_pass: micro1
+      upstream micro1:
+        server:
+        - 192.168.0.142:8080
+        - 192.168.0.223:8080
+        zone: upstream-micro1 64k
+    user: nginx
+    worker_processes: auto
+  discovery_time: '2022-06-24T16:09:49+02:00'
+  endpoints:
+  - type: generic
+    uri: http://127.0.0.1:82/nginx_status
+  extra_data:
+    name: nginx
+    nginx_build: nginx-standard
+    stub_status: true
+    stub_status_config: absent
+  files:
+  - name: nginx
+    path: /usr/sbin
+    subtype: generic
+    type: binary
+  - name: nginx.conf
+    path: /etc/nginx
+    subtype: generic
+    type: config
+  listening_ports:
+  - 81
+  - 82
+  packages:
+  - arch: x86_64
+    epoch: 1
+    name: nginx
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  - arch: noarch
+    epoch: 1
+    name: nginx-filesystem
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  - arch: x86_64
+    epoch: 1
+    name: nginx-mod-stream
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  process:
+    children:
+    - children: []
+      cmdline: 'nginx: worker process'
+      cwd: /
+      pid: '1156'
+      ppid: '1151'
+      user: nginx
+    - children: []
+      cmdline: 'nginx: worker process'
+      cwd: /
+      pid: '1157'
+      ppid: '1151'
+      user: nginx
+    cmdline: 'nginx: master process /usr/sbin/nginx'
+    cwd: /
+    listening_ports:
+    - 81
+    - 82
+    pid: '1151'
+    ppid: '1'
+    user: root
+  type: Nginx WebServer
+  version:
+  - number: 1.20.1
+    type: active
+  - number: 1.20.1
+    type: package
 mocked_plugin_tasks:
+  Read config file:
+    expected_args:
+      delegate_reading: true
+      file_path: /etc/nginx/nginx.conf
+      in_docker: true
+      parser: custom
+      parser_params:
+        module_args:
+          env_vars:
+            ocess /usr/sbin/nginx: ''
+          parser: nginx
+        module_name: file_parser
+    plugin_result:
+      parsed:
+        error_log: /var/log/nginx/error.log
+        events:
+          worker_connections: '1024'
+        http:
+          access_log: /var/log/nginx/access.log  main
+          default_type: application/octet-stream
+          keepalive_timeout: '65'
+          l: g
+          sendfile: 'on'
+          server:
+            error_page:
+            - 404 /404.html
+            - 500 502 503 504 /50x.html
+            listen:
+            - '81'
+            - '[::]:81'
+            location = /404.html: {}
+            location = /50x.html: {}
+            root: /usr/share/nginx/html
+            server_name: _
+          tcp_nodelay: 'on'
+          tcp_nopush: 'on'
+          types:
+            a:
+            - p
+            - p
+            - p
+            application/atom+xml: atom
+            application/java-archive: jar war ear
+            application/javascript: js
+            application/json: json
+            application/mac-binhex40: hqx
+            application/msword: doc
+            application/octet-stream:
+            - bin exe dll
+            - deb
+            - dmg
+            - iso img
+            - msi msp msm
+            application/pdf: pdf
+            application/postscript: ps eps ai
+            application/rss+xml: rss
+            application/rtf: rtf
+            application/vnd.apple.mpegurl: m3u8
+            application/vnd.google-earth.kml+xml: kml
+            application/vnd.google-earth.kmz: kmz
+            application/vnd.ms-excel: xls
+            application/vnd.ms-fontobject: eot
+            application/vnd.ms-powerpoint: ppt
+            application/vnd.oasis.opendocument.graphics: odg
+            application/vnd.oasis.opendocument.presentation: odp
+            application/vnd.oasis.opendocument.spreadsheet: ods
+            application/vnd.oasis.opendocument.text: odt
+            application/vnd.wap.wmlc: wmlc
+            application/x-7z-compressed: 7z
+            application/x-cocoa: cco
+            application/x-java-archive-diff: jardiff
+            application/x-java-jnlp-file: jnlp
+            application/x-makeself: run
+            application/x-perl: pl pm
+            application/x-pilot: prc pdb
+            application/x-rar-compressed: rar
+            application/x-redhat-package-manager: rpm
+            application/x-sea: sea
+            application/x-shockwave-flash: swf
+            application/x-stuffit: sit
+            application/x-tcl: tcl tk
+            application/x-x509-ca-cert: der pem crt
+            application/x-xpinstall: xpi
+            application/xhtml+xml: xhtml
+            application/xspf+xml: xspf
+            application/zip: zip
+            audio/midi: mid midi kar
+            audio/mpeg: mp3
+            audio/ogg: ogg
+            audio/x-m4a: m4a
+            audio/x-realaudio: ra
+            font/woff: woff
+            font/woff2: woff2
+            image/gif: gif
+            image/jpeg: jpeg jpg
+            image/png: png
+            image/svg+xml: svg svgz
+            image/tiff: tif tiff
+            image/vnd.wap.wbmp: wbmp
+            image/webp: webp
+            image/x-icon: ico
+            image/x-jng: jng
+            image/x-ms-bmp: bmp
+            text/css: css
+            text/html: html htm shtml
+            text/mathml: mml
+            text/plain: txt
+            text/vnd.sun.j2me.app-descriptor: jad
+            text/vnd.wap.wml: wml
+            text/x-component: htc
+            text/xml: xml
+            video/3gpp: 3gpp 3gp
+            video/mp2t: ts
+            video/mp4: mp4
+            video/mpeg: mpeg mpg
+            video/quicktime: mov
+            video/webm: webm
+            video/x-flv: flv
+            video/x-m4v: m4v
+            video/x-mng: mng
+            video/x-ms-asf: asx asf
+            video/x-ms-wmv: wmv
+            video/x-msvideo: avi
+          types_hash_max_size: '4096'
+        load_module: '"/usr/lib64/nginx/modules/ngx_stream_module.so"'
+        pid: /run/nginx.pid
+        stream:
+          access_log: /var/log/nginx/stream.log  basic  buffer=1k flush=5s
+          l: g
+          server:
+            listen: '82'
+            proxy_pass: micro1
+          upstream micro1:
+            server:
+            - 192.168.0.142:8080
+            - 192.168.0.223:8080
+            zone: upstream-micro1 64k
+        user: nginx
+        worker_processes: auto
+  Read config file raw:
+    expected_args:
+      delegate_reading: false
+      file_path: /etc/nginx/nginx.conf
+      in_docker: true
+      parser: null
+      parser_params: null
+    plugin_result:
+      content: "# For more information on configuration, see:\n#   * Official English\
+        \ Documentation: http://nginx.org/en/docs/\n#   * Official Russian Documentation:\
+        \ http://nginx.org/ru/docs/\n\nuser nginx;\nworker_processes auto;\nerror_log\
+        \ /var/log/nginx/error.log;\npid /run/nginx.pid;\n\n# Load dynamic modules.\
+        \ See /usr/share/doc/nginx/README.dynamic.\ninclude /usr/share/nginx/modules/*.conf;\n\
+        \nevents {\n    worker_connections 1024;\n}\n\nhttp {\n    log_format  main\
+        \  '$remote_addr - $remote_user [$time_local] \"$request\" '\n           \
+        \           '$status $body_bytes_sent \"$http_referer\" '\n              \
+        \        '\"$http_user_agent\" \"$http_x_forwarded_for\"';\n\n    access_log\
+        \  /var/log/nginx/access.log  main;\n\n    sendfile            on;\n    tcp_nopush\
+        \          on;\n    tcp_nodelay         on;\n    keepalive_timeout   65;\n\
+        \    types_hash_max_size 4096;\n\n    include             /etc/nginx/mime.types;\n\
+        \    default_type        application/octet-stream;\n\n    # Load modular configuration\
+        \ files from the /etc/nginx/conf.d directory.\n    # See http://nginx.org/en/docs/ngx_core_module.html#include\n\
+        \    # for more information.\n    include /etc/nginx/conf.d/*.conf;\n\n  \
+        \  server {\n        listen       81;\n        listen       [::]:81;\n   \
+        \     server_name  _;\n        root         /usr/share/nginx/html;\n\n   \
+        \     # Load configuration files for the default server block.\n        include\
+        \ /etc/nginx/default.d/*.conf;\n\n        error_page 404 /404.html;\n    \
+        \    location = /404.html {\n        }\n\n        error_page 500 502 503 504\
+        \ /50x.html;\n        location = /50x.html {\n        }\n    }\n\n# Settings\
+        \ for a TLS enabled server.\n#\n#    server {\n#        listen       443 ssl\
+        \ http2;\n#        listen       [::]:443 ssl http2;\n#        server_name\
+        \  _;\n#        root         /usr/share/nginx/html;\n#\n#        ssl_certificate\
+        \ \"/etc/pki/nginx/server.crt\";\n#        ssl_certificate_key \"/etc/pki/nginx/private/server.key\"\
+        ;\n#        ssl_session_cache shared:SSL:1m;\n#        ssl_session_timeout\
+        \  10m;\n#        ssl_ciphers HIGH:!aNULL:!MD5;\n#        ssl_prefer_server_ciphers\
+        \ on;\n#\n#        # Load configuration files for the default server block.\n\
+        #        include /etc/nginx/default.d/*.conf;\n#\n#        error_page 404\
+        \ /404.html;\n#            location = /40x.html {\n#        }\n#\n#      \
+        \  error_page 500 502 503 504 /50x.html;\n#            location = /50x.html\
+        \ {\n#        }\n#    }\n\n}\nstream {\n    # Example configuration for TCP\
+        \ load balancing\n\nlog_format basic '$remote_addr [$time_local] '\n     \
+        \            '$protocol $status $bytes_sent $bytes_received '\n          \
+        \       '$session_time \"$upstream_addr\" '\n                 '\"$upstream_bytes_sent\"\
+        \ \"$upstream_bytes_received\" \"$upstream_connect_time\"';\n\n    access_log\
+        \      /var/log/nginx/stream.log  basic  buffer=1k flush=5s;\n\n\n\n\n#Microservicios\n\
+        \n     upstream micro1 {\n        server 192.168.0.142:8080 ;\n        server\
+        \ 192.168.0.223:8080 ;\n        zone upstream-micro1 64k;\n\n    }\n\n   \
+        \ server {\n        listen 82;\n        proxy_pass micro1;\n\n    }\n}\n\n"
   Read process environment:
     expected_args:
       pid: '1151'
     plugin_result:
       failed: false
       parsed:
-        "ocess /usr/sbin/nginx": ""
+        ocess /usr/sbin/nginx: ''
+  Request information from endpoint:
+    calls:
+    - expected_args:
+        uri:
+          body:
+            operation: read-resource
+          body_format: json
+          method: GET
+          url: http://127.0.0.1:81/status
+      plugin_result:
+        _ansible_parsed: true
+        changed: false
+        connection: close
+        content_length: '3650'
+        content_type: text/html
+        date: Mon, 27 Jun 2022 09:30:53 GMT
+        elapsed: 0
+        etag: '"60b6cf1d-e42"'
+        failed: true
+        invocation:
+          module_args:
+            attributes: null
+            body:
+              operation: read-resource
+            body_format: json
+            ca_path: null
+            client_cert: null
+            client_key: null
+            creates: null
+            dest: null
+            follow_redirects: safe
+            force: false
+            force_basic_auth: false
+            group: null
+            headers:
+              Content-Type: application/json
+            http_agent: ansible-httpget
+            method: GET
+            mode: null
+            owner: null
+            remote_src: false
+            removes: null
+            return_content: false
+            selevel: null
+            serole: null
+            setype: null
+            seuser: null
+            src: null
+            status_code:
+            - 200
+            timeout: 30
+            unix_socket: null
+            unredirected_headers: []
+            unsafe_writes: false
+            url: http://127.0.0.1:81/status
+            url_password: null
+            url_username: null
+            use_gssapi: false
+            use_proxy: true
+            validate_certs: true
+        msg: 'Status code was 404 and not [200]: HTTP Error 404: Not Found'
+        redirected: false
+        server: nginx/1.20.1
+        skipped: false
+        status: 404
+        task: Request information from endpoint
+        url: http://127.0.0.1:81/status
+    - expected_args:
+        uri:
+          body:
+            operation: read-resource
+          body_format: json
+          method: GET
+          url: http://127.0.0.1:81/nginx_status
+      plugin_result:
+        _ansible_parsed: true
+        changed: false
+        connection: close
+        content_length: '3650'
+        content_type: text/html
+        date: Mon, 27 Jun 2022 09:30:54 GMT
+        elapsed: 0
+        etag: '"60b6cf1d-e42"'
+        failed: true
+        invocation:
+          module_args:
+            attributes: null
+            body:
+              operation: read-resource
+            body_format: json
+            ca_path: null
+            client_cert: null
+            client_key: null
+            creates: null
+            dest: null
+            follow_redirects: safe
+            force: false
+            force_basic_auth: false
+            group: null
+            headers:
+              Content-Type: application/json
+            http_agent: ansible-httpget
+            method: GET
+            mode: null
+            owner: null
+            remote_src: false
+            removes: null
+            return_content: false
+            selevel: null
+            serole: null
+            setype: null
+            seuser: null
+            src: null
+            status_code:
+            - 200
+            timeout: 30
+            unix_socket: null
+            unredirected_headers: []
+            unsafe_writes: false
+            url: http://127.0.0.1:81/nginx_status
+            url_password: null
+            url_username: null
+            use_gssapi: false
+            use_proxy: true
+            validate_certs: true
+        msg: 'Status code was 404 and not [200]: HTTP Error 404: Not Found'
+        redirected: false
+        server: nginx/1.20.1
+        skipped: false
+        status: 404
+        task: Request information from endpoint
+        url: http://127.0.0.1:81/nginx_status
+    - expected_args:
+        uri:
+          body:
+            operation: read-resource
+          body_format: json
+          method: GET
+          url: http://127.0.0.1:82/status
+      plugin_result:
+        _ansible_parsed: true
+        changed: false
+        connection: close
+        content_language: en
+        content_length: '963'
+        content_type: text/html;charset=utf-8
+        date: Mon, 27 Jun 2022 09:30:54 GMT
+        elapsed: 0
+        failed: true
+        invocation:
+          module_args:
+            attributes: null
+            body:
+              operation: read-resource
+            body_format: json
+            ca_path: null
+            client_cert: null
+            client_key: null
+            creates: null
+            dest: null
+            follow_redirects: safe
+            force: false
+            force_basic_auth: false
+            group: null
+            headers:
+              Content-Type: application/json
+            http_agent: ansible-httpget
+            method: GET
+            mode: null
+            owner: null
+            remote_src: false
+            removes: null
+            return_content: false
+            selevel: null
+            serole: null
+            setype: null
+            seuser: null
+            src: null
+            status_code:
+            - 200
+            timeout: 30
+            unix_socket: null
+            unredirected_headers: []
+            unsafe_writes: false
+            url: http://127.0.0.1:82/status
+            url_password: null
+            url_username: null
+            use_gssapi: false
+            use_proxy: true
+            validate_certs: true
+        msg: 'Status code was 404 and not [200]: HTTP Error 404: Not Found'
+        redirected: false
+        server: Apache-Coyote/1.1
+        skipped: false
+        status: 404
+        task: Request information from endpoint
+        url: http://127.0.0.1:82/status
+    - expected_args:
+        uri:
+          body:
+            operation: read-resource
+          body_format: json
+          method: GET
+          url: http://127.0.0.1:82/nginx_status
+      plugin_result:
+        _ansible_parsed: true
+        changed: false
+        connection: close
+        content_language: en
+        content_length: '975'
+        content_type: text/html;charset=utf-8
+        date: Mon, 27 Jun 2022 09:30:54 GMT
+        elapsed: 0
+        failed: true
+        invocation:
+          module_args:
+            attributes: null
+            body:
+              operation: read-resource
+            body_format: json
+            ca_path: null
+            client_cert: null
+            client_key: null
+            creates: null
+            dest: null
+            follow_redirects: safe
+            force: false
+            force_basic_auth: false
+            group: null
+            headers:
+              Content-Type: application/json
+            http_agent: ansible-httpget
+            method: GET
+            mode: null
+            owner: null
+            remote_src: false
+            removes: null
+            return_content: false
+            selevel: null
+            serole: null
+            setype: null
+            seuser: null
+            src: null
+            status_code:
+            - 200
+            timeout: 30
+            unix_socket: null
+            unredirected_headers: []
+            unsafe_writes: false
+            url: http://127.0.0.1:82/nginx_status
+            url_password: null
+            url_username: null
+            use_gssapi: false
+            use_proxy: true
+            validate_certs: true
+        msg: 'Status code was 404 and not [200]: HTTP Error 404: Not Found'
+        redirected: false
+        server: Apache-Coyote/1.1
+        skipped: false
+        status: 200
+        task: Request information from endpoint
+        url: http://127.0.0.1:82/nginx_status
+  Run version command:
+    expected_args:
+      argv:
+      - /usr/sbin/nginx
+      - -V
+      cmd: null
+      in_docker: true
+    plugin_result:
+      stderr: "nginx version: nginx/1.20.1\nbuilt by gcc 4.8.5 20150623 (Red Hat 4.8.5-44)\
+        \ (GCC) \nbuilt with OpenSSL 1.1.1g FIPS  21 Apr 2020\nTLS SNI support enabled\n\
+        configure arguments: --prefix=/usr/share/nginx --sbin-path=/usr/sbin/nginx\
+        \ --modules-path=/usr/lib64/nginx/modules --conf-path=/etc/nginx/nginx.conf\
+        \ --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log\
+        \ --http-client-body-temp-path=/var/lib/nginx/tmp/client_body --http-proxy-temp-path=/var/lib/nginx/tmp/proxy\
+        \ --http-fastcgi-temp-path=/var/lib/nginx/tmp/fastcgi --http-uwsgi-temp-path=/var/lib/nginx/tmp/uwsgi\
+        \ --http-scgi-temp-path=/var/lib/nginx/tmp/scgi --pid-path=/run/nginx.pid\
+        \ --lock-path=/run/lock/subsys/nginx --user=nginx --group=nginx --with-compat\
+        \ --with-debug --with-file-aio --with-google_perftools_module --with-http_addition_module\
+        \ --with-http_auth_request_module --with-http_dav_module --with-http_degradation_module\
+        \ --with-http_flv_module --with-http_gunzip_module --with-http_gzip_static_module\
+        \ --with-http_image_filter_module=dynamic --with-http_mp4_module --with-http_perl_module=dynamic\
+        \ --with-http_random_index_module --with-http_realip_module --with-http_secure_link_module\
+        \ --with-http_slice_module --with-http_ssl_module --with-http_stub_status_module\
+        \ --with-http_sub_module --with-http_v2_module --with-http_xslt_module=dynamic\
+        \ --with-mail=dynamic --with-mail_ssl_module --with-pcre --with-pcre-jit --with-stream=dynamic\
+        \ --with-stream_ssl_module --with-stream_ssl_preread_module --with-threads\
+        \ --with-cc-opt='-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong\
+        \ --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1\
+        \ -m64 -mtune=generic' --with-ld-opt='-Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld\
+        \ -Wl,-E'"
   Stat bin file:
     expected_args:
       follow: false
       get_attributes: true
       get_mime: true
       in_docker: true
-      path: "/usr/sbin/nginx"
+      path: /usr/sbin/nginx
     plugin_result:
-      failed: false
       defined: true
+      failed: false
       stat:
         executable: true
-  Run version command:
-    expected_args:
-      argv:
-        - "/usr/sbin/nginx"
-        - "-V"
-      cmd: null
-      in_docker: true
-    plugin_result:
-      stderr: "nginx version: nginx/1.20.1\nbuilt by gcc 4.8.5 20150623 (Red Hat 4.8.5-44) (GCC) \nbuilt with OpenSSL 1.1.1g FIPS  21 Apr 2020\nTLS SNI support enabled\nconfigure arguments: --prefix=/usr/share/nginx --sbin-path=/usr/sbin/nginx --modules-path=/usr/lib64/nginx/modules --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --http-client-body-temp-path=/var/lib/nginx/tmp/client_body --http-proxy-temp-path=/var/lib/nginx/tmp/proxy --http-fastcgi-temp-path=/var/lib/nginx/tmp/fastcgi --http-uwsgi-temp-path=/var/lib/nginx/tmp/uwsgi --http-scgi-temp-path=/var/lib/nginx/tmp/scgi --pid-path=/run/nginx.pid --lock-path=/run/lock/subsys/nginx --user=nginx --group=nginx --with-compat --with-debug --with-file-aio --with-google_perftools_module --with-http_addition_module --with-http_auth_request_module --with-http_dav_module --with-http_degradation_module --with-http_flv_module --with-http_gunzip_module --with-http_gzip_static_module --with-http_image_filter_module=dynamic --with-http_mp4_module --with-http_perl_module=dynamic --with-http_random_index_module --with-http_realip_module --with-http_secure_link_module --with-http_slice_module --with-http_ssl_module --with-http_stub_status_module --with-http_sub_module --with-http_v2_module --with-http_xslt_module=dynamic --with-mail=dynamic --with-mail_ssl_module --with-pcre --with-pcre-jit --with-stream=dynamic --with-stream_ssl_module --with-stream_ssl_preread_module --with-threads --with-cc-opt='-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -m64 -mtune=generic' --with-ld-opt='-Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -Wl,-E'"
-  Read config file raw:
-    expected_args:
-      delegate_reading: false
-      file_path: "/etc/nginx/nginx.conf"
-      in_docker: true
-      parser: null
-      parser_params: null
-    plugin_result:
-      content: "# For more information on configuration, see:\n#   * Official English Documentation: http://nginx.org/en/docs/\n#   * Official Russian Documentation: http://nginx.org/ru/docs/\n\nuser nginx;\nworker_processes auto;\nerror_log /var/log/nginx/error.log;\npid /run/nginx.pid;\n\n# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.\ninclude /usr/share/nginx/modules/*.conf;\n\nevents {\n    worker_connections 1024;\n}\n\nhttp {\n    log_format  main  '$remote_addr - $remote_user [$time_local] \"$request\" '\n                      '$status $body_bytes_sent \"$http_referer\" '\n                      '\"$http_user_agent\" \"$http_x_forwarded_for\"';\n\n    access_log  /var/log/nginx/access.log  main;\n\n    sendfile            on;\n    tcp_nopush          on;\n    tcp_nodelay         on;\n    keepalive_timeout   65;\n    types_hash_max_size 4096;\n\n    include             /etc/nginx/mime.types;\n    default_type        application/octet-stream;\n\n    # Load modular configuration files from the /etc/nginx/conf.d directory.\n    # See http://nginx.org/en/docs/ngx_core_module.html#include\n    # for more information.\n    include /etc/nginx/conf.d/*.conf;\n\n    server {\n        listen       81;\n        listen       [::]:81;\n        server_name  _;\n        root         /usr/share/nginx/html;\n\n        # Load configuration files for the default server block.\n        include /etc/nginx/default.d/*.conf;\n\n        error_page 404 /404.html;\n        location = /404.html {\n        }\n\n        error_page 500 502 503 504 /50x.html;\n        location = /50x.html {\n        }\n    }\n\n# Settings for a TLS enabled server.\n#\n#    server {\n#        listen       443 ssl http2;\n#        listen       [::]:443 ssl http2;\n#        server_name  _;\n#        root         /usr/share/nginx/html;\n#\n#        ssl_certificate \"/etc/pki/nginx/server.crt\";\n#        ssl_certificate_key \"/etc/pki/nginx/private/server.key\";\n#        ssl_session_cache shared:SSL:1m;\n#        ssl_session_timeout  10m;\n#        ssl_ciphers HIGH:!aNULL:!MD5;\n#        ssl_prefer_server_ciphers on;\n#\n#        # Load configuration files for the default server block.\n#        include /etc/nginx/default.d/*.conf;\n#\n#        error_page 404 /404.html;\n#            location = /40x.html {\n#        }\n#\n#        error_page 500 502 503 504 /50x.html;\n#            location = /50x.html {\n#        }\n#    }\n\n}\nstream {\n    # Example configuration for TCP load balancing\n\nlog_format basic '$remote_addr [$time_local] '\n                 '$protocol $status $bytes_sent $bytes_received '\n                 '$session_time \"$upstream_addr\" '\n                 '\"$upstream_bytes_sent\" \"$upstream_bytes_received\" \"$upstream_connect_time\"';\n\n    access_log      /var/log/nginx/stream.log  basic  buffer=1k flush=5s;\n\n\n\n\n#Microservicios\n\n     upstream micro1 {\n        server 192.168.0.142:8080 ;\n        server 192.168.0.223:8080 ;\n        zone upstream-micro1 64k;\n\n    }\n\n    server {\n        listen 82;\n        proxy_pass micro1;\n\n    }\n}\n\n"
-  Read config file:
-    expected_args: {
-      "file_path": "/etc/nginx/nginx.conf",
-      "in_docker": true,
-      "delegate_reading": true,
-      "parser": "custom",
-      "parser_params": {
-        "module_name": "file_parser",
-        "module_args": {
-          "parser": "nginx",
-          "env_vars": { 'ocess /usr/sbin/nginx': '' }
-        }
-      }
-    }
-    plugin_result:
-      parsed: {
-        "load_module": "\"/usr/lib64/nginx/modules/ngx_stream_module.so\"",
-        "http": {
-          "sendfile": "on",
-          "types_hash_max_size": "4096",
-          "tcp_nodelay": "on",
-          "l": "g",
-          "default_type": "application/octet-stream",
-          "keepalive_timeout": "65",
-          "access_log": "/var/log/nginx/access.log  main",
-          "tcp_nopush": "on",
-          "server": {
-            "server_name": "_",
-            "location = /50x.html": { },
-            "location = /404.html": { },
-            "error_page": [
-              "404 /404.html",
-              "500 502 503 504 /50x.html"
-            ],
-            "root": "/usr/share/nginx/html",
-            "listen": [
-              "81",
-              "[::]:81"
-            ]
-          },
-          "types": {
-            "application/vnd.oasis.opendocument.spreadsheet": "ods",
-            "image/x-ms-bmp": "bmp",
-            "image/x-jng": "jng",
-            "image/jpeg": "jpeg jpg",
-            "image/svg+xml": "svg svgz",
-            "application/postscript": "ps eps ai",
-            "video/quicktime": "mov",
-            "image/png": "png",
-            "application/json": "json",
-            "application/x-7z-compressed": "7z",
-            "application/x-x509-ca-cert": "der pem crt",
-            "text/xml": "xml",
-            "text/x-component": "htc",
-            "video/mp2t": "ts",
-            "audio/x-realaudio": "ra",
-            "application/pdf": "pdf",
-            "application/x-perl": "pl pm",
-            "application/java-archive": "jar war ear",
-            "application/vnd.ms-fontobject": "eot",
-            "image/vnd.wap.wbmp": "wbmp",
-            "application/vnd.google-earth.kmz": "kmz",
-            "application/xspf+xml": "xspf",
-            "video/mpeg": "mpeg mpg",
-            "font/woff": "woff",
-            "application/x-makeself": "run",
-            "application/vnd.oasis.opendocument.graphics": "odg",
-            "application/vnd.wap.wmlc": "wmlc",
-            "application/x-redhat-package-manager": "rpm",
-            "image/gif": "gif",
-            "application/javascript": "js",
-            "text/css": "css",
-            "video/webm": "webm",
-            "application/atom+xml": "atom",
-            "application/vnd.ms-excel": "xls",
-            "application/x-cocoa": "cco",
-            "video/x-m4v": "m4v",
-            "application/x-java-archive-diff": "jardiff",
-            "image/tiff": "tif tiff",
-            "application/x-rar-compressed": "rar",
-            "application/x-sea": "sea",
-            "a": [
-              "p",
-              "p",
-              "p"
-            ],
-            "audio/midi": "mid midi kar",
-            "image/webp": "webp",
-            "audio/mpeg": "mp3",
-            "video/x-ms-wmv": "wmv",
-            "application/x-xpinstall": "xpi",
-            "video/x-flv": "flv",
-            "video/x-ms-asf": "asx asf",
-            "video/x-msvideo": "avi",
-            "video/x-mng": "mng",
-            "text/vnd.wap.wml": "wml",
-            "video/mp4": "mp4",
-            "application/octet-stream": [
-              "bin exe dll",
-              "deb",
-              "dmg",
-              "iso img",
-              "msi msp msm"
-            ],
-            "font/woff2": "woff2",
-            "application/vnd.oasis.opendocument.text": "odt",
-            "application/rtf": "rtf",
-            "application/vnd.google-earth.kml+xml": "kml",
-            "text/plain": "txt",
-            "application/xhtml+xml": "xhtml",
-            "application/x-java-jnlp-file": "jnlp",
-            "application/vnd.ms-powerpoint": "ppt",
-            "application/x-stuffit": "sit",
-            "text/html": "html htm shtml",
-            "text/mathml": "mml",
-            "application/vnd.apple.mpegurl": "m3u8",
-            "application/rss+xml": "rss",
-            "audio/ogg": "ogg",
-            "image/x-icon": "ico",
-            "application/vnd.oasis.opendocument.presentation": "odp",
-            "text/vnd.sun.j2me.app-descriptor": "jad",
-            "audio/x-m4a": "m4a",
-            "video/3gpp": "3gpp 3gp",
-            "application/x-tcl": "tcl tk",
-            "application/x-pilot": "prc pdb",
-            "application/x-shockwave-flash": "swf",
-            "application/zip": "zip",
-            "application/mac-binhex40": "hqx",
-            "application/msword": "doc"
-          }
-        },
-        "stream": {
-          "upstream micro1": {
-            "zone": "upstream-micro1 64k",
-            "server": [
-              "192.168.0.142:8080",
-              "192.168.0.223:8080"
-            ]
-          },
-          "l": "g",
-          "server": {
-            "proxy_pass": "micro1",
-            "listen": "82"
-          },
-          "access_log": "/var/log/nginx/stream.log  basic  buffer=1k flush=5s"
-        },
-        "pid": "/run/nginx.pid",
-        "error_log": "/var/log/nginx/error.log",
-        "worker_processes": "auto",
-        "user": "nginx",
-        "events": {
-          "worker_connections": "1024"
-        }
-      }
-  Request information from endpoint:
-    calls:
-      - expected_args:
-          uri:
-            url: "http://127.0.0.1:81/status"
-            method: "GET"
-            body_format: "json"
-            body:
-              operation: "read-resource"
-        plugin_result: {
-          "failed": true,
-          "skipped": false,
-          "msg": "Status code was 404 and not [200]: HTTP Error 404: Not Found",
-          "invocation": {
-            "module_args": {
-              "force": false,
-              "remote_src": false,
-              "status_code": [
-                200
-              ],
-              "owner": null,
-              "body_format": "json",
-              "client_key": null,
-              "group": null,
-              "use_proxy": true,
-              "unix_socket": null,
-              "unsafe_writes": false,
-              "serole": null,
-              "setype": null,
-              "follow_redirects": "safe",
-              "unredirected_headers": [ ],
-              "return_content": false,
-              "method": "GET",
-              "mode": null,
-              "body": {
-                "operation": "read-resource"
-              },
-              "url_username": null,
-              "url_password": null,
-              "dest": null,
-              "selevel": null,
-              "force_basic_auth": false,
-              "removes": null,
-              "http_agent": "ansible-httpget",
-              "use_gssapi": false,
-              "src": null,
-              "url": "http://127.0.0.1:81/status",
-              "seuser": null,
-              "client_cert": null,
-              "creates": null,
-              "headers": {
-                "Content-Type": "application/json"
-              },
-              "ca_path": null,
-              "timeout": 30,
-              "attributes": null,
-              "validate_certs": true
-            }
-          },
-          "task": "Request information from endpoint",
-          "status": 404,
-          "content_length": "3650",
-          "date": "Mon, 27 Jun 2022 09:30:53 GMT",
-          "url": "http://127.0.0.1:81/status",
-          "changed": false,
-          "server": "nginx/1.20.1",
-          "connection": "close",
-          "etag": "\"60b6cf1d-e42\"",
-          "content_type": "text/html",
-          "redirected": false,
-          "elapsed": 0,
-          "_ansible_parsed": true
-        }
-      - expected_args:
-          uri:
-            url: "http://127.0.0.1:81/nginx_status"
-            method: "GET"
-            body_format: "json"
-            body:
-              operation: "read-resource"
-        plugin_result: {
-          "failed": true,
-          "skipped": false,
-          "msg": "Status code was 404 and not [200]: HTTP Error 404: Not Found",
-          "invocation": {
-            "module_args": {
-              "force": false,
-              "remote_src": false,
-              "status_code": [
-                200
-              ],
-              "owner": null,
-              "body_format": "json",
-              "client_key": null,
-              "group": null,
-              "use_proxy": true,
-              "unix_socket": null,
-              "unsafe_writes": false,
-              "serole": null,
-              "setype": null,
-              "follow_redirects": "safe",
-              "unredirected_headers": [ ],
-              "return_content": false,
-              "method": "GET",
-              "mode": null,
-              "body": {
-                "operation": "read-resource"
-              },
-              "url_username": null,
-              "url_password": null,
-              "dest": null,
-              "selevel": null,
-              "force_basic_auth": false,
-              "removes": null,
-              "http_agent": "ansible-httpget",
-              "use_gssapi": false,
-              "src": null,
-              "url": "http://127.0.0.1:81/nginx_status",
-              "seuser": null,
-              "client_cert": null,
-              "creates": null,
-              "headers": {
-                "Content-Type": "application/json"
-              },
-              "ca_path": null,
-              "timeout": 30,
-              "attributes": null,
-              "validate_certs": true
-            }
-          },
-          "task": "Request information from endpoint",
-          "status": 404,
-          "content_length": "3650",
-          "date": "Mon, 27 Jun 2022 09:30:54 GMT",
-          "url": "http://127.0.0.1:81/nginx_status",
-          "changed": false,
-          "server": "nginx/1.20.1",
-          "connection": "close",
-          "etag": "\"60b6cf1d-e42\"",
-          "content_type": "text/html",
-          "redirected": false,
-          "elapsed": 0,
-          "_ansible_parsed": true
-        }
-      - expected_args:
-          uri:
-            url: "http://127.0.0.1:82/status"
-            method: "GET"
-            body_format: "json"
-            body:
-              operation: "read-resource"
-        plugin_result: {
-          "failed": true,
-          "skipped": false,
-          "msg": "Status code was 404 and not [200]: HTTP Error 404: Not Found",
-          "invocation": {
-            "module_args": {
-              "force": false,
-              "remote_src": false,
-              "status_code": [
-                200
-              ],
-              "owner": null,
-              "body_format": "json",
-              "client_key": null,
-              "group": null,
-              "use_proxy": true,
-              "unix_socket": null,
-              "unsafe_writes": false,
-              "serole": null,
-              "setype": null,
-              "follow_redirects": "safe",
-              "unredirected_headers": [ ],
-              "return_content": false,
-              "method": "GET",
-              "mode": null,
-              "body": {
-                "operation": "read-resource"
-              },
-              "url_username": null,
-              "url_password": null,
-              "dest": null,
-              "selevel": null,
-              "force_basic_auth": false,
-              "removes": null,
-              "http_agent": "ansible-httpget",
-              "use_gssapi": false,
-              "src": null,
-              "url": "http://127.0.0.1:82/status",
-              "seuser": null,
-              "client_cert": null,
-              "creates": null,
-              "headers": {
-                "Content-Type": "application/json"
-              },
-              "ca_path": null,
-              "timeout": 30,
-              "attributes": null,
-              "validate_certs": true
-            }
-          },
-          "task": "Request information from endpoint",
-          "status": 404,
-          "content_length": "963",
-          "date": "Mon, 27 Jun 2022 09:30:54 GMT",
-          "url": "http://127.0.0.1:82/status",
-          "changed": false,
-          "server": "Apache-Coyote/1.1",
-          "connection": "close",
-          "content_language": "en",
-          "content_type": "text/html;charset=utf-8",
-          "redirected": false,
-          "elapsed": 0,
-          "_ansible_parsed": true
-        }
-      - expected_args:
-          uri:
-            url: "http://127.0.0.1:82/nginx_status"
-            method: "GET"
-            body_format: "json"
-            body:
-              operation: "read-resource"
-        plugin_result: {
-          "failed": true,
-          "skipped": false,
-          "msg": "Status code was 404 and not [200]: HTTP Error 404: Not Found",
-          "invocation": {
-            "module_args": {
-              "force": false,
-              "remote_src": false,
-              "status_code": [
-                200
-              ],
-              "owner": null,
-              "body_format": "json",
-              "client_key": null,
-              "group": null,
-              "use_proxy": true,
-              "unix_socket": null,
-              "unsafe_writes": false,
-              "serole": null,
-              "setype": null,
-              "follow_redirects": "safe",
-              "unredirected_headers": [ ],
-              "return_content": false,
-              "method": "GET",
-              "mode": null,
-              "body": {
-                "operation": "read-resource"
-              },
-              "url_username": null,
-              "url_password": null,
-              "dest": null,
-              "selevel": null,
-              "force_basic_auth": false,
-              "removes": null,
-              "http_agent": "ansible-httpget",
-              "use_gssapi": false,
-              "src": null,
-              "url": "http://127.0.0.1:82/nginx_status",
-              "seuser": null,
-              "client_cert": null,
-              "creates": null,
-              "headers": {
-                "Content-Type": "application/json"
-              },
-              "ca_path": null,
-              "timeout": 30,
-              "attributes": null,
-              "validate_certs": true
-            }
-          },
-          "task": "Request information from endpoint",
-          "status": 200,
-          "content_length": "975",
-          "date": "Mon, 27 Jun 2022 09:30:54 GMT",
-          "url": "http://127.0.0.1:82/nginx_status",
-          "changed": false,
-          "server": "Apache-Coyote/1.1",
-          "connection": "close",
-          "content_language": "en",
-          "content_type": "text/html;charset=utf-8",
-          "redirected": false,
-          "elapsed": 0,
-          "_ansible_parsed": true
-        }
-expected_result:
-  - extra_data:
-      name: nginx
-      nginx_build: nginx-standard
-      stub_status: True
-      stub_status_config: absent
-    files:
-      - path: /usr/sbin
-        name: nginx
-        subtype: generic
-        type: binary
-      - path: /etc/nginx
-        name: nginx.conf
-        subtype: generic
-        type: config
-    bindings:
-      - address: 0.0.0.0
-        class: service
-        extra_data:
-          protocol: http
-          status: '404'
-        port: 81
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        extra_data:
-          protocol: http
-          status: '200'
-        port: 82
-        protocol: tcp
-      - address: "::"
-        class: service
-        port: 81
-        protocol: tcp
-    endpoints:
-      - uri: http://127.0.0.1:82/nginx_status
-        type: generic
-    discovery_time: '2022-06-24T16:09:49+02:00'
-    listening_ports:
-      - 81
-      - 82
-    packages:
-      - arch: x86_64
-        epoch: 1
-        name: nginx
-        release: 2.el7
-        source: rpm
-        version: 1.20.1
-      - arch: noarch
-        epoch: 1
-        name: nginx-filesystem
-        release: 2.el7
-        source: rpm
-        version: 1.20.1
-      - arch: x86_64
-        epoch: 1
-        name: nginx-mod-stream
-        release: 2.el7
-        source: rpm
-        version: 1.20.1
-    configuration:
-      error_log: /var/log/nginx/error.log
-      events:
-        worker_connections: '1024'
-      http:
-        access_log: /var/log/nginx/access.log  main
-        default_type: application/octet-stream
-        keepalive_timeout: '65'
-        l: g
-        sendfile: 'on'
-        server:
-          error_page:
-            - 404 /404.html
-            - 500 502 503 504 /50x.html
-          listen:
-            - '81'
-            - '[::]:81'
-          location = /404.html: { }
-          location = /50x.html: { }
-          root: /usr/share/nginx/html
-          server_name: _
-        tcp_nodelay: 'on'
-        tcp_nopush: 'on'
-        types:
-          a:
-            - p
-            - p
-            - p
-          application/atom+xml: atom
-          application/java-archive: jar war ear
-          application/javascript: js
-          application/json: json
-          application/mac-binhex40: hqx
-          application/msword: doc
-          application/octet-stream:
-            - bin exe dll
-            - deb
-            - dmg
-            - iso img
-            - msi msp msm
-          application/pdf: pdf
-          application/postscript: ps eps ai
-          application/rss+xml: rss
-          application/rtf: rtf
-          application/vnd.apple.mpegurl: m3u8
-          application/vnd.google-earth.kml+xml: kml
-          application/vnd.google-earth.kmz: kmz
-          application/vnd.ms-excel: xls
-          application/vnd.ms-fontobject: eot
-          application/vnd.ms-powerpoint: ppt
-          application/vnd.oasis.opendocument.graphics: odg
-          application/vnd.oasis.opendocument.presentation: odp
-          application/vnd.oasis.opendocument.spreadsheet: ods
-          application/vnd.oasis.opendocument.text: odt
-          application/vnd.wap.wmlc: wmlc
-          application/x-7z-compressed: 7z
-          application/x-cocoa: cco
-          application/x-java-archive-diff: jardiff
-          application/x-java-jnlp-file: jnlp
-          application/x-makeself: run
-          application/x-perl: pl pm
-          application/x-pilot: prc pdb
-          application/x-rar-compressed: rar
-          application/x-redhat-package-manager: rpm
-          application/x-sea: sea
-          application/x-shockwave-flash: swf
-          application/x-stuffit: sit
-          application/x-tcl: tcl tk
-          application/x-x509-ca-cert: der pem crt
-          application/x-xpinstall: xpi
-          application/xhtml+xml: xhtml
-          application/xspf+xml: xspf
-          application/zip: zip
-          audio/midi: mid midi kar
-          audio/mpeg: mp3
-          audio/ogg: ogg
-          audio/x-m4a: m4a
-          audio/x-realaudio: ra
-          font/woff: woff
-          font/woff2: woff2
-          image/gif: gif
-          image/jpeg: jpeg jpg
-          image/png: png
-          image/svg+xml: svg svgz
-          image/tiff: tif tiff
-          image/vnd.wap.wbmp: wbmp
-          image/webp: webp
-          image/x-icon: ico
-          image/x-jng: jng
-          image/x-ms-bmp: bmp
-          text/css: css
-          text/html: html htm shtml
-          text/mathml: mml
-          text/plain: txt
-          text/vnd.sun.j2me.app-descriptor: jad
-          text/vnd.wap.wml: wml
-          text/x-component: htc
-          text/xml: xml
-          video/3gpp: 3gpp 3gp
-          video/mp2t: ts
-          video/mp4: mp4
-          video/mpeg: mpeg mpg
-          video/quicktime: mov
-          video/webm: webm
-          video/x-flv: flv
-          video/x-m4v: m4v
-          video/x-mng: mng
-          video/x-ms-asf: asx asf
-          video/x-ms-wmv: wmv
-          video/x-msvideo: avi
-        types_hash_max_size: '4096'
-      load_module: '"/usr/lib64/nginx/modules/ngx_stream_module.so"'
-      pid: /run/nginx.pid
-      stream:
-        access_log: /var/log/nginx/stream.log  basic  buffer=1k flush=5s
-        l: g
-        server:
-          listen: '82'
-          proxy_pass: micro1
-        upstream micro1:
-          server:
-            - '192.168.0.142:8080'
-            - '192.168.0.223:8080'
-          zone: upstream-micro1 64k
-      user: nginx
-      worker_processes: auto
-    process:
-      children:
-        - children: [ ]
-          cmdline: 'nginx: worker process'
-          pid: '1156'
-          ppid: '1151'
-          user: nginx
-        - children: [ ]
-          cmdline: 'nginx: worker process'
-          pid: '1157'
-          ppid: '1151'
-          user: nginx
-      cmdline: 'nginx: master process /usr/sbin/nginx'
-      listening_ports:
-        - 81
-        - 82
-      pid: '1151'
-      ppid: '1'
-      user: root
-    type: Nginx WebServer
-    version:
-      - number: 1.20.1
-        type: active
-      - number: 1.20.1
-        type: package
-software_list:
-  - cmd_regexp: 'nginx\:?\s*master.*(nginx)?'
-    name: Nginx WebServer
-    pkg_regexp: nginx
-    custom_tasks:
-      - include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/nginx.yaml"
-        name: Include nginx specific plugins
-    process_type: parent
-    return_children: true
-    return_packages: true
-dockers:
-  containers: [ ]
 packages:
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   apache-commons-collections:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-collections
-      release: 22.el7_2
-      source: rpm
-      version: 3.2.1
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
   apache-commons-daemon:
-    - arch: x86_64
-      epoch: null
-      name: apache-commons-daemon
-      release: 7.el7
-      source: rpm
-      version: 1.0.13
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
   apache-commons-dbcp:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-dbcp
-      release: 17.el7
-      source: rpm
-      version: '1.4'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
   apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
   apache-commons-pool:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-pool
-      release: 9.el7
-      source: rpm
-      version: '1.6'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
   apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-devel
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr-devel
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   apr-util-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-util-devel
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util-devel
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autoconf:
-    - arch: noarch
-      epoch: null
-      name: autoconf
-      release: 11.el7
-      source: rpm
-      version: '2.69'
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
   automake:
-    - arch: noarch
-      epoch: null
-      name: automake
-      release: 3.el7
-      source: rpm
-      version: 1.13.4
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
   avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 16.P2.el7_8.2
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 16.P2.el7_8.2
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 43.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 43.base.el7
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 76.el7_7
-      source: rpm
-      version: 2019.2.32
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 76.el7_7
+    source: rpm
+    version: 2019.2.32
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   centos-indexhtml:
-    - arch: noarch
-      epoch: null
-      name: centos-indexhtml
-      release: 9.el7.centos
-      source: rpm
-      version: '7'
+  - arch: noarch
+    epoch: null
+    name: centos-indexhtml
+    release: 9.el7.centos
+    source: rpm
+    version: '7'
   centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 8.2003.0.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 8.2003.0.el7.centos
+    source: rpm
+    version: '7'
   centos-release-scl-rh:
-    - arch: noarch
-      epoch: null
-      name: centos-release-scl-rh
-      release: 3.el7.centos
-      source: rpm
-      version: '2'
+  - arch: noarch
+    epoch: null
+    name: centos-release-scl-rh
+    release: 3.el7.centos
+    source: rpm
+    version: '2'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 6.el7.centos
-      source: rpm
-      version: '18.5'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 6.el7.centos
+    source: rpm
+    version: '18.5'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
   cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
   cyrus-sasl:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-devel:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-devel
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-devel
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
   devtoolset-7-binutils:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-binutils
-      release: 11.el7
-      source: rpm
-      version: '2.28'
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-binutils
+    release: 11.el7
+    source: rpm
+    version: '2.28'
   devtoolset-7-gcc:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
   devtoolset-7-gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc-c++
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc-c++
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
   devtoolset-7-libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-libstdc++-devel
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-libstdc++-devel
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
   devtoolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: '7.1'
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: '7.1'
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 3.el7
-      source: rpm
-      version: '3.2'
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dwz:
-    - arch: x86_64
-      epoch: null
-      name: dwz
-      release: 3.el7
-      source: rpm
-      version: '0.11'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  ecj:
-    - arch: x86_64
-      epoch: 1
-      name: ecj
-      release: 3.el7
-      source: rpm
-      version: 4.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  expat-devel:
-    - arch: x86_64
-      epoch: null
-      name: expat-devel
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  geronimo-jta:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jta
-      release: 17.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 5.el7
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gperftools-libs:
-    - arch: x86_64
-      epoch: null
-      name: gperftools-libs
-      release: 1.el7
-      source: rpm
-      version: 2.6.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 608c8351
-      source: rpm
-      version: 442df0f8
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 560cfc0a
-      source: rpm
-      version: f2ee9d55
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 28.el7
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  haproxy:
-    - arch: x86_64
-      epoch: null
-      name: haproxy
-      release: 9.el7_9.1
-      source: rpm
-      version: 1.5.18
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  httpd:
-    - arch: x86_64
-      epoch: null
-      name: httpd
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-devel:
-    - arch: x86_64
-      epoch: null
-      name: httpd-devel
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-tools:
-    - arch: x86_64
-      epoch: null
-      name: httpd-tools
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.5.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.49
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 25.el7_7.2
-      source: rpm
-      version: 4.11.0
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 34.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-taglibs-standard:
-    - arch: noarch
-      epoch: 0
-      name: jakarta-taglibs-standard
-      release: 14.el7_1
-      source: rpm
-      version: 1.1.2
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  keepalived:
-    - arch: x86_64
-      epoch: null
-      name: keepalived
-      release: 19.el7
-      source: rpm
-      version: 1.3.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.42.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 43.el7
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 131.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-devel:
-    - arch: x86_64
-      epoch: null
-      name: libdb-devel
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libedit-devel:
-    - arch: x86_64
-      epoch: null
-      name: libedit-devel
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libicu-devel:
-    - arch: x86_64
-      epoch: null
-      name: libicu-devel
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 3.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libtool:
-    - arch: x86_64
-      epoch: null
-      name: libtool
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  llvm-toolset-7-clang:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-clang-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang-libs
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-compiler-rt:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-compiler-rt
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-libomp:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-libomp
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-llvm-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-llvm-libs
-      release: 8.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-devel:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-devel
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-libs
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 16.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 14.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.65
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 61.el7
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-devel:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-devel
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.66.el7
-      source: rpm
-      version: 1.3.0
-  nginx:
-    - arch: x86_64
-      epoch: 1
-      name: nginx
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: nginx-filesystem
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-mod-stream:
-    - arch: x86_64
-      epoch: 1
-      name: nginx-mod-stream
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7
-      source: rpm
-      version: 4.21.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 4.el7_7
-      source: rpm
-      version: 3.44.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openldap-devel:
-    - arch: x86_64
-      epoch: null
-      name: openldap-devel
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Thread-Queue:
-    - arch: noarch
-      epoch: null
-      name: perl-Thread-Queue
-      release: 2.el7
-      source: rpm
-      version: '3.02'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: perl-srpm-macros
-      release: 8.el7
-      source: rpm
-      version: '1'
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pgdg-redhat-repo:
-    - arch: noarch
-      epoch: null
-      name: pgdg-redhat-repo
-      release: '24'
-      source: rpm
-      version: '42.0'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql11:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-contrib
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-devel:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-devel
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-libs
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-server
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 27.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-devel:
-    - arch: x86_64
-      epoch: null
-      name: python-devel
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 9.el7_8
-      source: rpm
-      version: 2.6.0
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python2-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python2-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-devel:
-    - arch: x86_64
-      epoch: null
-      name: python3-devel
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-rpm-generators:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-generators
-      release: 2.el7
-      source: rpm
-      version: '6'
-  python3-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redhat-rpm-config:
-    - arch: noarch
-      epoch: null
-      name: redhat-rpm-config
-      release: 88.el7.centos
-      source: rpm
-      version: 9.1.0
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 52.el7
-      source: rpm
-      version: 8.24.0
-  scl-utils:
-    - arch: x86_64
-      epoch: null
-      name: scl-utils
-      release: 19.el7
-      source: rpm
-      version: '20130529'
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 6.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 9.el7
-      source: rpm
-      version: 1.8.23
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  tomcat:
-    - arch: noarch
-      epoch: 0
-      name: tomcat
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-admin-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-admin-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-el-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-el-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-jsp-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-jsp-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-lib:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-lib
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 8.el7
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019c
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021a
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 20.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 167.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  zip:
-    - arch: x86_64
-      epoch: null
-      name: zip
-      release: 11.el7
-      source: rpm
-      version: '3.0'
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '50'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '65'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '197'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '198'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '274'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '275'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '276'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '277'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '279'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '294'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '295'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '297'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '298'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '299'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '412'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '444'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '466'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '469'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '511'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '513'
-    ppid: '1'
-    user: dbus
-  - cmdline: ''
-    pid: '514'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '556'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '559'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '564'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '566'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '567'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '581'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/rpcbind -w
-    pid: '582'
-    ppid: '1'
-    user: rpc
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H loadbalancer-2 eth0
-    pid: '830'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/lib/jvm/jre/bin/java
-      -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
-      -classpath
-      /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
-      -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat
-      -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp
-      -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      org.apache.catalina.startup.Bootstrap start
-    pid: '887'
-    ppid: '1'
-    user: tomcat
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '888'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '889'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p
-      /run/haproxy.pid
-    pid: '891'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-    pid: '896'
-    ppid: '891'
-    user: haproxy
-  - cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
-    pid: '905'
-    ppid: '896'
-    user: haproxy
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1074'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1077'
-    ppid: '1074'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1079'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1083'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1089'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1090'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1092'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: master process /usr/sbin/nginx'
-    pid: '1151'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '1156'
-    ppid: '1151'
-    user: nginx
-  - cmdline: 'nginx: worker process'
-    pid: '1157'
-    ppid: '1151'
-    user: nginx
-  - cmdline: ''
-    pid: '2661'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '4122'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '4123'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '4124'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '4125'
-    ppid: '889'
-    user: apache
-  - cmdline: /usr/sbin/httpd -DFOREGROUND
-    pid: '4126'
-    ppid: '889'
-    user: apache
-  - cmdline: ''
-    pid: '20331'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20579'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20613'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20636'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20650'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '20651'
-    ppid: '1079'
-    user: root
-  - cmdline: 'sshd: centos@notty'
-    pid: '20653'
-    ppid: '20651'
-    user: centos
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20808'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20809'
-    ppid: '20808'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '20810'
-    ppid: '20808'
-    user: root
-  - cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
-    pid: '21221'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: logger'
-    pid: '21223'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: checkpointer'
-    pid: '21225'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: background writer'
-    pid: '21226'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: walwriter'
-    pid: '21227'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '21228'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: stats collector'
-    pid: '21229'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '21230'
-    ppid: '21221'
-    user: postgres
-  - cmdline: 'sshd: centos [priv]'
-    pid: '21614'
-    ppid: '1079'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '21616'
-    ppid: '21614'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-fzjxqvrcbxrveubepepdppdeytvaovlu ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656079773.677516-4866-70331870181747/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '21875'
-    ppid: '21616'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-fzjxqvrcbxrveubepepdppdeytvaovlu ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656079773.677516-4866-70331870181747/AnsiballZ_process_facts.py
-    pid: '21888'
-    ppid: '21875'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-fzjxqvrcbxrveubepepdppdeytvaovlu ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656079773.677516-4866-70331870181747/AnsiballZ_process_facts.py
-    pid: '21889'
-    ppid: '21888'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656079773.677516-4866-70331870181747/AnsiballZ_process_facts.py
-    pid: '21890'
-    ppid: '21889'
-    user: root
-  - cmdline: ''
-    pid: '27662'
-    ppid: '2'
-    user: root
-tcp_listen:
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 1151
-    port: 81
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:54 2022'
-    user: root
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 1151
-    port: 82
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:54 2022'
-    user: root
-  - address: 0.0.0.0
-    name: haproxy
-    pid: 905
-    port: 83
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: haproxy
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1079
-    port: 22
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:53 2022'
-    user: root
-  - address: 127.0.0.1
-    name: postmaster
-    pid: 21221
-    port: 5432
-    protocol: tcp
-    stime: 'Thu Apr 28 13:53:52 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1074
-    port: 25
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:53 2022'
-    user: root
-  - address: 0.0.0.0
-    name: haproxy
-    pid: 905
-    port: 5000
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: haproxy
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: '::'
-    name: java
-    pid: 887
-    port: 8080
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: tomcat
-  - address: '::'
-    name: httpd
-    pid: 889
-    port: 80
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: root
-  - address: '::'
-    name: 'nginx:'
-    pid: 1151
-    port: 81
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:54 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1079
-    port: 22
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:53 2022'
-    user: root
-  - address: '::1'
-    name: postmaster
-    pid: 21221
-    port: 5432
-    protocol: tcp
-    stime: 'Thu Apr 28 13:53:52 2022'
-    user: postgres
-  - address: '::1'
-    name: master
-    pid: 1074
-    port: 25
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:53 2022'
-    user: root
-  - address: 127.0.0.1
-    name: java
-    pid: 887
-    port: 8005
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 887
-    port: 8009
-    protocol: tcp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: tomcat
-udp_listen:
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 830
-    port: 68
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: root
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 581
-    port: 323
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 3.el7
+    source: rpm
+    version: '3.2'
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dwz:
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  expat-devel:
+  - arch: x86_64
+    epoch: null
+    name: expat-devel
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 5.el7
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gperftools-libs:
+  - arch: x86_64
+    epoch: null
+    name: gperftools-libs
+    release: 1.el7
+    source: rpm
+    version: 2.6.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 560cfc0a
+    source: rpm
+    version: f2ee9d55
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 28.el7
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  haproxy:
+  - arch: x86_64
+    epoch: null
     name: haproxy
-    pid: 896
-    port: 49899
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:52 2022'
-    user: haproxy
-  - address: 0.0.0.0
+    release: 9.el7_9.1
+    source: rpm
+    version: 1.5.18
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  httpd:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-devel:
+  - arch: x86_64
+    epoch: null
+    name: httpd-devel
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-tools:
+  - arch: x86_64
+    epoch: null
+    name: httpd-tools
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.5.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.49
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 25.el7_7.2
+    source: rpm
+    version: 4.11.0
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 34.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  keepalived:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 19.el7
+    source: rpm
+    version: 1.3.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.42.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 43.el7
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 131.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-devel:
+  - arch: x86_64
+    epoch: null
+    name: libdb-devel
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libedit-devel:
+  - arch: x86_64
+    epoch: null
+    name: libedit-devel
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libicu-devel:
+  - arch: x86_64
+    epoch: null
+    name: libicu-devel
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 3.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libtool:
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  llvm-toolset-7-clang:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-clang-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang-libs
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-compiler-rt:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-compiler-rt
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-libomp:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-libomp
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-llvm-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-llvm-libs
+    release: 8.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-runtime:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-devel:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-devel
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-libs
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 16.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 14.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.65
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 61.el7
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-devel:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-devel
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.66.el7
+    source: rpm
+    version: 1.3.0
+  nginx:
+  - arch: x86_64
+    epoch: 1
+    name: nginx
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: nginx-filesystem
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-mod-stream:
+  - arch: x86_64
+    epoch: 1
+    name: nginx-mod-stream
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7
+    source: rpm
+    version: 4.21.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 4.el7_7
+    source: rpm
+    version: 3.44.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openldap-devel:
+  - arch: x86_64
+    epoch: null
+    name: openldap-devel
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Thread-Queue:
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pgdg-redhat-repo:
+  - arch: noarch
+    epoch: null
+    name: pgdg-redhat-repo
+    release: '24'
+    source: rpm
+    version: '42.0'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql11:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-devel:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-devel
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 27.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-devel:
+  - arch: x86_64
+    epoch: null
+    name: python-devel
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 9.el7_8
+    source: rpm
+    version: 2.6.0
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python2-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python2-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 582
-    port: 750
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 111
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 581
-    port: 323
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 582
-    port: 750
-    protocol: udp
-    stime: 'Wed Apr 27 08:37:48 2022'
-    user: rpc
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 52.el7
+    source: rpm
+    version: 8.24.0
+  scl-utils:
+  - arch: x86_64
+    epoch: null
+    name: scl-utils
+    release: 19.el7
+    source: rpm
+    version: '20130529'
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 6.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 9.el7
+    source: rpm
+    version: 1.8.23
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 8.el7
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019c
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 20.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 167.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '197'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '198'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '275'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '276'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '277'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '279'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '295'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '297'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '412'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '444'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '466'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '469'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '511'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '513'
+  ppid: '1'
+  user: dbus
+- cmdline: ''
+  cwd: /
+  pid: '514'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '556'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '559'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '564'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '566'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '567'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '581'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '582'
+  ppid: '1'
+  user: rpc
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H loadbalancer-2 eth0
+  cwd: /sbin/
+  pid: '830'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+    -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+    -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+    -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+    start
+  cwd: /usr/lib/jvm/jre/bin/
+  pid: '887'
+  ppid: '1'
+  user: tomcat
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '888'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '889'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
+  cwd: /usr/sbin/
+  pid: '891'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '896'
+  ppid: '891'
+  user: haproxy
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '905'
+  ppid: '896'
+  user: haproxy
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1074'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1077'
+  ppid: '1074'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1079'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1083'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1089'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1090'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1092'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: master process /usr/sbin/nginx'
+  cwd: /
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1156'
+  ppid: '1151'
+  user: nginx
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1157'
+  ppid: '1151'
+  user: nginx
+- cmdline: ''
+  cwd: /
+  pid: '2661'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '4122'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '4123'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '4124'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '4125'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '4126'
+  ppid: '889'
+  user: apache
+- cmdline: ''
+  cwd: /
+  pid: '20331'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20579'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20613'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20636'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20650'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '20651'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@notty'
+  cwd: /
+  pid: '20653'
+  ppid: '20651'
+  user: centos
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20808'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20809'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20810'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
+  cwd: /usr/pgsql-11/bin/
+  pid: '21221'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: logger'
+  cwd: /
+  pid: '21223'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '21225'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '21226'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '21227'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '21228'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '21229'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '21230'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '21614'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '21616'
+  ppid: '21614'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-fzjxqvrcbxrveubepepdppdeytvaovlu
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656079773.677516-4866-70331870181747/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '21875'
+  ppid: '21616'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-fzjxqvrcbxrveubepepdppdeytvaovlu
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656079773.677516-4866-70331870181747/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '21888'
+  ppid: '21875'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-fzjxqvrcbxrveubepepdppdeytvaovlu ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656079773.677516-4866-70331870181747/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '21889'
+  ppid: '21888'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656079773.677516-4866-70331870181747/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '21890'
+  ppid: '21889'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27662'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: nginx\:?\s*master.*(nginx)?
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/nginx.yaml'
+    name: Include nginx specific plugins
+  name: Nginx WebServer
+  pkg_regexp: nginx
+  process_type: parent
+  return_children: true
+  return_packages: true
+tcp_listen:
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 82
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 83
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 5000
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: java
+  pid: 887
+  port: 8080
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: httpd
+  pid: 889
+  port: 80
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: '::'
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: ::1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: ::1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: 887
+  port: 8005
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 887
+  port: 8009
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 830
+  port: 68
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: 0.0.0.0
+  name: haproxy
+  pid: 896
+  port: 49899
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/oracle/oracle12_centos7.7_5instances.yaml
+++ b/tests/unit/plugins/action/auto/resources/oracle/oracle12_centos7.7_5instances.yaml
@@ -1,11678 +1,12726 @@
-task_vars:
-  oracle_monitor_user: the_user
-  oracle_monitor_pass: the_password
-  oracle_monitor_users_info:
-    - username: "{{ oracle_monitor_user }}"
-      password: "{{ oracle_monitor_pass }}"
-    - username: the_user2
-      password: the_password2
-  oracle_monitor_cluster_hostname: the_cluster_hostname
-  oracle_monitor_read_configuration: no
-
+dockers:
+  containers: []
+expected_result:
+- bindings: []
+  discovery_time: '2022-06-14T17:44:32+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    databases: +ASM
+    instance:
+      connection_sid: +ASM
+      name: +ASM
+      name_normalized: ASM
+      service_names:
+      - +ASM
+    role: ASM NODE
+  files:
+  - path: /softOracle_local/app/oragrid/diag/asm/+asm/+ASM/trace
+    subtype: generic
+    type: log
+  - path: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    subtype: generic
+    type: home
+  listening_ports:
+  - 1521
+  process:
+    cmdline: asm_pmon_+ASM
+    cwd: /
+    pid: '15350'
+    ppid: '1'
+    user: oragrid
+  type: Oracle DatabaseServer
+  version:
+  - number: 12.1.0.2
+    type: file
+  - number: 12.1.0.2.0
+    type: active
+- bindings: []
+  discovery_time: '2022-06-14T17:44:52+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    databases: ARSYS
+    instance:
+      connection_sid: ARSYS
+      name: ARSYS
+      name_normalized: ARSYS
+      service_names:
+      - ARSYS
+      - ARSYSXDB
+    role: PRIMARY
+  files:
+  - path: /softOracle/app/oracle/diag/rdbms/arsys/ARSYS/trace
+    subtype: generic
+    type: log
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1
+    subtype: generic
+    type: home
+  listening_ports:
+  - 1522
+  process:
+    cmdline: ora_pmon_ARSYS
+    cwd: /
+    pid: '15612'
+    ppid: '1'
+    user: oragrid
+  type: Oracle DatabaseServer
+  version:
+  - number: 12.1.0.2
+    type: file
+  - number: 12.1.0.2.0
+    type: active
+- bindings: []
+  discovery_time: '2022-06-14T17:45:10+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    databases: BSAAPP
+    instance:
+      connection_sid: BSAAPP
+      name: BSAAPP
+      name_normalized: BSAAPP
+      service_names:
+      - BSAAPP
+      - BSAAPPXDB
+    role: PRIMARY
+  files:
+  - path: /softOracle/app/oracle/diag/rdbms/bsaapp/BSAAPP/trace
+    subtype: generic
+    type: log
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1
+    subtype: generic
+    type: home
+  listening_ports:
+  - 1524
+  process:
+    cmdline: ora_pmon_BSAAPP
+    cwd: /
+    pid: '15684'
+    ppid: '1'
+    user: oragrid
+  type: Oracle DatabaseServer
+  version:
+  - number: 12.1.0.2
+    type: file
+  - number: 12.1.0.2.0
+    type: active
+- bindings: []
+  discovery_time: '2022-06-14T17:45:29+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    databases: BNABBDD
+    instance:
+      connection_sid: BNABBDD
+      name: BNABBDD
+      name_normalized: BNABBDD
+      service_names:
+      - BNABBDD
+      - BNABBDDXDB
+    role: PRIMARY
+  files:
+  - path: /softOracle/app/oracle/diag/rdbms/bnabbdd/BNABBDD/trace
+    subtype: generic
+    type: log
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1
+    subtype: generic
+    type: home
+  listening_ports:
+  - 1523
+  process:
+    cmdline: ora_pmon_BNABBDD
+    cwd: /
+    pid: '15688'
+    ppid: '1'
+    user: oragrid
+  type: Oracle DatabaseServer
+  version:
+  - number: 12.1.0.2
+    type: file
+  - number: 12.1.0.2.0
+    type: active
+- bindings: []
+  discovery_time: '2022-06-14T17:45:47+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    databases: BSAREP
+    instance:
+      connection_sid: BSAREP
+      name: BSAREP
+      name_normalized: BSAREP
+      service_names:
+      - BSAREP
+      - BSAREPXDB
+    role: PRIMARY
+  files:
+  - path: /softOracle/app/oracle/diag/rdbms/bsarep/BSAREP/trace
+    subtype: generic
+    type: log
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1
+    subtype: generic
+    type: home
+  listening_ports:
+  - 1527
+  process:
+    cmdline: ora_pmon_BSAREP
+    cwd: /
+    pid: '15692'
+    ppid: '1'
+    user: oragrid
+  type: Oracle DatabaseServer
+  version:
+  - number: 12.1.0.2
+    type: file
+  - number: 12.1.0.2.0
+    type: active
 mocked_plugin_tasks:
-  Read env from listener:
-    calls:
-      - expected_args:
-          pid: '14496'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14500'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14505'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14763'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-      - expected_args:
-          pid: '14782'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14496'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14500'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14505'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14763'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-      - expected_args:
-          pid: '14782'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14496'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14500'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14505'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14763'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-      - expected_args:
-          pid: '14782'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14496'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14500'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14505'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14763'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-      - expected_args:
-          pid: '14782'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14496'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14500'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14505'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14763'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-      - expected_args:
-          pid: '14782'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
   Create lsnrctl temp file:
     calls:
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAAPP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAREP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BNABBDD
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_ARSYS
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAAPP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAREP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BNABBDD
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_ARSYS
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAAPP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAREP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BNABBDD
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_ARSYS
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAAPP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAREP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BNABBDD
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_ARSYS
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAAPP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BSAREP
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_BNABBDD
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER
-            insertbefore: BOF
-        plugin_result:
-          failed: false
-      - expected_args:
-          ansible.builtin.blockinfile:
-            create: yes
-            path: /tmp/os_facts_oracledb
-            block: |
-              SET DISPLAYMODE raw
-              status LISTENER_ARSYS
-            insertbefore: BOF
-        plugin_result:
-          failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAAPP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAREP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BNABBDD
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_ARSYS
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAAPP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAREP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BNABBDD
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_ARSYS
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAAPP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAREP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BNABBDD
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_ARSYS
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAAPP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAREP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BNABBDD
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_ARSYS
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAAPP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BSAREP
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_BNABBDD
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
+    - expected_args:
+        ansible.builtin.blockinfile:
+          block: 'SET DISPLAYMODE raw
+
+            status LISTENER_ARSYS
+
+            '
+          create: true
+          insertbefore: BOF
+          path: /tmp/os_facts_oracledb
+      plugin_result:
+        failed: false
   Execute lsnrctl:
     calls:
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAAPP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 12 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAREP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 14 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BNABBDD"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 17 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-            TNS_ADMIN: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 18 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora"
-            - "Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_ARSYS"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 21 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAAPP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 12 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAREP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 14 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BNABBDD"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 17 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-            TNS_ADMIN: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 18 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora"
-            - "Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_ARSYS"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 21 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAAPP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 12 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAREP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 14 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BNABBDD"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 17 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-            TNS_ADMIN: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 18 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora"
-            - "Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_ARSYS"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 21 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAAPP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 12 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAREP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 14 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BNABBDD"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 17 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-            TNS_ADMIN: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 18 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora"
-            - "Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_ARSYS"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 21 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAAPP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 12 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BSAREP"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 14 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_BNABBDD"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:26"
-            - "Uptime                    33 days 17 hr. 24 min. 17 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-            TNS_ADMIN: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 18 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora"
-            - "Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))"
-            - "The command completed successfully"
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
-          in_docker: True
-        expected_attributes:
-          environment:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-            TNS_ADMIN: "/softOracle/app/oracle/product/12.1.0.2/db_1/network/admin"
-          register: any
-          when: any
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - ""
-            - "LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49"
-            - ""
-            - "Copyright (c) 1991, 2014, Oracle.  All rights reserved."
-            - ""
-            - "Service display mode is RAW"
-            - "Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))"
-            - "STATUS of the LISTENER"
-            - "------------------------"
-            - "Alias                     LISTENER_ARSYS"
-            - "Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production"
-            - "Start Date                12-MAY-2022 19:11:27"
-            - "Uptime                    33 days 17 hr. 24 min. 21 sec"
-            - "Trace Level               off"
-            - "Security                  ON: Local OS Authentication"
-            - "SNMP                      OFF"
-            - "Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora"
-            - "Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))"
-            - "(ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))"
-            - "(ENDPOINT=)"
-            - "(SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "(SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))"
-            - "The command completed successfully"
-  Read env from process:
-    calls:
-      - expected_args:
-          pid: '15350'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-      - expected_args:
-          pid: '15612'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '15684'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '15688'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '15692'
-        plugin_result:
-          failed: false
-          parsed:
-            ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-  Get ORAHOME from path:
-    fail: Should not be called
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAAPP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 12 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAREP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 14 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BNABBDD
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 17 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl
+          @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+          TNS_ADMIN: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 18 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora
+        - Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_ARSYS
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 21 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAAPP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 12 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAREP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 14 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BNABBDD
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 17 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl
+          @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+          TNS_ADMIN: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 18 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora
+        - Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_ARSYS
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 21 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAAPP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 12 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAREP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 14 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BNABBDD
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 17 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl
+          @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+          TNS_ADMIN: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 18 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora
+        - Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_ARSYS
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 21 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAAPP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 12 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAREP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 14 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BNABBDD
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 17 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl
+          @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+          TNS_ADMIN: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 18 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora
+        - Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_ARSYS
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 21 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:38'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAAPP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 12 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27F5A-38A0-E053-E5D0470A5390)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1524)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAAPP)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAAPPXDB)(INSTANCE=(INSTANCE_NAME=BSAAPP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:40'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BSAREP
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 14 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E27382-38A4-E053-E5D0470A4FEF)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1527)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BSAREP)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BSAREPXDB)(INSTANCE=(INSTANCE_NAME=BSAREP)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:43'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_BNABBDD
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:26
+        - Uptime                    33 days 17 hr. 24 min. 17 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5E4DECA-38A9-E053-E5D0470A3429)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1523)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=BNABBDD)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=BNABBDDXDB)(INSTANCE=(INSTANCE_NAME=BNABBDD)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl
+          @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+          TNS_ADMIN: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:46'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 18 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/network/admin/listener.ora
+        - Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE88-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1521)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5F9DE89-39AB-E053-E5D0470A7793)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=+ASM)(INSTANCE=(INSTANCE_NAME=+ASM)(NUM=1)(NUMREL=1)))
+        - The command completed successfully
+    - expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl @/tmp/os_facts_oracledb
+        in_docker: true
+      expected_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+          TNS_ADMIN: /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin
+        register: any
+        when: any
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - ''
+        - 'LSNRCTL for Linux: Version 12.1.0.2.0 - Production on 15-JUN-2022 12:35:49'
+        - ''
+        - Copyright (c) 1991, 2014, Oracle.  All rights reserved.
+        - ''
+        - Service display mode is RAW
+        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))
+        - STATUS of the LISTENER
+        - '------------------------'
+        - Alias                     LISTENER_ARSYS
+        - 'Version                   TNSLSNR for Linux: Version 12.1.0.2.0 - Production'
+        - Start Date                12-MAY-2022 19:11:27
+        - Uptime                    33 days 17 hr. 24 min. 21 sec
+        - Trace Level               off
+        - 'Security                  ON: Local OS Authentication'
+        - SNMP                      OFF
+        - Listener Parameter File   /softOracle/app/oracle/product/12.1.0.2/db_1/network/admin/listener.ora
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C59-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=ld1bmb02.es.wcorp.carrefour.com)(PORT=1522)))))
+        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=DED4A5FE8C5A-39BE-E053-E5D0470A985E)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1522)))))
+        - (ENDPOINT=)
+        - (SERVICE=(SERVICE_NAME=ARSYS)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - (SERVICE=(SERVICE_NAME=ARSYSXDB)(INSTANCE=(INSTANCE_NAME=ARSYS)(NUM=2)(NUMREL=1)))
+        - The command completed successfully
   Get ORAHOME from oratab:
     fail: Should not be called
-  Run command to get version:
+  Get ORAHOME from path:
+    fail: Should not be called
+  Read env from listener:
     calls:
-      - expected_args:
-          argv: null
-          cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/sqlplus -V
-          in_docker: True
-        expeced_attributes:
-          environment:
-            ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
-          register: any
-        plugin_result:
-          failed: false
-          stdout: |-
-            
-            SQL*Plus: Release 12.1.0.2.0 - Production
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/sqlplus -V
-          in_docker: True
-        expeced_attributes:
-          environment:
-            ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
-          register: any
-        plugin_result:
-          failed: false
-          stdout: |-
-            
-            SQL*Plus: Release 12.1.0.2.0 - Production
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/sqlplus -V
-          in_docker: True
-        expeced_attributes:
-          environment:
-            ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
-          register: any
-        plugin_result:
-          failed: false
-          stdout: |-
-            
-            SQL*Plus: Release 12.1.0.2.0 - Production
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/sqlplus -V
-          in_docker: True
-        expeced_attributes:
-          environment:
-            ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
-          register: any
-        plugin_result:
-          failed: false
-          stdout: |-
-            
-            SQL*Plus: Release 12.1.0.2.0 - Production
-      - expected_args:
-          argv: null
-          cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/sqlplus -V
-          in_docker: True
-        expeced_attributes:
-          environment:
-            ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
-          register: any
-        plugin_result:
-          failed: false
-          stdout: |-
-            
-            SQL*Plus: Release 12.1.0.2.0 - Production
+    - expected_args:
+        pid: '14496'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14500'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14505'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14763'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    - expected_args:
+        pid: '14782'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14496'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14500'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14505'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14763'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    - expected_args:
+        pid: '14782'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14496'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14500'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14505'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14763'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    - expected_args:
+        pid: '14782'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14496'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14500'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14505'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14763'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    - expected_args:
+        pid: '14782'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14496'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14500'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14505'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14763'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    - expected_args:
+        pid: '14782'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+  Read env from process:
+    calls:
+    - expected_args:
+        pid: '15350'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    - expected_args:
+        pid: '15612'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '15684'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '15688'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '15692'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
   Run command to get log dir:
     calls:
-      - plugin_result:
-          failed: false
-          stdout: /softOracle_local/app/oragrid/diag/asm/+asm/+ASM/trace
-      - plugin_result:
-          failed: false
-          stdout: /softOracle/app/oracle/diag/rdbms/arsys/ARSYS/trace
-      - plugin_result:
-          failed: false
-          stdout: /softOracle/app/oracle/diag/rdbms/bsaapp/BSAAPP/trace
-      - plugin_result:
-          failed: false
-          stdout: /softOracle/app/oracle/diag/rdbms/bnabbdd/BNABBDD/trace
-      - plugin_result:
-          failed: false
-          stdout: /softOracle/app/oracle/diag/rdbms/bsarep/BSAREP/trace
+    - plugin_result:
+        failed: false
+        stdout: /softOracle_local/app/oragrid/diag/asm/+asm/+ASM/trace
+    - plugin_result:
+        failed: false
+        stdout: /softOracle/app/oracle/diag/rdbms/arsys/ARSYS/trace
+    - plugin_result:
+        failed: false
+        stdout: /softOracle/app/oracle/diag/rdbms/bsaapp/BSAAPP/trace
+    - plugin_result:
+        failed: false
+        stdout: /softOracle/app/oracle/diag/rdbms/bnabbdd/BNABBDD/trace
+    - plugin_result:
+        failed: false
+        stdout: /softOracle/app/oracle/diag/rdbms/bsarep/BSAREP/trace
   Run command to get role:
     plugin_result:
       failed: false
       stdout: PRIMARY
+  Run command to get version:
+    calls:
+    - expeced_attributes:
+        environment:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+        register: any
+      expected_args:
+        argv: null
+        cmd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/sqlplus
+          -V
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout: '
 
-expected_result:
-  - bindings: [ ]
-    discovery_time: '2022-06-14T17:44:32+02:00'
-    extra_data:
-      ORACLE_HOME: "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-      databases: "+ASM"
-      instance:
-        connection_sid: "+ASM"
-        name: "+ASM"
-        name_normalized: ASM
-        service_names:
-          - "+ASM"
-      role: ASM NODE
-    files:
-      - path: /softOracle_local/app/oragrid/diag/asm/+asm/+ASM/trace
-        subtype: generic
-        type: log
-      - path: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
-        subtype: generic
-        type: home
-    listening_ports:
-      - 1521
-    process:
-      cmdline: asm_pmon_+ASM
-      pid: '15350'
-      ppid: '1'
-      user: oragrid
-    type: Oracle DatabaseServer
-    version:
-      - number: 12.1.0.2
-        type: file
-      - number: 12.1.0.2.0
-        type: active
-  - bindings: [ ]
-    discovery_time: '2022-06-14T17:44:52+02:00'
-    extra_data:
-      ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      databases: ARSYS
-      instance:
-        connection_sid: ARSYS
-        name: ARSYS
-        name_normalized: ARSYS
-        service_names:
-          - ARSYS
-          - ARSYSXDB
-      role: PRIMARY
-    files:
-      - path: /softOracle/app/oracle/diag/rdbms/arsys/ARSYS/trace
-        subtype: generic
-        type: log
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1
-        subtype: generic
-        type: home
-    listening_ports:
-      - 1522
-    process:
-      cmdline: ora_pmon_ARSYS
-      pid: '15612'
-      ppid: '1'
-      user: oragrid
-    type: Oracle DatabaseServer
-    version:
-      - number: 12.1.0.2
-        type: file
-      - number: 12.1.0.2.0
-        type: active
-  - bindings: [ ]
-    discovery_time: '2022-06-14T17:45:10+02:00'
-    extra_data:
-      ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      databases: BSAAPP
-      instance:
-        connection_sid: BSAAPP
-        name: BSAAPP
-        name_normalized: BSAAPP
-        service_names:
-          - BSAAPP
-          - BSAAPPXDB
-      role: PRIMARY
-    files:
-      - path: "/softOracle/app/oracle/diag/rdbms/bsaapp/BSAAPP/trace"
-        subtype: generic
-        type: log
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1
-        subtype: generic
-        type: home
-    listening_ports:
-      - 1524
-    process:
-      cmdline: ora_pmon_BSAAPP
-      pid: '15684'
-      ppid: '1'
-      user: oragrid
-    type: Oracle DatabaseServer
-    version:
-      - number: 12.1.0.2
-        type: file
-      - number: 12.1.0.2.0
-        type: active
-  - bindings: [ ]
-    discovery_time: '2022-06-14T17:45:29+02:00'
-    extra_data:
-      ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      databases: BNABBDD
-      instance:
-        connection_sid: BNABBDD
-        name: BNABBDD
-        name_normalized: BNABBDD
-        service_names:
-          - BNABBDD
-          - BNABBDDXDB
-      role: PRIMARY
-    files:
-      - path: /softOracle/app/oracle/diag/rdbms/bnabbdd/BNABBDD/trace
-        subtype: generic
-        type: log
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1
-        subtype: generic
-        type: home
-    listening_ports:
-      - 1523
-    process:
-      cmdline: ora_pmon_BNABBDD
-      pid: '15688'
-      ppid: '1'
-      user: oragrid
-    type: Oracle DatabaseServer
-    version:
-      - number: 12.1.0.2
-        type: file
-      - number: 12.1.0.2.0
-        type: active
-  - bindings: [ ]
-    discovery_time: '2022-06-14T17:45:47+02:00'
-    extra_data:
-      ORACLE_HOME: "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      databases: BSAREP
-      instance:
-        connection_sid: BSAREP
-        name: BSAREP
-        name_normalized: BSAREP
-        service_names:
-          - BSAREP
-          - BSAREPXDB
-      role: PRIMARY
-    files:
-      - path: /softOracle/app/oracle/diag/rdbms/bsarep/BSAREP/trace
-        subtype: generic
-        type: log
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1
-        subtype: generic
-        type: home
-    listening_ports:
-      - 1527
-    process:
-      cmdline: ora_pmon_BSAREP
-      pid: '15692'
-      ppid: '1'
-      user: oragrid
-    type: Oracle DatabaseServer
-    version:
-      - number: 12.1.0.2
-        type: file
-      - number: 12.1.0.2.0
-        type: active
+          SQL*Plus: Release 12.1.0.2.0 - Production'
+    - expeced_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+        register: any
+      expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/sqlplus -V
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout: '
 
-software_list:
-  - name: Oracle DatabaseServer
-    cmd_regexp: _pmon_
-    process_type: parent
-    return_children: false
-    return_packages: false
-    vars:
-      connect_with_users: "{{ oracle_monitor_users_info 
-        | default([{'username': oracle_monitor_user | default('oracle'), 
-        'password': oracle_monitor_pass | default('oracle')}]) }}"
-      monitor_cluster_hostname: "{{ oracle_monitor_cluster_hostname | default('localhost') }}"
-      read_configuration: "{{ oracle_monitor_read_configuration | default(False) }}"
-    custom_tasks:
-      - name: Include Oracle specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/oracle.yaml"
-dockers:
-  containers: [ ]
+          SQL*Plus: Release 12.1.0.2.0 - Production'
+    - expeced_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+        register: any
+      expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/sqlplus -V
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout: '
+
+          SQL*Plus: Release 12.1.0.2.0 - Production'
+    - expeced_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+        register: any
+      expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/sqlplus -V
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout: '
+
+          SQL*Plus: Release 12.1.0.2.0 - Production'
+    - expeced_attributes:
+        environment:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+        register: any
+      expected_args:
+        argv: null
+        cmd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/sqlplus -V
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout: '
+
+          SQL*Plus: Release 12.1.0.2.0 - Production'
 packages:
   AvamarClient:
-    - arch: x86_64
-      epoch: null
-      name: AvamarClient
-      release: '149'
-      source: rpm
-      version: 19.3.100
+  - arch: x86_64
+    epoch: null
+    name: AvamarClient
+    release: '149'
+    source: rpm
+    version: 19.3.100
   AvamarRMAN:
-    - arch: x86_64
-      epoch: null
-      name: AvamarRMAN
-      release: '149'
-      source: rpm
-      version: 19.3.100
+  - arch: x86_64
+    epoch: null
+    name: AvamarRMAN
+    release: '149'
+    source: rpm
+    version: 19.3.100
   BladeLogic_RSCD_Agent:
-    - arch: x86_64
-      epoch: null
-      name: BladeLogic_RSCD_Agent
-      release: '200'
-      source: rpm
-      version: 8.9.04
+  - arch: x86_64
+    epoch: null
+    name: BladeLogic_RSCD_Agent
+    release: '200'
+    source: rpm
+    version: 8.9.04
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   NetworkManager:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
   NetworkManager-config-server:
-    - arch: noarch
-      epoch: 1
-      name: NetworkManager-config-server
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
+  - arch: noarch
+    epoch: 1
+    name: NetworkManager-config-server
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
   NetworkManager-libnm:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-libnm
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-libnm
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
   NetworkManager-ppp:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-ppp
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-ppp
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
   NetworkManager-team:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-team
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-team
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
   NetworkManager-tui:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-tui
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-tui
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
   OpenIPMI:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
   OpenIPMI-libs:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI-libs
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI-libs
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
   OpenIPMI-modalias:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI-modalias
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI-modalias
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
   Red_Hat_Enterprise_Linux-Release_Notes-7-en-US:
-    - arch: noarch
-      epoch: null
-      name: Red_Hat_Enterprise_Linux-Release_Notes-7-en-US
-      release: 2.el7
-      source: rpm
-      version: '7'
+  - arch: noarch
+    epoch: null
+    name: Red_Hat_Enterprise_Linux-Release_Notes-7-en-US
+    release: 2.el7
+    source: rpm
+    version: '7'
   TDP-Oracle:
-    - arch: x86_64
-      epoch: null
-      name: TDP-Oracle
-      release: '0'
-      source: rpm
-      version: 8.1.0
+  - arch: x86_64
+    epoch: null
+    name: TDP-Oracle
+    release: '0'
+    source: rpm
+    version: 8.1.0
   TDP-Oracle.Utility:
-    - arch: x86_64
-      epoch: null
-      name: TDP-Oracle.Utility
-      release: '0'
-      source: rpm
-      version: 8.1.0
+  - arch: x86_64
+    epoch: null
+    name: TDP-Oracle.Utility
+    release: '0'
+    source: rpm
+    version: 8.1.0
   TIVsm-API64:
-    - arch: x86_64
-      epoch: null
-      name: TIVsm-API64
-      release: '0'
-      source: rpm
-      version: 8.1.7
+  - arch: x86_64
+    epoch: null
+    name: TIVsm-API64
+    release: '0'
+    source: rpm
+    version: 8.1.7
   TIVsm-BA:
-    - arch: x86_64
-      epoch: null
-      name: TIVsm-BA
-      release: '0'
-      source: rpm
-      version: 8.1.7
+  - arch: x86_64
+    epoch: null
+    name: TIVsm-BA
+    release: '0'
+    source: rpm
+    version: 8.1.7
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
   adcli:
-    - arch: x86_64
-      epoch: null
-      name: adcli
-      release: 9.el7
-      source: rpm
-      version: 0.8.1
+  - arch: x86_64
+    epoch: null
+    name: adcli
+    release: 9.el7
+    source: rpm
+    version: 0.8.1
   adobe-mappings-cmap:
-    - arch: noarch
-      epoch: null
-      name: adobe-mappings-cmap
-      release: 3.el7
-      source: rpm
-      version: '20171205'
+  - arch: noarch
+    epoch: null
+    name: adobe-mappings-cmap
+    release: 3.el7
+    source: rpm
+    version: '20171205'
   adobe-mappings-cmap-deprecated:
-    - arch: noarch
-      epoch: null
-      name: adobe-mappings-cmap-deprecated
-      release: 3.el7
-      source: rpm
-      version: '20171205'
+  - arch: noarch
+    epoch: null
+    name: adobe-mappings-cmap-deprecated
+    release: 3.el7
+    source: rpm
+    version: '20171205'
   adobe-mappings-pdf:
-    - arch: noarch
-      epoch: null
-      name: adobe-mappings-pdf
-      release: 1.el7
-      source: rpm
-      version: '20180407'
+  - arch: noarch
+    epoch: null
+    name: adobe-mappings-pdf
+    release: 1.el7
+    source: rpm
+    version: '20180407'
   aic94xx-firmware:
-    - arch: noarch
-      epoch: null
-      name: aic94xx-firmware
-      release: 6.el7
-      source: rpm
-      version: '30'
+  - arch: noarch
+    epoch: null
+    name: aic94xx-firmware
+    release: 6.el7
+    source: rpm
+    version: '30'
   aide:
-    - arch: x86_64
-      epoch: null
-      name: aide
-      release: 13.el7_9.1
-      source: rpm
-      version: 0.15.1
+  - arch: x86_64
+    epoch: null
+    name: aide
+    release: 13.el7_9.1
+    source: rpm
+    version: 0.15.1
   alsa-firmware:
-    - arch: noarch
-      epoch: null
-      name: alsa-firmware
-      release: 2.el7
-      source: rpm
-      version: 1.0.28
+  - arch: noarch
+    epoch: null
+    name: alsa-firmware
+    release: 2.el7
+    source: rpm
+    version: 1.0.28
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   alsa-tools-firmware:
-    - arch: x86_64
-      epoch: null
-      name: alsa-tools-firmware
-      release: 1.el7
-      source: rpm
-      version: 1.1.0
+  - arch: x86_64
+    epoch: null
+    name: alsa-tools-firmware
+    release: 1.el7
+    source: rpm
+    version: 1.1.0
   at:
-    - arch: x86_64
-      epoch: null
-      name: at
-      release: 24.el7
-      source: rpm
-      version: 3.1.13
+  - arch: x86_64
+    epoch: null
+    name: at
+    release: 24.el7
+    source: rpm
+    version: 3.1.13
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: i686
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: i686
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autofs:
-    - arch: x86_64
-      epoch: 1
-      name: autofs
-      release: 106.el7
-      source: rpm
-      version: 5.0.7
+  - arch: x86_64
+    epoch: 1
+    name: autofs
+    release: 106.el7
+    source: rpm
+    version: 5.0.7
   autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
   avahi-autoipd:
-    - arch: x86_64
-      epoch: null
-      name: avahi-autoipd
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-autoipd
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
   bash-completion:
-    - arch: noarch
-      epoch: 1
-      name: bash-completion
-      release: 6.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 1
+    name: bash-completion
+    release: 6.el7
+    source: rpm
+    version: '2.1'
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
   biosdevname:
-    - arch: x86_64
-      epoch: null
-      name: biosdevname
-      release: 2.el7
-      source: rpm
-      version: 0.7.3
+  - arch: x86_64
+    epoch: null
+    name: biosdevname
+    release: 2.el7
+    source: rpm
+    version: 0.7.3
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2:
-    - arch: x86_64
-      epoch: null
-      name: bzip2
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   bzip2-libs:
-    - arch: i686
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: i686
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   c-ares:
-    - arch: x86_64
-      epoch: null
-      name: c-ares
-      release: 3.el7
-      source: rpm
-      version: 1.10.0
+  - arch: x86_64
+    epoch: null
+    name: c-ares
+    release: 3.el7
+    source: rpm
+    version: 1.10.0
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   cfg2html:
-    - arch: noarch
-      epoch: null
-      name: cfg2html
-      release: '151.1'
-      source: rpm
-      version: '6.30'
+  - arch: noarch
+    epoch: null
+    name: cfg2html
+    release: '151.1'
+    source: rpm
+    version: '6.30'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
   compat-libcap1:
-    - arch: x86_64
-      epoch: null
-      name: compat-libcap1
-      release: 7.el7
-      source: rpm
-      version: '1.10'
+  - arch: x86_64
+    epoch: null
+    name: compat-libcap1
+    release: 7.el7
+    source: rpm
+    version: '1.10'
   compat-libstdc++-33:
-    - arch: i686
-      epoch: null
-      name: compat-libstdc++-33
-      release: 72.el7
-      source: rpm
-      version: 3.2.3
-    - arch: x86_64
-      epoch: null
-      name: compat-libstdc++-33
-      release: 72.el7
-      source: rpm
-      version: 3.2.3
+  - arch: i686
+    epoch: null
+    name: compat-libstdc++-33
+    release: 72.el7
+    source: rpm
+    version: 3.2.3
+  - arch: x86_64
+    epoch: null
+    name: compat-libstdc++-33
+    release: 72.el7
+    source: rpm
+    version: 3.2.3
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-    - arch: i686
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  - arch: i686
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.3
   cups-client:
-    - arch: x86_64
-      epoch: 1
-      name: cups-client
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-client
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-gssapi:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-gssapi
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-gssapi
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   desktop-file-utils:
-    - arch: x86_64
-      epoch: null
-      name: desktop-file-utils
-      release: 2.el7
-      source: rpm
-      version: '0.23'
+  - arch: x86_64
+    epoch: null
+    name: desktop-file-utils
+    release: 2.el7
+    source: rpm
+    version: '0.23'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
   device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
   device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
   device-mapper-multipath:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-multipath
-      release: 127.el7
-      source: rpm
-      version: 0.4.9
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-multipath
+    release: 127.el7
+    source: rpm
+    version: 0.4.9
   device-mapper-multipath-libs:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-multipath-libs
-      release: 127.el7
-      source: rpm
-      version: 0.4.9
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-multipath-libs
+    release: 127.el7
+    source: rpm
+    version: 0.4.9
   device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 1.el7
-      source: rpm
-      version: 0.8.5
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 1.el7
+    source: rpm
+    version: 0.8.5
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7_9.1
-      source: rpm
-      version: 4.2.5
+  - arch: x86_64
+    epoch: 12
+    name: dhclient
+    release: 83.el7_9.1
+    source: rpm
+    version: 4.2.5
   dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7_9.1
-      source: rpm
-      version: 4.2.5
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7_9.1
+    source: rpm
+    version: 4.2.5
   dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7_9.1
-      source: rpm
-      version: 4.2.5
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7_9.1
+    source: rpm
+    version: 4.2.5
   diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
   dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 3.el7
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 3.el7
+    source: rpm
+    version: '3.2'
   dnsmasq:
-    - arch: x86_64
-      epoch: null
-      name: dnsmasq
-      release: 16.el7_9.1
-      source: rpm
-      version: '2.76'
+  - arch: x86_64
+    epoch: null
+    name: dnsmasq
+    release: 16.el7_9.1
+    source: rpm
+    version: '2.76'
   dosfstools:
-    - arch: x86_64
-      epoch: null
-      name: dosfstools
-      release: 10.el7
-      source: rpm
-      version: 3.0.20
+  - arch: x86_64
+    epoch: null
+    name: dosfstools
+    release: 10.el7
+    source: rpm
+    version: 3.0.20
   dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 564.el7
-      source: rpm
-      version: '033'
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 564.el7
+    source: rpm
+    version: '033'
   dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 564.el7
-      source: rpm
-      version: '033'
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 564.el7
+    source: rpm
+    version: '033'
   dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 564.el7
-      source: rpm
-      version: '033'
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 564.el7
+    source: rpm
+    version: '033'
   e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   ebtables:
-    - arch: x86_64
-      epoch: null
-      name: ebtables
-      release: 16.el7
-      source: rpm
-      version: 2.0.10
+  - arch: x86_64
+    epoch: null
+    name: ebtables
+    release: 16.el7
+    source: rpm
+    version: 2.0.10
   ed:
-    - arch: x86_64
-      epoch: null
-      name: ed
-      release: 4.el7
-      source: rpm
-      version: '1.9'
+  - arch: x86_64
+    epoch: null
+    name: ed
+    release: 4.el7
+    source: rpm
+    version: '1.9'
   efibootmgr:
-    - arch: x86_64
-      epoch: null
-      name: efibootmgr
-      release: 2.el7
-      source: rpm
-      version: '17'
+  - arch: x86_64
+    epoch: null
+    name: efibootmgr
+    release: 2.el7
+    source: rpm
+    version: '17'
   efivar-libs:
-    - arch: x86_64
-      epoch: null
-      name: efivar-libs
-      release: 12.el7
-      source: rpm
-      version: '36'
+  - arch: x86_64
+    epoch: null
+    name: efivar-libs
+    release: 12.el7
+    source: rpm
+    version: '36'
   elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.176'
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.176'
   elfutils-libelf:
-    - arch: i686
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.176'
+  - arch: i686
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.176'
   elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-    - arch: i686
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  - arch: i686
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.176'
   emacs-common:
-    - arch: x86_64
-      epoch: 1
-      name: emacs-common
-      release: 23.el7
-      source: rpm
-      version: '24.3'
+  - arch: x86_64
+    epoch: 1
+    name: emacs-common
+    release: 23.el7
+    source: rpm
+    version: '24.3'
   emacs-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: emacs-filesystem
-      release: 23.el7
-      source: rpm
-      version: '24.3'
+  - arch: noarch
+    epoch: 1
+    name: emacs-filesystem
+    release: 23.el7
+    source: rpm
+    version: '24.3'
   emacs-nox:
-    - arch: x86_64
-      epoch: 1
-      name: emacs-nox
-      release: 23.el7
-      source: rpm
-      version: '24.3'
+  - arch: x86_64
+    epoch: 1
+    name: emacs-nox
+    release: 23.el7
+    source: rpm
+    version: '24.3'
   ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
   expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 14.el7_9
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 14.el7_9
+    source: rpm
+    version: 2.1.0
   expect:
-    - arch: x86_64
-      epoch: null
-      name: expect
-      release: 14.el7_1
-      source: rpm
-      version: '5.45'
+  - arch: x86_64
+    epoch: null
+    name: expect
+    release: 14.el7_1
+    source: rpm
+    version: '5.45'
   falcon-sensor:
-    - arch: x86_64
-      epoch: null
-      name: falcon-sensor
-      release: 10402.el7
-      source: rpm
-      version: 5.38.0
+  - arch: x86_64
+    epoch: null
+    name: falcon-sensor
+    release: 10402.el7
+    source: rpm
+    version: 5.38.0
   file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 36.el7
-      source: rpm
-      version: '5.11'
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 36.el7
+    source: rpm
+    version: '5.11'
   file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 36.el7
-      source: rpm
-      version: '5.11'
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 36.el7
+    source: rpm
+    version: '5.11'
   filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 6.8.8
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 6.8.8
   filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
   findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
   finger:
-    - arch: x86_64
-      epoch: null
-      name: finger
-      release: 52.el7
-      source: rpm
-      version: '0.17'
+  - arch: x86_64
+    epoch: null
+    name: finger
+    release: 52.el7
+    source: rpm
+    version: '0.17'
   fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
   fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
   firewalld:
-    - arch: noarch
-      epoch: null
-      name: firewalld
-      release: 2.el7_7.1
-      source: rpm
-      version: 0.6.3
+  - arch: noarch
+    epoch: null
+    name: firewalld
+    release: 2.el7_7.1
+    source: rpm
+    version: 0.6.3
   firewalld-filesystem:
-    - arch: noarch
-      epoch: null
-      name: firewalld-filesystem
-      release: 2.el7_7.1
-      source: rpm
-      version: 0.6.3
+  - arch: noarch
+    epoch: null
+    name: firewalld-filesystem
+    release: 2.el7_7.1
+    source: rpm
+    version: 0.6.3
   fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
   fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
   foomatic-filters:
-    - arch: x86_64
-      epoch: null
-      name: foomatic-filters
-      release: 9.el7
-      source: rpm
-      version: 4.0.9
+  - arch: x86_64
+    epoch: null
+    name: foomatic-filters
+    release: 9.el7
+    source: rpm
+    version: 4.0.9
   forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
   freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
   fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
   ftp:
-    - arch: x86_64
-      epoch: null
-      name: ftp
-      release: 67.el7
-      source: rpm
-      version: '0.17'
+  - arch: x86_64
+    epoch: null
+    name: ftp
+    release: 67.el7
+    source: rpm
+    version: '0.17'
   fxload:
-    - arch: x86_64
-      epoch: null
-      name: fxload
-      release: 16.el7
-      source: rpm
-      version: '2002_04_11'
+  - arch: x86_64
+    epoch: null
+    name: fxload
+    release: 16.el7
+    source: rpm
+    version: '2002_04_11'
   gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
   gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
   gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
   gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
   gdbm-devel:
-    - arch: x86_64
-      epoch: null
-      name: gdbm-devel
-      release: 8.el7
-      source: rpm
-      version: '1.10'
+  - arch: x86_64
+    epoch: null
+    name: gdbm-devel
+    release: 8.el7
+    source: rpm
+    version: '1.10'
   gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
   geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
   gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   ghostscript:
-    - arch: x86_64
-      epoch: null
-      name: ghostscript
-      release: 2.el7_7.3
-      source: rpm
-      version: '9.25'
+  - arch: x86_64
+    epoch: null
+    name: ghostscript
+    release: 2.el7_7.3
+    source: rpm
+    version: '9.25'
   ghostscript-fonts:
-    - arch: noarch
-      epoch: null
-      name: ghostscript-fonts
-      release: 32.el7
-      source: rpm
-      version: '5.50'
+  - arch: noarch
+    epoch: null
+    name: ghostscript-fonts
+    release: 32.el7
+    source: rpm
+    version: '5.50'
   glib-networking:
-    - arch: x86_64
-      epoch: null
-      name: glib-networking
-      release: 1.el7
-      source: rpm
-      version: 2.56.1
+  - arch: x86_64
+    epoch: null
+    name: glib-networking
+    release: 1.el7
+    source: rpm
+    version: 2.56.1
   glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
   glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
   glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
   glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc-devel
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc-devel
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
   glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
   gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
   gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
   gnutls:
-    - arch: x86_64
-      epoch: null
-      name: gnutls
-      release: 9.el7_6
-      source: rpm
-      version: 3.3.29
+  - arch: x86_64
+    epoch: null
+    name: gnutls
+    release: 9.el7_6
+    source: rpm
+    version: 3.3.29
   gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
   gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 45700c69
-      source: rpm
-      version: 2fa658e0
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 4ae0493b
-      source: rpm
-      version: fd431d51
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 45700c69
+    source: rpm
+    version: 2fa658e0
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 4ae0493b
+    source: rpm
+    version: fd431d51
   gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
   gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
   graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
   grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
   groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
   grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
   grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
   grub2-efi-x64:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-efi-x64
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-efi-x64
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
   grub2-efi-x64-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-efi-x64-modules
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-efi-x64-modules
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
   grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
   grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
   grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
   grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
   grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
   grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
   gsettings-desktop-schemas:
-    - arch: x86_64
-      epoch: null
-      name: gsettings-desktop-schemas
-      release: 3.el7
-      source: rpm
-      version: 3.28.0
+  - arch: x86_64
+    epoch: null
+    name: gsettings-desktop-schemas
+    release: 3.el7
+    source: rpm
+    version: 3.28.0
   gskcrypt64:
-    - arch: x86_64
-      epoch: null
-      name: gskcrypt64
-      release: '55.2'
-      source: rpm
-      version: '8.0'
+  - arch: x86_64
+    epoch: null
+    name: gskcrypt64
+    release: '55.2'
+    source: rpm
+    version: '8.0'
   gskssl64:
-    - arch: x86_64
-      epoch: null
-      name: gskssl64
-      release: '55.2'
-      source: rpm
-      version: '8.0'
+  - arch: x86_64
+    epoch: null
+    name: gskssl64
+    release: '55.2'
+    source: rpm
+    version: '8.0'
   gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 26.el7
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 26.el7
+    source: rpm
+    version: 0.7.0
   gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 5.el7
-      source: rpm
-      version: 3.22.30
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 5.el7
+    source: rpm
+    version: 3.22.30
   gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
   gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
   hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
   harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
   hesiod:
-    - arch: x86_64
-      epoch: null
-      name: hesiod
-      release: 3.el7
-      source: rpm
-      version: 3.2.1
+  - arch: x86_64
+    epoch: null
+    name: hesiod
+    release: 3.el7
+    source: rpm
+    version: 3.2.1
   hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
   hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
   http-parser:
-    - arch: x86_64
-      epoch: null
-      name: http-parser
-      release: 8.el7_7.2
-      source: rpm
-      version: 2.7.1
+  - arch: x86_64
+    epoch: null
+    name: http-parser
+    release: 8.el7_7.2
+    source: rpm
+    version: 2.7.1
   hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.3.el7
-      source: rpm
-      version: '0.252'
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.3.el7
+    source: rpm
+    version: '0.252'
   info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
   initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.47
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.47
   iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
   iometrics-agent-plugin-oracle-lib-connector:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-lib-connector
-      release: '25'
-      source: rpm
-      version: 18.5.0_1.11.3
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-lib-connector
+    release: '25'
+    source: rpm
+    version: 18.5.0_1.11.3
   iometrics-agent-plugin-oracle-libs:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-libs
-      release: '1'
-      source: rpm
-      version: 18.5.0
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-libs
+    release: '1'
+    source: rpm
+    version: 18.5.0
   iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
   ipmitool:
-    - arch: x86_64
-      epoch: null
-      name: ipmitool
-      release: 9.el7_7
-      source: rpm
-      version: 1.8.18
+  - arch: x86_64
+    epoch: null
+    name: ipmitool
+    release: 9.el7_7
+    source: rpm
+    version: 1.8.18
   iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 25.el7
-      source: rpm
-      version: 4.11.0
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 25.el7
+    source: rpm
+    version: 4.11.0
   iprutils:
-    - arch: x86_64
-      epoch: null
-      name: iprutils
-      release: 2.el7
-      source: rpm
-      version: 2.4.17.1
+  - arch: x86_64
+    epoch: null
+    name: iprutils
+    release: 2.el7
+    source: rpm
+    version: 2.4.17.1
   ipset:
-    - arch: x86_64
-      epoch: null
-      name: ipset
-      release: 1.el7
-      source: rpm
-      version: '7.1'
+  - arch: x86_64
+    epoch: null
+    name: ipset
+    release: 1.el7
+    source: rpm
+    version: '7.1'
   ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
   iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 33.el7
-      source: rpm
-      version: 1.4.21
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 33.el7
+    source: rpm
+    version: 1.4.21
   iptables-services:
-    - arch: x86_64
-      epoch: null
-      name: iptables-services
-      release: 33.el7
-      source: rpm
-      version: 1.4.21
+  - arch: x86_64
+    epoch: null
+    name: iptables-services
+    release: 33.el7
+    source: rpm
+    version: 1.4.21
   iptraf-ng:
-    - arch: x86_64
-      epoch: null
-      name: iptraf-ng
-      release: 7.el7
-      source: rpm
-      version: 1.1.4
+  - arch: x86_64
+    epoch: null
+    name: iptraf-ng
+    release: 7.el7
+    source: rpm
+    version: 1.1.4
   iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
   irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
   ivtv-firmware:
-    - arch: noarch
-      epoch: 2
-      name: ivtv-firmware
-      release: 26.el7
-      source: rpm
-      version: '20080701'
+  - arch: noarch
+    epoch: 2
+    name: ivtv-firmware
+    release: 26.el7
+    source: rpm
+    version: '20080701'
   iwl100-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl100-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
+  - arch: noarch
+    epoch: null
+    name: iwl100-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
   iwl1000-firmware:
-    - arch: noarch
-      epoch: 1
-      name: iwl1000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
+  - arch: noarch
+    epoch: 1
+    name: iwl1000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
   iwl105-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl105-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl105-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl135-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl135-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl135-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl2000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl2000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl2030-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2030-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl2030-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl3160-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3160-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
+  - arch: noarch
+    epoch: null
+    name: iwl3160-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
   iwl3945-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3945-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 15.32.2.9
+  - arch: noarch
+    epoch: null
+    name: iwl3945-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 15.32.2.9
   iwl4965-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl4965-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 228.61.2.24
+  - arch: noarch
+    epoch: null
+    name: iwl4965-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 228.61.2.24
   iwl5000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.83.5.1_1
+  - arch: noarch
+    epoch: null
+    name: iwl5000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.83.5.1_1
   iwl5150-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5150-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.24.2.2
+  - arch: noarch
+    epoch: null
+    name: iwl5150-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.24.2.2
   iwl6000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 9.221.4.1
+  - arch: noarch
+    epoch: null
+    name: iwl6000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 9.221.4.1
   iwl6000g2a-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2a-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2a-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl6000g2b-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2b-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2b-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl6050-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6050-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 41.28.5.1
+  - arch: noarch
+    epoch: null
+    name: iwl6050-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 41.28.5.1
   iwl7260-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7260-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
+  - arch: noarch
+    epoch: null
+    name: iwl7260-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
   jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
   jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
   jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
   json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
   kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
   kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
   kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
   kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
   kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
   kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
   kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
   kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 33.el7
-      source: rpm
-      version: 2.0.15
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 33.el7
+    source: rpm
+    version: 2.0.15
   keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
   keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
   kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 25.el7
-      source: rpm
-      version: '20'
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 25.el7
+    source: rpm
+    version: '20'
   kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 25.el7
-      source: rpm
-      version: '20'
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 25.el7
+    source: rpm
+    version: '20'
   kmod-oracleasm:
-    - arch: x86_64
-      epoch: null
-      name: kmod-oracleasm
-      release: 26.el7
-      source: rpm
-      version: 2.0.8
+  - arch: x86_64
+    epoch: null
+    name: kmod-oracleasm
+    release: 26.el7
+    source: rpm
+    version: 2.0.8
   kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 127.el7
-      source: rpm
-      version: 0.4.9
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 127.el7
+    source: rpm
+    version: 0.4.9
   krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
   krb5-workstation:
-    - arch: x86_64
-      epoch: null
-      name: krb5-workstation
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
+  - arch: x86_64
+    epoch: null
+    name: krb5-workstation
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
   ksh:
-    - arch: x86_64
-      epoch: null
-      name: ksh
-      release: 142.el7
-      source: rpm
-      version: '20120801'
+  - arch: x86_64
+    epoch: null
+    name: ksh
+    release: 142.el7
+    source: rpm
+    version: '20120801'
   lcms2:
-    - arch: x86_64
-      epoch: null
-      name: lcms2
-      release: 3.el7
-      source: rpm
-      version: '2.6'
+  - arch: x86_64
+    epoch: null
+    name: lcms2
+    release: 3.el7
+    source: rpm
+    version: '2.6'
   less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
   libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
   libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
   libX11:
-    - arch: i686
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
+  - arch: i686
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
   libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
   libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-    - arch: i686
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  - arch: i686
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
   libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
   libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
   libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
   libXext:
-    - arch: i686
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
+  - arch: i686
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
   libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
   libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
   libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-    - arch: i686
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  - arch: i686
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
   libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
   libXmu:
-    - arch: x86_64
-      epoch: null
-      name: libXmu
-      release: 2.el7
-      source: rpm
-      version: 1.1.2
+  - arch: x86_64
+    epoch: null
+    name: libXmu
+    release: 2.el7
+    source: rpm
+    version: 1.1.2
   libXp:
-    - arch: x86_64
-      epoch: null
-      name: libXp
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.2
+  - arch: x86_64
+    epoch: null
+    name: libXp
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.2
   libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
   libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
   libXt:
-    - arch: x86_64
-      epoch: null
-      name: libXt
-      release: 3.el7
-      source: rpm
-      version: 1.1.5
+  - arch: x86_64
+    epoch: null
+    name: libXt
+    release: 3.el7
+    source: rpm
+    version: 1.1.5
   libXtst:
-    - arch: i686
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
+  - arch: i686
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
   libXv:
-    - arch: x86_64
-      epoch: null
-      name: libXv
-      release: 1.el7
-      source: rpm
-      version: 1.0.11
+  - arch: x86_64
+    epoch: null
+    name: libXv
+    release: 1.el7
+    source: rpm
+    version: 1.0.11
   libXxf86dga:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86dga
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.4
+  - arch: x86_64
+    epoch: null
+    name: libXxf86dga
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.4
   libXxf86misc:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86misc
-      release: 7.1.el7
-      source: rpm
-      version: 1.0.3
+  - arch: x86_64
+    epoch: null
+    name: libXxf86misc
+    release: 7.1.el7
+    source: rpm
+    version: 1.0.3
   libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
   libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
   libaio:
-    - arch: i686
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
+  - arch: i686
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
   libaio-devel:
-    - arch: i686
-      epoch: null
-      name: libaio-devel
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-    - arch: x86_64
-      epoch: null
-      name: libaio-devel
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
+  - arch: i686
+    epoch: null
+    name: libaio-devel
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  - arch: x86_64
+    epoch: null
+    name: libaio-devel
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
   libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
   libattr:
-    - arch: i686
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
+  - arch: i686
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
   libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
   libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
   libcap:
-    - arch: i686
-      epoch: null
-      name: libcap
-      release: 10.el7
-      source: rpm
-      version: '2.22'
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 10.el7
-      source: rpm
-      version: '2.22'
+  - arch: i686
+    epoch: null
+    name: libcap
+    release: 10.el7
+    source: rpm
+    version: '2.22'
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 10.el7
+    source: rpm
+    version: '2.22'
   libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-    - arch: i686
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  - arch: i686
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
   libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
   libcgroup-tools:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup-tools
-      release: 21.el7
-      source: rpm
-      version: '0.41'
+  - arch: x86_64
+    epoch: null
+    name: libcgroup-tools
+    release: 21.el7
+    source: rpm
+    version: '0.41'
   libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
   libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
   libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
   libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-    - arch: i686
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  - arch: i686
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
   libdb-devel:
-    - arch: x86_64
-      epoch: null
-      name: libdb-devel
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb-devel
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
   libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
   libdhash:
-    - arch: x86_64
-      epoch: null
-      name: libdhash
-      release: 32.el7
-      source: rpm
-      version: 0.5.0
+  - arch: x86_64
+    epoch: null
+    name: libdhash
+    release: 32.el7
+    source: rpm
+    version: 0.5.0
   libdmx:
-    - arch: x86_64
-      epoch: null
-      name: libdmx
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
+  - arch: x86_64
+    epoch: null
+    name: libdmx
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
   libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
   libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
   libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
   libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
   libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
   libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
   libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
   libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
   libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-    - arch: i686
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  - arch: i686
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
   libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
   libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
   libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
   libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
   libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-    - arch: i686
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  - arch: i686
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
   libgs:
-    - arch: x86_64
-      epoch: null
-      name: libgs
-      release: 2.el7_7.3
-      source: rpm
-      version: '9.25'
+  - arch: x86_64
+    epoch: null
+    name: libgs
+    release: 2.el7_7.3
+    source: rpm
+    version: '9.25'
   libgudev1:
-    - arch: x86_64
-      epoch: null
-      name: libgudev1
-      release: 78.el7
-      source: rpm
-      version: '219'
+  - arch: x86_64
+    epoch: null
+    name: libgudev1
+    release: 78.el7
+    source: rpm
+    version: '219'
   libhugetlbfs:
-    - arch: x86_64
-      epoch: null
-      name: libhugetlbfs
-      release: 13.el7
-      source: rpm
-      version: '2.16'
+  - arch: x86_64
+    epoch: null
+    name: libhugetlbfs
+    release: 13.el7
+    source: rpm
+    version: '2.16'
   libhugetlbfs-utils:
-    - arch: x86_64
-      epoch: null
-      name: libhugetlbfs-utils
-      release: 13.el7
-      source: rpm
-      version: '2.16'
+  - arch: x86_64
+    epoch: null
+    name: libhugetlbfs-utils
+    release: 13.el7
+    source: rpm
+    version: '2.16'
   libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
   libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
   libipa_hbac:
-    - arch: x86_64
-      epoch: null
-      name: libipa_hbac
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: libipa_hbac
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
   libkadm5:
-    - arch: x86_64
-      epoch: null
-      name: libkadm5
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
+  - arch: x86_64
+    epoch: null
+    name: libkadm5
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
   libldb:
-    - arch: x86_64
-      epoch: null
-      name: libldb
-      release: 2.el7_9
-      source: rpm
-      version: 1.5.4
+  - arch: x86_64
+    epoch: null
+    name: libldb
+    release: 2.el7_9
+    source: rpm
+    version: 1.5.4
   liblockfile:
-    - arch: x86_64
-      epoch: null
-      name: liblockfile
-      release: 17.el7
-      source: rpm
-      version: '1.08'
+  - arch: x86_64
+    epoch: null
+    name: liblockfile
+    release: 17.el7
+    source: rpm
+    version: '1.08'
   libmng:
-    - arch: x86_64
-      epoch: null
-      name: libmng
-      release: 14.el7
-      source: rpm
-      version: 1.0.10
+  - arch: x86_64
+    epoch: null
+    name: libmng
+    release: 14.el7
+    source: rpm
+    version: 1.0.10
   libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
   libmodman:
-    - arch: x86_64
-      epoch: null
-      name: libmodman
-      release: 8.el7
-      source: rpm
-      version: 2.0.1
+  - arch: x86_64
+    epoch: null
+    name: libmodman
+    release: 8.el7
+    source: rpm
+    version: 2.0.1
   libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
   libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
   libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
   libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
   libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
   libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
   libnl:
-    - arch: x86_64
-      epoch: null
-      name: libnl
-      release: 3.el7
-      source: rpm
-      version: 1.1.4
+  - arch: x86_64
+    epoch: null
+    name: libnl
+    release: 3.el7
+    source: rpm
+    version: 1.1.4
   libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
   libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
   libpaper:
-    - arch: x86_64
-      epoch: null
-      name: libpaper
-      release: 8.el7
-      source: rpm
-      version: 1.1.24
+  - arch: x86_64
+    epoch: null
+    name: libpaper
+    release: 8.el7
+    source: rpm
+    version: 1.1.24
   libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
   libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 11.el7
-      source: rpm
-      version: 1.5.3
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 11.el7
+    source: rpm
+    version: 1.5.3
   libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
   libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
   libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
   libpng12:
-    - arch: x86_64
-      epoch: null
-      name: libpng12
-      release: 10.el7
-      source: rpm
-      version: 1.2.50
+  - arch: x86_64
+    epoch: null
+    name: libpng12
+    release: 10.el7
+    source: rpm
+    version: 1.2.50
   libproxy:
-    - arch: x86_64
-      epoch: null
-      name: libproxy
-      release: 11.el7
-      source: rpm
-      version: 0.4.11
+  - arch: x86_64
+    epoch: null
+    name: libproxy
+    release: 11.el7
+    source: rpm
+    version: 0.4.11
   libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
   libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
   libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
   libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
   libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
   libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
   libsmbclient:
-    - arch: x86_64
-      epoch: 0
-      name: libsmbclient
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
+  - arch: x86_64
+    epoch: 0
+    name: libsmbclient
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
   libsoup:
-    - arch: x86_64
-      epoch: null
-      name: libsoup
-      release: 2.el7
-      source: rpm
-      version: 2.62.2
+  - arch: x86_64
+    epoch: null
+    name: libsoup
+    release: 2.el7
+    source: rpm
+    version: 2.62.2
   libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
   libsss_autofs:
-    - arch: x86_64
-      epoch: null
-      name: libsss_autofs
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: libsss_autofs
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   libsss_certmap:
-    - arch: x86_64
-      epoch: null
-      name: libsss_certmap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: libsss_certmap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   libsss_idmap:
-    - arch: x86_64
-      epoch: null
-      name: libsss_idmap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: libsss_idmap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   libsss_nss_idmap:
-    - arch: x86_64
-      epoch: null
-      name: libsss_nss_idmap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: libsss_nss_idmap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   libsss_sudo:
-    - arch: x86_64
-      epoch: null
-      name: libsss_sudo
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: libsss_sudo
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
   libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++-devel
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++-devel
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
   libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
   libtalloc:
-    - arch: x86_64
-      epoch: null
-      name: libtalloc
-      release: 1.el7
-      source: rpm
-      version: 2.1.16
+  - arch: x86_64
+    epoch: null
+    name: libtalloc
+    release: 1.el7
+    source: rpm
+    version: 2.1.16
   libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
   libtdb:
-    - arch: x86_64
-      epoch: null
-      name: libtdb
-      release: 1.el7
-      source: rpm
-      version: 1.3.18
+  - arch: x86_64
+    epoch: null
+    name: libtdb
+    release: 1.el7
+    source: rpm
+    version: 1.3.18
   libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 9.el7
-      source: rpm
-      version: '1.27'
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 9.el7
+    source: rpm
+    version: '1.27'
   libtevent:
-    - arch: x86_64
-      epoch: null
-      name: libtevent
-      release: 1.el7
-      source: rpm
-      version: 0.9.39
+  - arch: x86_64
+    epoch: null
+    name: libtevent
+    release: 1.el7
+    source: rpm
+    version: 0.9.39
   libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
   libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
   libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
   libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
   libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
   libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
   libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
   libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
   libverto-tevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-tevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
+  - arch: x86_64
+    epoch: null
+    name: libverto-tevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
   libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
   libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
   libwbclient:
-    - arch: x86_64
-      epoch: 0
-      name: libwbclient
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
+  - arch: x86_64
+    epoch: 0
+    name: libwbclient
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
   libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-    - arch: i686
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  - arch: i686
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
   libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
   libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
   libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
   libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
   linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
   lm_sensors:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
   lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
   logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
   lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 13.el7
-      source: rpm
-      version: B.02.18
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 13.el7
+    source: rpm
+    version: B.02.18
   lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
   lsscsi:
-    - arch: x86_64
-      epoch: null
-      name: lsscsi
-      release: 6.el7
-      source: rpm
-      version: '0.27'
+  - arch: x86_64
+    epoch: null
+    name: lsscsi
+    release: 6.el7
+    source: rpm
+    version: '0.27'
   lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
   lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 2.el7
-      source: rpm
-      version: 2.02.185
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 2.el7
+    source: rpm
+    version: 2.02.185
   lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 2.el7
-      source: rpm
-      version: 2.02.185
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 2.el7
+    source: rpm
+    version: 2.02.185
   lz4:
-    - arch: i686
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
+  - arch: i686
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
   lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
   m2crypto:
-    - arch: x86_64
-      epoch: null
-      name: m2crypto
-      release: 17.el7
-      source: rpm
-      version: 0.21.1
+  - arch: x86_64
+    epoch: null
+    name: m2crypto
+    release: 17.el7
+    source: rpm
+    version: 0.21.1
   m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
   mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
   mailx:
-    - arch: x86_64
-      epoch: null
-      name: mailx
-      release: 19.el7
-      source: rpm
-      version: '12.5'
+  - arch: x86_64
+    epoch: null
+    name: mailx
+    release: 19.el7
+    source: rpm
+    version: '12.5'
   make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
   man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
   mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
   mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
   mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
   mesa-libGLU:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGLU
-      release: 4.el7
-      source: rpm
-      version: 9.0.0
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGLU
+    release: 4.el7
+    source: rpm
+    version: 9.0.0
   mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
   mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
   microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
   mlocate:
-    - arch: x86_64
-      epoch: null
-      name: mlocate
-      release: 8.el7
-      source: rpm
-      version: '0.26'
+  - arch: x86_64
+    epoch: null
+    name: mlocate
+    release: 8.el7
+    source: rpm
+    version: '0.26'
   mokutil:
-    - arch: x86_64
-      epoch: null
-      name: mokutil
-      release: 8.el7_8
-      source: rpm
-      version: '15'
+  - arch: x86_64
+    epoch: null
+    name: mokutil
+    release: 8.el7_8
+    source: rpm
+    version: '15'
   motif:
-    - arch: x86_64
-      epoch: null
-      name: motif
-      release: 14.el7_5
-      source: rpm
-      version: 2.3.4
+  - arch: x86_64
+    epoch: null
+    name: motif
+    release: 14.el7_5
+    source: rpm
+    version: 2.3.4
   mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
   mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
   ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
   ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
   ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
   net-snmp:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
   net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
   net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
   net-snmp-utils:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-utils
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-utils
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
   net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
   nettle:
-    - arch: x86_64
-      epoch: null
-      name: nettle
-      release: 9.el7_9
-      source: rpm
-      version: 2.7.1
+  - arch: x86_64
+    epoch: null
+    name: nettle
+    release: 9.el7_9
+    source: rpm
+    version: 2.7.1
   newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
   newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
   nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.65.el7
-      source: rpm
-      version: 1.3.0
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.65.el7
+    source: rpm
+    version: 1.3.0
   nscd:
-    - arch: x86_64
-      epoch: null
-      name: nscd
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: nscd
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
   nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
   nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
   nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
   nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
   nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
   nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
   nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
   nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
   ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7_8.2
-      source: rpm
-      version: 4.2.6p5
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7_8.2
+    source: rpm
+    version: 4.2.6p5
   ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7_8.2
-      source: rpm
-      version: 4.2.6p5
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7_8.2
+    source: rpm
+    version: 4.2.6p5
   numactl:
-    - arch: x86_64
-      epoch: null
-      name: numactl
-      release: 3.el7
-      source: rpm
-      version: 2.0.12
+  - arch: x86_64
+    epoch: null
+    name: numactl
+    release: 3.el7
+    source: rpm
+    version: 2.0.12
   numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.12
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.12
   numad:
-    - arch: x86_64
-      epoch: null
-      name: numad
-      release: 18.20150602git.el7
-      source: rpm
-      version: '0.5'
+  - arch: x86_64
+    epoch: null
+    name: numad
+    release: 18.20150602git.el7
+    source: rpm
+    version: '0.5'
   oddjob:
-    - arch: x86_64
-      epoch: null
-      name: oddjob
-      release: 4.el7
-      source: rpm
-      version: 0.31.5
+  - arch: x86_64
+    epoch: null
+    name: oddjob
+    release: 4.el7
+    source: rpm
+    version: 0.31.5
   oddjob-mkhomedir:
-    - arch: x86_64
-      epoch: null
-      name: oddjob-mkhomedir
-      release: 4.el7
-      source: rpm
-      version: 0.31.5
+  - arch: x86_64
+    epoch: null
+    name: oddjob-mkhomedir
+    release: 4.el7
+    source: rpm
+    version: 0.31.5
   openjpeg2:
-    - arch: x86_64
-      epoch: null
-      name: openjpeg2
-      release: 3.el7_7
-      source: rpm
-      version: 2.3.1
+  - arch: x86_64
+    epoch: null
+    name: openjpeg2
+    release: 3.el7_7
+    source: rpm
+    version: 2.3.1
   openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 25.el7_9
-      source: rpm
-      version: 2.4.44
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 25.el7_9
+    source: rpm
+    version: 2.4.44
   openldap-clients:
-    - arch: x86_64
-      epoch: null
-      name: openldap-clients
-      release: 25.el7_9
-      source: rpm
-      version: 2.4.44
+  - arch: x86_64
+    epoch: null
+    name: openldap-clients
+    release: 25.el7_9
+    source: rpm
+    version: 2.4.44
   openscap:
-    - arch: x86_64
-      epoch: null
-      name: openscap
-      release: 4.el7
-      source: rpm
-      version: 1.2.17
+  - arch: x86_64
+    epoch: null
+    name: openscap
+    release: 4.el7
+    source: rpm
+    version: 1.2.17
   openscap-scanner:
-    - arch: x86_64
-      epoch: null
-      name: openscap-scanner
-      release: 4.el7
-      source: rpm
-      version: 1.2.17
+  - arch: x86_64
+    epoch: null
+    name: openscap-scanner
+    release: 4.el7
+    source: rpm
+    version: 1.2.17
   openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
   openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
   openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
   openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 25.el7_9
-      source: rpm
-      version: 1.0.2k
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 25.el7_9
+    source: rpm
+    version: 1.0.2k
   openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 25.el7_9
-      source: rpm
-      version: 1.0.2k
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 25.el7_9
+    source: rpm
+    version: 1.0.2k
   oracleasm-support:
-    - arch: x86_64
-      epoch: null
-      name: oracleasm-support
-      release: 3.el7
-      source: rpm
-      version: 2.1.8
+  - arch: x86_64
+    epoch: null
+    name: oracleasm-support
+    release: 3.el7
+    source: rpm
+    version: 2.1.8
   oracleasmlib:
-    - arch: x86_64
-      epoch: null
-      name: oracleasmlib
-      release: 1.el7
-      source: rpm
-      version: 2.0.12
+  - arch: x86_64
+    epoch: null
+    name: oracleasmlib
+    release: 1.el7
+    source: rpm
+    version: 2.0.12
   os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
   p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
   p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
   pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-    - arch: i686
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  - arch: i686
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
   pam-devel:
-    - arch: x86_64
-      epoch: null
-      name: pam-devel
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: pam-devel
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
   pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
   parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 31.el7
-      source: rpm
-      version: '3.1'
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 31.el7
+    source: rpm
+    version: '3.1'
   passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 5.el7
-      source: rpm
-      version: '0.79'
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 5.el7
+    source: rpm
+    version: '0.79'
   patch:
-    - arch: x86_64
-      epoch: null
-      name: patch
-      release: 12.el7_7
-      source: rpm
-      version: 2.7.1
+  - arch: x86_64
+    epoch: null
+    name: patch
+    release: 12.el7_7
+    source: rpm
+    version: 2.7.1
   pciutils:
-    - arch: x86_64
-      epoch: null
-      name: pciutils
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
+  - arch: x86_64
+    epoch: null
+    name: pciutils
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
   pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
   pcre:
-    - arch: i686
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
+  - arch: i686
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
   perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-B-Lint:
-    - arch: noarch
-      epoch: null
-      name: perl-B-Lint
-      release: 3.el7
-      source: rpm
-      version: '1.17'
+  - arch: noarch
+    epoch: null
+    name: perl-B-Lint
+    release: 3.el7
+    source: rpm
+    version: '1.17'
   perl-Business-ISBN:
-    - arch: noarch
-      epoch: null
-      name: perl-Business-ISBN
-      release: 2.el7
-      source: rpm
-      version: '2.06'
+  - arch: noarch
+    epoch: null
+    name: perl-Business-ISBN
+    release: 2.el7
+    source: rpm
+    version: '2.06'
   perl-Business-ISBN-Data:
-    - arch: noarch
-      epoch: null
-      name: perl-Business-ISBN-Data
-      release: 2.el7
-      source: rpm
-      version: '20120719.001'
+  - arch: noarch
+    epoch: null
+    name: perl-Business-ISBN-Data
+    release: 2.el7
+    source: rpm
+    version: '20120719.001'
   perl-CGI:
-    - arch: noarch
-      epoch: null
-      name: perl-CGI
-      release: 4.el7
-      source: rpm
-      version: '3.63'
+  - arch: noarch
+    epoch: null
+    name: perl-CGI
+    release: 4.el7
+    source: rpm
+    version: '3.63'
   perl-CPAN:
-    - arch: noarch
-      epoch: 0
-      name: perl-CPAN
-      release: 299.el7_9
-      source: rpm
-      version: '1.9800'
+  - arch: noarch
+    epoch: 0
+    name: perl-CPAN
+    release: 299.el7_9
+    source: rpm
+    version: '1.9800'
   perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
   perl-Class-ISA:
-    - arch: noarch
-      epoch: null
-      name: perl-Class-ISA
-      release: 1010.el7
-      source: rpm
-      version: '0.36'
+  - arch: noarch
+    epoch: null
+    name: perl-Class-ISA
+    release: 1010.el7
+    source: rpm
+    version: '0.36'
   perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
   perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
   perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
   perl-Digest:
-    - arch: noarch
-      epoch: null
-      name: perl-Digest
-      release: 245.el7
-      source: rpm
-      version: '1.17'
+  - arch: noarch
+    epoch: null
+    name: perl-Digest
+    release: 245.el7
+    source: rpm
+    version: '1.17'
   perl-Digest-MD5:
-    - arch: x86_64
-      epoch: null
-      name: perl-Digest-MD5
-      release: 3.el7
-      source: rpm
-      version: '2.52'
+  - arch: x86_64
+    epoch: null
+    name: perl-Digest-MD5
+    release: 3.el7
+    source: rpm
+    version: '2.52'
   perl-Digest-SHA:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Digest-SHA
-      release: 4.el7
-      source: rpm
-      version: '5.85'
+  - arch: x86_64
+    epoch: 1
+    name: perl-Digest-SHA
+    release: 4.el7
+    source: rpm
+    version: '5.85'
   perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
   perl-Encode-Locale:
-    - arch: noarch
-      epoch: null
-      name: perl-Encode-Locale
-      release: 5.el7
-      source: rpm
-      version: '1.03'
+  - arch: noarch
+    epoch: null
+    name: perl-Encode-Locale
+    release: 5.el7
+    source: rpm
+    version: '1.03'
   perl-Env:
-    - arch: noarch
-      epoch: null
-      name: perl-Env
-      release: 2.el7
-      source: rpm
-      version: '1.04'
+  - arch: noarch
+    epoch: null
+    name: perl-Env
+    release: 2.el7
+    source: rpm
+    version: '1.04'
   perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
   perl-ExtUtils-Install:
-    - arch: noarch
-      epoch: 0
-      name: perl-ExtUtils-Install
-      release: 299.el7_9
-      source: rpm
-      version: '1.58'
+  - arch: noarch
+    epoch: 0
+    name: perl-ExtUtils-Install
+    release: 299.el7_9
+    source: rpm
+    version: '1.58'
   perl-ExtUtils-MakeMaker:
-    - arch: noarch
-      epoch: null
-      name: perl-ExtUtils-MakeMaker
-      release: 3.el7
-      source: rpm
-      version: '6.68'
+  - arch: noarch
+    epoch: null
+    name: perl-ExtUtils-MakeMaker
+    release: 3.el7
+    source: rpm
+    version: '6.68'
   perl-ExtUtils-Manifest:
-    - arch: noarch
-      epoch: null
-      name: perl-ExtUtils-Manifest
-      release: 244.el7
-      source: rpm
-      version: '1.61'
+  - arch: noarch
+    epoch: null
+    name: perl-ExtUtils-Manifest
+    release: 244.el7
+    source: rpm
+    version: '1.61'
   perl-ExtUtils-ParseXS:
-    - arch: noarch
-      epoch: 1
-      name: perl-ExtUtils-ParseXS
-      release: 3.el7
-      source: rpm
-      version: '3.18'
+  - arch: noarch
+    epoch: 1
+    name: perl-ExtUtils-ParseXS
+    release: 3.el7
+    source: rpm
+    version: '3.18'
   perl-FCGI:
-    - arch: x86_64
-      epoch: 1
-      name: perl-FCGI
-      release: 8.el7
-      source: rpm
-      version: '0.74'
+  - arch: x86_64
+    epoch: 1
+    name: perl-FCGI
+    release: 8.el7
+    source: rpm
+    version: '0.74'
   perl-File-CheckTree:
-    - arch: noarch
-      epoch: null
-      name: perl-File-CheckTree
-      release: 3.el7
-      source: rpm
-      version: '4.42'
+  - arch: noarch
+    epoch: null
+    name: perl-File-CheckTree
+    release: 3.el7
+    source: rpm
+    version: '4.42'
   perl-File-Listing:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Listing
-      release: 7.el7
-      source: rpm
-      version: '6.04'
+  - arch: noarch
+    epoch: null
+    name: perl-File-Listing
+    release: 7.el7
+    source: rpm
+    version: '6.04'
   perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
   perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
   perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
   perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
   perl-HTML-Parser:
-    - arch: x86_64
-      epoch: null
-      name: perl-HTML-Parser
-      release: 4.el7
-      source: rpm
-      version: '3.71'
+  - arch: x86_64
+    epoch: null
+    name: perl-HTML-Parser
+    release: 4.el7
+    source: rpm
+    version: '3.71'
   perl-HTML-Tagset:
-    - arch: noarch
-      epoch: null
-      name: perl-HTML-Tagset
-      release: 15.el7
-      source: rpm
-      version: '3.20'
+  - arch: noarch
+    epoch: null
+    name: perl-HTML-Tagset
+    release: 15.el7
+    source: rpm
+    version: '3.20'
   perl-HTTP-Cookies:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Cookies
-      release: 5.el7
-      source: rpm
-      version: '6.01'
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Cookies
+    release: 5.el7
+    source: rpm
+    version: '6.01'
   perl-HTTP-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Daemon
-      release: 8.el7
-      source: rpm
-      version: '6.01'
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Daemon
+    release: 8.el7
+    source: rpm
+    version: '6.01'
   perl-HTTP-Date:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Date
-      release: 8.el7
-      source: rpm
-      version: '6.02'
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Date
+    release: 8.el7
+    source: rpm
+    version: '6.02'
   perl-HTTP-Message:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Message
-      release: 6.el7
-      source: rpm
-      version: '6.06'
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Message
+    release: 6.el7
+    source: rpm
+    version: '6.06'
   perl-HTTP-Negotiate:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Negotiate
-      release: 5.el7
-      source: rpm
-      version: '6.01'
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Negotiate
+    release: 5.el7
+    source: rpm
+    version: '6.01'
   perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
   perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
   perl-IO-HTML:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-HTML
-      release: 2.el7
-      source: rpm
-      version: '1.00'
+  - arch: noarch
+    epoch: null
+    name: perl-IO-HTML
+    release: 2.el7
+    source: rpm
+    version: '1.00'
   perl-IO-Socket-IP:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Socket-IP
-      release: 5.el7
-      source: rpm
-      version: '0.21'
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Socket-IP
+    release: 5.el7
+    source: rpm
+    version: '0.21'
   perl-IO-Socket-SSL:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Socket-SSL
-      release: 7.el7
-      source: rpm
-      version: '1.94'
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Socket-SSL
+    release: 7.el7
+    source: rpm
+    version: '1.94'
   perl-LWP-MediaTypes:
-    - arch: noarch
-      epoch: null
-      name: perl-LWP-MediaTypes
-      release: 2.el7
-      source: rpm
-      version: '6.02'
+  - arch: noarch
+    epoch: null
+    name: perl-LWP-MediaTypes
+    release: 2.el7
+    source: rpm
+    version: '6.02'
   perl-Locale-Codes:
-    - arch: noarch
-      epoch: null
-      name: perl-Locale-Codes
-      release: 2.el7
-      source: rpm
-      version: '3.26'
+  - arch: noarch
+    epoch: null
+    name: perl-Locale-Codes
+    release: 2.el7
+    source: rpm
+    version: '3.26'
   perl-Locale-Maketext:
-    - arch: noarch
-      epoch: null
-      name: perl-Locale-Maketext
-      release: 3.el7
-      source: rpm
-      version: '1.23'
+  - arch: noarch
+    epoch: null
+    name: perl-Locale-Maketext
+    release: 3.el7
+    source: rpm
+    version: '1.23'
   perl-Module-Pluggable:
-    - arch: noarch
-      epoch: 1
-      name: perl-Module-Pluggable
-      release: 3.el7
-      source: rpm
-      version: '4.8'
+  - arch: noarch
+    epoch: 1
+    name: perl-Module-Pluggable
+    release: 3.el7
+    source: rpm
+    version: '4.8'
   perl-Mozilla-CA:
-    - arch: noarch
-      epoch: null
-      name: perl-Mozilla-CA
-      release: 5.el7
-      source: rpm
-      version: '20130114'
+  - arch: noarch
+    epoch: null
+    name: perl-Mozilla-CA
+    release: 5.el7
+    source: rpm
+    version: '20130114'
   perl-Net-HTTP:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-HTTP
-      release: 2.el7
-      source: rpm
-      version: '6.06'
+  - arch: noarch
+    epoch: null
+    name: perl-Net-HTTP
+    release: 2.el7
+    source: rpm
+    version: '6.06'
   perl-Net-LibIDN:
-    - arch: x86_64
-      epoch: null
-      name: perl-Net-LibIDN
-      release: 15.el7
-      source: rpm
-      version: '0.12'
+  - arch: x86_64
+    epoch: null
+    name: perl-Net-LibIDN
+    release: 15.el7
+    source: rpm
+    version: '0.12'
   perl-Net-SSLeay:
-    - arch: x86_64
-      epoch: null
-      name: perl-Net-SSLeay
-      release: 6.el7
-      source: rpm
-      version: '1.55'
+  - arch: x86_64
+    epoch: null
+    name: perl-Net-SSLeay
+    release: 6.el7
+    source: rpm
+    version: '1.55'
   perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
   perl-Pod-Checker:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Checker
-      release: 2.el7
-      source: rpm
-      version: '1.60'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Checker
+    release: 2.el7
+    source: rpm
+    version: '1.60'
   perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
   perl-Pod-LaTeX:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-LaTeX
-      release: 2.el7
-      source: rpm
-      version: '0.61'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-LaTeX
+    release: 2.el7
+    source: rpm
+    version: '0.61'
   perl-Pod-Parser:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Parser
-      release: 2.el7
-      source: rpm
-      version: '1.61'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Parser
+    release: 2.el7
+    source: rpm
+    version: '1.61'
   perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
   perl-Pod-Plainer:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Plainer
-      release: 4.el7
-      source: rpm
-      version: '1.03'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Plainer
+    release: 4.el7
+    source: rpm
+    version: '1.03'
   perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
   perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
   perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
   perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 4.el7
-      source: rpm
-      version: '2.010'
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 4.el7
+    source: rpm
+    version: '2.010'
   perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
   perl-Sys-Syslog:
-    - arch: x86_64
-      epoch: null
-      name: perl-Sys-Syslog
-      release: 3.el7
-      source: rpm
-      version: '0.33'
+  - arch: x86_64
+    epoch: null
+    name: perl-Sys-Syslog
+    release: 3.el7
+    source: rpm
+    version: '0.33'
   perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
   perl-Test-Simple:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Simple
-      release: 243.el7
-      source: rpm
-      version: '0.98'
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Simple
+    release: 243.el7
+    source: rpm
+    version: '0.98'
   perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
   perl-Text-Soundex:
-    - arch: x86_64
-      epoch: null
-      name: perl-Text-Soundex
-      release: 4.el7
-      source: rpm
-      version: '3.04'
+  - arch: x86_64
+    epoch: null
+    name: perl-Text-Soundex
+    release: 4.el7
+    source: rpm
+    version: '3.04'
   perl-Text-Unidecode:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-Unidecode
-      release: 20.el7
-      source: rpm
-      version: '0.04'
+  - arch: noarch
+    epoch: null
+    name: perl-Text-Unidecode
+    release: 20.el7
+    source: rpm
+    version: '0.04'
   perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
   perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
   perl-TimeDate:
-    - arch: noarch
-      epoch: 1
-      name: perl-TimeDate
-      release: 2.el7
-      source: rpm
-      version: '2.30'
+  - arch: noarch
+    epoch: 1
+    name: perl-TimeDate
+    release: 2.el7
+    source: rpm
+    version: '2.30'
   perl-URI:
-    - arch: noarch
-      epoch: null
-      name: perl-URI
-      release: 9.el7
-      source: rpm
-      version: '1.60'
+  - arch: noarch
+    epoch: null
+    name: perl-URI
+    release: 9.el7
+    source: rpm
+    version: '1.60'
   perl-WWW-RobotRules:
-    - arch: noarch
-      epoch: null
-      name: perl-WWW-RobotRules
-      release: 5.el7
-      source: rpm
-      version: '6.02'
+  - arch: noarch
+    epoch: null
+    name: perl-WWW-RobotRules
+    release: 5.el7
+    source: rpm
+    version: '6.02'
   perl-XML-LibXML:
-    - arch: x86_64
-      epoch: 1
-      name: perl-XML-LibXML
-      release: 5.el7
-      source: rpm
-      version: '2.0018'
+  - arch: x86_64
+    epoch: 1
+    name: perl-XML-LibXML
+    release: 5.el7
+    source: rpm
+    version: '2.0018'
   perl-XML-NamespaceSupport:
-    - arch: noarch
-      epoch: null
-      name: perl-XML-NamespaceSupport
-      release: 10.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: perl-XML-NamespaceSupport
+    release: 10.el7
+    source: rpm
+    version: '1.11'
   perl-XML-SAX:
-    - arch: noarch
-      epoch: null
-      name: perl-XML-SAX
-      release: 9.el7
-      source: rpm
-      version: '0.99'
+  - arch: noarch
+    epoch: null
+    name: perl-XML-SAX
+    release: 9.el7
+    source: rpm
+    version: '0.99'
   perl-XML-SAX-Base:
-    - arch: noarch
-      epoch: null
-      name: perl-XML-SAX-Base
-      release: 7.el7
-      source: rpm
-      version: '1.08'
+  - arch: noarch
+    epoch: null
+    name: perl-XML-SAX-Base
+    release: 7.el7
+    source: rpm
+    version: '1.08'
   perl-autodie:
-    - arch: noarch
-      epoch: null
-      name: perl-autodie
-      release: 2.el7
-      source: rpm
-      version: '2.16'
+  - arch: noarch
+    epoch: null
+    name: perl-autodie
+    release: 2.el7
+    source: rpm
+    version: '2.16'
   perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
   perl-devel:
-    - arch: x86_64
-      epoch: 4
-      name: perl-devel
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl-devel
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-libwww-perl:
-    - arch: noarch
-      epoch: null
-      name: perl-libwww-perl
-      release: 2.el7
-      source: rpm
-      version: '6.05'
+  - arch: noarch
+    epoch: null
+    name: perl-libwww-perl
+    release: 2.el7
+    source: rpm
+    version: '6.05'
   perl-local-lib:
-    - arch: noarch
-      epoch: null
-      name: perl-local-lib
-      release: 4.el7
-      source: rpm
-      version: '1.008010'
+  - arch: noarch
+    epoch: null
+    name: perl-local-lib
+    release: 4.el7
+    source: rpm
+    version: '1.008010'
   perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
   perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
   perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
   perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
   pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
   pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
   pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
   plymouth:
-    - arch: x86_64
-      epoch: null
-      name: plymouth
-      release: 0.32.20140113.el7
-      source: rpm
-      version: 0.8.9
+  - arch: x86_64
+    epoch: null
+    name: plymouth
+    release: 0.32.20140113.el7
+    source: rpm
+    version: 0.8.9
   plymouth-core-libs:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-core-libs
-      release: 0.32.20140113.el7
-      source: rpm
-      version: 0.8.9
+  - arch: x86_64
+    epoch: null
+    name: plymouth-core-libs
+    release: 0.32.20140113.el7
+    source: rpm
+    version: 0.8.9
   plymouth-scripts:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-scripts
-      release: 0.32.20140113.el7
-      source: rpm
-      version: 0.8.9
+  - arch: x86_64
+    epoch: null
+    name: plymouth-scripts
+    release: 0.32.20140113.el7
+    source: rpm
+    version: 0.8.9
   policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 33.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 33.el7
+    source: rpm
+    version: '2.5'
   policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 33.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 33.el7
+    source: rpm
+    version: '2.5'
   polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
   polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
   poppler-data:
-    - arch: noarch
-      epoch: null
-      name: poppler-data
-      release: 3.el7
-      source: rpm
-      version: 0.4.6
+  - arch: noarch
+    epoch: null
+    name: poppler-data
+    release: 3.el7
+    source: rpm
+    version: 0.4.6
   popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
   postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
   powertop:
-    - arch: x86_64
-      epoch: null
-      name: powertop
-      release: 1.el7
-      source: rpm
-      version: '2.9'
+  - arch: x86_64
+    epoch: null
+    name: powertop
+    release: 1.el7
+    source: rpm
+    version: '2.9'
   ppp:
-    - arch: x86_64
-      epoch: null
-      name: ppp
-      release: 34.el7_7
-      source: rpm
-      version: 2.4.5
+  - arch: x86_64
+    epoch: null
+    name: ppp
+    release: 34.el7_7
+    source: rpm
+    version: 2.4.5
   procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 26.el7
-      source: rpm
-      version: 3.3.10
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 26.el7
+    source: rpm
+    version: 3.3.10
   psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 16.el7
-      source: rpm
-      version: '22.20'
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 16.el7
+    source: rpm
+    version: '22.20'
   pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
   pyOpenSSL:
-    - arch: x86_64
-      epoch: null
-      name: pyOpenSSL
-      release: 4.el7
-      source: rpm
-      version: 0.13.1
+  - arch: x86_64
+    epoch: null
+    name: pyOpenSSL
+    release: 4.el7
+    source: rpm
+    version: 0.13.1
   pygobject2:
-    - arch: x86_64
-      epoch: null
-      name: pygobject2
-      release: 11.el7
-      source: rpm
-      version: 2.28.6
+  - arch: x86_64
+    epoch: null
+    name: pygobject2
+    release: 11.el7
+    source: rpm
+    version: 2.28.6
   pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
   pyldb:
-    - arch: x86_64
-      epoch: null
-      name: pyldb
-      release: 2.el7_9
-      source: rpm
-      version: 1.5.4
+  - arch: x86_64
+    epoch: null
+    name: pyldb
+    release: 2.el7_9
+    source: rpm
+    version: 1.5.4
   pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
   pyparsing:
-    - arch: noarch
-      epoch: null
-      name: pyparsing
-      release: 9.el7
-      source: rpm
-      version: 1.5.6
+  - arch: noarch
+    epoch: null
+    name: pyparsing
+    release: 9.el7
+    source: rpm
+    version: 1.5.6
   pytalloc:
-    - arch: x86_64
-      epoch: null
-      name: pytalloc
-      release: 1.el7
-      source: rpm
-      version: 2.1.16
+  - arch: x86_64
+    epoch: null
+    name: pytalloc
+    release: 1.el7
+    source: rpm
+    version: 2.1.16
   python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
   python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
   python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
   python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
   python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
   python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
   python-dateutil:
-    - arch: noarch
-      epoch: null
-      name: python-dateutil
-      release: 7.el7
-      source: rpm
-      version: '1.5'
+  - arch: noarch
+    epoch: null
+    name: python-dateutil
+    release: 7.el7
+    source: rpm
+    version: '1.5'
   python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
   python-dmidecode:
-    - arch: x86_64
-      epoch: null
-      name: python-dmidecode
-      release: 3.el7
-      source: rpm
-      version: 3.12.2
+  - arch: x86_64
+    epoch: null
+    name: python-dmidecode
+    release: 3.el7
+    source: rpm
+    version: 3.12.2
   python-ethtool:
-    - arch: x86_64
-      epoch: null
-      name: python-ethtool
-      release: 8.el7
-      source: rpm
-      version: '0.8'
+  - arch: x86_64
+    epoch: null
+    name: python-ethtool
+    release: 8.el7
+    source: rpm
+    version: '0.8'
   python-firewall:
-    - arch: noarch
-      epoch: null
-      name: python-firewall
-      release: 2.el7_7.1
-      source: rpm
-      version: 0.6.3
+  - arch: noarch
+    epoch: null
+    name: python-firewall
+    release: 2.el7_7.1
+    source: rpm
+    version: 0.6.3
   python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
   python-gudev:
-    - arch: x86_64
-      epoch: null
-      name: python-gudev
-      release: 7.el7
-      source: rpm
-      version: '147.2'
+  - arch: x86_64
+    epoch: null
+    name: python-gudev
+    release: 7.el7
+    source: rpm
+    version: '147.2'
   python-hwdata:
-    - arch: noarch
-      epoch: null
-      name: python-hwdata
-      release: 4.el7
-      source: rpm
-      version: 1.7.3
+  - arch: noarch
+    epoch: null
+    name: python-hwdata
+    release: 4.el7
+    source: rpm
+    version: 1.7.3
   python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
   python-inotify:
-    - arch: noarch
-      epoch: null
-      name: python-inotify
-      release: 4.el7
-      source: rpm
-      version: 0.9.4
+  - arch: noarch
+    epoch: null
+    name: python-inotify
+    release: 4.el7
+    source: rpm
+    version: 0.9.4
   python-ipaddr:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddr
-      release: 2.el7
-      source: rpm
-      version: 2.1.11
+  - arch: noarch
+    epoch: null
+    name: python-ipaddr
+    release: 2.el7
+    source: rpm
+    version: 2.1.11
   python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
   python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
   python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
   python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
   python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
   python-magic:
-    - arch: noarch
-      epoch: null
-      name: python-magic
-      release: 36.el7
-      source: rpm
-      version: '5.11'
+  - arch: noarch
+    epoch: null
+    name: python-magic
+    release: 36.el7
+    source: rpm
+    version: '5.11'
   python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
   python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
   python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
   python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
   python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
   python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
   python-slip:
-    - arch: noarch
-      epoch: null
-      name: python-slip
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
+  - arch: noarch
+    epoch: null
+    name: python-slip
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
   python-slip-dbus:
-    - arch: noarch
-      epoch: null
-      name: python-slip-dbus
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
+  - arch: noarch
+    epoch: null
+    name: python-slip-dbus
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
   python-sssdconfig:
-    - arch: noarch
-      epoch: null
-      name: python-sssdconfig
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: noarch
+    epoch: null
+    name: python-sssdconfig
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   python-syspurpose:
-    - arch: x86_64
-      epoch: null
-      name: python-syspurpose
-      release: 3.el7_7
-      source: rpm
-      version: 1.24.13
+  - arch: x86_64
+    epoch: null
+    name: python-syspurpose
+    release: 3.el7_7
+    source: rpm
+    version: 1.24.13
   python-tdb:
-    - arch: x86_64
-      epoch: null
-      name: python-tdb
-      release: 1.el7
-      source: rpm
-      version: 1.3.18
+  - arch: x86_64
+    epoch: null
+    name: python-tdb
+    release: 1.el7
+    source: rpm
+    version: 1.3.18
   python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
   python2-futures:
-    - arch: noarch
-      epoch: null
-      name: python2-futures
-      release: 5.el7
-      source: rpm
-      version: 3.1.1
+  - arch: noarch
+    epoch: null
+    name: python2-futures
+    release: 5.el7
+    source: rpm
+    version: 3.1.1
   python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
   python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
   python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_8
-      source: rpm
-      version: 9.0.3
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_8
+    source: rpm
+    version: 9.0.3
   python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
   pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
   qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
   qt:
-    - arch: x86_64
-      epoch: 1
-      name: qt
-      release: 9.el7_9
-      source: rpm
-      version: 4.8.7
+  - arch: x86_64
+    epoch: 1
+    name: qt
+    release: 9.el7_9
+    source: rpm
+    version: 4.8.7
   qt-settings:
-    - arch: noarch
-      epoch: null
-      name: qt-settings
-      release: 23.10.el7_7
-      source: rpm
-      version: '19'
+  - arch: noarch
+    epoch: null
+    name: qt-settings
+    release: 23.10.el7_7
+    source: rpm
+    version: '19'
   qt-x11:
-    - arch: x86_64
-      epoch: 1
-      name: qt-x11
-      release: 9.el7_9
-      source: rpm
-      version: 4.8.7
+  - arch: x86_64
+    epoch: 1
+    name: qt-x11
+    release: 9.el7_9
+    source: rpm
+    version: 4.8.7
   qt3:
-    - arch: x86_64
-      epoch: null
-      name: qt3
-      release: 51.el7
-      source: rpm
-      version: 3.3.8b
+  - arch: x86_64
+    epoch: null
+    name: qt3
+    release: 51.el7
+    source: rpm
+    version: 3.3.8b
   qualys-cloud-agent:
-    - arch: x86_64
-      epoch: null
-      name: qualys-cloud-agent
-      release: '49'
-      source: rpm
-      version: 4.8.0
+  - arch: x86_64
+    epoch: null
+    name: qualys-cloud-agent
+    release: '49'
+    source: rpm
+    version: 4.8.0
   quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
   quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
   rdma-core:
-    - arch: i686
-      epoch: null
-      name: rdma-core
-      release: 3.el7
-      source: rpm
-      version: '22.1'
-    - arch: x86_64
-      epoch: null
-      name: rdma-core
-      release: 3.el7
-      source: rpm
-      version: '22.1'
+  - arch: i686
+    epoch: null
+    name: rdma-core
+    release: 3.el7
+    source: rpm
+    version: '22.1'
+  - arch: x86_64
+    epoch: null
+    name: rdma-core
+    release: 3.el7
+    source: rpm
+    version: '22.1'
   readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
   realmd:
-    - arch: x86_64
-      epoch: null
-      name: realmd
-      release: 11.el7
-      source: rpm
-      version: 0.16.1
+  - arch: x86_64
+    epoch: null
+    name: realmd
+    release: 11.el7
+    source: rpm
+    version: 0.16.1
   redhat-logos:
-    - arch: noarch
-      epoch: null
-      name: redhat-logos
-      release: 1.el7
-      source: rpm
-      version: 70.7.0
+  - arch: noarch
+    epoch: null
+    name: redhat-logos
+    release: 1.el7
+    source: rpm
+    version: 70.7.0
   redhat-lsb:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb
-      release: 27.el7
-      source: rpm
-      version: '4.1'
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb
+    release: 27.el7
+    source: rpm
+    version: '4.1'
   redhat-lsb-core:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-core
-      release: 27.el7
-      source: rpm
-      version: '4.1'
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-core
+    release: 27.el7
+    source: rpm
+    version: '4.1'
   redhat-lsb-cxx:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-cxx
-      release: 27.el7
-      source: rpm
-      version: '4.1'
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-cxx
+    release: 27.el7
+    source: rpm
+    version: '4.1'
   redhat-lsb-desktop:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-desktop
-      release: 27.el7
-      source: rpm
-      version: '4.1'
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-desktop
+    release: 27.el7
+    source: rpm
+    version: '4.1'
   redhat-lsb-languages:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-languages
-      release: 27.el7
-      source: rpm
-      version: '4.1'
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-languages
+    release: 27.el7
+    source: rpm
+    version: '4.1'
   redhat-lsb-printing:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-printing
-      release: 27.el7
-      source: rpm
-      version: '4.1'
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-printing
+    release: 27.el7
+    source: rpm
+    version: '4.1'
   redhat-lsb-submod-multimedia:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-submod-multimedia
-      release: 27.el7
-      source: rpm
-      version: '4.1'
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-submod-multimedia
+    release: 27.el7
+    source: rpm
+    version: '4.1'
   redhat-lsb-submod-security:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-submod-security
-      release: 27.el7
-      source: rpm
-      version: '4.1'
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-submod-security
+    release: 27.el7
+    source: rpm
+    version: '4.1'
   redhat-release-server:
-    - arch: x86_64
-      epoch: null
-      name: redhat-release-server
-      release: 10.el7
-      source: rpm
-      version: '7.7'
+  - arch: x86_64
+    epoch: null
+    name: redhat-release-server
+    release: 10.el7
+    source: rpm
+    version: '7.7'
   redhat-support-lib-python:
-    - arch: noarch
-      epoch: null
-      name: redhat-support-lib-python
-      release: 6.el7
-      source: rpm
-      version: 0.9.7
+  - arch: noarch
+    epoch: null
+    name: redhat-support-lib-python
+    release: 6.el7
+    source: rpm
+    version: 0.9.7
   redhat-support-tool:
-    - arch: noarch
-      epoch: null
-      name: redhat-support-tool
-      release: 1.el7
-      source: rpm
-      version: 0.9.11
+  - arch: noarch
+    epoch: null
+    name: redhat-support-tool
+    release: 1.el7
+    source: rpm
+    version: 0.9.11
   rhn-client-tools:
-    - arch: x86_64
-      epoch: null
-      name: rhn-client-tools
-      release: 24.el7
-      source: rpm
-      version: 2.0.2
+  - arch: x86_64
+    epoch: null
+    name: rhn-client-tools
+    release: 24.el7
+    source: rpm
+    version: 2.0.2
   rhnlib:
-    - arch: noarch
-      epoch: null
-      name: rhnlib
-      release: 8.el7
-      source: rpm
-      version: 2.5.65
+  - arch: noarch
+    epoch: null
+    name: rhnlib
+    release: 8.el7
+    source: rpm
+    version: 2.5.65
   rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
   rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 48.el7
-      source: rpm
-      version: 0.2.0
+  - arch: x86_64
+    epoch: null
+    name: rpcbind
+    release: 48.el7
+    source: rpm
+    version: 0.2.0
   rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
   rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
   rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
   rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
   rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
   rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 52.el7
-      source: rpm
-      version: 8.24.0
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 52.el7
+    source: rpm
+    version: 8.24.0
   samba-client-libs:
-    - arch: x86_64
-      epoch: 0
-      name: samba-client-libs
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
+  - arch: x86_64
+    epoch: 0
+    name: samba-client-libs
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
   samba-common:
-    - arch: noarch
-      epoch: 0
-      name: samba-common
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
+  - arch: noarch
+    epoch: 0
+    name: samba-common
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
   samba-common-libs:
-    - arch: x86_64
-      epoch: 0
-      name: samba-common-libs
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
+  - arch: x86_64
+    epoch: 0
+    name: samba-common-libs
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
   samba-common-tools:
-    - arch: x86_64
-      epoch: 0
-      name: samba-common-tools
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
+  - arch: x86_64
+    epoch: 0
+    name: samba-common-tools
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
   samba-libs:
-    - arch: x86_64
-      epoch: 0
-      name: samba-libs
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
+  - arch: x86_64
+    epoch: 0
+    name: samba-libs
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
   scap-security-guide:
-    - arch: noarch
-      epoch: null
-      name: scap-security-guide
-      release: 13.el7
-      source: rpm
-      version: 0.1.43
+  - arch: noarch
+    epoch: null
+    name: scap-security-guide
+    release: 13.el7
+    source: rpm
+    version: 0.1.43
   screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
   sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
   selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 252.el7.1
-      source: rpm
-      version: 3.13.1
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 252.el7.1
+    source: rpm
+    version: 3.13.1
   selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 252.el7.1
-      source: rpm
-      version: 3.13.1
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 252.el7.1
+    source: rpm
+    version: 3.13.1
   setools-console:
-    - arch: x86_64
-      epoch: null
-      name: setools-console
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
+  - arch: x86_64
+    epoch: null
+    name: setools-console
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
   setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
   setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
   sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 18.el7_7.1
-      source: rpm
-      version: '1.37'
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 18.el7_7.1
+    source: rpm
+    version: '1.37'
   sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 18.el7_7.1
-      source: rpm
-      version: '1.37'
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 18.el7_7.1
+    source: rpm
+    version: '1.37'
   shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
   shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
   shim-unsigned:
-    - arch: x86_64
-      epoch: null
-      name: shim-unsigned
-      release: 1.el7
-      source: rpm
-      version: '0.9'
+  - arch: x86_64
+    epoch: null
+    name: shim-unsigned
+    release: 1.el7
+    source: rpm
+    version: '0.9'
   shim-x64:
-    - arch: x86_64
-      epoch: null
-      name: shim-x64
-      release: 8.el7_8
-      source: rpm
-      version: '15'
+  - arch: x86_64
+    epoch: null
+    name: shim-x64
+    release: 8.el7_8
+    source: rpm
+    version: '15'
   slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
   smartmontools:
-    - arch: x86_64
-      epoch: 1
-      name: smartmontools
-      release: 1.el7
-      source: rpm
-      version: '7.0'
+  - arch: x86_64
+    epoch: 1
+    name: smartmontools
+    release: 1.el7
+    source: rpm
+    version: '7.0'
   smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
   snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
   sos:
-    - arch: noarch
-      epoch: null
-      name: sos
-      release: 6.el7_7
-      source: rpm
-      version: '3.7'
+  - arch: noarch
+    epoch: null
+    name: sos
+    release: 6.el7_7
+    source: rpm
+    version: '3.7'
   spax:
-    - arch: x86_64
-      epoch: null
-      name: spax
-      release: 13.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: spax
+    release: 13.el7
+    source: rpm
+    version: 1.5.2
   sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
   sssd:
-    - arch: x86_64
-      epoch: null
-      name: sssd
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   sssd-ad:
-    - arch: x86_64
-      epoch: null
-      name: sssd-ad
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd-ad
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   sssd-client:
-    - arch: x86_64
-      epoch: null
-      name: sssd-client
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd-client
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   sssd-common:
-    - arch: x86_64
-      epoch: null
-      name: sssd-common
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd-common
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   sssd-common-pac:
-    - arch: x86_64
-      epoch: null
-      name: sssd-common-pac
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd-common-pac
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   sssd-ipa:
-    - arch: x86_64
-      epoch: null
-      name: sssd-ipa
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd-ipa
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   sssd-krb5:
-    - arch: x86_64
-      epoch: null
-      name: sssd-krb5
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd-krb5
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   sssd-krb5-common:
-    - arch: x86_64
-      epoch: null
-      name: sssd-krb5-common
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd-krb5-common
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   sssd-ldap:
-    - arch: x86_64
-      epoch: null
-      name: sssd-ldap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd-ldap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   sssd-proxy:
-    - arch: x86_64
-      epoch: null
-      name: sssd-proxy
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
+  - arch: x86_64
+    epoch: null
+    name: sssd-proxy
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
   strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 9.el7
-      source: rpm
-      version: '4.12'
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 9.el7
+    source: rpm
+    version: '4.12'
   subscription-manager:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager
-      release: 1.el7
-      source: rpm
-      version: 1.24.26
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager
+    release: 1.el7
+    source: rpm
+    version: 1.24.26
   subscription-manager-rhsm:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm
-      release: 1.el7
-      source: rpm
-      version: 1.24.26
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm
+    release: 1.el7
+    source: rpm
+    version: 1.24.26
   subscription-manager-rhsm-certificates:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm-certificates
-      release: 1.el7
-      source: rpm
-      version: 1.24.26
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm-certificates
+    release: 1.el7
+    source: rpm
+    version: 1.24.26
   sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.1
-      source: rpm
-      version: 1.8.23
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.1
+    source: rpm
+    version: 1.8.23
   sysfsutils:
-    - arch: x86_64
-      epoch: null
-      name: sysfsutils
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: sysfsutils
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
   sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 18.el7
-      source: rpm
-      version: 10.1.5
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 18.el7
+    source: rpm
+    version: 10.1.5
   systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7
-      source: rpm
-      version: '219'
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7
+    source: rpm
+    version: '219'
   systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7
-      source: rpm
-      version: '219'
-    - arch: i686
-      epoch: null
-      name: systemd-libs
-      release: 78.el7
-      source: rpm
-      version: '219'
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7
+    source: rpm
+    version: '219'
+  - arch: i686
+    epoch: null
+    name: systemd-libs
+    release: 78.el7
+    source: rpm
+    version: '219'
   systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7
-      source: rpm
-      version: '219'
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7
+    source: rpm
+    version: '219'
   systemtap-sdt-devel:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-sdt-devel
-      release: 9.el7
-      source: rpm
-      version: '4.0'
+  - arch: x86_64
+    epoch: null
+    name: systemtap-sdt-devel
+    release: 9.el7
+    source: rpm
+    version: '4.0'
   sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
   tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
   tcl:
-    - arch: x86_64
-      epoch: 1
-      name: tcl
-      release: 8.el7
-      source: rpm
-      version: 8.5.13
+  - arch: x86_64
+    epoch: 1
+    name: tcl
+    release: 8.el7
+    source: rpm
+    version: 8.5.13
   tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
   tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
   tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
   teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 9.el7
-      source: rpm
-      version: '1.27'
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 9.el7
+    source: rpm
+    version: '1.27'
   telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 65.el7_8
-      source: rpm
-      version: '0.17'
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 65.el7_8
+    source: rpm
+    version: '0.17'
   time:
-    - arch: x86_64
-      epoch: null
-      name: time
-      release: 45.el7
-      source: rpm
-      version: '1.7'
+  - arch: x86_64
+    epoch: null
+    name: time
+    release: 45.el7
+    source: rpm
+    version: '1.7'
   tk:
-    - arch: x86_64
-      epoch: 1
-      name: tk
-      release: 6.el7
-      source: rpm
-      version: 8.5.13
+  - arch: x86_64
+    epoch: 1
+    name: tk
+    release: 6.el7
+    source: rpm
+    version: 8.5.13
   traceroute:
-    - arch: x86_64
-      epoch: 3
-      name: traceroute
-      release: 2.el7
-      source: rpm
-      version: 2.0.22
+  - arch: x86_64
+    epoch: 3
+    name: traceroute
+    release: 2.el7
+    source: rpm
+    version: 2.0.22
   tree:
-    - arch: x86_64
-      epoch: null
-      name: tree
-      release: 10.el7
-      source: rpm
-      version: 1.6.0
+  - arch: x86_64
+    epoch: null
+    name: tree
+    release: 10.el7
+    source: rpm
+    version: 1.6.0
   trousers:
-    - arch: x86_64
-      epoch: null
-      name: trousers
-      release: 2.el7
-      source: rpm
-      version: 0.3.14
+  - arch: x86_64
+    epoch: null
+    name: trousers
+    release: 2.el7
+    source: rpm
+    version: 0.3.14
   tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 5.el7_7.1
-      source: rpm
-      version: 2.11.0
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 5.el7_7.1
+    source: rpm
+    version: 2.11.0
   tuned-utils:
-    - arch: noarch
-      epoch: null
-      name: tuned-utils
-      release: 5.el7_7.1
-      source: rpm
-      version: 2.11.0
+  - arch: noarch
+    epoch: null
+    name: tuned-utils
+    release: 5.el7_7.1
+    source: rpm
+    version: 2.11.0
   tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019c
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019c
   unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
   urw-base35-bookman-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-bookman-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-bookman-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-c059-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-c059-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-c059-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-d050000l-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-d050000l-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-d050000l-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-fonts-common
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-fonts-common
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-gothic-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-gothic-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-gothic-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-nimbus-mono-ps-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-nimbus-mono-ps-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-nimbus-mono-ps-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-nimbus-roman-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-nimbus-roman-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-nimbus-roman-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-nimbus-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-nimbus-sans-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-nimbus-sans-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-p052-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-p052-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-p052-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-standard-symbols-ps-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-standard-symbols-ps-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-standard-symbols-ps-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   urw-base35-z003-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-z003-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
+  - arch: noarch
+    epoch: null
+    name: urw-base35-z003-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
   usermode:
-    - arch: x86_64
-      epoch: null
-      name: usermode
-      release: 6.el7
-      source: rpm
-      version: '1.111'
+  - arch: x86_64
+    epoch: null
+    name: usermode
+    release: 6.el7
+    source: rpm
+    version: '1.111'
   ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
   util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
   vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
   vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
   vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
   vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
   virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
   wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
   which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
   wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
   xdg-utils:
-    - arch: noarch
-      epoch: null
-      name: xdg-utils
-      release: 0.17.20120809git.el7
-      source: rpm
-      version: 1.1.0
+  - arch: noarch
+    epoch: null
+    name: xdg-utils
+    release: 0.17.20120809git.el7
+    source: rpm
+    version: 1.1.0
   xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 20.el7
-      source: rpm
-      version: 4.5.0
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 20.el7
+    source: rpm
+    version: 4.5.0
   xinetd:
-    - arch: x86_64
-      epoch: 2
-      name: xinetd
-      release: 13.el7
-      source: rpm
-      version: 2.3.15
+  - arch: x86_64
+    epoch: 2
+    name: xinetd
+    release: 13.el7
+    source: rpm
+    version: 2.3.15
   xml-common:
-    - arch: noarch
-      epoch: null
-      name: xml-common
-      release: 39.el7
-      source: rpm
-      version: 0.6.3
+  - arch: noarch
+    epoch: null
+    name: xml-common
+    release: 39.el7
+    source: rpm
+    version: 0.6.3
   xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
   xorg-x11-server-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-server-utils
-      release: 20.el7
-      source: rpm
-      version: '7.7'
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-server-utils
+    release: 20.el7
+    source: rpm
+    version: '7.7'
   xorg-x11-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-utils
-      release: 23.el7
-      source: rpm
-      version: '7.5'
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-utils
+    release: 23.el7
+    source: rpm
+    version: '7.5'
   xorg-x11-xauth:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-xauth
-      release: 1.el7
-      source: rpm
-      version: 1.0.9
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-xauth
+    release: 1.el7
+    source: rpm
+    version: 1.0.9
   xorg-x11-xbitmaps:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-xbitmaps
-      release: 6.el7
-      source: rpm
-      version: 1.1.1
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-xbitmaps
+    release: 6.el7
+    source: rpm
+    version: 1.1.1
   xorg-x11-xinit:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-xinit
-      release: 2.el7
-      source: rpm
-      version: 1.3.4
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-xinit
+    release: 2.el7
+    source: rpm
+    version: 1.3.4
   xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
   xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-    - arch: i686
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  - arch: i686
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
   yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 163.el7
-      source: rpm
-      version: 3.4.3
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 163.el7
+    source: rpm
+    version: 3.4.3
   yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
   yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 52.el7
-      source: rpm
-      version: 1.1.31
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 52.el7
+    source: rpm
+    version: 1.1.31
   zlib:
-    - arch: i686
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
+  - arch: i686
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
 processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '54'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '63'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '64'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '66'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '67'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '71'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '72'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '73'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '74'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '77'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '78'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '81'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '82'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '83'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '84'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '86'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '88'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '89'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '90'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '91'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '92'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '93'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '94'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '95'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '96'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '97'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '98'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '99'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '105'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '106'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '107'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '108'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '118'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '119'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '121'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '123'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '137'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '176'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '365'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '366'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '367'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '369'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '370'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '371'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '373'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '413'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '414'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '512'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '612'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '613'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '624'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '625'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '638'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '639'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '640'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '641'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '642'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '643'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '644'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '645'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '646'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '647'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '648'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '649'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '732'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '765'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '768'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '810'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '811'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '812'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '813'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '814'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1167'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1168'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1169'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1170'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1171'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1172'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1184'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1185'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1186'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1188'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1195'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1196'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1197'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1198'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1199'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1200'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1201'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1202'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1204'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1205'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1207'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1208'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1210'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1211'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1213'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1214'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1217'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1218'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1219'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1222'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1224'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1225'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1227'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1228'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1237'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1238'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1240'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1241'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1243'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1244'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1246'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1247'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1258'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1259'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1260'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1261'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1262'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1263'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1271'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1273'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1274'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1275'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1277'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1278'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1279'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1280'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1281'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1282'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1283'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1294'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1297'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1298'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1299'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1300'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1301'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1302'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1303'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1304'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1311'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1312'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1313'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1315'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1316'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1318'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1319'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1321'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1322'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1324'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1325'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1326'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1329'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1330'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1331'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1332'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1333'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1334'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1335'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1350'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1351'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1353'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1354'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1355'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1356'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1357'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1358'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1359'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1360'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1361'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1362'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1363'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1364'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1365'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1366'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1367'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1368'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1370'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1371'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1372'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1373'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1374'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1375'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1385'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1386'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1387'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1388'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1389'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1401'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1402'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1403'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1404'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1405'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1406'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1413'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1414'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1415'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1416'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1417'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1418'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1419'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1420'
-    ppid: '2'
-    user: root
-  - cmdline: /opt/CrowdStrike/falcond
-    pid: '1436'
-    ppid: '1'
-    user: root
-  - cmdline: falcon-sensor
-    pid: '1438'
-    ppid: '1436'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '1448'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '1494'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '1499'
-    ppid: '1'
-    user: polkitd
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '1500'
-    ppid: '1'
-    user: dbus
-  - cmdline: '/usr/sbin/ntpd -u ntp:ntp -u ntp:ntp -p /var/run/ntpd.pid -g'
-    pid: '1514'
-    ppid: '1'
-    user: ntp
-  - cmdline: /usr/sbin/NetworkManager --no-daemon
-    pid: '1516'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sssd -i --logger=files
-    pid: '1520'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/rpcbind -w
-    pid: '1564'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/nscd
-    pid: '1597'
-    ppid: '1'
-    user: nscd
-  - cmdline: >-
-      /usr/libexec/sssd/sssd_be --domain ES.WCORP.CARREFOUR.COM --uid 0 --gid 0
-      --logger=files
-    pid: '2392'
-    ppid: '1520'
-    user: root
-  - cmdline: >-
-      /usr/local/avamar/bin/avagent.bin --bindir="/usr/local/avamar/bin"
-      --vardir="/usr/local/avamar/var" --sysdir="/usr/local/avamar/etc"
-      --logfile="/usr/local/avamar/var/avagent.log"
-    pid: '2479'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/vmtoolsd
-    pid: '2490'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/vmware-vgauth/VGAuthService -s
-    pid: '2583'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
-    pid: '2697'
-    ppid: '1520'
-    user: root
-  - cmdline: /usr/libexec/sssd/sssd_pam --uid 0 --gid 0 --logger=files
-    pid: '2698'
-    ppid: '1520'
-    user: root
-  - cmdline: /usr/libexec/sssd/sssd_pac --uid 0 --gid 0 --logger=files
-    pid: '2699'
-    ppid: '1520'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '2722'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/atd -f
-    pid: '2731'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '2735'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '2743'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '2882'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '2884'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '2888'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/share/filebeat/bin/filebeat -c /etc/filebeat/filebeat.yml -path.home
-      /usr/share/filebeat -path.config /etc/filebeat -path.data
-      /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '2891'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh /etc/init.d/init.ohasd run >/dev/null 2>&1 </dev/null
-    pid: '2892'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '2893'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/local/qualys/cloud-agent/bin/qualys-cloud-agent
-    pid: '2907'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/rhsmcertd
-    pid: '2909'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/xinetd -stayalive -pidfile /var/run/xinetd.pid
-    pid: '2919'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm.opt
-    pid: '3268'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '3451'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '3539'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '3568'
-    ppid: '3539'
-    user: postfix
-  - cmdline: bin/rscw
-    pid: '4017'
-    ppid: '1'
-    user: root
-  - cmdline: bin/rscd
-    pid: '4019'
-    ppid: '4017'
-    user: root
-  - cmdline: bin/rscd
-    pid: '4020'
-    ppid: '4017'
-    user: root
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_ARSYS.opt
-      -pass
-    pid: '5787'
-    ppid: '1'
-    user: root
-  - cmdline: ora_o001_BSAREP
-    pid: '7109'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o001_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '7111'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_w005_BSAREP
-    pid: '8166'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w004_BSAAPP
-    pid: '8584'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BNABBDD.opt
-      -pass
-    pid: '9365'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '10723'
-    ppid: '2'
-    user: root
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '11271'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAAPP.opt
-      -pass
-    pid: '11643'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAREP.opt
-      -pass
-    pid: '12211'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/perl
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/bin/emwd.pl
-      agent
-      /softOracle/app/oracle/product/12.1.0.4/agentes/gcinst/sysman/log/emagent.nohup
-    pid: '13389'
-    ppid: '1'
-    user: oracle
-  - cmdline: >-
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/bin/emwd.pl
-      agent
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_inst/sysman/log/emagent.nohup
-    pid: '13482'
-    ppid: '1'
-    user: oracle
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ohasd.bin
-      reboot
-    pid: '13578'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdk/bin/java
-      -Xmx128M -XX:MaxPermSize=96M -server
-      -Djava.security.egd=file:///dev/./urandom
-      -Dsun.lang.ClassLoader.allowArraySyntax=true
-      -XX:+UseLinuxPosixThreadCPUClocks -XX:+UseConcMarkSweepGC
-      -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -Dwatchdog.pid=13389
-      -cp
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdbc/lib/ojdbc5.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.http_client_11.1.1.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/xmlparserv2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/jsch.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/optic.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.dms_11.1.1/dms.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK.jar
-      oracle.sysman.gcagent.tmmain.TMMain
-    pid: '13590'
-    ppid: '13389'
-    user: oracle
-  - cmdline: >-
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/jdk/bin/java
-      -Xmx128M -XX:MaxMetaspaceSize=224M -server
-      -Djava.security.egd=file:///dev/./urandom
-      -Dsun.lang.ClassLoader.allowArraySyntax=true -XX:-UseLargePages
-      -XX:+UseLinuxPosixThreadCPUClocks -XX:+UseConcMarkSweepGC
-      -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops
-      -DHTTPClient.dontSeekTerminatingChunk=true -Dwatchdog.pid=13482 -cp
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jdbc/lib/ojdbc7.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/jsch-0.1.54.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/com.oracle.http_client.http_client.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.xdk/xmlparserv2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.dms/dms.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/lib/optic.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK.jar
-      oracle.sysman.gcagent.tmmain.TMMain
-    pid: '13648'
-    ppid: '13482'
-    user: oracle
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/oraagent.bin
-    pid: '14470'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmd.bin
-    pid: '14491'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAAPP
-      -no_crs_notify -inherit
-    pid: '14496'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAREP
-      -no_crs_notify -inherit
-    pid: '14500'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BNABBDD
-      -no_crs_notify -inherit
-    pid: '14505'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmlogger.bin
-      -o
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.info
-      -l
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.log
-    pid: '14758'
-    ppid: '14491'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/tnslsnr
-      LISTENER -no_crs_notify -inherit
-    pid: '14763'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_ARSYS
-      -no_crs_notify -inherit
-    pid: '14782'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /usr/local/qualys/cloud-agent/bin/agentid-service -config
-      /etc/qualys/cloud-agent/agentid-service.conf -logdir /var/log/qualys/
-    pid: '14887'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/cssdagent
-    pid: '15030'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ocssd.bin
-    pid: '15057'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_pmon_+ASM
-    pid: '15350'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_psp0_+ASM
-    pid: '15354'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_vktm_+ASM
-    pid: '15357'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_gen0_+ASM
-    pid: '15363'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_mman_+ASM
-    pid: '15365'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_diag_+ASM
-    pid: '15369'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_dia0_+ASM
-    pid: '15371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_dbw0_+ASM
-    pid: '15373'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_lgwr_+ASM
-    pid: '15375'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_ckpt_+ASM
-    pid: '15377'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_smon_+ASM
-    pid: '15379'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_lreg_+ASM
-    pid: '15381'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_pxmn_+ASM
-    pid: '15383'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_rbal_+ASM
-    pid: '15385'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_gmon_+ASM
-    pid: '15387'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_mmon_+ASM
-    pid: '15389'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_mmnl_+ASM
-    pid: '15391'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15491'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15494'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15509'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_asmb_+ASM
-    pid: '15538'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_+asm (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15545'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '15554'
-    ppid: '2'
-    user: root
-  - cmdline: ora_pmon_ARSYS
-    pid: '15612'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_ARSYS
-    pid: '15614'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_ARSYS
-    pid: '15621'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_ARSYS
-    pid: '15625'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_ARSYS
-    pid: '15627'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_ARSYS
-    pid: '15631'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_ARSYS
-    pid: '15633'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_ARSYS
-    pid: '15635'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_ARSYS
-    pid: '15637'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_ARSYS
-    pid: '15639'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_ARSYS
-    pid: '15641'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_ARSYS
-    pid: '15643'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_ARSYS
-    pid: '15645'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_ARSYS
-    pid: '15647'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_ARSYS
-    pid: '15649'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_ARSYS
-    pid: '15651'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_ARSYS
-    pid: '15653'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_ARSYS
-    pid: '15655'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pxmn_ARSYS
-    pid: '15657'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_ARSYS
-    pid: '15659'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_ARSYS
-    pid: '15661'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_ARSYS
-    pid: '15663'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmnl_ARSYS
-    pid: '15667'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15669'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_d000_ARSYS
-    pid: '15674'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_ARSYS
-    pid: '15676'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_ARSYS
-    pid: '15678'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pmon_BSAAPP
-    pid: '15684'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_BSAAPP
-    pid: '15686'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pmon_BNABBDD
-    pid: '15688'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_BNABBDD
-    pid: '15690'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pmon_BSAREP
-    pid: '15692'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_BSAREP
-    pid: '15694'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_BSAAPP
-    pid: '15697'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_BSAAPP
-    pid: '15701'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_BSAAPP
-    pid: '15703'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_BNABBDD
-    pid: '15707'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_BSAAPP
-    pid: '15709'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_BSAAPP
-    pid: '15714'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_BNABBDD
-    pid: '15715'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_BSAREP
-    pid: '15717'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_BSAAPP
-    pid: '15719'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_BNABBDD
-    pid: '15723'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_BSAREP
-    pid: '15725'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_BSAAPP
-    pid: '15727'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_BSAREP
-    pid: '15731'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_BNABBDD
-    pid: '15735'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_BSAAPP
-    pid: '15737'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_BSAREP
-    pid: '15739'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_BNABBDD
-    pid: '15741'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_BSAAPP
-    pid: '15744'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_BSAREP
-    pid: '15746'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_BNABBDD
-    pid: '15747'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_BSAREP
-    pid: '15749'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_BNABBDD
-    pid: '15751'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_BSAAPP
-    pid: '15753'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_BSAREP
-    pid: '15755'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_BNABBDD
-    pid: '15757'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_BSAAPP
-    pid: '15759'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_BSAREP
-    pid: '15761'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_BSAAPP
-    pid: '15763'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_BNABBDD
-    pid: '15765'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_BSAAPP
-    pid: '15767'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_BSAREP
-    pid: '15769'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_BNABBDD
-    pid: '15771'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_BSAAPP
-    pid: '15773'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_BSAREP
-    pid: '15776'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_BNABBDD
-    pid: '15778'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_BSAAPP
-    pid: '15780'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_BSAREP
-    pid: '15782'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_BSAAPP
-    pid: '15784'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pxmn_BSAAPP
-    pid: '15786'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_BSAREP
-    pid: '15788'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_BNABBDD
-    pid: '15790'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_BSAAPP
-    pid: '15792'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_BSAREP
-    pid: '15794'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_BNABBDD
-    pid: '15796'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_BNABBDD
-    pid: '15798'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_BSAAPP
-    pid: '15800'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_BSAREP
-    pid: '15802'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_BNABBDD
-    pid: '15804'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_BSAAPP
-    pid: '15807'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_BSAREP
-    pid: '15808'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_BNABBDD
-    pid: '15810'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_BSAREP
-    pid: '15813'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmnl_BSAAPP
-    pid: '15814'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15816'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_pxmn_BNABBDD
-    pid: '15818'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_d000_BSAAPP
-    pid: '15821'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pxmn_BSAREP
-    pid: '15822'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_BSAAPP
-    pid: '15825'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_BSAREP
-    pid: '15826'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_BNABBDD
-    pid: '15828'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_BSAREP
-    pid: '15830'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_BNABBDD
-    pid: '15832'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_BSAAPP
-    pid: '15834'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_BSAREP
-    pid: '15836'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_BNABBDD
-    pid: '15838'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15840'
-    ppid: '1'
-    user: oracle
-  - cmdline: oracle+ASM_asmb_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15842'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_mmnl_BSAREP
-    pid: '15844'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmnl_BNABBDD
-    pid: '15846'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_d000_BSAREP
-    pid: '15848'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_d000_BNABBDD
-    pid: '15852'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_BSAREP
-    pid: '15854'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_BNABBDD
-    pid: '15856'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_BSAREP
-    pid: '15858'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_BNABBDD
-    pid: '15862'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_ARSYS
-    pid: '15964'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_ARSYS
-    pid: '15966'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_ARSYS
-    pid: '15968'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_ARSYS
-    pid: '15970'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_ARSYS
-    pid: '15972'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_ARSYS
-    pid: '15974'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_ARSYS
-    pid: '15976'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_ARSYS
-    pid: '15978'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_ARSYS
-    pid: '15980'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_ARSYS
-    pid: '15982'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_ARSYS
-    pid: '15984'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_ARSYS
-    pid: '15986'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_ARSYS
-    pid: '15988'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_ARSYS
-    pid: '15990'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_ARSYS
-    pid: '15992'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_BNABBDD
-    pid: '15995'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_BNABBDD
-    pid: '15997'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_BSAREP
-    pid: '15999'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_BSAAPP
-    pid: '16001'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_BNABBDD
-    pid: '16004'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_BSAREP
-    pid: '16005'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_BSAAPP
-    pid: '16007'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_BNABBDD
-    pid: '16010'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_BSAREP
-    pid: '16011'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_BSAAPP
-    pid: '16013'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_BNABBDD
-    pid: '16015'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_BSAREP
-    pid: '16017'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_BNABBDD
-    pid: '16019'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_BSAAPP
-    pid: '16021'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_BSAREP
-    pid: '16023'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_BNABBDD
-    pid: '16027'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_BSAREP
-    pid: '16028'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_BSAAPP
-    pid: '16029'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_BSAREP
-    pid: '16031'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_BSAAPP
-    pid: '16033'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_BNABBDD
-    pid: '16035'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_BSAREP
-    pid: '16037'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_BNABBDD
-    pid: '16039'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_BSAAPP
-    pid: '16041'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_BSAREP
-    pid: '16044'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_BSAAPP
-    pid: '16045'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_BNABBDD
-    pid: '16047'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_BSAREP
-    pid: '16051'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_BNABBDD
-    pid: '16052'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_BSAAPP
-    pid: '16053'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_BSAREP
-    pid: '16057'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_BSAAPP
-    pid: '16058'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_BNABBDD
-    pid: '16059'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_BSAREP
-    pid: '16063'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_BSAAPP
-    pid: '16064'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_BNABBDD
-    pid: '16065'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_BSAREP
-    pid: '16069'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_BNABBDD
-    pid: '16070'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_BSAAPP
-    pid: '16071'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_BSAREP
-    pid: '16075'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_BSAAPP
-    pid: '16076'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_BNABBDD
-    pid: '16077'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_BSAAPP
-    pid: '16079'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_BSAREP
-    pid: '16081'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_BSAAPP
-    pid: '16084'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_BNABBDD
-    pid: '16123'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_ARSYS
-    pid: '16131'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_BNABBDD
-    pid: '16133'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_ARSYS
-    pid: '16141'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_BNABBDD
-    pid: '16145'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_BNABBDD
-    pid: '16151'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_ARSYS
-    pid: '16153'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_ARSYS
-    pid: '16156'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_BNABBDD
-    pid: '16157'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_ARSYS
-    pid: '16161'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_BSAAPP
-    pid: '16167'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_BSAAPP
-    pid: '16173'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_ARSYS
-    pid: '16177'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_BSAAPP
-    pid: '16179'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_BNABBDD
-    pid: '16181'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_BSAAPP
-    pid: '16183'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_BSAREP
-    pid: '16185'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_BSAAPP
-    pid: '16187'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_BSAREP
-    pid: '16189'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_BSAREP
-    pid: '16191'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_BSAREP
-    pid: '16194'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_BSAREP
-    pid: '16196'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_BSAAPP
-    pid: '16198'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_BSAREP
-    pid: '16200'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_ARSYS
-    pid: '16208'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_BNABBDD
-    pid: '16215'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_BSAAPP
-    pid: '16217'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_BSAREP
-    pid: '16253'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_BNABBDD
-    pid: '16285'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_ARSYS
-    pid: '16287'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_BSAAPP
-    pid: '16292'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '16304'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_BSAREP
-    pid: '16309'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_BSAAPP
-    pid: '16318'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_BSAAPP
-    pid: '16320'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_BSAAPP
-    pid: '16322'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_BSAAPP
-    pid: '16324'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_BSAAPP
-    pid: '16328'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_BNABBDD
-    pid: '16330'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_BSAAPP
-    pid: '16332'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_BNABBDD
-    pid: '16334'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_BSAAPP
-    pid: '16336'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_BNABBDD
-    pid: '16338'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_BSAAPP
-    pid: '16340'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_BSAAPP
-    pid: '16343'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_BNABBDD
-    pid: '16344'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_BNABBDD
-    pid: '16346'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_BSAAPP
-    pid: '16348'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_BNABBDD
-    pid: '16351'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_BSAAPP
-    pid: '16352'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_BSAAPP
-    pid: '16354'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_BNABBDD
-    pid: '16356'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_BSAAPP
-    pid: '16361'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_BNABBDD
-    pid: '16363'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_BSAAPP
-    pid: '16365'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_BNABBDD
-    pid: '16367'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_ARSYS
-    pid: '16369'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_BSAAPP
-    pid: '16371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_ARSYS
-    pid: '16373'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_BNABBDD
-    pid: '16375'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_BSAAPP
-    pid: '16377'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_ARSYS
-    pid: '16380'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_BNABBDD
-    pid: '16381'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_BNABBDD
-    pid: '16383'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_BSAAPP
-    pid: '16385'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_ARSYS
-    pid: '16387'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_BSAAPP
-    pid: '16389'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_ARSYS
-    pid: '16391'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_BNABBDD
-    pid: '16393'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_ARSYS
-    pid: '16396'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_BSAAPP
-    pid: '16397'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_BNABBDD
-    pid: '16399'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_BNABBDD
-    pid: '16401'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_ARSYS
-    pid: '16403'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_BSAAPP
-    pid: '16405'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_BSAAPP
-    pid: '16408'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_BNABBDD
-    pid: '16409'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_ARSYS
-    pid: '16411'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_BSAAPP
-    pid: '16413'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_BNABBDD
-    pid: '16415'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_ARSYS
-    pid: '16417'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_BSAAPP
-    pid: '16419'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_ARSYS
-    pid: '16422'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_BNABBDD
-    pid: '16423'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_BSAAPP
-    pid: '16425'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_ARSYS
-    pid: '16428'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_BNABBDD
-    pid: '16429'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_BSAAPP
-    pid: '16431'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_BNABBDD
-    pid: '16434'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_ARSYS
-    pid: '16435'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_BSAAPP
-    pid: '16437'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_ARSYS
-    pid: '16439'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_BNABBDD
-    pid: '16441'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_BSAAPP
-    pid: '16443'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_BNABBDD
-    pid: '16446'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_ARSYS
-    pid: '16447'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_BNABBDD
-    pid: '16449'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_ARSYS
-    pid: '16451'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_BSAAPP
-    pid: '16453'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_ARSYS
-    pid: '16457'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_BNABBDD
-    pid: '16458'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_BSAAPP
-    pid: '16460'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_ARSYS
-    pid: '16462'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_BNABBDD
-    pid: '16464'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_BSAAPP
-    pid: '16466'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_BNABBDD
-    pid: '16468'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_ARSYS
-    pid: '16470'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_BSAAPP
-    pid: '16472'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_BNABBDD
-    pid: '16475'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_ARSYS
-    pid: '16476'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_BSAAPP
-    pid: '16478'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_BNABBDD
-    pid: '16480'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_ARSYS
-    pid: '16482'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_BSAAPP
-    pid: '16484'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_BNABBDD
-    pid: '16486'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_ARSYS
-    pid: '16488'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_BSAAPP
-    pid: '16490'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_ARSYS
-    pid: '16492'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_BNABBDD
-    pid: '16494'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_BSAAPP
-    pid: '16496'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_ARSYS
-    pid: '16498'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_BNABBDD
-    pid: '16500'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_BSAAPP
-    pid: '16502'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_ARSYS
-    pid: '16505'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_BNABBDD
-    pid: '16506'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_BSAAPP
-    pid: '16508'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_ARSYS
-    pid: '16511'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_BNABBDD
-    pid: '16512'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_BSAAPP
-    pid: '16514'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_BNABBDD
-    pid: '16517'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_ARSYS
-    pid: '16518'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_BSAAPP
-    pid: '16520'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_BNABBDD
-    pid: '16523'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_ARSYS
-    pid: '16524'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_BSAAPP
-    pid: '16526'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_BNABBDD
-    pid: '16529'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_ARSYS
-    pid: '16530'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_BSAAPP
-    pid: '16532'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_BNABBDD
-    pid: '16534'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_BSAAPP
-    pid: '16536'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_ARSYS
-    pid: '16538'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_BNABBDD
-    pid: '16540'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_BSAAPP
-    pid: '16542'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_ARSYS
-    pid: '16544'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_BNABBDD
-    pid: '16546'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_BSAAPP
-    pid: '16548'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_ARSYS
-    pid: '16550'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_BNABBDD
-    pid: '16552'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_BSAAPP
-    pid: '16554'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_BNABBDD
-    pid: '16556'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_ARSYS
-    pid: '16558'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_BSAAPP
-    pid: '16560'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_ARSYS
-    pid: '16562'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_BNABBDD
-    pid: '16564'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_BSAAPP
-    pid: '16566'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_ARSYS
-    pid: '16568'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_BNABBDD
-    pid: '16570'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_BSAAPP
-    pid: '16572'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_ARSYS
-    pid: '16574'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_BNABBDD
-    pid: '16576'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_BSAAPP
-    pid: '16579'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_ARSYS
-    pid: '16581'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_BNABBDD
-    pid: '16583'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_BSAAPP
-    pid: '16585'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_ARSYS
-    pid: '16587'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_BNABBDD
-    pid: '16589'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_ARSYS
-    pid: '16591'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_BNABBDD
-    pid: '16593'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_ARSYS
-    pid: '16595'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_BNABBDD
-    pid: '16597'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_ARSYS
-    pid: '16599'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_BNABBDD
-    pid: '16601'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_ARSYS
-    pid: '16603'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_BNABBDD
-    pid: '16605'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_ARSYS
-    pid: '16607'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_ARSYS
-    pid: '16609'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_ARSYS
-    pid: '16611'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_ARSYS
-    pid: '16613'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_ARSYS
-    pid: '16615'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_ARSYS
-    pid: '16617'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_ARSYS
-    pid: '16619'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_ARSYS
-    pid: '16621'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_ARSYS
-    pid: '16623'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '16625'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_BSAAPP
-    pid: '16627'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_BSAAPP
-    pid: '16629'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_BSAAPP
-    pid: '16635'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '16637'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_BNABBDD
-    pid: '16639'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_BNABBDD
-    pid: '16643'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_BSAREP
-    pid: '16645'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_BSAREP
-    pid: '16649'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_BSAREP
-    pid: '16653'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_BNABBDD
-    pid: '16655'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_BSAREP
-    pid: '16657'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_BSAREP
-    pid: '16659'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_ARSYS
-    pid: '16661'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_BSAREP
-    pid: '16663'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_ARSYS
-    pid: '16665'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_BSAREP
-    pid: '16667'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q002_ARSYS
-    pid: '16669'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_BSAREP
-    pid: '16671'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_BSAREP
-    pid: '16673'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_BSAREP
-    pid: '16677'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_ARSYS
-    pid: '16679'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_BSAREP
-    pid: '16681'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_BSAREP
-    pid: '16683'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_BSAREP
-    pid: '16685'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_BSAREP
-    pid: '16687'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_BSAREP
-    pid: '16689'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_BSAREP
-    pid: '16691'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_BSAREP
-    pid: '16693'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_BSAREP
-    pid: '16695'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_BSAREP
-    pid: '16698'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_BSAREP
-    pid: '16700'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_BSAREP
-    pid: '16702'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_BSAREP
-    pid: '16704'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_BSAREP
-    pid: '16706'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_BSAREP
-    pid: '16708'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_BSAREP
-    pid: '16710'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_BSAREP
-    pid: '16712'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_BSAREP
-    pid: '16714'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_BSAREP
-    pid: '16716'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_BSAREP
-    pid: '16718'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_BSAREP
-    pid: '16720'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_BSAREP
-    pid: '16722'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_BSAREP
-    pid: '16724'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_BSAREP
-    pid: '16726'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_BSAREP
-    pid: '16728'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_BSAREP
-    pid: '16730'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_BSAREP
-    pid: '16732'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_BSAREP
-    pid: '16734'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_BSAAPP
-    pid: '16736'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_BSAREP
-    pid: '16738'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_BSAAPP
-    pid: '16740'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_BSAREP
-    pid: '16742'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_BSAAPP
-    pid: '16744'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_BSAREP
-    pid: '16746'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_BSAREP
-    pid: '16748'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_BSAAPP
-    pid: '16750'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_BSAREP
-    pid: '16752'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_BSAAPP
-    pid: '16754'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_BSAREP
-    pid: '16756'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_BSAREP
-    pid: '16758'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q00a_BSAAPP
-    pid: '16760'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_BSAREP
-    pid: '16762'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_BSAREP
-    pid: '16764'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_BSAREP
-    pid: '16766'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_BSAREP
-    pid: '16768'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_BSAREP
-    pid: '16770'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_BSAREP
-    pid: '16772'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_ARSYS
-    pid: '16774'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_ARSYS
-    pid: '16777'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_ARSYS
-    pid: '16779'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_ARSYS
-    pid: '16781'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_ARSYS
-    pid: '16783'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_BNABBDD
-    pid: '16785'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_BNABBDD
-    pid: '16788'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_BNABBDD
-    pid: '16790'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_BNABBDD
-    pid: '16792'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_BNABBDD
-    pid: '16794'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_BSAREP
-    pid: '16797'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_BSAREP
-    pid: '16799'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q002_BSAREP
-    pid: '16801'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '16805'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_BSAREP
-    pid: '16807'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '16837'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_BSAREP
-    pid: '16840'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_BSAREP
-    pid: '16842'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_BSAREP
-    pid: '16844'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_BSAREP
-    pid: '16848'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_BSAREP
-    pid: '16854'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '16951'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '17039'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '17069'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '17109'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '17371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '17411'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '17651'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '17657'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '17796'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '18038'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '19700'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '19811'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '19813'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '20577'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '20645'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '20663'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '20675'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '20679'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '21794'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '21914'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '22175'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22208'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22219'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22258'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22262'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22316'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22318'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22320'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22322'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22324'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22326'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22328'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22330'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22332'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22334'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22336'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22338'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22340'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22342'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22344'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22346'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22348'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22350'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22352'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22354'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22356'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22358'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22360'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22363'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22365'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22368'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22373'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22375'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22379'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22385'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22387'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22393'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22399'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22405'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22411'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22415'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22421'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22425'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22431'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22437'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22443'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22445'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22449'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22451'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22453'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22455'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22458'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22460'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22462'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22464'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22468'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22473'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22477'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22479'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22481'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22483'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22485'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22487'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22489'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22491'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22493'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22495'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22497'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22499'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22501'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22545'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22563'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '32378'
-    ppid: '1'
-    user: oragrid
-  - cmdline: 'sshd: cyberark [priv]'
-    pid: '32623'
-    ppid: '2882'
-    user: root
-  - cmdline: 'sshd: cyberark@pts/1'
-    pid: '32631'
-    ppid: '32623'
-    user: cyberark
-  - cmdline: '-bash'
-    pid: '32632'
-    ppid: '32631'
-    user: cyberark
-  - cmdline: su - root
-    pid: '32668'
-    ppid: '32632'
-    user: cyberark
-  - cmdline: '-bash'
-    pid: '32676'
-    ppid: '32668'
-    user: root
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/sqlplus                                        
-      as sysasm
-    pid: '33023'
-    ppid: '32676'
-    user: root
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '33025'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '34800'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34963'
-    ppid: '2'
-    user: root
-  - cmdline: ora_w004_BSAREP
-    pid: '35257'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w002_BSAAPP
-    pid: '35341'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w003_ARSYS
-    pid: '35409'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_o001_BNABBDD
-    pid: '35698'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o001_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '35700'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_o002_ARSYS
-    pid: '35703'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o002_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '35705'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '36134'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37614'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38019'
-    ppid: '2'
-    user: root
-  - cmdline: ora_w001_BNABBDD
-    pid: '38039'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '38380'
-    ppid: '2'
-    user: root
-  - cmdline: ora_w000_BNABBDD
-    pid: '40559'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '41466'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42316'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51639'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53968'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '55115'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57812'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57921'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58479'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58505'
-    ppid: '2'
-    user: root
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '59259'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '62085'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62951'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '67682'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68499'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68515'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68597'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68768'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68938'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68960'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69565'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '74694'
-    ppid: '2'
-    user: root
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '76012'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '76666'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76667'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76736'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '77158'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79085'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79092'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79256'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79490'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79648'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '79666'
-    ppid: '3539'
-    user: postfix
-  - cmdline: ''
-    pid: '79880'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79915'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79930'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79931'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79933'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80004'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80194'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80196'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80292'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/plugins/oracle.sysman.db.agent.plugin_13.4.1.0.0/scripts/failedLogin.pl
-    pid: '80308'
-    ppid: '13648'
-    user: oracle
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '80326'
-    ppid: '1'
-    user: oragrid
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1655221424
-    pid: '80481'
-    ppid: '2884'
-    user: root
-  - cmdline: 'sshd: cyberark [priv]'
-    pid: '80506'
-    ppid: '2882'
-    user: root
-  - cmdline: 'sshd: cyberark@pts/2'
-    pid: '80508'
-    ppid: '80506'
-    user: cyberark
-  - cmdline: ''
-    pid: '80735'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80741'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80819'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80820'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80821'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80822'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80823'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80824'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80825'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80826'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80827'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80828'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80829'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80830'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80831'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80832'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80833'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80834'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80835'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80836'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80837'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80838'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80839'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80840'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80841'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80842'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80843'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80844'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80845'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80846'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80847'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80848'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80849'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80850'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80851'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80852'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80853'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80854'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80855'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80856'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80857'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80858'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80859'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80860'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80861'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80862'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80863'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80864'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80865'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80866'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /bin/sh -c su - root -c '/bin/sh -c '"'"'echo
-      BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ; /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'"'"''
-      && sleep 0
-    pid: '80972'
-    ppid: '80508'
-    user: cyberark
-  - cmdline: >-
-      su - root -c /bin/sh -c 'echo
-      BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ; /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'
-    pid: '80990'
-    ppid: '80972'
-    user: cyberark
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ;
-      /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
-    pid: '80991'
-    ppid: '80990'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
-    pid: '81026'
-    ppid: '80991'
-    user: root
-  - cmdline: ''
-    pid: '81076'
-    ppid: '2'
-    user: root
-  - cmdline: ora_q003_BNABBDD
-    pid: '85919'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '98298'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w000_ARSYS
-    pid: '105757'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_o002_BSAAPP
-    pid: '121249'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o002_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '121251'
-    ppid: '1'
-    user: oracle
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '123382'
-    ppid: '1'
-    user: oragrid
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '54'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '64'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '66'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '67'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '71'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '72'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '73'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '74'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '77'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '78'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '82'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '84'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '86'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '88'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '89'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '90'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '91'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '92'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '93'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '94'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '95'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '96'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '97'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '98'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '99'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '105'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '106'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '107'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '108'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '118'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '119'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '121'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '123'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '137'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '176'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '365'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '366'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '367'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '369'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '370'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '371'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '373'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '413'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '414'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '512'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '612'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '613'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '624'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '625'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '638'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '639'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '640'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '641'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '642'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '643'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '644'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '645'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '646'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '647'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '648'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '649'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '732'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '765'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '768'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '810'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '811'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '812'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '813'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '814'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1167'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1168'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1169'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1170'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1171'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1172'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1184'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1185'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1186'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1188'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1195'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1196'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1197'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1198'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1199'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1200'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1201'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1202'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1204'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1205'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1207'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1208'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1210'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1211'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1213'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1214'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1217'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1218'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1219'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1222'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1224'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1225'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1227'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1228'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1237'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1238'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1240'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1241'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1243'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1244'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1246'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1247'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1258'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1259'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1260'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1261'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1262'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1263'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1271'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1273'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1275'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1277'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1278'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1279'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1280'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1281'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1282'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1297'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1301'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1302'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1303'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1304'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1311'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1312'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1315'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1321'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1322'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1324'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1325'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1326'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1329'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1330'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1331'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1332'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1333'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1334'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1335'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1350'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1351'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1353'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1354'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1355'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1356'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1357'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1358'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1359'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1360'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1361'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1362'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1363'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1364'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1365'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1366'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1367'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1368'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1370'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1371'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1372'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1373'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1374'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1375'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1385'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1386'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1387'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1388'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1389'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1401'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1402'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1403'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1404'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1405'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1406'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1413'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1414'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1415'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1416'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1417'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1418'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1419'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1420'
+  ppid: '2'
+  user: root
+- cmdline: /opt/CrowdStrike/falcond
+  cwd: /opt/CrowdStrike/
+  pid: '1436'
+  ppid: '1'
+  user: root
+- cmdline: falcon-sensor
+  cwd: /
+  pid: '1438'
+  ppid: '1436'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '1448'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '1494'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '1499'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '1500'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/ntpd -u ntp:ntp -u ntp:ntp -p /var/run/ntpd.pid -g
+  cwd: /usr/sbin/
+  pid: '1514'
+  ppid: '1'
+  user: ntp
+- cmdline: /usr/sbin/NetworkManager --no-daemon
+  cwd: /usr/sbin/
+  pid: '1516'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sssd -i --logger=files
+  cwd: /usr/sbin/
+  pid: '1520'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '1564'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/nscd
+  cwd: /usr/sbin/
+  pid: '1597'
+  ppid: '1'
+  user: nscd
+- cmdline: /usr/libexec/sssd/sssd_be --domain ES.WCORP.CARREFOUR.COM --uid 0 --gid
+    0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2392'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/local/avamar/bin/avagent.bin --bindir="/usr/local/avamar/bin" --vardir="/usr/local/avamar/var"
+    --sysdir="/usr/local/avamar/etc" --logfile="/usr/local/avamar/var/avagent.log"
+  cwd: /usr/local/avamar/bin/
+  pid: '2479'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/vmtoolsd
+  cwd: /usr/sbin/
+  pid: '2490'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/vmware-vgauth/VGAuthService -s
+  cwd: /usr/lib/vmware-vgauth/
+  pid: '2583'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2697'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/libexec/sssd/sssd_pam --uid 0 --gid 0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2698'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/libexec/sssd/sssd_pac --uid 0 --gid 0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2699'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '2722'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/atd -f
+  cwd: /usr/sbin/
+  pid: '2731'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '2735'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '2743'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '2882'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '2884'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '2888'
+  ppid: '1'
+  user: root
+- cmdline: /usr/share/filebeat/bin/filebeat -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '2891'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh /etc/init.d/init.ohasd run >/dev/null 2>&1 </dev/null
+  cwd: /bin/
+  pid: '2892'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '2893'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/qualys/cloud-agent/bin/qualys-cloud-agent
+  cwd: /usr/local/qualys/cloud-agent/bin/
+  pid: '2907'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/rhsmcertd
+  cwd: /usr/bin/
+  pid: '2909'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/xinetd -stayalive -pidfile /var/run/xinetd.pid
+  cwd: /usr/sbin/
+  pid: '2919'
+  ppid: '1'
+  user: root
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm.opt
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '3268'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3451'
+  ppid: '2'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '3539'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '3568'
+  ppid: '3539'
+  user: postfix
+- cmdline: bin/rscw
+  cwd: bin/
+  pid: '4017'
+  ppid: '1'
+  user: root
+- cmdline: bin/rscd
+  cwd: bin/
+  pid: '4019'
+  ppid: '4017'
+  user: root
+- cmdline: bin/rscd
+  cwd: bin/
+  pid: '4020'
+  ppid: '4017'
+  user: root
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_ARSYS.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '5787'
+  ppid: '1'
+  user: root
+- cmdline: ora_o001_BSAREP
+  cwd: /
+  pid: '7109'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o001_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '7111'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_w005_BSAREP
+  cwd: /
+  pid: '8166'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w004_BSAAPP
+  cwd: /
+  pid: '8584'
+  ppid: '1'
+  user: oragrid
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BNABBDD.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '9365'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10723'
+  ppid: '2'
+  user: root
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '11271'
+  ppid: '1'
+  user: oragrid
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAAPP.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '11643'
+  ppid: '1'
+  user: root
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAREP.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '12211'
+  ppid: '1'
+  user: root
+- cmdline: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/perl
+    /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/bin/emwd.pl
+    agent /softOracle/app/oracle/product/12.1.0.4/agentes/gcinst/sysman/log/emagent.nohup
+  cwd: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/
+  pid: '13389'
+  ppid: '1'
+  user: oracle
+- cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
+    /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/bin/emwd.pl
+    agent /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_inst/sysman/log/emagent.nohup
+  cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/
+  pid: '13482'
+  ppid: '1'
+  user: oracle
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ohasd.bin
+    reboot
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '13578'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdk/bin/java
+    -Xmx128M -XX:MaxPermSize=96M -server -Djava.security.egd=file:///dev/./urandom
+    -Dsun.lang.ClassLoader.allowArraySyntax=true -XX:+UseLinuxPosixThreadCPUClocks
+    -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -Dwatchdog.pid=13389
+    -cp /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdbc/lib/ojdbc5.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.http_client_11.1.1.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/xmlparserv2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/jsch.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/optic.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.dms_11.1.1/dms.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK.jar
+    oracle.sysman.gcagent.tmmain.TMMain
+  cwd: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdk/bin/
+  pid: '13590'
+  ppid: '13389'
+  user: oracle
+- cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/jdk/bin/java
+    -Xmx128M -XX:MaxMetaspaceSize=224M -server -Djava.security.egd=file:///dev/./urandom
+    -Dsun.lang.ClassLoader.allowArraySyntax=true -XX:-UseLargePages -XX:+UseLinuxPosixThreadCPUClocks
+    -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -DHTTPClient.dontSeekTerminatingChunk=true
+    -Dwatchdog.pid=13482 -cp /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jdbc/lib/ojdbc7.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/jsch-0.1.54.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/com.oracle.http_client.http_client.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.xdk/xmlparserv2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.dms/dms.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/lib/optic.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK.jar
+    oracle.sysman.gcagent.tmmain.TMMain
+  cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/jdk/bin/
+  pid: '13648'
+  ppid: '13482'
+  user: oracle
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/oraagent.bin
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14470'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmd.bin
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14491'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAAPP
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14496'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAREP
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14500'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BNABBDD
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14505'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmlogger.bin
+    -o /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.info
+    -l /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.log
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14758'
+  ppid: '14491'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/tnslsnr
+    LISTENER -no_crs_notify -inherit
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14763'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_ARSYS
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14782'
+  ppid: '1'
+  user: oragrid
+- cmdline: /usr/local/qualys/cloud-agent/bin/agentid-service -config /etc/qualys/cloud-agent/agentid-service.conf
+    -logdir /var/log/qualys/
+  cwd: /usr/local/qualys/cloud-agent/bin/
+  pid: '14887'
+  ppid: '1'
+  user: root
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/cssdagent
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '15030'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ocssd.bin
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '15057'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_pmon_+ASM
+  cwd: /
+  pid: '15350'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_psp0_+ASM
+  cwd: /
+  pid: '15354'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_vktm_+ASM
+  cwd: /
+  pid: '15357'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_gen0_+ASM
+  cwd: /
+  pid: '15363'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_mman_+ASM
+  cwd: /
+  pid: '15365'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_diag_+ASM
+  cwd: /
+  pid: '15369'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_dia0_+ASM
+  cwd: /
+  pid: '15371'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_dbw0_+ASM
+  cwd: /
+  pid: '15373'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_lgwr_+ASM
+  cwd: /
+  pid: '15375'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_ckpt_+ASM
+  cwd: /
+  pid: '15377'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_smon_+ASM
+  cwd: /
+  pid: '15379'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_lreg_+ASM
+  cwd: /
+  pid: '15381'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_pxmn_+ASM
+  cwd: /
+  pid: '15383'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_rbal_+ASM
+  cwd: /
+  pid: '15385'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_gmon_+ASM
+  cwd: /
+  pid: '15387'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_mmon_+ASM
+  cwd: /
+  pid: '15389'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_mmnl_+ASM
+  cwd: /
+  pid: '15391'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15491'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15494'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15509'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_asmb_+ASM
+  cwd: /
+  pid: '15538'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_+asm (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15545'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '15554'
+  ppid: '2'
+  user: root
+- cmdline: ora_pmon_ARSYS
+  cwd: /
+  pid: '15612'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_ARSYS
+  cwd: /
+  pid: '15614'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_ARSYS
+  cwd: /
+  pid: '15621'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_ARSYS
+  cwd: /
+  pid: '15625'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_ARSYS
+  cwd: /
+  pid: '15627'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_ARSYS
+  cwd: /
+  pid: '15631'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_ARSYS
+  cwd: /
+  pid: '15633'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_ARSYS
+  cwd: /
+  pid: '15635'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_ARSYS
+  cwd: /
+  pid: '15637'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_ARSYS
+  cwd: /
+  pid: '15639'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_ARSYS
+  cwd: /
+  pid: '15641'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_ARSYS
+  cwd: /
+  pid: '15643'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_ARSYS
+  cwd: /
+  pid: '15645'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_ARSYS
+  cwd: /
+  pid: '15647'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_ARSYS
+  cwd: /
+  pid: '15649'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_ARSYS
+  cwd: /
+  pid: '15651'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_ARSYS
+  cwd: /
+  pid: '15653'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_ARSYS
+  cwd: /
+  pid: '15655'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pxmn_ARSYS
+  cwd: /
+  pid: '15657'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_ARSYS
+  cwd: /
+  pid: '15659'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_ARSYS
+  cwd: /
+  pid: '15661'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_ARSYS
+  cwd: /
+  pid: '15663'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmnl_ARSYS
+  cwd: /
+  pid: '15667'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15669'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_d000_ARSYS
+  cwd: /
+  pid: '15674'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_ARSYS
+  cwd: /
+  pid: '15676'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_ARSYS
+  cwd: /
+  pid: '15678'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pmon_BSAAPP
+  cwd: /
+  pid: '15684'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_BSAAPP
+  cwd: /
+  pid: '15686'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pmon_BNABBDD
+  cwd: /
+  pid: '15688'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_BNABBDD
+  cwd: /
+  pid: '15690'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pmon_BSAREP
+  cwd: /
+  pid: '15692'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_BSAREP
+  cwd: /
+  pid: '15694'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_BSAAPP
+  cwd: /
+  pid: '15697'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_BSAAPP
+  cwd: /
+  pid: '15701'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_BSAAPP
+  cwd: /
+  pid: '15703'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_BNABBDD
+  cwd: /
+  pid: '15707'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_BSAAPP
+  cwd: /
+  pid: '15709'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_BSAAPP
+  cwd: /
+  pid: '15714'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_BNABBDD
+  cwd: /
+  pid: '15715'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_BSAREP
+  cwd: /
+  pid: '15717'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_BSAAPP
+  cwd: /
+  pid: '15719'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_BNABBDD
+  cwd: /
+  pid: '15723'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_BSAREP
+  cwd: /
+  pid: '15725'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_BSAAPP
+  cwd: /
+  pid: '15727'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_BSAREP
+  cwd: /
+  pid: '15731'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_BNABBDD
+  cwd: /
+  pid: '15735'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_BSAAPP
+  cwd: /
+  pid: '15737'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_BSAREP
+  cwd: /
+  pid: '15739'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_BNABBDD
+  cwd: /
+  pid: '15741'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_BSAAPP
+  cwd: /
+  pid: '15744'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_BSAREP
+  cwd: /
+  pid: '15746'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_BNABBDD
+  cwd: /
+  pid: '15747'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_BSAREP
+  cwd: /
+  pid: '15749'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_BNABBDD
+  cwd: /
+  pid: '15751'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_BSAAPP
+  cwd: /
+  pid: '15753'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_BSAREP
+  cwd: /
+  pid: '15755'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_BNABBDD
+  cwd: /
+  pid: '15757'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_BSAAPP
+  cwd: /
+  pid: '15759'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_BSAREP
+  cwd: /
+  pid: '15761'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_BSAAPP
+  cwd: /
+  pid: '15763'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_BNABBDD
+  cwd: /
+  pid: '15765'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_BSAAPP
+  cwd: /
+  pid: '15767'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_BSAREP
+  cwd: /
+  pid: '15769'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_BNABBDD
+  cwd: /
+  pid: '15771'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_BSAAPP
+  cwd: /
+  pid: '15773'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_BSAREP
+  cwd: /
+  pid: '15776'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_BNABBDD
+  cwd: /
+  pid: '15778'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_BSAAPP
+  cwd: /
+  pid: '15780'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_BSAREP
+  cwd: /
+  pid: '15782'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_BSAAPP
+  cwd: /
+  pid: '15784'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pxmn_BSAAPP
+  cwd: /
+  pid: '15786'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_BSAREP
+  cwd: /
+  pid: '15788'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_BNABBDD
+  cwd: /
+  pid: '15790'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_BSAAPP
+  cwd: /
+  pid: '15792'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_BSAREP
+  cwd: /
+  pid: '15794'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_BNABBDD
+  cwd: /
+  pid: '15796'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_BNABBDD
+  cwd: /
+  pid: '15798'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_BSAAPP
+  cwd: /
+  pid: '15800'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_BSAREP
+  cwd: /
+  pid: '15802'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_BNABBDD
+  cwd: /
+  pid: '15804'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_BSAAPP
+  cwd: /
+  pid: '15807'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_BSAREP
+  cwd: /
+  pid: '15808'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_BNABBDD
+  cwd: /
+  pid: '15810'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_BSAREP
+  cwd: /
+  pid: '15813'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmnl_BSAAPP
+  cwd: /
+  pid: '15814'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15816'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_pxmn_BNABBDD
+  cwd: /
+  pid: '15818'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_d000_BSAAPP
+  cwd: /
+  pid: '15821'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pxmn_BSAREP
+  cwd: /
+  pid: '15822'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_BSAAPP
+  cwd: /
+  pid: '15825'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_BSAREP
+  cwd: /
+  pid: '15826'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_BNABBDD
+  cwd: /
+  pid: '15828'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_BSAREP
+  cwd: /
+  pid: '15830'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_BNABBDD
+  cwd: /
+  pid: '15832'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_BSAAPP
+  cwd: /
+  pid: '15834'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_BSAREP
+  cwd: /
+  pid: '15836'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_BNABBDD
+  cwd: /
+  pid: '15838'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15840'
+  ppid: '1'
+  user: oracle
+- cmdline: oracle+ASM_asmb_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15842'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_mmnl_BSAREP
+  cwd: /
+  pid: '15844'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmnl_BNABBDD
+  cwd: /
+  pid: '15846'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_d000_BSAREP
+  cwd: /
+  pid: '15848'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_d000_BNABBDD
+  cwd: /
+  pid: '15852'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_BSAREP
+  cwd: /
+  pid: '15854'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_BNABBDD
+  cwd: /
+  pid: '15856'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_BSAREP
+  cwd: /
+  pid: '15858'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_BNABBDD
+  cwd: /
+  pid: '15862'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_ARSYS
+  cwd: /
+  pid: '15964'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_ARSYS
+  cwd: /
+  pid: '15966'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_ARSYS
+  cwd: /
+  pid: '15968'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_ARSYS
+  cwd: /
+  pid: '15970'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_ARSYS
+  cwd: /
+  pid: '15972'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_ARSYS
+  cwd: /
+  pid: '15974'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_ARSYS
+  cwd: /
+  pid: '15976'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_ARSYS
+  cwd: /
+  pid: '15978'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_ARSYS
+  cwd: /
+  pid: '15980'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_ARSYS
+  cwd: /
+  pid: '15982'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_ARSYS
+  cwd: /
+  pid: '15984'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_ARSYS
+  cwd: /
+  pid: '15986'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_ARSYS
+  cwd: /
+  pid: '15988'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_ARSYS
+  cwd: /
+  pid: '15990'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_ARSYS
+  cwd: /
+  pid: '15992'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_BNABBDD
+  cwd: /
+  pid: '15995'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_BNABBDD
+  cwd: /
+  pid: '15997'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_BSAREP
+  cwd: /
+  pid: '15999'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_BSAAPP
+  cwd: /
+  pid: '16001'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_BNABBDD
+  cwd: /
+  pid: '16004'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_BSAREP
+  cwd: /
+  pid: '16005'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_BSAAPP
+  cwd: /
+  pid: '16007'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_BNABBDD
+  cwd: /
+  pid: '16010'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_BSAREP
+  cwd: /
+  pid: '16011'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_BSAAPP
+  cwd: /
+  pid: '16013'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_BNABBDD
+  cwd: /
+  pid: '16015'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_BSAREP
+  cwd: /
+  pid: '16017'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_BNABBDD
+  cwd: /
+  pid: '16019'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_BSAAPP
+  cwd: /
+  pid: '16021'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_BSAREP
+  cwd: /
+  pid: '16023'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_BNABBDD
+  cwd: /
+  pid: '16027'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_BSAREP
+  cwd: /
+  pid: '16028'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_BSAAPP
+  cwd: /
+  pid: '16029'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_BSAREP
+  cwd: /
+  pid: '16031'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_BSAAPP
+  cwd: /
+  pid: '16033'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_BNABBDD
+  cwd: /
+  pid: '16035'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_BSAREP
+  cwd: /
+  pid: '16037'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_BNABBDD
+  cwd: /
+  pid: '16039'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_BSAAPP
+  cwd: /
+  pid: '16041'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_BSAREP
+  cwd: /
+  pid: '16044'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_BSAAPP
+  cwd: /
+  pid: '16045'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_BNABBDD
+  cwd: /
+  pid: '16047'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_BSAREP
+  cwd: /
+  pid: '16051'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_BNABBDD
+  cwd: /
+  pid: '16052'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_BSAAPP
+  cwd: /
+  pid: '16053'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_BSAREP
+  cwd: /
+  pid: '16057'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_BSAAPP
+  cwd: /
+  pid: '16058'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_BNABBDD
+  cwd: /
+  pid: '16059'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_BSAREP
+  cwd: /
+  pid: '16063'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_BSAAPP
+  cwd: /
+  pid: '16064'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_BNABBDD
+  cwd: /
+  pid: '16065'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_BSAREP
+  cwd: /
+  pid: '16069'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_BNABBDD
+  cwd: /
+  pid: '16070'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_BSAAPP
+  cwd: /
+  pid: '16071'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_BSAREP
+  cwd: /
+  pid: '16075'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_BSAAPP
+  cwd: /
+  pid: '16076'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_BNABBDD
+  cwd: /
+  pid: '16077'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_BSAAPP
+  cwd: /
+  pid: '16079'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_BSAREP
+  cwd: /
+  pid: '16081'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_BSAAPP
+  cwd: /
+  pid: '16084'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_BNABBDD
+  cwd: /
+  pid: '16123'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_ARSYS
+  cwd: /
+  pid: '16131'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_BNABBDD
+  cwd: /
+  pid: '16133'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_ARSYS
+  cwd: /
+  pid: '16141'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_BNABBDD
+  cwd: /
+  pid: '16145'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_BNABBDD
+  cwd: /
+  pid: '16151'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_ARSYS
+  cwd: /
+  pid: '16153'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_ARSYS
+  cwd: /
+  pid: '16156'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_BNABBDD
+  cwd: /
+  pid: '16157'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_ARSYS
+  cwd: /
+  pid: '16161'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_BSAAPP
+  cwd: /
+  pid: '16167'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_BSAAPP
+  cwd: /
+  pid: '16173'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_ARSYS
+  cwd: /
+  pid: '16177'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_BSAAPP
+  cwd: /
+  pid: '16179'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_BNABBDD
+  cwd: /
+  pid: '16181'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_BSAAPP
+  cwd: /
+  pid: '16183'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_BSAREP
+  cwd: /
+  pid: '16185'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_BSAAPP
+  cwd: /
+  pid: '16187'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_BSAREP
+  cwd: /
+  pid: '16189'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_BSAREP
+  cwd: /
+  pid: '16191'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_BSAREP
+  cwd: /
+  pid: '16194'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_BSAREP
+  cwd: /
+  pid: '16196'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_BSAAPP
+  cwd: /
+  pid: '16198'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_BSAREP
+  cwd: /
+  pid: '16200'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_ARSYS
+  cwd: /
+  pid: '16208'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_BNABBDD
+  cwd: /
+  pid: '16215'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_BSAAPP
+  cwd: /
+  pid: '16217'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_BSAREP
+  cwd: /
+  pid: '16253'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_BNABBDD
+  cwd: /
+  pid: '16285'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_ARSYS
+  cwd: /
+  pid: '16287'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_BSAAPP
+  cwd: /
+  pid: '16292'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '16304'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_BSAREP
+  cwd: /
+  pid: '16309'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_BSAAPP
+  cwd: /
+  pid: '16318'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_BSAAPP
+  cwd: /
+  pid: '16320'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_BSAAPP
+  cwd: /
+  pid: '16322'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_BSAAPP
+  cwd: /
+  pid: '16324'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_BSAAPP
+  cwd: /
+  pid: '16328'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_BNABBDD
+  cwd: /
+  pid: '16330'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_BSAAPP
+  cwd: /
+  pid: '16332'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_BNABBDD
+  cwd: /
+  pid: '16334'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_BSAAPP
+  cwd: /
+  pid: '16336'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_BNABBDD
+  cwd: /
+  pid: '16338'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_BSAAPP
+  cwd: /
+  pid: '16340'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_BSAAPP
+  cwd: /
+  pid: '16343'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_BNABBDD
+  cwd: /
+  pid: '16344'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_BNABBDD
+  cwd: /
+  pid: '16346'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_BSAAPP
+  cwd: /
+  pid: '16348'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_BNABBDD
+  cwd: /
+  pid: '16351'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_BSAAPP
+  cwd: /
+  pid: '16352'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_BSAAPP
+  cwd: /
+  pid: '16354'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_BNABBDD
+  cwd: /
+  pid: '16356'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_BSAAPP
+  cwd: /
+  pid: '16361'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_BNABBDD
+  cwd: /
+  pid: '16363'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_BSAAPP
+  cwd: /
+  pid: '16365'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_BNABBDD
+  cwd: /
+  pid: '16367'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_ARSYS
+  cwd: /
+  pid: '16369'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_BSAAPP
+  cwd: /
+  pid: '16371'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_ARSYS
+  cwd: /
+  pid: '16373'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_BNABBDD
+  cwd: /
+  pid: '16375'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_BSAAPP
+  cwd: /
+  pid: '16377'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_ARSYS
+  cwd: /
+  pid: '16380'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_BNABBDD
+  cwd: /
+  pid: '16381'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_BNABBDD
+  cwd: /
+  pid: '16383'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_BSAAPP
+  cwd: /
+  pid: '16385'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_ARSYS
+  cwd: /
+  pid: '16387'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_BSAAPP
+  cwd: /
+  pid: '16389'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_ARSYS
+  cwd: /
+  pid: '16391'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_BNABBDD
+  cwd: /
+  pid: '16393'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_ARSYS
+  cwd: /
+  pid: '16396'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_BSAAPP
+  cwd: /
+  pid: '16397'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_BNABBDD
+  cwd: /
+  pid: '16399'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_BNABBDD
+  cwd: /
+  pid: '16401'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_ARSYS
+  cwd: /
+  pid: '16403'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_BSAAPP
+  cwd: /
+  pid: '16405'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_BSAAPP
+  cwd: /
+  pid: '16408'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_BNABBDD
+  cwd: /
+  pid: '16409'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_ARSYS
+  cwd: /
+  pid: '16411'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_BSAAPP
+  cwd: /
+  pid: '16413'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_BNABBDD
+  cwd: /
+  pid: '16415'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_ARSYS
+  cwd: /
+  pid: '16417'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_BSAAPP
+  cwd: /
+  pid: '16419'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_ARSYS
+  cwd: /
+  pid: '16422'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_BNABBDD
+  cwd: /
+  pid: '16423'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_BSAAPP
+  cwd: /
+  pid: '16425'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_ARSYS
+  cwd: /
+  pid: '16428'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_BNABBDD
+  cwd: /
+  pid: '16429'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_BSAAPP
+  cwd: /
+  pid: '16431'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_BNABBDD
+  cwd: /
+  pid: '16434'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_ARSYS
+  cwd: /
+  pid: '16435'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_BSAAPP
+  cwd: /
+  pid: '16437'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_ARSYS
+  cwd: /
+  pid: '16439'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_BNABBDD
+  cwd: /
+  pid: '16441'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_BSAAPP
+  cwd: /
+  pid: '16443'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_BNABBDD
+  cwd: /
+  pid: '16446'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_ARSYS
+  cwd: /
+  pid: '16447'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_BNABBDD
+  cwd: /
+  pid: '16449'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_ARSYS
+  cwd: /
+  pid: '16451'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_BSAAPP
+  cwd: /
+  pid: '16453'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_ARSYS
+  cwd: /
+  pid: '16457'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_BNABBDD
+  cwd: /
+  pid: '16458'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_BSAAPP
+  cwd: /
+  pid: '16460'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_ARSYS
+  cwd: /
+  pid: '16462'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_BNABBDD
+  cwd: /
+  pid: '16464'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_BSAAPP
+  cwd: /
+  pid: '16466'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_BNABBDD
+  cwd: /
+  pid: '16468'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_ARSYS
+  cwd: /
+  pid: '16470'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_BSAAPP
+  cwd: /
+  pid: '16472'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_BNABBDD
+  cwd: /
+  pid: '16475'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_ARSYS
+  cwd: /
+  pid: '16476'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_BSAAPP
+  cwd: /
+  pid: '16478'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_BNABBDD
+  cwd: /
+  pid: '16480'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_ARSYS
+  cwd: /
+  pid: '16482'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_BSAAPP
+  cwd: /
+  pid: '16484'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_BNABBDD
+  cwd: /
+  pid: '16486'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_ARSYS
+  cwd: /
+  pid: '16488'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_BSAAPP
+  cwd: /
+  pid: '16490'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_ARSYS
+  cwd: /
+  pid: '16492'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_BNABBDD
+  cwd: /
+  pid: '16494'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_BSAAPP
+  cwd: /
+  pid: '16496'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_ARSYS
+  cwd: /
+  pid: '16498'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_BNABBDD
+  cwd: /
+  pid: '16500'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_BSAAPP
+  cwd: /
+  pid: '16502'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_ARSYS
+  cwd: /
+  pid: '16505'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_BNABBDD
+  cwd: /
+  pid: '16506'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_BSAAPP
+  cwd: /
+  pid: '16508'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_ARSYS
+  cwd: /
+  pid: '16511'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_BNABBDD
+  cwd: /
+  pid: '16512'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_BSAAPP
+  cwd: /
+  pid: '16514'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_BNABBDD
+  cwd: /
+  pid: '16517'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_ARSYS
+  cwd: /
+  pid: '16518'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_BSAAPP
+  cwd: /
+  pid: '16520'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_BNABBDD
+  cwd: /
+  pid: '16523'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_ARSYS
+  cwd: /
+  pid: '16524'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_BSAAPP
+  cwd: /
+  pid: '16526'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_BNABBDD
+  cwd: /
+  pid: '16529'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_ARSYS
+  cwd: /
+  pid: '16530'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_BSAAPP
+  cwd: /
+  pid: '16532'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_BNABBDD
+  cwd: /
+  pid: '16534'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_BSAAPP
+  cwd: /
+  pid: '16536'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_ARSYS
+  cwd: /
+  pid: '16538'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_BNABBDD
+  cwd: /
+  pid: '16540'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_BSAAPP
+  cwd: /
+  pid: '16542'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_ARSYS
+  cwd: /
+  pid: '16544'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_BNABBDD
+  cwd: /
+  pid: '16546'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_BSAAPP
+  cwd: /
+  pid: '16548'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_ARSYS
+  cwd: /
+  pid: '16550'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_BNABBDD
+  cwd: /
+  pid: '16552'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_BSAAPP
+  cwd: /
+  pid: '16554'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_BNABBDD
+  cwd: /
+  pid: '16556'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_ARSYS
+  cwd: /
+  pid: '16558'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_BSAAPP
+  cwd: /
+  pid: '16560'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_ARSYS
+  cwd: /
+  pid: '16562'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_BNABBDD
+  cwd: /
+  pid: '16564'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_BSAAPP
+  cwd: /
+  pid: '16566'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_ARSYS
+  cwd: /
+  pid: '16568'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_BNABBDD
+  cwd: /
+  pid: '16570'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_BSAAPP
+  cwd: /
+  pid: '16572'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_ARSYS
+  cwd: /
+  pid: '16574'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_BNABBDD
+  cwd: /
+  pid: '16576'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_BSAAPP
+  cwd: /
+  pid: '16579'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_ARSYS
+  cwd: /
+  pid: '16581'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_BNABBDD
+  cwd: /
+  pid: '16583'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_BSAAPP
+  cwd: /
+  pid: '16585'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_ARSYS
+  cwd: /
+  pid: '16587'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_BNABBDD
+  cwd: /
+  pid: '16589'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_ARSYS
+  cwd: /
+  pid: '16591'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_BNABBDD
+  cwd: /
+  pid: '16593'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_ARSYS
+  cwd: /
+  pid: '16595'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_BNABBDD
+  cwd: /
+  pid: '16597'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_ARSYS
+  cwd: /
+  pid: '16599'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_BNABBDD
+  cwd: /
+  pid: '16601'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_ARSYS
+  cwd: /
+  pid: '16603'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_BNABBDD
+  cwd: /
+  pid: '16605'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_ARSYS
+  cwd: /
+  pid: '16607'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_ARSYS
+  cwd: /
+  pid: '16609'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_ARSYS
+  cwd: /
+  pid: '16611'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_ARSYS
+  cwd: /
+  pid: '16613'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_ARSYS
+  cwd: /
+  pid: '16615'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_ARSYS
+  cwd: /
+  pid: '16617'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_ARSYS
+  cwd: /
+  pid: '16619'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_ARSYS
+  cwd: /
+  pid: '16621'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_ARSYS
+  cwd: /
+  pid: '16623'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '16625'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_BSAAPP
+  cwd: /
+  pid: '16627'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_BSAAPP
+  cwd: /
+  pid: '16629'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_BSAAPP
+  cwd: /
+  pid: '16635'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '16637'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_BNABBDD
+  cwd: /
+  pid: '16639'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_BNABBDD
+  cwd: /
+  pid: '16643'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_BSAREP
+  cwd: /
+  pid: '16645'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_BSAREP
+  cwd: /
+  pid: '16649'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_BSAREP
+  cwd: /
+  pid: '16653'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_BNABBDD
+  cwd: /
+  pid: '16655'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_BSAREP
+  cwd: /
+  pid: '16657'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_BSAREP
+  cwd: /
+  pid: '16659'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_ARSYS
+  cwd: /
+  pid: '16661'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_BSAREP
+  cwd: /
+  pid: '16663'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_ARSYS
+  cwd: /
+  pid: '16665'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_BSAREP
+  cwd: /
+  pid: '16667'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q002_ARSYS
+  cwd: /
+  pid: '16669'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_BSAREP
+  cwd: /
+  pid: '16671'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_BSAREP
+  cwd: /
+  pid: '16673'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_BSAREP
+  cwd: /
+  pid: '16677'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_ARSYS
+  cwd: /
+  pid: '16679'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_BSAREP
+  cwd: /
+  pid: '16681'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_BSAREP
+  cwd: /
+  pid: '16683'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_BSAREP
+  cwd: /
+  pid: '16685'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_BSAREP
+  cwd: /
+  pid: '16687'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_BSAREP
+  cwd: /
+  pid: '16689'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_BSAREP
+  cwd: /
+  pid: '16691'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_BSAREP
+  cwd: /
+  pid: '16693'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_BSAREP
+  cwd: /
+  pid: '16695'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_BSAREP
+  cwd: /
+  pid: '16698'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_BSAREP
+  cwd: /
+  pid: '16700'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_BSAREP
+  cwd: /
+  pid: '16702'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_BSAREP
+  cwd: /
+  pid: '16704'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_BSAREP
+  cwd: /
+  pid: '16706'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_BSAREP
+  cwd: /
+  pid: '16708'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_BSAREP
+  cwd: /
+  pid: '16710'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_BSAREP
+  cwd: /
+  pid: '16712'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_BSAREP
+  cwd: /
+  pid: '16714'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_BSAREP
+  cwd: /
+  pid: '16716'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_BSAREP
+  cwd: /
+  pid: '16718'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_BSAREP
+  cwd: /
+  pid: '16720'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_BSAREP
+  cwd: /
+  pid: '16722'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_BSAREP
+  cwd: /
+  pid: '16724'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_BSAREP
+  cwd: /
+  pid: '16726'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_BSAREP
+  cwd: /
+  pid: '16728'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_BSAREP
+  cwd: /
+  pid: '16730'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_BSAREP
+  cwd: /
+  pid: '16732'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_BSAREP
+  cwd: /
+  pid: '16734'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_BSAAPP
+  cwd: /
+  pid: '16736'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_BSAREP
+  cwd: /
+  pid: '16738'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_BSAAPP
+  cwd: /
+  pid: '16740'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_BSAREP
+  cwd: /
+  pid: '16742'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_BSAAPP
+  cwd: /
+  pid: '16744'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_BSAREP
+  cwd: /
+  pid: '16746'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_BSAREP
+  cwd: /
+  pid: '16748'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_BSAAPP
+  cwd: /
+  pid: '16750'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_BSAREP
+  cwd: /
+  pid: '16752'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_BSAAPP
+  cwd: /
+  pid: '16754'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_BSAREP
+  cwd: /
+  pid: '16756'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_BSAREP
+  cwd: /
+  pid: '16758'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q00a_BSAAPP
+  cwd: /
+  pid: '16760'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_BSAREP
+  cwd: /
+  pid: '16762'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_BSAREP
+  cwd: /
+  pid: '16764'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_BSAREP
+  cwd: /
+  pid: '16766'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_BSAREP
+  cwd: /
+  pid: '16768'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_BSAREP
+  cwd: /
+  pid: '16770'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_BSAREP
+  cwd: /
+  pid: '16772'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_ARSYS
+  cwd: /
+  pid: '16774'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_ARSYS
+  cwd: /
+  pid: '16777'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_ARSYS
+  cwd: /
+  pid: '16779'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_ARSYS
+  cwd: /
+  pid: '16781'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_ARSYS
+  cwd: /
+  pid: '16783'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_BNABBDD
+  cwd: /
+  pid: '16785'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_BNABBDD
+  cwd: /
+  pid: '16788'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_BNABBDD
+  cwd: /
+  pid: '16790'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_BNABBDD
+  cwd: /
+  pid: '16792'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_BNABBDD
+  cwd: /
+  pid: '16794'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_BSAREP
+  cwd: /
+  pid: '16797'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_BSAREP
+  cwd: /
+  pid: '16799'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q002_BSAREP
+  cwd: /
+  pid: '16801'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '16805'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_BSAREP
+  cwd: /
+  pid: '16807'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '16837'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_BSAREP
+  cwd: /
+  pid: '16840'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_BSAREP
+  cwd: /
+  pid: '16842'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_BSAREP
+  cwd: /
+  pid: '16844'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_BSAREP
+  cwd: /
+  pid: '16848'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_BSAREP
+  cwd: /
+  pid: '16854'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '16951'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '17039'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '17069'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '17109'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '17371'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '17411'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '17651'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '17657'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '17796'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '18038'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '19700'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '19811'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '19813'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '20577'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '20645'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '20663'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '20675'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '20679'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '21794'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '21914'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '22175'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22208'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22219'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22258'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22262'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22316'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22318'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22320'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22322'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22324'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22326'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22328'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22330'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22332'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22334'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22336'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22338'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22340'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22342'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22344'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22346'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22348'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22350'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22352'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22354'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22356'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22358'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22360'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22363'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22365'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22368'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22371'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22373'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22375'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22379'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22385'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22387'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22393'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22399'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22405'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22411'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22415'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22421'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22425'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22431'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22437'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22443'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22445'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22449'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22451'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22453'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22455'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22458'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22460'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22462'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22464'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22468'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22473'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22477'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22479'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22481'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22483'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22485'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22487'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22489'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22491'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22493'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22495'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22497'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22499'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22501'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22545'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22563'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '32378'
+  ppid: '1'
+  user: oragrid
+- cmdline: 'sshd: cyberark [priv]'
+  cwd: /
+  pid: '32623'
+  ppid: '2882'
+  user: root
+- cmdline: 'sshd: cyberark@pts/1'
+  cwd: /
+  pid: '32631'
+  ppid: '32623'
+  user: cyberark
+- cmdline: -bash
+  cwd: /
+  pid: '32632'
+  ppid: '32631'
+  user: cyberark
+- cmdline: su - root
+  cwd: /
+  pid: '32668'
+  ppid: '32632'
+  user: cyberark
+- cmdline: -bash
+  cwd: /
+  pid: '32676'
+  ppid: '32668'
+  user: root
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/sqlplus                                         as
+    sysasm
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '33023'
+  ppid: '32676'
+  user: root
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '33025'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '34800'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34963'
+  ppid: '2'
+  user: root
+- cmdline: ora_w004_BSAREP
+  cwd: /
+  pid: '35257'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w002_BSAAPP
+  cwd: /
+  pid: '35341'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w003_ARSYS
+  cwd: /
+  pid: '35409'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_o001_BNABBDD
+  cwd: /
+  pid: '35698'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o001_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '35700'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_o002_ARSYS
+  cwd: /
+  pid: '35703'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o002_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '35705'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '36134'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37614'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38019'
+  ppid: '2'
+  user: root
+- cmdline: ora_w001_BNABBDD
+  cwd: /
+  pid: '38039'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '38380'
+  ppid: '2'
+  user: root
+- cmdline: ora_w000_BNABBDD
+  cwd: /
+  pid: '40559'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '41466'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51639'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53968'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '55115'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57812'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57921'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58479'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58505'
+  ppid: '2'
+  user: root
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '59259'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '62085'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62951'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '67682'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68499'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68515'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68597'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68768'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68938'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68960'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69565'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '74694'
+  ppid: '2'
+  user: root
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '76012'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '76666'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76667'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76736'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '77158'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79085'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79092'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79256'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79490'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79648'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '79666'
+  ppid: '3539'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '79880'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79915'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79930'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79931'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79933'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80004'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80194'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80196'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80292'
+  ppid: '2'
+  user: root
+- cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
+    /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/plugins/oracle.sysman.db.agent.plugin_13.4.1.0.0/scripts/failedLogin.pl
+  cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/
+  pid: '80308'
+  ppid: '13648'
+  user: oracle
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '80326'
+  ppid: '1'
+  user: oragrid
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1655221424
+  cwd: /usr/lib64/sa/
+  pid: '80481'
+  ppid: '2884'
+  user: root
+- cmdline: 'sshd: cyberark [priv]'
+  cwd: /
+  pid: '80506'
+  ppid: '2882'
+  user: root
+- cmdline: 'sshd: cyberark@pts/2'
+  cwd: /
+  pid: '80508'
+  ppid: '80506'
+  user: cyberark
+- cmdline: ''
+  cwd: /
+  pid: '80735'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80741'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80819'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80820'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80821'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80822'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80823'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80824'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80825'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80826'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80827'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80828'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80829'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80830'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80831'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80832'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80833'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80834'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80835'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80836'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80837'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80838'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80839'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80840'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80841'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80842'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80843'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80844'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80845'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80846'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80847'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80848'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80849'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80850'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80851'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80852'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80853'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80854'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80855'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80856'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80857'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80858'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80859'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80860'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80861'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80862'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80863'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80864'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80865'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80866'
+  ppid: '2'
+  user: root
+- cmdline: /bin/sh -c su - root -c '/bin/sh -c '"'"'echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve
+    ; /usr/bin/python /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'"'"''
+    && sleep 0
+  cwd: /bin/
+  pid: '80972'
+  ppid: '80508'
+  user: cyberark
+- cmdline: su - root -c /bin/sh -c 'echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve
+    ; /usr/bin/python /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'
+  cwd: /
+  pid: '80990'
+  ppid: '80972'
+  user: cyberark
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ; /usr/bin/python
+    /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '80991'
+  ppid: '80990'
+  user: root
+- cmdline: /usr/bin/python /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '81026'
+  ppid: '80991'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81076'
+  ppid: '2'
+  user: root
+- cmdline: ora_q003_BNABBDD
+  cwd: /
+  pid: '85919'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '98298'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w000_ARSYS
+  cwd: /
+  pid: '105757'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_o002_BSAAPP
+  cwd: /
+  pid: '121249'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o002_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '121251'
+  ppid: '1'
+  user: oracle
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '123382'
+  ppid: '1'
+  user: oragrid
+software_list:
+- cmd_regexp: _pmon_
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/oracle.yaml'
+    name: Include Oracle specific plugins
+  name: Oracle DatabaseServer
+  process_type: parent
+  return_children: false
+  return_packages: false
+  vars:
+    connect_with_users: '{{ oracle_monitor_users_info | default([{''username'': oracle_monitor_user
+      | default(''oracle''), ''password'': oracle_monitor_pass | default(''oracle'')}])
+      }}'
+    monitor_cluster_hostname: '{{ oracle_monitor_cluster_hostname | default(''localhost'')
+      }}'
+    read_configuration: '{{ oracle_monitor_read_configuration | default(False) }}'
+task_vars:
+  oracle_monitor_cluster_hostname: the_cluster_hostname
+  oracle_monitor_pass: the_password
+  oracle_monitor_read_configuration: false
+  oracle_monitor_user: the_user
+  oracle_monitor_users_info:
+  - password: '{{ oracle_monitor_pass }}'
+    username: '{{ oracle_monitor_user }}'
+  - password: the_password2
+    username: the_user2
 tcp_listen:
-  - address: 0.0.0.0
-    name: java
-    pid: 13648
-    port: 47632
-    protocol: tcp
-    stime: 'Thu May 12 19:11:16 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_BSAR
-    pid: 15848
-    port: 24016
-    protocol: tcp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 192.168.25.186
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 192.168.22.25
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 192.168.28.229
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14763
-    port: 1521
-    protocol: tcp
-    stime: 'Thu May 12 19:11:29 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14782
-    port: 1522
-    protocol: tcp
-    stime: 'Thu May 12 19:11:29 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14505
-    port: 1523
-    protocol: tcp
-    stime: 'Thu May 12 19:11:28 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14496
-    port: 1524
-    protocol: tcp
-    stime: 'Thu May 12 19:11:27 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: sshd
-    pid: 2882
-    port: 22
-    protocol: tcp
-    stime: 'Thu May 12 19:10:27 2022'
-    user: root
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14500
-    port: 1527
-    protocol: tcp
-    stime: 'Thu May 12 19:11:27 2022'
-    user: oragrid
-  - address: 127.0.0.1
-    name: master
-    pid: 3539
-    port: 25
-    protocol: tcp
-    stime: 'Thu May 12 19:10:28 2022'
-    user: root
-  - address: 0.0.0.0
-    name: dsmc
-    pid: 3268
-    port: 1501
-    protocol: tcp
-    stime: 'Thu May 12 19:10:28 2022'
-    user: root
-  - address: 127.0.0.1
-    name: oraagent.bin
-    pid: 14470
-    port: 2016
-    protocol: tcp
-    stime: 'Thu May 12 19:11:27 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: java
-    pid: 13590
-    port: 3872
-    protocol: tcp
-    stime: 'Thu May 12 19:11:14 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: java
-    pid: 13648
-    port: 3873
-    protocol: tcp
-    stime: 'Thu May 12 19:11:16 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_ARSY
-    pid: 15674
-    port: 20266
-    protocol: tcp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_BSAA
-    pid: 15821
-    port: 20267
-    protocol: tcp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_BNAB
-    pid: 15852
-    port: 13966
-    protocol: tcp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Thu May 12 19:10:02 2022'
-    user: root
-  - address: '::'
-    name: avagent.bin
-    pid: 2479
-    port: 30002
-    protocol: tcp
-    stime: 'Thu May 12 19:10:25 2022'
-    user: root
-  - address: '::'
-    name: avagent.bin
-    pid: 2479
-    port: 28002
-    protocol: tcp
-    stime: 'Thu May 12 19:10:25 2022'
-    user: root
-  - address: 127.0.0.1
-    name: avagent.bin
-    pid: 2479
-    port: 30984
-    protocol: tcp
-    stime: 'Thu May 12 19:10:25 2022'
-    user: root
-  - address: '::'
-    name: bin/rscd
-    pid: 4020
-    port: 4750
-    protocol: tcp
-    stime: 'Thu May 12 19:10:29 2022'
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 1564
-    port: 111
-    protocol: tcp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: java
+  pid: 13648
+  port: 47632
+  protocol: tcp
+  stime: Thu May 12 19:11:16 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_BSAR
+  pid: 15848
+  port: 24016
+  protocol: tcp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 192.168.25.186
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 192.168.22.25
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 192.168.28.229
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 127.0.0.1
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14763
+  port: 1521
+  protocol: tcp
+  stime: Thu May 12 19:11:29 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14782
+  port: 1522
+  protocol: tcp
+  stime: Thu May 12 19:11:29 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14505
+  port: 1523
+  protocol: tcp
+  stime: Thu May 12 19:11:28 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14496
+  port: 1524
+  protocol: tcp
+  stime: Thu May 12 19:11:27 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: sshd
+  pid: 2882
+  port: 22
+  protocol: tcp
+  stime: Thu May 12 19:10:27 2022
+  user: root
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14500
+  port: 1527
+  protocol: tcp
+  stime: Thu May 12 19:11:27 2022
+  user: oragrid
+- address: 127.0.0.1
+  name: master
+  pid: 3539
+  port: 25
+  protocol: tcp
+  stime: Thu May 12 19:10:28 2022
+  user: root
+- address: 0.0.0.0
+  name: dsmc
+  pid: 3268
+  port: 1501
+  protocol: tcp
+  stime: Thu May 12 19:10:28 2022
+  user: root
+- address: 127.0.0.1
+  name: oraagent.bin
+  pid: 14470
+  port: 2016
+  protocol: tcp
+  stime: Thu May 12 19:11:27 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: java
+  pid: 13590
+  port: 3872
+  protocol: tcp
+  stime: Thu May 12 19:11:14 2022
+  user: oracle
+- address: 0.0.0.0
+  name: java
+  pid: 13648
+  port: 3873
+  protocol: tcp
+  stime: Thu May 12 19:11:16 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_ARSY
+  pid: 15674
+  port: 20266
+  protocol: tcp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_BSAA
+  pid: 15821
+  port: 20267
+  protocol: tcp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_BNAB
+  pid: 15852
+  port: 13966
+  protocol: tcp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Thu May 12 19:10:02 2022
+  user: root
+- address: '::'
+  name: avagent.bin
+  pid: 2479
+  port: 30002
+  protocol: tcp
+  stime: Thu May 12 19:10:25 2022
+  user: root
+- address: '::'
+  name: avagent.bin
+  pid: 2479
+  port: 28002
+  protocol: tcp
+  stime: Thu May 12 19:10:25 2022
+  user: root
+- address: 127.0.0.1
+  name: avagent.bin
+  pid: 2479
+  port: 30984
+  protocol: tcp
+  stime: Thu May 12 19:10:25 2022
+  user: root
+- address: '::'
+  name: bin/rscd
+  pid: 4020
+  port: 4750
+  protocol: tcp
+  stime: Thu May 12 19:10:29 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 1564
+  port: 111
+  protocol: tcp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc
 udp_listen:
-  - address: 127.0.0.1
-    name: ora_s000_BNAB
-    pid: 15862
-    port: 9756
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: rsyslogd
-    pid: 2888
-    port: 10583
-    protocol: udp
-    stime: 'Thu May 12 19:10:27 2022'
-    user: root
-  - address: 127.0.0.1
-    name: ora_d000_BNAB
-    pid: 15852
-    port: 43469
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_lreg_BNAB
-    pid: 15810
-    port: 43845
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_s000_ARSY
-    pid: 15676
-    port: 46109
-    protocol: udp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_s000_BSAA
-    pid: 15825
-    port: 15051
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_d000_BSAR
-    pid: 15848
-    port: 18969
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_s000_BSAR
-    pid: 15858
-    port: 52283
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ohasd.bin
-    pid: 13578
-    port: 53703
-    protocol: udp
-    stime: 'Thu May 12 19:11:11 2022'
-    user: oragrid
-  - address: 127.0.0.1
-    name: asm_lreg_+ASM
-    pid: 15381
-    port: 23389
-    protocol: udp
-    stime: 'Thu May 12 19:12:03 2022'
-    user: oragrid
-  - address: 127.0.0.1
-    name: ora_lreg_ARSY
-    pid: 15655
-    port: 57074
-    protocol: udp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_d000_BSAA
-    pid: 15821
-    port: 26201
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_lreg_BSAR
-    pid: 15813
-    port: 60678
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_d000_ARSY
-    pid: 15674
-    port: 62388
-    protocol: udp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Thu May 12 19:10:02 2022'
-    user: root
-  - address: 192.168.25.186
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 192.168.22.25
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 192.168.28.229
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 127.0.0.1
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 0.0.0.0
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 1564
-    port: 850
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
-  - address: 127.0.0.1
-    name: ora_lreg_BSAA
-    pid: 15784
-    port: 34911
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: java
-    pid: 13648
-    port: 3873
-    protocol: udp
-    stime: 'Thu May 12 19:11:16 2022'
-    user: oracle
-  - address: '::'
-    name: rpcbind
-    pid: 1564
-    port: 111
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
-  - address: '::'
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: '::'
-    name: rpcbind
-    pid: 1564
-    port: 850
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
+- address: 127.0.0.1
+  name: ora_s000_BNAB
+  pid: 15862
+  port: 9756
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: rsyslogd
+  pid: 2888
+  port: 10583
+  protocol: udp
+  stime: Thu May 12 19:10:27 2022
+  user: root
+- address: 127.0.0.1
+  name: ora_d000_BNAB
+  pid: 15852
+  port: 43469
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_lreg_BNAB
+  pid: 15810
+  port: 43845
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_s000_ARSY
+  pid: 15676
+  port: 46109
+  protocol: udp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_s000_BSAA
+  pid: 15825
+  port: 15051
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_d000_BSAR
+  pid: 15848
+  port: 18969
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_s000_BSAR
+  pid: 15858
+  port: 52283
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ohasd.bin
+  pid: 13578
+  port: 53703
+  protocol: udp
+  stime: Thu May 12 19:11:11 2022
+  user: oragrid
+- address: 127.0.0.1
+  name: asm_lreg_+ASM
+  pid: 15381
+  port: 23389
+  protocol: udp
+  stime: Thu May 12 19:12:03 2022
+  user: oragrid
+- address: 127.0.0.1
+  name: ora_lreg_ARSY
+  pid: 15655
+  port: 57074
+  protocol: udp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_d000_BSAA
+  pid: 15821
+  port: 26201
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_lreg_BSAR
+  pid: 15813
+  port: 60678
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_d000_ARSY
+  pid: 15674
+  port: 62388
+  protocol: udp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Thu May 12 19:10:02 2022
+  user: root
+- address: 192.168.25.186
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 192.168.22.25
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 192.168.28.229
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 127.0.0.1
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 0.0.0.0
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 1564
+  port: 850
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc
+- address: 127.0.0.1
+  name: ora_lreg_BSAA
+  pid: 15784
+  port: 34911
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: java
+  pid: 13648
+  port: 3873
+  protocol: udp
+  stime: Thu May 12 19:11:16 2022
+  user: oracle
+- address: '::'
+  name: rpcbind
+  pid: 1564
+  port: 111
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc
+- address: '::'
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: '::'
+  name: rpcbind
+  pid: 1564
+  port: 850
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/oracle/oracle21_centos7.9.yaml
+++ b/tests/unit/plugins/action/auto/resources/oracle/oracle21_centos7.9.yaml
@@ -1,4829 +1,4980 @@
----
-task_vars:
-  oracle_monitor_user: the_user
-  oracle_monitor_pass: the_password
-  oracle_monitor_users_info:
-    - username: "{{ oracle_monitor_user }}"
-      password: "{{ oracle_monitor_pass }}"
-    - username: the_user2
-      password: the_password2
-  oracle_monitor_cluster_hostname: the_cluster_hostname
-  oracle_monitor_read_configuration: True
-
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - analyzer
+    - -c
+    - /etc/iometrics/skydive/skydive.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - analyzer
+      - -c
+      - /etc/iometrics/skydive/skydive.yml
+      Domainname: ''
+      Entrypoint:
+      - /usr/local/bin/skydive
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      ExposedPorts:
+        8082/tcp: {}
+      Hostname: test-ram-norm01.novalocal
+      Image: nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-4
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/iometrics/skydive/skydive.yml: {}
+        /var/lib/skydive: {}
+      WorkingDir: ''
+    Created: '2022-02-11T16:39:16.436847232Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631-init/diff:/var/lib/docker/overlay2/98c8fc8a1198391d57b52bfc7481b12d8fcb3f1460fa681558aaa7306730bd9a/diff:/var/lib/docker/overlay2/9b3407fa7b3cf45082812007500f2249298b9522aeeb6b5e8c324eb8e7291ad5/diff:/var/lib/docker/overlay2/2a70d40f778c8683b234911bdff488726b2d1931d804bca86b612015cabbcfec/diff
+        MergedDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/merged
+        UpperDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/diff
+        WorkDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/iometrics/skydive/:/var/lib/skydive:rw
+      - /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hostname
+    HostsPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hosts
+    Id: 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
+    Image: sha256:7b966f2ba2092efb97f038f14563b84b32e98879ad8d52189af823c594b185ed
+    LogPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/iometrics/skydive/skydive.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics/skydive/skydive.yml
+      Type: bind
+    - Destination: /var/lib/skydive
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/iometrics/skydive
+      Type: bind
+    Name: /skydive-analyzer
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 36711925279b4b1ac03d5cdb68a3d4d765d86759714aaae8c976b8bce04ce890
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 6e919553642bae0550eee9382a797f886036f8f6f296d65183121041f1da3b83
+      Ports: {}
+      SandboxID: be98496481fa878c6ad9f140fbcae075d3bccea63ad36757fecf011ab94b6dd3
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/local/bin/skydive
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T14:45:04.915207484Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1512
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:45:08.126872087Z'
+      Status: running
+expected_result:
+- bindings: []
+  configuration:
+    key1: value1
+    key2: value2
+  discovery_time: any
+  extra_data:
+    ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
+    databases: XE
+    instance:
+      connection_sid: XE
+      name: XE
+      name_normalized: XE
+      service_names:
+      - XE
+      - XEXDB
+      - d6e0afed43d66145e055000000000001
+      - xepdb1
+    role: PRIMARY
+  files:
+  - path: /opt/oracle/diag/rdbms/xe/XE/trace
+    subtype: generic
+    type: log
+  - path: /opt/oracle/product/21c/dbhomeXE
+    subtype: generic
+    type: home
+  listening_ports:
+  - 1539
+  process:
+    cmdline: xe_pmon_XE
+    cwd: /
+    pid: '22942'
+    ppid: '1'
+    user: oracle
+  type: Oracle DatabaseServer
+  version:
+  - number: 21.0.0.0.0
+    type: active
+  - number: 21c
+    type: file
 mocked_plugin_tasks:
-  Read env from listener:
-    expected_args:
-      pid: '22926'
-    plugin_result:
-      failed: false
-      parsed:
-        "XDG_SESSION_ID": "c3"
-        "LISTENER_NAME": "LISTENER"
-        "TEMPLATE_NAME": "XE_Database.dbc"
-        "SHELL": "/bin/bash"
-        "USER": "oracle"
-        "ORACLE_SID": "XE"
-        "PDB_NAME": "XEPDB1"
-        "CREATE_AS_CDB": "true"
-        "PATH": "/opt/oracle/product/21c/dbhomeXE/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
-        "_": "/opt/oracle/product/21c/dbhomeXE/bin/lsnrctl"
-        "PWD": "/"
-        "LANG": "en_US.UTF-8"
-        "NUMBER_OF_PDBS": "1"
-        "HOME": "/home/oracle"
-        "SHLVL": "2"
-        "LOGNAME": "oracle"
-        "XDG_RUNTIME_DIR": "/run/user/54321"
-        "ORACLE_HOME": "/opt/oracle/product/21c/dbhomeXE"
-        "ORA_NET2_DESC": "7,10"
   Create lsnrctl temp file:
     expected_args:
       ansible.builtin.blockinfile:
-        create: yes
-        path:  /tmp/os_facts_oracledb
-        block: |
-          SET DISPLAYMODE raw
+        block: 'SET DISPLAYMODE raw
+
           status LISTENER
+
+          '
+        create: true
         insertbefore: BOF
+        path: /tmp/os_facts_oracledb
     plugin_result:
       failed: false
   Execute lsnrctl:
     expected_args:
       argv: null
       cmd: /opt/oracle/product/21c/dbhomeXE/bin/lsnrctl @/tmp/os_facts_oracledb
-      in_docker: True
+      in_docker: true
     expected_attributes:
       environment:
-        ORACLE_HOME: "/opt/oracle/product/21c/dbhomeXE"
-        TNS_ADMIN: "/opt/oracle/product/21c/dbhomeXE/network/admin"
+        ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
+        TNS_ADMIN: /opt/oracle/product/21c/dbhomeXE/network/admin
       register: any
       when: any
     plugin_result:
       failed: false
       stdout_lines:
-        - ''
-        - LSNRCTL for Linux: Version 21.0.0.0.0 - Production on 10-JUN-2022 08:49:07
-        - ''
-        - Copyright (c) 1991, 2021, Oracle.  All rights reserved.
-        - ''
-        - Service display mode is RAW
-        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=test-ram-norm01.novalocal)(PORT=1539)))
-        - STATUS of the LISTENER
-        - ------------------------
-        - Alias                     LISTENER
-        - Version                   TNSLSNR for Linux: Version 21.0.0.0.0 - Production
-        - Start Date                09-JUN-2022 09:15:35
-        - Uptime                    0 days 23 hr. 33 min. 32 sec
-        - Trace Level               off
-        - Security                  ON: Local OS Authentication
-        - SNMP                      OFF
-        - Default Service           XE
-        - Listener Parameter File   /opt/oracle/homes/OraDBHome21cXE/network/admin/listener.ora
-        - Listener Log File         /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/alert/log.xml
-        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=E10143B6EC20-598E-E055-000000000001)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1539)))))
-        - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=E10143B6EC21-598E-E055-000000000001)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))
-        - (ENDPOINT=)
-        - (ENDPOINT=(HANDLER=(STA=ready)(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=E10143B6EC2F-598E-E055-000000000001)(PRE=http)(SESSION=RAW)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=localhost)(PORT=5500))(Security=(my_wallet_directory=/opt/oracle/homes/OraDBHome21cXE/admin/XE/xdb_wallet))(Presentation=HTTP)(Session=RAW))))
-        - (SERVICE=(SERVICE_NAME=XE)(INSTANCE=(INSTANCE_NAME=XE)(NUM=2)(GOODNESS=65535)(DELTA=0)(NUMREL=1)))
-        - (SERVICE=(SERVICE_NAME=XEXDB)(INSTANCE=(INSTANCE_NAME=XE)(NUM=2)(GOODNESS=65535)(DELTA=0)(NUMREL=1)))
-        - (SERVICE=(SERVICE_NAME=d6e0afed43d66145e055000000000001)(INSTANCE=(INSTANCE_NAME=XE)(NUM=2)(GOODNESS=65535)(DELTA=0)(NUMREL=1)))
-        - (SERVICE=(SERVICE_NAME=xepdb1)(INSTANCE=(INSTANCE_NAME=XE)(NUM=2)(GOODNESS=65535)(DELTA=0)(NUMREL=1)))
-        - The command completed successfully
+      - ''
+      - LSNRCTL for Linux: Version 21.0.0.0.0 - Production on 10-JUN-2022 08:49:07
+      - ''
+      - Copyright (c) 1991, 2021, Oracle.  All rights reserved.
+      - ''
+      - Service display mode is RAW
+      - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=test-ram-norm01.novalocal)(PORT=1539)))
+      - STATUS of the LISTENER
+      - '------------------------'
+      - Alias                     LISTENER
+      - Version                   TNSLSNR for Linux: Version 21.0.0.0.0 - Production
+      - Start Date                09-JUN-2022 09:15:35
+      - Uptime                    0 days 23 hr. 33 min. 32 sec
+      - Trace Level               off
+      - Security                  ON: Local OS Authentication
+      - SNMP                      OFF
+      - Default Service           XE
+      - Listener Parameter File   /opt/oracle/homes/OraDBHome21cXE/network/admin/listener.ora
+      - Listener Log File         /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/alert/log.xml
+      - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=E10143B6EC20-598E-E055-000000000001)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1539)))))
+      - (ENDPOINT=(HANDLER=(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=E10143B6EC21-598E-E055-000000000001)(PRE=any)(SESSION=NS)(DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))))
+      - (ENDPOINT=)
+      - (ENDPOINT=(HANDLER=(STA=ready)(HANDLER_MAXLOAD=0)(HANDLER_LOAD=0)(ESTABLISHED=0)(REFUSED=0)(HANDLER_ID=E10143B6EC2F-598E-E055-000000000001)(PRE=http)(SESSION=RAW)(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=localhost)(PORT=5500))(Security=(my_wallet_directory=/opt/oracle/homes/OraDBHome21cXE/admin/XE/xdb_wallet))(Presentation=HTTP)(Session=RAW))))
+      - (SERVICE=(SERVICE_NAME=XE)(INSTANCE=(INSTANCE_NAME=XE)(NUM=2)(GOODNESS=65535)(DELTA=0)(NUMREL=1)))
+      - (SERVICE=(SERVICE_NAME=XEXDB)(INSTANCE=(INSTANCE_NAME=XE)(NUM=2)(GOODNESS=65535)(DELTA=0)(NUMREL=1)))
+      - (SERVICE=(SERVICE_NAME=d6e0afed43d66145e055000000000001)(INSTANCE=(INSTANCE_NAME=XE)(NUM=2)(GOODNESS=65535)(DELTA=0)(NUMREL=1)))
+      - (SERVICE=(SERVICE_NAME=xepdb1)(INSTANCE=(INSTANCE_NAME=XE)(NUM=2)(GOODNESS=65535)(DELTA=0)(NUMREL=1)))
+      - The command completed successfully
+  Get ORAHOME from oratab:
+    fail: Should not be called
+  Get ORAHOME from path:
+    fail: Should not be called
+  Read config file:
+    fail: Should not be called
+  Read env from listener:
+    expected_args:
+      pid: '22926'
+    plugin_result:
+      failed: false
+      parsed:
+        CREATE_AS_CDB: 'true'
+        HOME: /home/oracle
+        LANG: en_US.UTF-8
+        LISTENER_NAME: LISTENER
+        LOGNAME: oracle
+        NUMBER_OF_PDBS: '1'
+        ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
+        ORACLE_SID: XE
+        ORA_NET2_DESC: 7,10
+        PATH: /opt/oracle/product/21c/dbhomeXE/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+        PDB_NAME: XEPDB1
+        PWD: /
+        SHELL: /bin/bash
+        SHLVL: '2'
+        TEMPLATE_NAME: XE_Database.dbc
+        USER: oracle
+        XDG_RUNTIME_DIR: /run/user/54321
+        XDG_SESSION_ID: c3
+        _: /opt/oracle/product/21c/dbhomeXE/bin/lsnrctl
   Read env from process:
     expected_args:
       pid: '22942'
     plugin_result:
       failed: false
       parsed:
-        XDG_SESSION_ID: c4
-        LISTENER_NAME: LISTENER
-        TEMPLATE_NAME: XE_Database.dbc
-        SHELL: /bin/bash
-        USER: oracle
-        ORACLE_SID: XE
-        PDB_NAME: XEPDB1
         CREATE_AS_CDB: true
-        PATH:
-        _: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus
-        PWD: /
-        LANG: en_US.UTF-8
-        NUMBER_OF_PDBS: 1
         HOME: /home/oracle
-        SHLVL: 2
+        LANG: en_US.UTF-8
+        LISTENER_NAME: LISTENER
         LOGNAME: oracle
-        XDG_RUNTIME_DIR: /run/user/54321
+        NUMBER_OF_PDBS: 1
         ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
-        ORA_NET2_DESC: 9,12
-        SKGP_SPAWN_DIAG_POST_FORK_TS: 1654766136
-        SKGP_HIDDEN_ARGS: <FATAL/S/PMON/x0/x1/x0/xE16A7308/22931/22931/x0/x2/x1/xE16A733D/1654766136/1654766136/196609/0/(nil)>^A0
-        SKGP_SPAWN_DIAG_PRE_FORK_TS: 1654766136
-        SKGP_SPAWN_DIAG_PRE_EXEC_TS: 1654766136
+        ORACLE_SID: XE
         ORACLE_SPAWNED_PROCESS: 1
+        ORA_NET2_DESC: 9,12
+        PATH: null
+        PDB_NAME: XEPDB1
+        PWD: /
         RDMAV_FORK_SAFE: 1
         RDMAV_HUGEPAGES_SAFE: 1
-  Get ORAHOME from path:
-    fail: Should not be called
-  Get ORAHOME from oratab:
-    fail: Should not be called
+        SHELL: /bin/bash
+        SHLVL: 2
+        SKGP_HIDDEN_ARGS: <FATAL/S/PMON/x0/x1/x0/xE16A7308/22931/22931/x0/x2/x1/xE16A733D/1654766136/1654766136/196609/0/(nil)>^A0
+        SKGP_SPAWN_DIAG_POST_FORK_TS: 1654766136
+        SKGP_SPAWN_DIAG_PRE_EXEC_TS: 1654766136
+        SKGP_SPAWN_DIAG_PRE_FORK_TS: 1654766136
+        TEMPLATE_NAME: XE_Database.dbc
+        USER: oracle
+        XDG_RUNTIME_DIR: /run/user/54321
+        XDG_SESSION_ID: c4
+        _: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus
+  Run command to get log dir:
+    calls:
+    - expected_args:
+        argv: null
+        cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user/the_password@localhost:1539/XE
+        in_docker: true
+        stdin: 'SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;
+
+          select value from v$diag_info where name = ''Diag Trace'';'
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user2/the_password2@localhost:1539/XE
+        in_docker: true
+        stdin: 'SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;
+
+          select value from v$diag_info where name = ''Diag Trace'';'
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user/the_password@target_host:1539/XE
+        in_docker: true
+        stdin: 'SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;
+
+          select value from v$diag_info where name = ''Diag Trace'';'
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user2/the_password2@target_host:1539/XE
+        in_docker: true
+        stdin: 'SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;
+
+          select value from v$diag_info where name = ''Diag Trace'';'
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user/the_password@the_cluster_hostname:1539/XE
+        in_docker: true
+        stdin: 'SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;
+
+          select value from v$diag_info where name = ''Diag Trace'';'
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user2/the_password2@the_cluster_hostname:1539/XE
+        in_docker: true
+        stdin: 'SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;
+
+          select value from v$diag_info where name = ''Diag Trace'';'
+      plugin_result:
+        failed: false
+        stdout: /opt/oracle/diag/rdbms/xe/XE/trace
+  Run command to get parameters from DB:
+    plugin_result:
+      failed: false
+      stdout: 'key1=value1
+
+        key2=value2'
+  Run command to get role:
+    calls:
+    - expected_args:
+        argv: null
+        cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user/the_password@localhost:1539/XE
+        in_docker: true
+        stdin: 'SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;
+
+          select database_role from v$database;'
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user2/the_password2@localhost:1539/XE
+        in_docker: true
+        stdin: 'SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;
+
+          select database_role from v$database;'
+      plugin_result:
+        failed: false
+        stdout: PRIMARY
   Run command to get version:
-    expected_args:
-      argv: null
-      cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -V
-      in_docker: True
     expeced_attributes:
       environment:
         ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
       register: any
+    expected_args:
+      argv: null
+      cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -V
+      in_docker: true
     plugin_result:
       failed: false
-      stdout: |-
-        
+      stdout: '
+
         SQL*Plus: Release 21.0.0.0.0 - Production
-        Version 21.3.0.0.0
-  Run command to get log dir:
-    calls:
-      - expected_args:
-          argv: null
-          cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user/the_password@localhost:1539/XE
-          in_docker: True
-          stdin: "SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;\nselect value from v$diag_info where name = 'Diag Trace';"
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user2/the_password2@localhost:1539/XE
-          in_docker: true
-          stdin: "SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;\nselect value from v$diag_info where name = 'Diag Trace';"
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user/the_password@target_host:1539/XE
-          in_docker: true
-          stdin: "SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;\nselect value from v$diag_info where name = 'Diag Trace';"
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user2/the_password2@target_host:1539/XE
-          in_docker: true
-          stdin: "SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;\nselect value from v$diag_info where name = 'Diag Trace';"
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user/the_password@the_cluster_hostname:1539/XE
-          in_docker: true
-          stdin: "SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;\nselect value from v$diag_info where name = 'Diag Trace';"
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user2/the_password2@the_cluster_hostname:1539/XE
-          in_docker: true
-          stdin: "SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;\nselect value from v$diag_info where name = 'Diag Trace';"
-        plugin_result:
-          failed: false
-          stdout: /opt/oracle/diag/rdbms/xe/XE/trace
-  Run command to get role:
-    calls:
-      - expected_args:
-          argv: null
-          cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user/the_password@localhost:1539/XE
-          in_docker: true
-          stdin: "SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;\nselect database_role from v$database;"
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: /opt/oracle/product/21c/dbhomeXE/bin/sqlplus -silent the_user2/the_password2@localhost:1539/XE
-          in_docker: true
-          stdin: "SET PAGESIZE 0 FEEDBACK OFF VERIFY OFF HEADING OFF ECHO OFF;\nselect database_role from v$database;"
-        plugin_result:
-          failed: false
-          stdout: PRIMARY
-  Run command to get parameters from DB:
-    plugin_result:
-      failed: false
-      stdout: |-
-        key1=value1
-        key2=value2
-  Read config file:
-    fail: Should not be called
 
-expected_result:
-  - bindings: [ ]
-    extra_data:
-      ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
-      databases: XE
-      role: PRIMARY
-      instance:
-        connection_sid: XE
-        name: XE
-        name_normalized: XE
-        service_names:
-          - XE
-          - XEXDB
-          - d6e0afed43d66145e055000000000001
-          - xepdb1
-    files:
-    - path: /opt/oracle/diag/rdbms/xe/XE/trace
-      subtype: generic
-      type: log
-    - path: /opt/oracle/product/21c/dbhomeXE
-      subtype: generic
-      type: home
-    configuration:
-      key1: value1
-      key2: value2
-    discovery_time: any
-    listening_ports:
-      - 1539
-    type: Oracle DatabaseServer
-    process:
-      cmdline: xe_pmon_XE
-      pid: '22942'
-      ppid: '1'
-      user: oracle
-    version:
-      - number: "21.0.0.0.0"
-        type: active
-      - number: 21c
-        type: file
-
-software_list:
-  - name: Oracle DatabaseServer
-    cmd_regexp: _pmon_
-    process_type: parent
-    return_children: false
-    return_packages: false
-    vars:
-      connect_with_users: "{{ oracle_monitor_users_info 
-        | default([{'username': oracle_monitor_user | default('oracle'), 
-        'password': oracle_monitor_pass | default('oracle')}]) }}"
-      monitor_cluster_hostname: "{{ oracle_monitor_cluster_hostname | default('localhost') }}"
-      read_configuration: "{{ oracle_monitor_read_configuration | default(False) }}"
-    custom_tasks:
-      - include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/oracle.yaml"
-        name: Include Oracle specific plugins
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - analyzer
-        - '-c'
-        - /etc/iometrics/skydive/skydive.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - analyzer
-          - '-c'
-          - /etc/iometrics/skydive/skydive.yml
-        Domainname: ''
-        Entrypoint:
-          - /usr/local/bin/skydive
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-        ExposedPorts:
-          8082/tcp: {}
-        Hostname: test-ram-norm01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-4'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/iometrics/skydive/skydive.yml: {}
-          /var/lib/skydive: {}
-        WorkingDir: ''
-      Created: '2022-02-11T16:39:16.436847232Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631-init/diff:/var/lib/docker/overlay2/98c8fc8a1198391d57b52bfc7481b12d8fcb3f1460fa681558aaa7306730bd9a/diff:/var/lib/docker/overlay2/9b3407fa7b3cf45082812007500f2249298b9522aeeb6b5e8c324eb8e7291ad5/diff:/var/lib/docker/overlay2/2a70d40f778c8683b234911bdff488726b2d1931d804bca86b612015cabbcfec/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/iometrics/skydive/:/var/lib/skydive:rw'
-          - >-
-            /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hosts
-      Id: 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
-      Image: 'sha256:7b966f2ba2092efb97f038f14563b84b32e98879ad8d52189af823c594b185ed'
-      LogPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/iometrics/skydive/skydive.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics/skydive/skydive.yml
-          Type: bind
-        - Destination: /var/lib/skydive
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/iometrics/skydive
-          Type: bind
-      Name: /skydive-analyzer
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 36711925279b4b1ac03d5cdb68a3d4d765d86759714aaae8c976b8bce04ce890
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 6e919553642bae0550eee9382a797f886036f8f6f296d65183121041f1da3b83
-        Ports: {}
-        SandboxID: be98496481fa878c6ad9f140fbcae075d3bccea63ad36757fecf011ab94b6dd3
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/local/bin/skydive
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T14:45:04.915207484Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1512
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:45:08.126872087Z'
-        Status: running
+        Version 21.3.0.0.0'
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   apache-commons-collections:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-collections
-      release: 22.el7_2
-      source: rpm
-      version: 3.2.1
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
   apache-commons-daemon:
-    - arch: x86_64
-      epoch: null
-      name: apache-commons-daemon
-      release: 7.el7
-      source: rpm
-      version: 1.0.13
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
   apache-commons-dbcp:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-dbcp
-      release: 17.el7
-      source: rpm
-      version: '1.4'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
   apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
   apache-commons-pool:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-pool
-      release: 9.el7
-      source: rpm
-      version: '1.6'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
   avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 35.el7_9
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 35.el7_9
+    source: rpm
+    version: 4.2.46
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 72.el7_9
-      source: rpm
-      version: 2021.2.50
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 72.el7_9
+    source: rpm
+    version: 2021.2.50
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 7.el7.centos.5
-      source: rpm
-      version: '19.4'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 7.el7.centos.5
+    source: rpm
+    version: '19.4'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.4.12
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.4.12
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: i686
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: i686
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-ce-rootless-extras:
-    - arch: x86_64
-      epoch: 0
-      name: docker-ce-rootless-extras
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-scan-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-scan-plugin
-      release: 3.el7
-      source: rpm
-      version: 0.12.0
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  ecj:
-    - arch: x86_64
-      epoch: 1
-      name: ecj
-      release: 3.el7
-      source: rpm
-      version: 4.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '14'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
-  fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  geronimo-jta:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jta
-      release: 17.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 467e318a
-      source: rpm
-      version: 00f97f56
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iometrics-agent-plugin-oracle-lib-connector:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-lib-connector
-      release: '25'
-      source: rpm
-      version: 18.5.0_1.11.3
-  iometrics-agent-plugin-oracle-libs:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-libs
-      release: '1'
-      source: rpm
-      version: 18.5.0
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-taglibs-standard:
-    - arch: noarch
-      epoch: 0
-      name: jakarta-taglibs-standard
-      release: 14.el7_1
-      source: rpm
-      version: 1.1.2
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.3
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: i686
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 135.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: i686
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  ksh:
-    - arch: x86_64
-      epoch: null
-      name: ksh
-      release: 143.el7_9
-      source: rpm
-      version: '20120801'
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXmu:
-    - arch: x86_64
-      epoch: null
-      name: libXmu
-      release: 2.el7
-      source: rpm
-      version: 1.1.2
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXt:
-    - arch: x86_64
-      epoch: null
-      name: libXt
-      release: 3.el7
-      source: rpm
-      version: 1.1.5
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXv:
-    - arch: x86_64
-      epoch: null
-      name: libXv
-      release: 1.el7
-      source: rpm
-      version: 1.0.11
-  libXxf86dga:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86dga
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.4
-  libXxf86misc:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86misc
-      release: 7.1.el7
-      source: rpm
-      version: 1.0.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-    - arch: i686
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: i686
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdmx:
-    - arch: x86_64
-      epoch: null
-      name: libdmx
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: i686
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-    - arch: i686
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 18.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  mailx:
-    - arch: x86_64
-      epoch: null
-      name: mailx
-      release: 19.el7
-      source: rpm
-      version: '12.5'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-    - arch: i686
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7.2
-      source: rpm
-      version: 1.3.0
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: i686
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-    - arch: i686
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-    - arch: i686
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-    - arch: i686
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  oracle-database-preinstall-21c:
-    - arch: x86_64
-      epoch: null
-      name: oracle-database-preinstall-21c
-      release: 1.el7
-      source: rpm
-      version: '1.0'
-  oracle-database-xe-21c:
-    - arch: x86_64
-      epoch: null
-      name: oracle-database-xe-21c
-      release: '1'
-      source: rpm
-      version: '1.0'
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: i686
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql:
-    - arch: x86_64
-      epoch: null
-      name: postgresql
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-contrib
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-    - arch: i686
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-server
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 17.el7
-      source: rpm
-      version: '22.20'
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 10.el7
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: i686
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redis:
-    - arch: x86_64
-      epoch: null
-      name: redis
-      release: 1.el7.remi
-      source: rpm
-      version: 6.2.6
-  remi-release:
-    - arch: noarch
-      epoch: null
-      name: remi-release
-      release: 2.el7.remi
-      source: rpm
-      version: '7.9'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9.1
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  smartmontools:
-    - arch: x86_64
-      epoch: 1
-      name: smartmontools
-      release: 2.el7
-      source: rpm
-      version: '7.0'
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: i686
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.2
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  tomcat:
-    - arch: noarch
-      epoch: 0
-      name: tomcat
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-admin-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-admin-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-docs-webapp:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-docs-webapp
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-el-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-el-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-javadoc:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-javadoc
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-jsp-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-jsp-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-lib:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-lib
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 24.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  uuid:
-    - arch: x86_64
-      epoch: null
-      name: uuid
-      release: 26.el7
-      source: rpm
-      version: 1.6.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7_9.1
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-utils
-      release: 23.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-xauth:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-xauth
-      release: 1.el7
-      source: rpm
-      version: 1.0.9
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-    - arch: i686
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '127'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '194'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '195'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '267'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '273'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '294'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '411'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '453'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '481'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '486'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '515'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '551'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '552'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '566'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/smartd -n -q never
-    pid: '567'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '570'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '573'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '584'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '594'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H test-ram-norm01 eth0
-    pid: '826'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/lib/jvm/jre/bin/java
-      -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
-      -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050
-      -Dcom.sun.management.jmxremote.rmi.port=8050
-      -Dcom.sun.management.jmxremote.ssl=false
-      -Dcom.sun.management.jmxremote.authenticate=false
-      -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath
-      /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
-      -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat
-      -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp
-      -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      org.apache.catalina.startup.Bootstrap start
-    pid: '881'
-    ppid: '1'
-    user: tomcat
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '883'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '902'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1058'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1063'
-    ppid: '1058'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1103'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1105'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml
-      -path.home /usr/share/filebeat -path.config /etc/filebeat -path.data
-      /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '1106'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/redis-server 127.0.0.1:6379'
-    pid: '1109'
-    ppid: '1'
-    user: redis
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1110'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1114'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1115'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1116'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9 -address
-      /run/containerd/containerd.sock
-    pid: '1494'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
-    pid: '1512'
-    ppid: '1494'
-    user: root
-  - cmdline: /usr/bin/docker start -a skydive-analyzer
-    pid: '1561'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/postgres -D /var/lib/pgsql/data -p 5432
-    pid: '7291'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: logger process'
-    pid: '7292'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: checkpointer process'
-    pid: '7294'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: writer process'
-    pid: '7295'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: wal writer process'
-    pid: '7296'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: autovacuum launcher process'
-    pid: '7297'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: stats collector process'
-    pid: '7298'
-    ppid: '7291'
-    user: postgres
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '14440'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: postgres datadope [local] idle'
-    pid: '14511'
-    ppid: '7291'
-    user: postgres
-  - cmdline: pickup -l -t unix -u
-    pid: '18090'
-    ppid: '1058'
-    user: postfix
-  - cmdline: ''
-    pid: '18693'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '22473'
-    ppid: '1103'
-    user: root
-  - cmdline: 'sshd: centos@pts/2'
-    pid: '22476'
-    ppid: '22473'
-    user: centos
-  - cmdline: '-bash'
-    pid: '22477'
-    ppid: '22476'
-    user: centos
-  - cmdline: sudo su -
-    pid: '22499'
-    ppid: '22477'
-    user: root
-  - cmdline: su -
-    pid: '22500'
-    ppid: '22499'
-    user: root
-  - cmdline: '-bash'
-    pid: '22501'
-    ppid: '22500'
-    user: root
-  - cmdline: ''
-    pid: '22846'
-    ppid: '2'
-    user: root
-  - cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
-    pid: '22926'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pmon_XE
-    pid: '22942'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_clmn_XE
-    pid: '22946'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_psp0_XE
-    pid: '22950'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vktm_XE
-    pid: '22954'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen0_XE
-    pid: '22961'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mman_XE
-    pid: '22967'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen1_XE
-    pid: '22971'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen2_XE
-    pid: '22973'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vosd_XE
-    pid: '22975'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_diag_XE
-    pid: '22979'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_ofsd_XE
-    pid: '22985'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dbrm_XE
-    pid: '22990'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vkrm_XE
-    pid: '22993'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_svcb_XE
-    pid: '22996'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pman_XE
-    pid: '23001'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dia0_XE
-    pid: '23004'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dbw0_XE
-    pid: '23008'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_lgwr_XE
-    pid: '23012'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_ckpt_XE
-    pid: '23015'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_smon_XE
-    pid: '23020'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_smco_XE
-    pid: '23023'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_reco_XE
-    pid: '23030'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_lreg_XE
-    pid: '23033'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pxmn_XE
-    pid: '23035'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mmon_XE
-    pid: '23041'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mmnl_XE
-    pid: '23045'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_bg00_XE
-    pid: '23049'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_d000_XE
-    pid: '23051'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w000_XE
-    pid: '23054'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_bg01_XE
-    pid: '23058'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_s000_XE
-    pid: '23060'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w001_XE
-    pid: '23063'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tmon_XE
-    pid: '23068'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt00_XE
-    pid: '23074'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt01_XE
-    pid: '23076'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt02_XE
-    pid: '23078'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_rcbg_XE
-    pid: '23098'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_aqpc_XE
-    pid: '23109'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w002_XE
-    pid: '23114'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w003_XE
-    pid: '23120'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w004_XE
-    pid: '23299'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_cjq0_XE
-    pid: '23309'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_qm02_XE
-    pid: '23311'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_q003_XE
-    pid: '23318'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_q005_XE
-    pid: '23374'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_cl00_XE
-    pid: '23486'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_m004_XE
-    pid: '24070'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w005_XE
-    pid: '24218'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w006_XE
-    pid: '24731'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w007_XE
-    pid: '24736'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_m000_XE
-    pid: '26069'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_m003_XE
-    pid: '26855'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '27532'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28851'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29511'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654769069
-    pid: '30393'
-    ppid: '14440'
-    user: root
-  - cmdline: xe_m002_XE
-    pid: '30487'
-    ppid: '1'
-    user: oracle
-  - cmdline: 'sshd: centos [priv]'
-    pid: '30501'
-    ppid: '1103'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '30503'
-    ppid: '30501'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '30659'
-    ppid: '30503'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
-    pid: '30672'
-    ppid: '30659'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
-    pid: '30673'
-    ppid: '30672'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
-    pid: '30674'
-    ppid: '30673'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: postgres
-    pid: 7291
-    port: 5432
-    protocol: tcp
-    stime: 'Fri Jun  3 09:22:29 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1058
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:01 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 1512
-    port: 12379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 1512
-    port: 12380
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: 192.168.0.26
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: 127.0.0.1
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1103
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: root
-  - address: '::1'
-    name: postgres
-    pid: 7291
-    port: 5432
-    protocol: tcp
-    stime: 'Fri Jun  3 09:22:29 2022'
-    user: postgres
-  - address: '::1'
-    name: master
-    pid: 1058
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:01 2022'
-    user: root
-  - address: '::'
-    name: tnslsnr
-    pid: 22926
-    port: 5500
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:34 2022'
-    user: oracle
-  - address: '::'
-    name: java
-    pid: 881
-    port: 11870
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 4000
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: tnslsnr
-    pid: 22926
-    port: 1539
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:34 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: java
-    pid: 881
-    port: 8005
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8009
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: xe_d000_XE
-    pid: 23051
-    port: 21899
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::1'
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8080
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8081
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8082
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8050
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: sshd
-    pid: 1103
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: root
-udp_listen:
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 584
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:54 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 566
-    port: 719
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 826
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: root
-  - address: 0.0.0.0
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-ce-rootless-extras:
+  - arch: x86_64
+    epoch: 0
+    name: docker-ce-rootless-extras
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-scan-plugin:
+  - arch: x86_64
+    epoch: 0
+    name: docker-scan-plugin
+    release: 3.el7
+    source: rpm
+    version: 0.12.0
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '14'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  fuse-overlayfs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
+  fuse3-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 467e318a
+    source: rpm
+    version: 00f97f56
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iometrics-agent-plugin-oracle-lib-connector:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-lib-connector
+    release: '25'
+    source: rpm
+    version: 18.5.0_1.11.3
+  iometrics-agent-plugin-oracle-libs:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-libs
+    release: '1'
+    source: rpm
+    version: 18.5.0
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.3
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: i686
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 135.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: i686
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  ksh:
+  - arch: x86_64
+    epoch: null
+    name: ksh
+    release: 143.el7_9
+    source: rpm
+    version: '20120801'
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXmu:
+  - arch: x86_64
+    epoch: null
+    name: libXmu
+    release: 2.el7
+    source: rpm
+    version: 1.1.2
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXt:
+  - arch: x86_64
+    epoch: null
+    name: libXt
+    release: 3.el7
+    source: rpm
+    version: 1.1.5
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXv:
+  - arch: x86_64
+    epoch: null
+    name: libXv
+    release: 1.el7
+    source: rpm
+    version: 1.0.11
+  libXxf86dga:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86dga
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.4
+  libXxf86misc:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86misc
+    release: 7.1.el7
+    source: rpm
+    version: 1.0.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  - arch: i686
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: i686
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdmx:
+  - arch: x86_64
+    epoch: null
+    name: libdmx
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: i686
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  - arch: i686
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 18.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  mailx:
+  - arch: x86_64
+    epoch: null
+    name: mailx
+    release: 19.el7
+    source: rpm
+    version: '12.5'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  - arch: i686
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7.2
+    source: rpm
+    version: 1.3.0
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: i686
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  - arch: i686
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  - arch: i686
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  - arch: i686
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  oracle-database-preinstall-21c:
+  - arch: x86_64
+    epoch: null
+    name: oracle-database-preinstall-21c
+    release: 1.el7
+    source: rpm
+    version: '1.0'
+  oracle-database-xe-21c:
+  - arch: x86_64
+    epoch: null
+    name: oracle-database-xe-21c
+    release: '1'
+    source: rpm
+    version: '1.0'
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: i686
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql:
+  - arch: x86_64
+    epoch: null
+    name: postgresql
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-contrib
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  - arch: i686
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-server
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  psmisc:
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 17.el7
+    source: rpm
+    version: '22.20'
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 10.el7
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: i686
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redis:
+  - arch: x86_64
+    epoch: null
+    name: redis
+    release: 1.el7.remi
+    source: rpm
+    version: 6.2.6
+  remi-release:
+  - arch: noarch
+    epoch: null
+    name: remi-release
+    release: 2.el7.remi
+    source: rpm
+    version: '7.9'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 566
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 584
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:54 2022'
-    user: chrony
-  - address: '::1'
-    name: xe_lreg_XE
-    pid: 23033
-    port: 33176
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 719
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::1'
-    name: xe_s000_XE
-    pid: 23060
-    port: 64452
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:38 2022'
-    user: oracle
-  - address: '::1'
-    name: xe_d000_XE
-    pid: 23051
-    port: 32251
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8081
-    protocol: udp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9.1
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  smartmontools:
+  - arch: x86_64
+    epoch: 1
+    name: smartmontools
+    release: 2.el7
+    source: rpm
+    version: '7.0'
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: i686
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.2
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-docs-webapp:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-docs-webapp
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-javadoc:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-javadoc
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 24.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  uuid:
+  - arch: x86_64
+    epoch: null
+    name: uuid
+    release: 26.el7
+    source: rpm
+    version: 1.6.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7_9.1
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-utils:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-utils
+    release: 23.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-xauth:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-xauth
+    release: 1.el7
+    source: rpm
+    version: 1.0.9
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+  - arch: i686
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '127'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '194'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '195'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '273'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '411'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '453'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '481'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '486'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '515'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '551'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '552'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '566'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/smartd -n -q never
+  cwd: /usr/sbin/
+  pid: '567'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '570'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '573'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '584'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '594'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H test-ram-norm01 eth0
+  cwd: /sbin/
+  pid: '826'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+    -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050 -Dcom.sun.management.jmxremote.rmi.port=8050
+    -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
+    -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+    -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+    -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+    start
+  cwd: /usr/lib/jvm/jre/bin/
+  pid: '881'
+  ppid: '1'
+  user: tomcat
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '883'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '902'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1058'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1063'
+  ppid: '1058'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1103'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1105'
+  ppid: '1'
+  user: root
+- cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '1106'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/redis-server 127.0.0.1:6379
+  cwd: /usr/bin/
+  pid: '1109'
+  ppid: '1'
+  user: redis
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1110'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1114'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1115'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1116'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1494'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
+  cwd: /usr/local/bin/
+  pid: '1512'
+  ppid: '1494'
+  user: root
+- cmdline: /usr/bin/docker start -a skydive-analyzer
+  cwd: /usr/bin/
+  pid: '1561'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/postgres -D /var/lib/pgsql/data -p 5432
+  cwd: /usr/bin/
+  pid: '7291'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: logger process'
+  cwd: /
+  pid: '7292'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: checkpointer process'
+  cwd: /
+  pid: '7294'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: writer process'
+  cwd: /
+  pid: '7295'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: wal writer process'
+  cwd: /
+  pid: '7296'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: autovacuum launcher process'
+  cwd: /
+  pid: '7297'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: stats collector process'
+  cwd: /
+  pid: '7298'
+  ppid: '7291'
+  user: postgres
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '14440'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: postgres datadope [local] idle'
+  cwd: /
+  pid: '14511'
+  ppid: '7291'
+  user: postgres
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '18090'
+  ppid: '1058'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '18693'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '22473'
+  ppid: '1103'
+  user: root
+- cmdline: 'sshd: centos@pts/2'
+  cwd: /
+  pid: '22476'
+  ppid: '22473'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '22477'
+  ppid: '22476'
+  user: centos
+- cmdline: sudo su -
+  cwd: /
+  pid: '22499'
+  ppid: '22477'
+  user: root
+- cmdline: su -
+  cwd: /
+  pid: '22500'
+  ppid: '22499'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '22501'
+  ppid: '22500'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22846'
+  ppid: '2'
+  user: root
+- cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
+  cwd: /opt/oracle/product/21c/dbhomeXE/bin/
+  pid: '22926'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pmon_XE
+  cwd: /
+  pid: '22942'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_clmn_XE
+  cwd: /
+  pid: '22946'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_psp0_XE
+  cwd: /
+  pid: '22950'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vktm_XE
+  cwd: /
+  pid: '22954'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen0_XE
+  cwd: /
+  pid: '22961'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mman_XE
+  cwd: /
+  pid: '22967'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen1_XE
+  cwd: /
+  pid: '22971'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen2_XE
+  cwd: /
+  pid: '22973'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vosd_XE
+  cwd: /
+  pid: '22975'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_diag_XE
+  cwd: /
+  pid: '22979'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_ofsd_XE
+  cwd: /
+  pid: '22985'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dbrm_XE
+  cwd: /
+  pid: '22990'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vkrm_XE
+  cwd: /
+  pid: '22993'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_svcb_XE
+  cwd: /
+  pid: '22996'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pman_XE
+  cwd: /
+  pid: '23001'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dia0_XE
+  cwd: /
+  pid: '23004'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dbw0_XE
+  cwd: /
+  pid: '23008'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_lgwr_XE
+  cwd: /
+  pid: '23012'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_ckpt_XE
+  cwd: /
+  pid: '23015'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_smon_XE
+  cwd: /
+  pid: '23020'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_smco_XE
+  cwd: /
+  pid: '23023'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_reco_XE
+  cwd: /
+  pid: '23030'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_lreg_XE
+  cwd: /
+  pid: '23033'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pxmn_XE
+  cwd: /
+  pid: '23035'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mmon_XE
+  cwd: /
+  pid: '23041'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mmnl_XE
+  cwd: /
+  pid: '23045'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_bg00_XE
+  cwd: /
+  pid: '23049'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_d000_XE
+  cwd: /
+  pid: '23051'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w000_XE
+  cwd: /
+  pid: '23054'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_bg01_XE
+  cwd: /
+  pid: '23058'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_s000_XE
+  cwd: /
+  pid: '23060'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w001_XE
+  cwd: /
+  pid: '23063'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tmon_XE
+  cwd: /
+  pid: '23068'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt00_XE
+  cwd: /
+  pid: '23074'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt01_XE
+  cwd: /
+  pid: '23076'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt02_XE
+  cwd: /
+  pid: '23078'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_rcbg_XE
+  cwd: /
+  pid: '23098'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_aqpc_XE
+  cwd: /
+  pid: '23109'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w002_XE
+  cwd: /
+  pid: '23114'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w003_XE
+  cwd: /
+  pid: '23120'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w004_XE
+  cwd: /
+  pid: '23299'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_cjq0_XE
+  cwd: /
+  pid: '23309'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_qm02_XE
+  cwd: /
+  pid: '23311'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_q003_XE
+  cwd: /
+  pid: '23318'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_q005_XE
+  cwd: /
+  pid: '23374'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_cl00_XE
+  cwd: /
+  pid: '23486'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_m004_XE
+  cwd: /
+  pid: '24070'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w005_XE
+  cwd: /
+  pid: '24218'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w006_XE
+  cwd: /
+  pid: '24731'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w007_XE
+  cwd: /
+  pid: '24736'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_m000_XE
+  cwd: /
+  pid: '26069'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_m003_XE
+  cwd: /
+  pid: '26855'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '27532'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28851'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29511'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654769069
+  cwd: /usr/lib64/sa/
+  pid: '30393'
+  ppid: '14440'
+  user: root
+- cmdline: xe_m002_XE
+  cwd: /
+  pid: '30487'
+  ppid: '1'
+  user: oracle
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '30501'
+  ppid: '1103'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '30503'
+  ppid: '30501'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '30659'
+  ppid: '30503'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '30672'
+  ppid: '30659'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '30673'
+  ppid: '30672'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '30674'
+  ppid: '30673'
+  user: root
+software_list:
+- cmd_regexp: _pmon_
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/oracle.yaml
+    name: Include Oracle specific plugins
+  name: Oracle DatabaseServer
+  process_type: parent
+  return_children: false
+  return_packages: false
+  vars:
+    connect_with_users: '{{ oracle_monitor_users_info | default([{''username'': oracle_monitor_user
+      | default(''oracle''), ''password'': oracle_monitor_pass | default(''oracle'')}])
+      }}'
+    monitor_cluster_hostname: '{{ oracle_monitor_cluster_hostname | default(''localhost'')
+      }}'
+    read_configuration: '{{ oracle_monitor_read_configuration | default(False) }}'
+task_vars:
+  oracle_monitor_cluster_hostname: the_cluster_hostname
+  oracle_monitor_pass: the_password
+  oracle_monitor_read_configuration: true
+  oracle_monitor_user: the_user
+  oracle_monitor_users_info:
+  - password: '{{ oracle_monitor_pass }}'
+    username: '{{ oracle_monitor_user }}'
+  - password: the_password2
+    username: the_user2
+tcp_listen:
+- address: 127.0.0.1
+  name: postgres
+  pid: 7291
+  port: 5432
+  protocol: tcp
+  stime: Fri Jun  3 09:22:29 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1058
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 14:45:01 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 1512
+  port: 12379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 1512
+  port: 12380
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: 192.168.0.26
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: 127.0.0.1
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: 0.0.0.0
+  name: sshd
+  pid: 1103
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: root
+- address: ::1
+  name: postgres
+  pid: 7291
+  port: 5432
+  protocol: tcp
+  stime: Fri Jun  3 09:22:29 2022
+  user: postgres
+- address: ::1
+  name: master
+  pid: 1058
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 14:45:01 2022
+  user: root
+- address: '::'
+  name: tnslsnr
+  pid: 22926
+  port: 5500
+  protocol: tcp
+  stime: Thu Jun  9 09:15:34 2022
+  user: oracle
+- address: '::'
+  name: java
+  pid: 881
+  port: 11870
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 4000
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: tnslsnr
+  pid: 22926
+  port: 1539
+  protocol: tcp
+  stime: Thu Jun  9 09:15:34 2022
+  user: oracle
+- address: 127.0.0.1
+  name: java
+  pid: 881
+  port: 8005
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 881
+  port: 8009
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: xe_d000_XE
+  pid: 23051
+  port: 21899
+  protocol: tcp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: ::1
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8080
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8081
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 881
+  port: 8082
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 881
+  port: 8050
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: sshd
+  pid: 1103
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: root
+udp_listen:
+- address: 127.0.0.1
+  name: chronyd
+  pid: 584
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 14:44:54 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 719
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 826
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 14:44:59 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 584
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 14:44:54 2022
+  user: chrony
+- address: ::1
+  name: xe_lreg_XE
+  pid: 23033
+  port: 33176
+  protocol: udp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 719
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: ::1
+  name: xe_s000_XE
+  pid: 23060
+  port: 64452
+  protocol: udp
+  stime: Thu Jun  9 09:15:38 2022
+  user: oracle
+- address: ::1
+  name: xe_d000_XE
+  pid: 23051
+  port: 32251
+  protocol: udp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8081
+  protocol: udp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/oracle_listener/oracle_listener12_centos7.7_5instances.yaml
+++ b/tests/unit/plugins/action/auto/resources/oracle_listener/oracle_listener12_centos7.7_5instances.yaml
@@ -1,10406 +1,11406 @@
-mocked_plugin_tasks:
-  Read env from process:
-    calls:
-      - expected_args:
-          pid: '14496'
-        plugin_result:
-          failed: false
-          parsed:
-            "ORACLE_HOME": "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14500'
-        plugin_result:
-          failed: false
-          parsed:
-            "ORACLE_HOME": "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14505'
-        plugin_result:
-          failed: false
-          parsed:
-            "ORACLE_HOME": "/softOracle/app/oracle/product/12.1.0.2/db_1"
-      - expected_args:
-          pid: '14763'
-        plugin_result:
-          failed: false
-          parsed:
-            "ORACLE_HOME": "/softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure"
-      - expected_args:
-          pid: '14782'
-        plugin_result:
-          failed: false
-          parsed:
-            "ORACLE_HOME": "/softOracle/app/oracle/product/12.1.0.2/db_1"
-  Execute lsnrctl:
-    calls:
-      - plugin_result:
-          failed: false
-          stdout: |-
-            Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml
-            (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1524)))
-            Services Summary...
-            Service "BSAAPP" has 1 instance(s).
-            Instance "BSAAPP", status READY, has 1 handler(s) for this service...
-          stdout_lines:
-            - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml
-            - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1524)))
-            - Services Summary...
-            - Service "BSAAPP" has 1 instance(s).
-            - Instance "BSAAPP", status READY, has 1 handler(s) for this service...
-      - plugin_result:
-          failed: false
-          stdout: |-
-            Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml
-            (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1527)))
-            Services Summary...
-            Service "BSAREP" has 1 instance(s).
-            Instance "BSAREP", status READY, has 1 handler(s) for this service...
-          stdout_lines:
-            - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml
-            - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1527)))
-            - Services Summary...
-            - Service "BSAREP" has 1 instance(s).
-            - Instance "BSAREP", status READY, has 1 handler(s) for this service...
-      - plugin_result:
-          failed: false
-          stdout: |-
-            Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml
-            (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1523)))
-            Services Summary...
-            Service "BNABBDD" has 1 instance(s).
-            Instance "BNABBDD", status READY, has 1 handler(s) for this service...
-          stdout_lines:
-            - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml
-            - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1523)))
-            - Services Summary...
-            - Service "BNABBDD" has 1 instance(s).
-            - Instance "BNABBDD", status READY, has 1 handler(s) for this service...
-      - plugin_result:
-          failed: false
-          stdout: |-
-            Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml
-            (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
-            Services Summary...
-            Service "+ASM" has 1 instance(s).
-            Instance "+ASM", status READY, has 1 handler(s) for this service...
-          stdout_lines:
-            - Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml
-            - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
-            - Services Summary...
-            - Service "+ASM" has 1 instance(s).
-            - Instance "+ASM", status READY, has 1 handler(s) for this service...
-      - plugin_result:
-          failed: false
-          stdout: |-
-            Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml
-            (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1522)))
-            Services Summary...
-            Service "ARSYS" has 1 instance(s).
-            Instance "ARSYS", status READY, has 1 handler(s) for this service...
-          stdout_lines:
-            - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml
-            - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1522)))
-            - Services Summary...
-            - Service "ARSYS" has 1 instance(s).
-            - Instance "ARSYS", status READY, has 1 handler(s) for this service...
-
-  Check log_dir is a dir:
-    calls:
-      - expected_args:
-          path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/trace
-          follow: false
-          get_attributes: true
-          get_mime: true
-          in_docker: true
-        plugin_result:
-          failed: false
-          stat:
-            exists: true
-            isdir: true
-      - expected_args:
-          path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/trace
-          follow: false
-          get_attributes: true
-          get_mime: true
-          in_docker: true
-        plugin_result:
-          failed: false
-          stat:
-            exists: true
-            isdir: true
-      - expected_args:
-          path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/trace
-          follow: false
-          get_attributes: true
-          get_mime: true
-          in_docker: true
-        plugin_result:
-          failed: false
-          stat:
-            exists: true
-            isdir: true
-      - expected_args:
-          path: /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/trace
-          follow: false
-          get_attributes: true
-          get_mime: true
-          in_docker: true
-        plugin_result:
-          failed: false
-          stat:
-            exists: true
-            isdir: true
-      - expected_args:
-          path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/trace
-          follow: false
-          get_attributes: true
-          get_mime: true
-          in_docker: true
-        plugin_result:
-          failed: false
-          stat:
-            exists: true
-            isdir: true
-
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 1524
-        protocol: 'tcp'
-    discovery_time: '2022-06-15T18:05:12+02:00'
-    extra_data:
-      ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
-      name: LISTENER_BSAAPP
-      instances:
-        - BSAAPP
-    files:
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1
-        subtype: generic
-        type: home
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl
-        subtype: generic
-        type: binary
-      - path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/trace
-        name: log.xml
-        subtype: generic
-        type: log
-    listening_ports:
-      - 1524
-    packages: []
-    process:
-      cmdline: >-
-        /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAAPP
-        -no_crs_notify -inherit
-      listening_ports:
-        - 1524
-      pid: '14496'
-      ppid: '1'
-      user: oragrid
-    type: Oracle Listener
-    version: []
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 1527
-        protocol: 'tcp'
-    discovery_time: '2022-06-15T18:05:15+02:00'
-    extra_data:
-      ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
-      name: LISTENER_BSAREP
-      instances:
-        - BSAREP
-    files:
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1
-        subtype: generic
-        type: home
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl
-        subtype: generic
-        type: binary
-      - path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/trace
-        name: log.xml
-        subtype: generic
-        type: log
-    listening_ports:
-      - 1527
-    packages: []
-    process:
-      cmdline: >-
-        /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAREP
-        -no_crs_notify -inherit
-      listening_ports:
-        - 1527
-      pid: '14500'
-      ppid: '1'
-      user: oragrid
-    type: Oracle Listener
-    version: []
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 1523
-        protocol: 'tcp'
-    discovery_time: '2022-06-15T18:05:18+02:00'
-    extra_data:
-      ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
-      name: LISTENER_BNABBDD
-      instances:
-        - BNABBDD
-    files:
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1
-        subtype: generic
-        type: home
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl
-        subtype: generic
-        type: binary
-      - path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/trace
-        name: log.xml
-        subtype: generic
-        type: log
-    listening_ports:
-      - 1523
-    packages: []
-    process:
-      cmdline: >-
-        /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BNABBDD
-        -no_crs_notify -inherit
-      listening_ports:
-        - 1523
-      pid: '14505'
-      ppid: '1'
-      user: oragrid
-    type: Oracle Listener
-    version: []
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 1521
-        protocol: 'tcp'
-    discovery_time: '2022-06-15T18:05:21+02:00'
-    extra_data:
-      ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
-      name: LISTENER
-      instances:
-        - +ASM
-    files:
-      - path: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
-        subtype: generic
-        type: home
-      - path: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl
-        subtype: generic
-        type: binary
-      - path: /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/trace
-        name: log.xml
-        subtype: generic
-        type: log
-    listening_ports:
-      - 1521
-    packages: []
-    process:
-      cmdline: >-
-        /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/tnslsnr
-        LISTENER -no_crs_notify -inherit
-      listening_ports:
-        - 1521
-      pid: '14763'
-      ppid: '1'
-      user: oragrid
-    type: Oracle Listener
-    version: []
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 1522
-        protocol: 'tcp'
-    discovery_time: '2022-06-15T18:05:23+02:00'
-    extra_data:
-      ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
-      name: LISTENER_ARSYS
-      instances:
-        - ARSYS
-    files:
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1
-        subtype: generic
-        type: home
-      - path: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl
-        subtype: generic
-        type: binary
-      - path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/trace
-        name: log.xml
-        subtype: generic
-        type: log
-    listening_ports:
-      - 1522
-    packages: []
-    process:
-      cmdline: >-
-        /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_ARSYS
-        -no_crs_notify -inherit
-      listening_ports:
-        - 1522
-      pid: '14782'
-      ppid: '1'
-      user: oragrid
-    type: Oracle Listener
-    version: []
-
-
-software_list:
-  - name: Oracle Listener
-    cmd_regexp: "tnslsnr"
-    process_type: parent
-    return_children: false
-    return_packages: true
-    vars: { }
-    custom_tasks:
-      - name: Include Oracle Listener specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/oracle_listener.yaml"
 dockers:
   containers: []
-packages:
-  AvamarClient:
-    - arch: x86_64
-      epoch: null
-      name: AvamarClient
-      release: '149'
-      source: rpm
-      version: 19.3.100
-  AvamarRMAN:
-    - arch: x86_64
-      epoch: null
-      name: AvamarRMAN
-      release: '149'
-      source: rpm
-      version: 19.3.100
-  BladeLogic_RSCD_Agent:
-    - arch: x86_64
-      epoch: null
-      name: BladeLogic_RSCD_Agent
-      release: '200'
-      source: rpm
-      version: 8.9.04
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
-  NetworkManager:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-config-server:
-    - arch: noarch
-      epoch: 1
-      name: NetworkManager-config-server
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-libnm:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-libnm
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-ppp:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-ppp
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-team:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-team
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-tui:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-tui
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  OpenIPMI:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
-  OpenIPMI-libs:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI-libs
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
-  OpenIPMI-modalias:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI-modalias
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
-  Red_Hat_Enterprise_Linux-Release_Notes-7-en-US:
-    - arch: noarch
-      epoch: null
-      name: Red_Hat_Enterprise_Linux-Release_Notes-7-en-US
-      release: 2.el7
-      source: rpm
-      version: '7'
-  TDP-Oracle:
-    - arch: x86_64
-      epoch: null
-      name: TDP-Oracle
-      release: '0'
-      source: rpm
-      version: 8.1.0
-  TDP-Oracle.Utility:
-    - arch: x86_64
-      epoch: null
-      name: TDP-Oracle.Utility
-      release: '0'
-      source: rpm
-      version: 8.1.0
-  TIVsm-API64:
-    - arch: x86_64
-      epoch: null
-      name: TIVsm-API64
-      release: '0'
-      source: rpm
-      version: 8.1.7
-  TIVsm-BA:
-    - arch: x86_64
-      epoch: null
-      name: TIVsm-BA
-      release: '0'
-      source: rpm
-      version: 8.1.7
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  adcli:
-    - arch: x86_64
-      epoch: null
-      name: adcli
-      release: 9.el7
-      source: rpm
-      version: 0.8.1
-  adobe-mappings-cmap:
-    - arch: noarch
-      epoch: null
-      name: adobe-mappings-cmap
-      release: 3.el7
-      source: rpm
-      version: '20171205'
-  adobe-mappings-cmap-deprecated:
-    - arch: noarch
-      epoch: null
-      name: adobe-mappings-cmap-deprecated
-      release: 3.el7
-      source: rpm
-      version: '20171205'
-  adobe-mappings-pdf:
-    - arch: noarch
-      epoch: null
-      name: adobe-mappings-pdf
-      release: 1.el7
-      source: rpm
-      version: '20180407'
-  aic94xx-firmware:
-    - arch: noarch
-      epoch: null
-      name: aic94xx-firmware
-      release: 6.el7
-      source: rpm
-      version: '30'
-  aide:
-    - arch: x86_64
-      epoch: null
-      name: aide
-      release: 13.el7_9.1
-      source: rpm
-      version: 0.15.1
-  alsa-firmware:
-    - arch: noarch
-      epoch: null
-      name: alsa-firmware
-      release: 2.el7
-      source: rpm
-      version: 1.0.28
-  alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
-  alsa-tools-firmware:
-    - arch: x86_64
-      epoch: null
-      name: alsa-tools-firmware
-      release: 1.el7
-      source: rpm
-      version: 1.1.0
-  at:
-    - arch: x86_64
-      epoch: null
-      name: at
-      release: 24.el7
-      source: rpm
-      version: 3.1.13
-  atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs:
-    - arch: i686
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autofs:
-    - arch: x86_64
-      epoch: 1
-      name: autofs
-      release: 106.el7
-      source: rpm
-      version: 5.0.7
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  avahi-autoipd:
-    - arch: x86_64
-      epoch: null
-      name: avahi-autoipd
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
-  avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
-  bash-completion:
-    - arch: noarch
-      epoch: 1
-      name: bash-completion
-      release: 6.el7
-      source: rpm
-      version: '2.1'
-  bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
-  biosdevname:
-    - arch: x86_64
-      epoch: null
-      name: biosdevname
-      release: 2.el7
-      source: rpm
-      version: 0.7.3
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2:
-    - arch: x86_64
-      epoch: null
-      name: bzip2
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  bzip2-libs:
-    - arch: i686
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  c-ares:
-    - arch: x86_64
-      epoch: null
-      name: c-ares
-      release: 3.el7
-      source: rpm
-      version: 1.10.0
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
-  cfg2html:
-    - arch: noarch
-      epoch: null
-      name: cfg2html
-      release: '151.1'
-      source: rpm
-      version: '6.30'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  compat-libcap1:
-    - arch: x86_64
-      epoch: null
-      name: compat-libcap1
-      release: 7.el7
-      source: rpm
-      version: '1.10'
-  compat-libstdc++-33:
-    - arch: i686
-      epoch: null
-      name: compat-libstdc++-33
-      release: 72.el7
-      source: rpm
-      version: 3.2.3
-    - arch: x86_64
-      epoch: null
-      name: compat-libstdc++-33
-      release: 72.el7
-      source: rpm
-      version: 3.2.3
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
-  cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-    - arch: i686
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.3
-  cups-client:
-    - arch: x86_64
-      epoch: 1
-      name: cups-client
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
-  cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-gssapi:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-gssapi
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  desktop-file-utils:
-    - arch: x86_64
-      epoch: null
-      name: desktop-file-utils
-      release: 2.el7
-      source: rpm
-      version: '0.23'
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
-  device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
-  device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
-  device-mapper-multipath:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-multipath
-      release: 127.el7
-      source: rpm
-      version: 0.4.9
-  device-mapper-multipath-libs:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-multipath-libs
-      release: 127.el7
-      source: rpm
-      version: 0.4.9
-  device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 1.el7
-      source: rpm
-      version: 0.8.5
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7_9.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7_9.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7_9.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 3.el7
-      source: rpm
-      version: '3.2'
-  dnsmasq:
-    - arch: x86_64
-      epoch: null
-      name: dnsmasq
-      release: 16.el7_9.1
-      source: rpm
-      version: '2.76'
-  dosfstools:
-    - arch: x86_64
-      epoch: null
-      name: dosfstools
-      release: 10.el7
-      source: rpm
-      version: 3.0.20
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 564.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 564.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 564.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  ebtables:
-    - arch: x86_64
-      epoch: null
-      name: ebtables
-      release: 16.el7
-      source: rpm
-      version: 2.0.10
-  ed:
-    - arch: x86_64
-      epoch: null
-      name: ed
-      release: 4.el7
-      source: rpm
-      version: '1.9'
-  efibootmgr:
-    - arch: x86_64
-      epoch: null
-      name: efibootmgr
-      release: 2.el7
-      source: rpm
-      version: '17'
-  efivar-libs:
-    - arch: x86_64
-      epoch: null
-      name: efivar-libs
-      release: 12.el7
-      source: rpm
-      version: '36'
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: i686
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-    - arch: i686
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-  emacs-common:
-    - arch: x86_64
-      epoch: 1
-      name: emacs-common
-      release: 23.el7
-      source: rpm
-      version: '24.3'
-  emacs-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: emacs-filesystem
-      release: 23.el7
-      source: rpm
-      version: '24.3'
-  emacs-nox:
-    - arch: x86_64
-      epoch: 1
-      name: emacs-nox
-      release: 23.el7
-      source: rpm
-      version: '24.3'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 14.el7_9
-      source: rpm
-      version: 2.1.0
-  expect:
-    - arch: x86_64
-      epoch: null
-      name: expect
-      release: 14.el7_1
-      source: rpm
-      version: '5.45'
-  falcon-sensor:
-    - arch: x86_64
-      epoch: null
-      name: falcon-sensor
-      release: 10402.el7
-      source: rpm
-      version: 5.38.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 6.8.8
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  finger:
-    - arch: x86_64
-      epoch: null
-      name: finger
-      release: 52.el7
-      source: rpm
-      version: '0.17'
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  firewalld:
-    - arch: noarch
-      epoch: null
-      name: firewalld
-      release: 2.el7_7.1
-      source: rpm
-      version: 0.6.3
-  firewalld-filesystem:
-    - arch: noarch
-      epoch: null
-      name: firewalld-filesystem
-      release: 2.el7_7.1
-      source: rpm
-      version: 0.6.3
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  foomatic-filters:
-    - arch: x86_64
-      epoch: null
-      name: foomatic-filters
-      release: 9.el7
-      source: rpm
-      version: 4.0.9
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  ftp:
-    - arch: x86_64
-      epoch: null
-      name: ftp
-      release: 67.el7
-      source: rpm
-      version: '0.17'
-  fxload:
-    - arch: x86_64
-      epoch: null
-      name: fxload
-      release: 16.el7
-      source: rpm
-      version: '2002_04_11'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdbm-devel:
-    - arch: x86_64
-      epoch: null
-      name: gdbm-devel
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  ghostscript:
-    - arch: x86_64
-      epoch: null
-      name: ghostscript
-      release: 2.el7_7.3
-      source: rpm
-      version: '9.25'
-  ghostscript-fonts:
-    - arch: noarch
-      epoch: null
-      name: ghostscript-fonts
-      release: 32.el7
-      source: rpm
-      version: '5.50'
-  glib-networking:
-    - arch: x86_64
-      epoch: null
-      name: glib-networking
-      release: 1.el7
-      source: rpm
-      version: 2.56.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc-devel
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gnutls:
-    - arch: x86_64
-      epoch: null
-      name: gnutls
-      release: 9.el7_6
-      source: rpm
-      version: 3.3.29
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 45700c69
-      source: rpm
-      version: 2fa658e0
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 4ae0493b
-      source: rpm
-      version: fd431d51
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-efi-x64:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-efi-x64
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-efi-x64-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-efi-x64-modules
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gsettings-desktop-schemas:
-    - arch: x86_64
-      epoch: null
-      name: gsettings-desktop-schemas
-      release: 3.el7
-      source: rpm
-      version: 3.28.0
-  gskcrypt64:
-    - arch: x86_64
-      epoch: null
-      name: gskcrypt64
-      release: '55.2'
-      source: rpm
-      version: '8.0'
-  gskssl64:
-    - arch: x86_64
-      epoch: null
-      name: gskssl64
-      release: '55.2'
-      source: rpm
-      version: '8.0'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 26.el7
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 5.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hesiod:
-    - arch: x86_64
-      epoch: null
-      name: hesiod
-      release: 3.el7
-      source: rpm
-      version: 3.2.1
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  http-parser:
-    - arch: x86_64
-      epoch: null
-      name: http-parser
-      release: 8.el7_7.2
-      source: rpm
-      version: 2.7.1
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.3.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.47
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iometrics-agent-plugin-oracle-lib-connector:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-lib-connector
-      release: '25'
-      source: rpm
-      version: 18.5.0_1.11.3
-  iometrics-agent-plugin-oracle-libs:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-libs
-      release: '1'
-      source: rpm
-      version: 18.5.0
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  ipmitool:
-    - arch: x86_64
-      epoch: null
-      name: ipmitool
-      release: 9.el7_7
-      source: rpm
-      version: 1.8.18
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 25.el7
-      source: rpm
-      version: 4.11.0
-  iprutils:
-    - arch: x86_64
-      epoch: null
-      name: iprutils
-      release: 2.el7
-      source: rpm
-      version: 2.4.17.1
-  ipset:
-    - arch: x86_64
-      epoch: null
-      name: ipset
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 33.el7
-      source: rpm
-      version: 1.4.21
-  iptables-services:
-    - arch: x86_64
-      epoch: null
-      name: iptables-services
-      release: 33.el7
-      source: rpm
-      version: 1.4.21
-  iptraf-ng:
-    - arch: x86_64
-      epoch: null
-      name: iptraf-ng
-      release: 7.el7
-      source: rpm
-      version: 1.1.4
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  ivtv-firmware:
-    - arch: noarch
-      epoch: 2
-      name: ivtv-firmware
-      release: 26.el7
-      source: rpm
-      version: '20080701'
-  iwl100-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl100-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
-  iwl1000-firmware:
-    - arch: noarch
-      epoch: 1
-      name: iwl1000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
-  iwl105-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl105-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl135-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl135-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl2000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl2030-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2030-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl3160-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3160-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
-  iwl3945-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3945-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 15.32.2.9
-  iwl4965-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl4965-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 228.61.2.24
-  iwl5000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.83.5.1_1
-  iwl5150-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5150-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.24.2.2
-  iwl6000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 9.221.4.1
-  iwl6000g2a-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2a-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl6000g2b-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2b-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl6050-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6050-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 41.28.5.1
-  iwl7260-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7260-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 33.el7
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 25.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 25.el7
-      source: rpm
-      version: '20'
-  kmod-oracleasm:
-    - arch: x86_64
-      epoch: null
-      name: kmod-oracleasm
-      release: 26.el7
-      source: rpm
-      version: 2.0.8
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 127.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  krb5-workstation:
-    - arch: x86_64
-      epoch: null
-      name: krb5-workstation
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  ksh:
-    - arch: x86_64
-      epoch: null
-      name: ksh
-      release: 142.el7
-      source: rpm
-      version: '20120801'
-  lcms2:
-    - arch: x86_64
-      epoch: null
-      name: lcms2
-      release: 3.el7
-      source: rpm
-      version: '2.6'
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: i686
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-    - arch: i686
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: i686
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-    - arch: i686
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXmu:
-    - arch: x86_64
-      epoch: null
-      name: libXmu
-      release: 2.el7
-      source: rpm
-      version: 1.1.2
-  libXp:
-    - arch: x86_64
-      epoch: null
-      name: libXp
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.2
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXt:
-    - arch: x86_64
-      epoch: null
-      name: libXt
-      release: 3.el7
-      source: rpm
-      version: 1.1.5
-  libXtst:
-    - arch: i686
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXv:
-    - arch: x86_64
-      epoch: null
-      name: libXv
-      release: 1.el7
-      source: rpm
-      version: 1.0.11
-  libXxf86dga:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86dga
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.4
-  libXxf86misc:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86misc
-      release: 7.1.el7
-      source: rpm
-      version: 1.0.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: i686
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libaio-devel:
-    - arch: i686
-      epoch: null
-      name: libaio-devel
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-    - arch: x86_64
-      epoch: null
-      name: libaio-devel
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: i686
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: i686
-      epoch: null
-      name: libcap
-      release: 10.el7
-      source: rpm
-      version: '2.22'
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 10.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-    - arch: i686
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcgroup-tools:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup-tools
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-    - arch: i686
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-devel:
-    - arch: x86_64
-      epoch: null
-      name: libdb-devel
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdhash:
-    - arch: x86_64
-      epoch: null
-      name: libdhash
-      release: 32.el7
-      source: rpm
-      version: 0.5.0
-  libdmx:
-    - arch: x86_64
-      epoch: null
-      name: libdmx
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-    - arch: i686
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-    - arch: i686
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libgs:
-    - arch: x86_64
-      epoch: null
-      name: libgs
-      release: 2.el7_7.3
-      source: rpm
-      version: '9.25'
-  libgudev1:
-    - arch: x86_64
-      epoch: null
-      name: libgudev1
-      release: 78.el7
-      source: rpm
-      version: '219'
-  libhugetlbfs:
-    - arch: x86_64
-      epoch: null
-      name: libhugetlbfs
-      release: 13.el7
-      source: rpm
-      version: '2.16'
-  libhugetlbfs-utils:
-    - arch: x86_64
-      epoch: null
-      name: libhugetlbfs-utils
-      release: 13.el7
-      source: rpm
-      version: '2.16'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libipa_hbac:
-    - arch: x86_64
-      epoch: null
-      name: libipa_hbac
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libkadm5:
-    - arch: x86_64
-      epoch: null
-      name: libkadm5
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  libldb:
-    - arch: x86_64
-      epoch: null
-      name: libldb
-      release: 2.el7_9
-      source: rpm
-      version: 1.5.4
-  liblockfile:
-    - arch: x86_64
-      epoch: null
-      name: liblockfile
-      release: 17.el7
-      source: rpm
-      version: '1.08'
-  libmng:
-    - arch: x86_64
-      epoch: null
-      name: libmng
-      release: 14.el7
-      source: rpm
-      version: 1.0.10
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmodman:
-    - arch: x86_64
-      epoch: null
-      name: libmodman
-      release: 8.el7
-      source: rpm
-      version: 2.0.1
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl:
-    - arch: x86_64
-      epoch: null
-      name: libnl
-      release: 3.el7
-      source: rpm
-      version: 1.1.4
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpaper:
-    - arch: x86_64
-      epoch: null
-      name: libpaper
-      release: 8.el7
-      source: rpm
-      version: 1.1.24
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 11.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpng12:
-    - arch: x86_64
-      epoch: null
-      name: libpng12
-      release: 10.el7
-      source: rpm
-      version: 1.2.50
-  libproxy:
-    - arch: x86_64
-      epoch: null
-      name: libproxy
-      release: 11.el7
-      source: rpm
-      version: 0.4.11
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  libsmbclient:
-    - arch: x86_64
-      epoch: 0
-      name: libsmbclient
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  libsoup:
-    - arch: x86_64
-      epoch: null
-      name: libsoup
-      release: 2.el7
-      source: rpm
-      version: 2.62.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libsss_autofs:
-    - arch: x86_64
-      epoch: null
-      name: libsss_autofs
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libsss_certmap:
-    - arch: x86_64
-      epoch: null
-      name: libsss_certmap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libsss_idmap:
-    - arch: x86_64
-      epoch: null
-      name: libsss_idmap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libsss_nss_idmap:
-    - arch: x86_64
-      epoch: null
-      name: libsss_nss_idmap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libsss_sudo:
-    - arch: x86_64
-      epoch: null
-      name: libsss_sudo
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++-devel
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtalloc:
-    - arch: x86_64
-      epoch: null
-      name: libtalloc
-      release: 1.el7
-      source: rpm
-      version: 2.1.16
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libtdb:
-    - arch: x86_64
-      epoch: null
-      name: libtdb
-      release: 1.el7
-      source: rpm
-      version: 1.3.18
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 9.el7
-      source: rpm
-      version: '1.27'
-  libtevent:
-    - arch: x86_64
-      epoch: null
-      name: libtevent
-      release: 1.el7
-      source: rpm
-      version: 0.9.39
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-tevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-tevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwbclient:
-    - arch: x86_64
-      epoch: 0
-      name: libwbclient
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-    - arch: i686
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lm_sensors:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 13.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lsscsi:
-    - arch: x86_64
-      epoch: null
-      name: lsscsi
-      release: 6.el7
-      source: rpm
-      version: '0.27'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 2.el7
-      source: rpm
-      version: 2.02.185
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 2.el7
-      source: rpm
-      version: 2.02.185
-  lz4:
-    - arch: i686
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  m2crypto:
-    - arch: x86_64
-      epoch: null
-      name: m2crypto
-      release: 17.el7
-      source: rpm
-      version: 0.21.1
-  m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  mailx:
-    - arch: x86_64
-      epoch: null
-      name: mailx
-      release: 19.el7
-      source: rpm
-      version: '12.5'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
-  mesa-libGLU:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGLU
-      release: 4.el7
-      source: rpm
-      version: 9.0.0
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mlocate:
-    - arch: x86_64
-      epoch: null
-      name: mlocate
-      release: 8.el7
-      source: rpm
-      version: '0.26'
-  mokutil:
-    - arch: x86_64
-      epoch: null
-      name: mokutil
-      release: 8.el7_8
-      source: rpm
-      version: '15'
-  motif:
-    - arch: x86_64
-      epoch: null
-      name: motif
-      release: 14.el7_5
-      source: rpm
-      version: 2.3.4
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-utils:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-utils
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  nettle:
-    - arch: x86_64
-      epoch: null
-      name: nettle
-      release: 9.el7_9
-      source: rpm
-      version: 2.7.1
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.65.el7
-      source: rpm
-      version: 1.3.0
-  nscd:
-    - arch: x86_64
-      epoch: null
-      name: nscd
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7_8.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7_8.2
-      source: rpm
-      version: 4.2.6p5
-  numactl:
-    - arch: x86_64
-      epoch: null
-      name: numactl
-      release: 3.el7
-      source: rpm
-      version: 2.0.12
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.12
-  numad:
-    - arch: x86_64
-      epoch: null
-      name: numad
-      release: 18.20150602git.el7
-      source: rpm
-      version: '0.5'
-  oddjob:
-    - arch: x86_64
-      epoch: null
-      name: oddjob
-      release: 4.el7
-      source: rpm
-      version: 0.31.5
-  oddjob-mkhomedir:
-    - arch: x86_64
-      epoch: null
-      name: oddjob-mkhomedir
-      release: 4.el7
-      source: rpm
-      version: 0.31.5
-  openjpeg2:
-    - arch: x86_64
-      epoch: null
-      name: openjpeg2
-      release: 3.el7_7
-      source: rpm
-      version: 2.3.1
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 25.el7_9
-      source: rpm
-      version: 2.4.44
-  openldap-clients:
-    - arch: x86_64
-      epoch: null
-      name: openldap-clients
-      release: 25.el7_9
-      source: rpm
-      version: 2.4.44
-  openscap:
-    - arch: x86_64
-      epoch: null
-      name: openscap
-      release: 4.el7
-      source: rpm
-      version: 1.2.17
-  openscap-scanner:
-    - arch: x86_64
-      epoch: null
-      name: openscap-scanner
-      release: 4.el7
-      source: rpm
-      version: 1.2.17
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 25.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 25.el7_9
-      source: rpm
-      version: 1.0.2k
-  oracleasm-support:
-    - arch: x86_64
-      epoch: null
-      name: oracleasm-support
-      release: 3.el7
-      source: rpm
-      version: 2.1.8
-  oracleasmlib:
-    - arch: x86_64
-      epoch: null
-      name: oracleasmlib
-      release: 1.el7
-      source: rpm
-      version: 2.0.12
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-    - arch: i686
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  pam-devel:
-    - arch: x86_64
-      epoch: null
-      name: pam-devel
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 31.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 5.el7
-      source: rpm
-      version: '0.79'
-  patch:
-    - arch: x86_64
-      epoch: null
-      name: patch
-      release: 12.el7_7
-      source: rpm
-      version: 2.7.1
-  pciutils:
-    - arch: x86_64
-      epoch: null
-      name: pciutils
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: i686
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-B-Lint:
-    - arch: noarch
-      epoch: null
-      name: perl-B-Lint
-      release: 3.el7
-      source: rpm
-      version: '1.17'
-  perl-Business-ISBN:
-    - arch: noarch
-      epoch: null
-      name: perl-Business-ISBN
-      release: 2.el7
-      source: rpm
-      version: '2.06'
-  perl-Business-ISBN-Data:
-    - arch: noarch
-      epoch: null
-      name: perl-Business-ISBN-Data
-      release: 2.el7
-      source: rpm
-      version: '20120719.001'
-  perl-CGI:
-    - arch: noarch
-      epoch: null
-      name: perl-CGI
-      release: 4.el7
-      source: rpm
-      version: '3.63'
-  perl-CPAN:
-    - arch: noarch
-      epoch: 0
-      name: perl-CPAN
-      release: 299.el7_9
-      source: rpm
-      version: '1.9800'
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Class-ISA:
-    - arch: noarch
-      epoch: null
-      name: perl-Class-ISA
-      release: 1010.el7
-      source: rpm
-      version: '0.36'
-  perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
-  perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Digest:
-    - arch: noarch
-      epoch: null
-      name: perl-Digest
-      release: 245.el7
-      source: rpm
-      version: '1.17'
-  perl-Digest-MD5:
-    - arch: x86_64
-      epoch: null
-      name: perl-Digest-MD5
-      release: 3.el7
-      source: rpm
-      version: '2.52'
-  perl-Digest-SHA:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Digest-SHA
-      release: 4.el7
-      source: rpm
-      version: '5.85'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Encode-Locale:
-    - arch: noarch
-      epoch: null
-      name: perl-Encode-Locale
-      release: 5.el7
-      source: rpm
-      version: '1.03'
-  perl-Env:
-    - arch: noarch
-      epoch: null
-      name: perl-Env
-      release: 2.el7
-      source: rpm
-      version: '1.04'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-ExtUtils-Install:
-    - arch: noarch
-      epoch: 0
-      name: perl-ExtUtils-Install
-      release: 299.el7_9
-      source: rpm
-      version: '1.58'
-  perl-ExtUtils-MakeMaker:
-    - arch: noarch
-      epoch: null
-      name: perl-ExtUtils-MakeMaker
-      release: 3.el7
-      source: rpm
-      version: '6.68'
-  perl-ExtUtils-Manifest:
-    - arch: noarch
-      epoch: null
-      name: perl-ExtUtils-Manifest
-      release: 244.el7
-      source: rpm
-      version: '1.61'
-  perl-ExtUtils-ParseXS:
-    - arch: noarch
-      epoch: 1
-      name: perl-ExtUtils-ParseXS
-      release: 3.el7
-      source: rpm
-      version: '3.18'
-  perl-FCGI:
-    - arch: x86_64
-      epoch: 1
-      name: perl-FCGI
-      release: 8.el7
-      source: rpm
-      version: '0.74'
-  perl-File-CheckTree:
-    - arch: noarch
-      epoch: null
-      name: perl-File-CheckTree
-      release: 3.el7
-      source: rpm
-      version: '4.42'
-  perl-File-Listing:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Listing
-      release: 7.el7
-      source: rpm
-      version: '6.04'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTML-Parser:
-    - arch: x86_64
-      epoch: null
-      name: perl-HTML-Parser
-      release: 4.el7
-      source: rpm
-      version: '3.71'
-  perl-HTML-Tagset:
-    - arch: noarch
-      epoch: null
-      name: perl-HTML-Tagset
-      release: 15.el7
-      source: rpm
-      version: '3.20'
-  perl-HTTP-Cookies:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Cookies
-      release: 5.el7
-      source: rpm
-      version: '6.01'
-  perl-HTTP-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Daemon
-      release: 8.el7
-      source: rpm
-      version: '6.01'
-  perl-HTTP-Date:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Date
-      release: 8.el7
-      source: rpm
-      version: '6.02'
-  perl-HTTP-Message:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Message
-      release: 6.el7
-      source: rpm
-      version: '6.06'
-  perl-HTTP-Negotiate:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Negotiate
-      release: 5.el7
-      source: rpm
-      version: '6.01'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
-  perl-IO-HTML:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-HTML
-      release: 2.el7
-      source: rpm
-      version: '1.00'
-  perl-IO-Socket-IP:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Socket-IP
-      release: 5.el7
-      source: rpm
-      version: '0.21'
-  perl-IO-Socket-SSL:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Socket-SSL
-      release: 7.el7
-      source: rpm
-      version: '1.94'
-  perl-LWP-MediaTypes:
-    - arch: noarch
-      epoch: null
-      name: perl-LWP-MediaTypes
-      release: 2.el7
-      source: rpm
-      version: '6.02'
-  perl-Locale-Codes:
-    - arch: noarch
-      epoch: null
-      name: perl-Locale-Codes
-      release: 2.el7
-      source: rpm
-      version: '3.26'
-  perl-Locale-Maketext:
-    - arch: noarch
-      epoch: null
-      name: perl-Locale-Maketext
-      release: 3.el7
-      source: rpm
-      version: '1.23'
-  perl-Module-Pluggable:
-    - arch: noarch
-      epoch: 1
-      name: perl-Module-Pluggable
-      release: 3.el7
-      source: rpm
-      version: '4.8'
-  perl-Mozilla-CA:
-    - arch: noarch
-      epoch: null
-      name: perl-Mozilla-CA
-      release: 5.el7
-      source: rpm
-      version: '20130114'
-  perl-Net-HTTP:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-HTTP
-      release: 2.el7
-      source: rpm
-      version: '6.06'
-  perl-Net-LibIDN:
-    - arch: x86_64
-      epoch: null
-      name: perl-Net-LibIDN
-      release: 15.el7
-      source: rpm
-      version: '0.12'
-  perl-Net-SSLeay:
-    - arch: x86_64
-      epoch: null
-      name: perl-Net-SSLeay
-      release: 6.el7
-      source: rpm
-      version: '1.55'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Checker:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Checker
-      release: 2.el7
-      source: rpm
-      version: '1.60'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-LaTeX:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-LaTeX
-      release: 2.el7
-      source: rpm
-      version: '0.61'
-  perl-Pod-Parser:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Parser
-      release: 2.el7
-      source: rpm
-      version: '1.61'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Plainer:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Plainer
-      release: 4.el7
-      source: rpm
-      version: '1.03'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 4.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Sys-Syslog:
-    - arch: x86_64
-      epoch: null
-      name: perl-Sys-Syslog
-      release: 3.el7
-      source: rpm
-      version: '0.33'
-  perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
-  perl-Test-Simple:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Simple
-      release: 243.el7
-      source: rpm
-      version: '0.98'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Text-Soundex:
-    - arch: x86_64
-      epoch: null
-      name: perl-Text-Soundex
-      release: 4.el7
-      source: rpm
-      version: '3.04'
-  perl-Text-Unidecode:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-Unidecode
-      release: 20.el7
-      source: rpm
-      version: '0.04'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-TimeDate:
-    - arch: noarch
-      epoch: 1
-      name: perl-TimeDate
-      release: 2.el7
-      source: rpm
-      version: '2.30'
-  perl-URI:
-    - arch: noarch
-      epoch: null
-      name: perl-URI
-      release: 9.el7
-      source: rpm
-      version: '1.60'
-  perl-WWW-RobotRules:
-    - arch: noarch
-      epoch: null
-      name: perl-WWW-RobotRules
-      release: 5.el7
-      source: rpm
-      version: '6.02'
-  perl-XML-LibXML:
-    - arch: x86_64
-      epoch: 1
-      name: perl-XML-LibXML
-      release: 5.el7
-      source: rpm
-      version: '2.0018'
-  perl-XML-NamespaceSupport:
-    - arch: noarch
-      epoch: null
-      name: perl-XML-NamespaceSupport
-      release: 10.el7
-      source: rpm
-      version: '1.11'
-  perl-XML-SAX:
-    - arch: noarch
-      epoch: null
-      name: perl-XML-SAX
-      release: 9.el7
-      source: rpm
-      version: '0.99'
-  perl-XML-SAX-Base:
-    - arch: noarch
-      epoch: null
-      name: perl-XML-SAX-Base
-      release: 7.el7
-      source: rpm
-      version: '1.08'
-  perl-autodie:
-    - arch: noarch
-      epoch: null
-      name: perl-autodie
-      release: 2.el7
-      source: rpm
-      version: '2.16'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-devel:
-    - arch: x86_64
-      epoch: 4
-      name: perl-devel
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-libwww-perl:
-    - arch: noarch
-      epoch: null
-      name: perl-libwww-perl
-      release: 2.el7
-      source: rpm
-      version: '6.05'
-  perl-local-lib:
-    - arch: noarch
-      epoch: null
-      name: perl-local-lib
-      release: 4.el7
-      source: rpm
-      version: '1.008010'
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  plymouth:
-    - arch: x86_64
-      epoch: null
-      name: plymouth
-      release: 0.32.20140113.el7
-      source: rpm
-      version: 0.8.9
-  plymouth-core-libs:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-core-libs
-      release: 0.32.20140113.el7
-      source: rpm
-      version: 0.8.9
-  plymouth-scripts:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-scripts
-      release: 0.32.20140113.el7
-      source: rpm
-      version: 0.8.9
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 33.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 33.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  poppler-data:
-    - arch: noarch
-      epoch: null
-      name: poppler-data
-      release: 3.el7
-      source: rpm
-      version: 0.4.6
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  powertop:
-    - arch: x86_64
-      epoch: null
-      name: powertop
-      release: 1.el7
-      source: rpm
-      version: '2.9'
-  ppp:
-    - arch: x86_64
-      epoch: null
-      name: ppp
-      release: 34.el7_7
-      source: rpm
-      version: 2.4.5
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 26.el7
-      source: rpm
-      version: 3.3.10
-  psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 16.el7
-      source: rpm
-      version: '22.20'
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pyOpenSSL:
-    - arch: x86_64
-      epoch: null
-      name: pyOpenSSL
-      release: 4.el7
-      source: rpm
-      version: 0.13.1
-  pygobject2:
-    - arch: x86_64
-      epoch: null
-      name: pygobject2
-      release: 11.el7
-      source: rpm
-      version: 2.28.6
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyldb:
-    - arch: x86_64
-      epoch: null
-      name: pyldb
-      release: 2.el7_9
-      source: rpm
-      version: 1.5.4
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyparsing:
-    - arch: noarch
-      epoch: null
-      name: pyparsing
-      release: 9.el7
-      source: rpm
-      version: 1.5.6
-  pytalloc:
-    - arch: x86_64
-      epoch: null
-      name: pytalloc
-      release: 1.el7
-      source: rpm
-      version: 2.1.16
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-dateutil:
-    - arch: noarch
-      epoch: null
-      name: python-dateutil
-      release: 7.el7
-      source: rpm
-      version: '1.5'
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-dmidecode:
-    - arch: x86_64
-      epoch: null
-      name: python-dmidecode
-      release: 3.el7
-      source: rpm
-      version: 3.12.2
-  python-ethtool:
-    - arch: x86_64
-      epoch: null
-      name: python-ethtool
-      release: 8.el7
-      source: rpm
-      version: '0.8'
-  python-firewall:
-    - arch: noarch
-      epoch: null
-      name: python-firewall
-      release: 2.el7_7.1
-      source: rpm
-      version: 0.6.3
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-gudev:
-    - arch: x86_64
-      epoch: null
-      name: python-gudev
-      release: 7.el7
-      source: rpm
-      version: '147.2'
-  python-hwdata:
-    - arch: noarch
-      epoch: null
-      name: python-hwdata
-      release: 4.el7
-      source: rpm
-      version: 1.7.3
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-inotify:
-    - arch: noarch
-      epoch: null
-      name: python-inotify
-      release: 4.el7
-      source: rpm
-      version: 0.9.4
-  python-ipaddr:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddr
-      release: 2.el7
-      source: rpm
-      version: 2.1.11
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-magic:
-    - arch: noarch
-      epoch: null
-      name: python-magic
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-slip:
-    - arch: noarch
-      epoch: null
-      name: python-slip
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-slip-dbus:
-    - arch: noarch
-      epoch: null
-      name: python-slip-dbus
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-sssdconfig:
-    - arch: noarch
-      epoch: null
-      name: python-sssdconfig
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  python-syspurpose:
-    - arch: x86_64
-      epoch: null
-      name: python-syspurpose
-      release: 3.el7_7
-      source: rpm
-      version: 1.24.13
-  python-tdb:
-    - arch: x86_64
-      epoch: null
-      name: python-tdb
-      release: 1.el7
-      source: rpm
-      version: 1.3.18
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python2-futures:
-    - arch: noarch
-      epoch: null
-      name: python2-futures
-      release: 5.el7
-      source: rpm
-      version: 3.1.1
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_8
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  qt:
-    - arch: x86_64
-      epoch: 1
-      name: qt
-      release: 9.el7_9
-      source: rpm
-      version: 4.8.7
-  qt-settings:
-    - arch: noarch
-      epoch: null
-      name: qt-settings
-      release: 23.10.el7_7
-      source: rpm
-      version: '19'
-  qt-x11:
-    - arch: x86_64
-      epoch: 1
-      name: qt-x11
-      release: 9.el7_9
-      source: rpm
-      version: 4.8.7
-  qt3:
-    - arch: x86_64
-      epoch: null
-      name: qt3
-      release: 51.el7
-      source: rpm
-      version: 3.3.8b
-  qualys-cloud-agent:
-    - arch: x86_64
-      epoch: null
-      name: qualys-cloud-agent
-      release: '49'
-      source: rpm
-      version: 4.8.0
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  rdma-core:
-    - arch: i686
-      epoch: null
-      name: rdma-core
-      release: 3.el7
-      source: rpm
-      version: '22.1'
-    - arch: x86_64
-      epoch: null
-      name: rdma-core
-      release: 3.el7
-      source: rpm
-      version: '22.1'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  realmd:
-    - arch: x86_64
-      epoch: null
-      name: realmd
-      release: 11.el7
-      source: rpm
-      version: 0.16.1
-  redhat-logos:
-    - arch: noarch
-      epoch: null
-      name: redhat-logos
-      release: 1.el7
-      source: rpm
-      version: 70.7.0
-  redhat-lsb:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-core:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-core
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-cxx:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-cxx
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-desktop:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-desktop
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-languages:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-languages
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-printing:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-printing
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-submod-multimedia:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-submod-multimedia
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-submod-security:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-submod-security
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-release-server:
-    - arch: x86_64
-      epoch: null
-      name: redhat-release-server
-      release: 10.el7
-      source: rpm
-      version: '7.7'
-  redhat-support-lib-python:
-    - arch: noarch
-      epoch: null
-      name: redhat-support-lib-python
-      release: 6.el7
-      source: rpm
-      version: 0.9.7
-  redhat-support-tool:
-    - arch: noarch
-      epoch: null
-      name: redhat-support-tool
-      release: 1.el7
-      source: rpm
-      version: 0.9.11
-  rhn-client-tools:
-    - arch: x86_64
-      epoch: null
-      name: rhn-client-tools
-      release: 24.el7
-      source: rpm
-      version: 2.0.2
-  rhnlib:
-    - arch: noarch
-      epoch: null
-      name: rhnlib
-      release: 8.el7
-      source: rpm
-      version: 2.5.65
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 48.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 52.el7
-      source: rpm
-      version: 8.24.0
-  samba-client-libs:
-    - arch: x86_64
-      epoch: 0
-      name: samba-client-libs
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  samba-common:
-    - arch: noarch
-      epoch: 0
-      name: samba-common
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  samba-common-libs:
-    - arch: x86_64
-      epoch: 0
-      name: samba-common-libs
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  samba-common-tools:
-    - arch: x86_64
-      epoch: 0
-      name: samba-common-tools
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  samba-libs:
-    - arch: x86_64
-      epoch: 0
-      name: samba-libs
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  scap-security-guide:
-    - arch: noarch
-      epoch: null
-      name: scap-security-guide
-      release: 13.el7
-      source: rpm
-      version: 0.1.43
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 252.el7.1
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 252.el7.1
-      source: rpm
-      version: 3.13.1
-  setools-console:
-    - arch: x86_64
-      epoch: null
-      name: setools-console
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 18.el7_7.1
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 18.el7_7.1
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  shim-unsigned:
-    - arch: x86_64
-      epoch: null
-      name: shim-unsigned
-      release: 1.el7
-      source: rpm
-      version: '0.9'
-  shim-x64:
-    - arch: x86_64
-      epoch: null
-      name: shim-x64
-      release: 8.el7_8
-      source: rpm
-      version: '15'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smartmontools:
-    - arch: x86_64
-      epoch: 1
-      name: smartmontools
-      release: 1.el7
-      source: rpm
-      version: '7.0'
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sos:
-    - arch: noarch
-      epoch: null
-      name: sos
-      release: 6.el7_7
-      source: rpm
-      version: '3.7'
-  spax:
-    - arch: x86_64
-      epoch: null
-      name: spax
-      release: 13.el7
-      source: rpm
-      version: 1.5.2
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sssd:
-    - arch: x86_64
-      epoch: null
-      name: sssd
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-ad:
-    - arch: x86_64
-      epoch: null
-      name: sssd-ad
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-client:
-    - arch: x86_64
-      epoch: null
-      name: sssd-client
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-common:
-    - arch: x86_64
-      epoch: null
-      name: sssd-common
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-common-pac:
-    - arch: x86_64
-      epoch: null
-      name: sssd-common-pac
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-ipa:
-    - arch: x86_64
-      epoch: null
-      name: sssd-ipa
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-krb5:
-    - arch: x86_64
-      epoch: null
-      name: sssd-krb5
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-krb5-common:
-    - arch: x86_64
-      epoch: null
-      name: sssd-krb5-common
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-ldap:
-    - arch: x86_64
-      epoch: null
-      name: sssd-ldap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-proxy:
-    - arch: x86_64
-      epoch: null
-      name: sssd-proxy
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 9.el7
-      source: rpm
-      version: '4.12'
-  subscription-manager:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager
-      release: 1.el7
-      source: rpm
-      version: 1.24.26
-  subscription-manager-rhsm:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm
-      release: 1.el7
-      source: rpm
-      version: 1.24.26
-  subscription-manager-rhsm-certificates:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm-certificates
-      release: 1.el7
-      source: rpm
-      version: 1.24.26
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.1
-      source: rpm
-      version: 1.8.23
-  sysfsutils:
-    - arch: x86_64
-      epoch: null
-      name: sysfsutils
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 18.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7
-      source: rpm
-      version: '219'
-    - arch: i686
-      epoch: null
-      name: systemd-libs
-      release: 78.el7
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7
-      source: rpm
-      version: '219'
-  systemtap-sdt-devel:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-sdt-devel
-      release: 9.el7
-      source: rpm
-      version: '4.0'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcl:
-    - arch: x86_64
-      epoch: 1
-      name: tcl
-      release: 8.el7
-      source: rpm
-      version: 8.5.13
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 9.el7
-      source: rpm
-      version: '1.27'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 65.el7_8
-      source: rpm
-      version: '0.17'
-  time:
-    - arch: x86_64
-      epoch: null
-      name: time
-      release: 45.el7
-      source: rpm
-      version: '1.7'
-  tk:
-    - arch: x86_64
-      epoch: 1
-      name: tk
-      release: 6.el7
-      source: rpm
-      version: 8.5.13
-  traceroute:
-    - arch: x86_64
-      epoch: 3
-      name: traceroute
-      release: 2.el7
-      source: rpm
-      version: 2.0.22
-  tree:
-    - arch: x86_64
-      epoch: null
-      name: tree
-      release: 10.el7
-      source: rpm
-      version: 1.6.0
-  trousers:
-    - arch: x86_64
-      epoch: null
-      name: trousers
-      release: 2.el7
-      source: rpm
-      version: 0.3.14
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 5.el7_7.1
-      source: rpm
-      version: 2.11.0
-  tuned-utils:
-    - arch: noarch
-      epoch: null
-      name: tuned-utils
-      release: 5.el7_7.1
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019c
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
-  urw-base35-bookman-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-bookman-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-c059-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-c059-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-d050000l-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-d050000l-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-fonts-common
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-gothic-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-gothic-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-nimbus-mono-ps-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-nimbus-mono-ps-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-nimbus-roman-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-nimbus-roman-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-nimbus-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-nimbus-sans-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-p052-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-p052-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-standard-symbols-ps-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-standard-symbols-ps-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-z003-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-z003-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  usermode:
-    - arch: x86_64
-      epoch: null
-      name: usermode
-      release: 6.el7
-      source: rpm
-      version: '1.111'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xdg-utils:
-    - arch: noarch
-      epoch: null
-      name: xdg-utils
-      release: 0.17.20120809git.el7
-      source: rpm
-      version: 1.1.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 20.el7
-      source: rpm
-      version: 4.5.0
-  xinetd:
-    - arch: x86_64
-      epoch: 2
-      name: xinetd
-      release: 13.el7
-      source: rpm
-      version: 2.3.15
-  xml-common:
-    - arch: noarch
-      epoch: null
-      name: xml-common
-      release: 39.el7
-      source: rpm
-      version: 0.6.3
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-server-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-server-utils
-      release: 20.el7
-      source: rpm
-      version: '7.7'
-  xorg-x11-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-utils
-      release: 23.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-xauth:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-xauth
-      release: 1.el7
-      source: rpm
-      version: 1.0.9
-  xorg-x11-xbitmaps:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-xbitmaps
-      release: 6.el7
-      source: rpm
-      version: 1.1.1
-  xorg-x11-xinit:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-xinit
-      release: 2.el7
-      source: rpm
-      version: 1.3.4
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-    - arch: i686
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 163.el7
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 52.el7
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: i686
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '54'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '63'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '64'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '66'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '67'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '71'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '72'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '73'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '74'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '77'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '78'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '81'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '82'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '83'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '84'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '86'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '88'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '89'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '90'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '91'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '92'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '93'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '94'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '95'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '96'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '97'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '98'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '99'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '105'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '106'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '107'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '108'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '118'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '119'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '121'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '123'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '137'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '176'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '365'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '366'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '367'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '369'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '370'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '371'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '373'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '413'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '414'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '512'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '612'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '613'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '624'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '625'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '638'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '639'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '640'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '641'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '642'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '643'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '644'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '645'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '646'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '647'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '648'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '649'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '732'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '765'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '768'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '810'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '811'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '812'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '813'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '814'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1167'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1168'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1169'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1170'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1171'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1172'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1184'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1185'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1186'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1188'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1195'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1196'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1197'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1198'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1199'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1200'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1201'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1202'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1204'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1205'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1207'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1208'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1210'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1211'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1213'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1214'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1217'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1218'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1219'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1222'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1224'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1225'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1227'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1228'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1237'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1238'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1240'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1241'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1243'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1244'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1246'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1247'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1258'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1259'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1260'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1261'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1262'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1263'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1271'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1273'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1274'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1275'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1277'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1278'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1279'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1280'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1281'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1282'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1283'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1294'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1297'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1298'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1299'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1300'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1301'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1302'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1303'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1304'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1311'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1312'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1313'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1315'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1316'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1318'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1319'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1321'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1322'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1324'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1325'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1326'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1329'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1330'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1331'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1332'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1333'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1334'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1335'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1350'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1351'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1353'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1354'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1355'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1356'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1357'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1358'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1359'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1360'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1361'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1362'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1363'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1364'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1365'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1366'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1367'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1368'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1370'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1371'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1372'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1373'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1374'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1375'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1385'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1386'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1387'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1388'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1389'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1401'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1402'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1403'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1404'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1405'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1406'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1413'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1414'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1415'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1416'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1417'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1418'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1419'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1420'
-    ppid: '2'
-    user: root
-  - cmdline: /opt/CrowdStrike/falcond
-    pid: '1436'
-    ppid: '1'
-    user: root
-  - cmdline: falcon-sensor
-    pid: '1438'
-    ppid: '1436'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '1448'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '1494'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '1499'
-    ppid: '1'
-    user: polkitd
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '1500'
-    ppid: '1'
-    user: dbus
-  - cmdline: '/usr/sbin/ntpd -u ntp:ntp -u ntp:ntp -p /var/run/ntpd.pid -g'
-    pid: '1514'
-    ppid: '1'
-    user: ntp
-  - cmdline: /usr/sbin/NetworkManager --no-daemon
-    pid: '1516'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sssd -i --logger=files
-    pid: '1520'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/rpcbind -w
-    pid: '1564'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/nscd
-    pid: '1597'
-    ppid: '1'
-    user: nscd
-  - cmdline: >-
-      /usr/libexec/sssd/sssd_be --domain ES.WCORP.CARREFOUR.COM --uid 0 --gid 0
-      --logger=files
-    pid: '2392'
-    ppid: '1520'
-    user: root
-  - cmdline: >-
-      /usr/local/avamar/bin/avagent.bin --bindir="/usr/local/avamar/bin"
-      --vardir="/usr/local/avamar/var" --sysdir="/usr/local/avamar/etc"
-      --logfile="/usr/local/avamar/var/avagent.log"
-    pid: '2479'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/vmtoolsd
-    pid: '2490'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/vmware-vgauth/VGAuthService -s
-    pid: '2583'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
-    pid: '2697'
-    ppid: '1520'
-    user: root
-  - cmdline: /usr/libexec/sssd/sssd_pam --uid 0 --gid 0 --logger=files
-    pid: '2698'
-    ppid: '1520'
-    user: root
-  - cmdline: /usr/libexec/sssd/sssd_pac --uid 0 --gid 0 --logger=files
-    pid: '2699'
-    ppid: '1520'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '2722'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/atd -f
-    pid: '2731'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '2735'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '2743'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '2882'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '2884'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '2888'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/share/filebeat/bin/filebeat -c /etc/filebeat/filebeat.yml -path.home
-      /usr/share/filebeat -path.config /etc/filebeat -path.data
-      /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '2891'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh /etc/init.d/init.ohasd run >/dev/null 2>&1 </dev/null
-    pid: '2892'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '2893'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/local/qualys/cloud-agent/bin/qualys-cloud-agent
-    pid: '2907'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/rhsmcertd
-    pid: '2909'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/xinetd -stayalive -pidfile /var/run/xinetd.pid
-    pid: '2919'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm.opt
-    pid: '3268'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '3451'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '3539'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '3568'
-    ppid: '3539'
-    user: postfix
-  - cmdline: bin/rscw
-    pid: '4017'
-    ppid: '1'
-    user: root
-  - cmdline: bin/rscd
-    pid: '4019'
-    ppid: '4017'
-    user: root
-  - cmdline: bin/rscd
-    pid: '4020'
-    ppid: '4017'
-    user: root
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_ARSYS.opt
-      -pass
-    pid: '5787'
-    ppid: '1'
-    user: root
-  - cmdline: ora_o001_BSAREP
-    pid: '7109'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o001_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '7111'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_w005_BSAREP
-    pid: '8166'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w004_BSAAPP
-    pid: '8584'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BNABBDD.opt
-      -pass
-    pid: '9365'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '10723'
-    ppid: '2'
-    user: root
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '11271'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAAPP.opt
-      -pass
-    pid: '11643'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAREP.opt
-      -pass
-    pid: '12211'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/perl
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/bin/emwd.pl
-      agent
-      /softOracle/app/oracle/product/12.1.0.4/agentes/gcinst/sysman/log/emagent.nohup
-    pid: '13389'
-    ppid: '1'
-    user: oracle
-  - cmdline: >-
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/bin/emwd.pl
-      agent
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_inst/sysman/log/emagent.nohup
-    pid: '13482'
-    ppid: '1'
-    user: oracle
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ohasd.bin
-      reboot
-    pid: '13578'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdk/bin/java
-      -Xmx128M -XX:MaxPermSize=96M -server
-      -Djava.security.egd=file:///dev/./urandom
-      -Dsun.lang.ClassLoader.allowArraySyntax=true
-      -XX:+UseLinuxPosixThreadCPUClocks -XX:+UseConcMarkSweepGC
-      -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -Dwatchdog.pid=13389
-      -cp
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdbc/lib/ojdbc5.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.http_client_11.1.1.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/xmlparserv2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/jsch.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/optic.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.dms_11.1.1/dms.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK.jar
-      oracle.sysman.gcagent.tmmain.TMMain
-    pid: '13590'
-    ppid: '13389'
-    user: oracle
-  - cmdline: >-
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/jdk/bin/java
-      -Xmx128M -XX:MaxMetaspaceSize=224M -server
-      -Djava.security.egd=file:///dev/./urandom
-      -Dsun.lang.ClassLoader.allowArraySyntax=true -XX:-UseLargePages
-      -XX:+UseLinuxPosixThreadCPUClocks -XX:+UseConcMarkSweepGC
-      -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops
-      -DHTTPClient.dontSeekTerminatingChunk=true -Dwatchdog.pid=13482 -cp
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jdbc/lib/ojdbc7.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/jsch-0.1.54.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/com.oracle.http_client.http_client.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.xdk/xmlparserv2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.dms/dms.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/lib/optic.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK.jar
-      oracle.sysman.gcagent.tmmain.TMMain
-    pid: '13648'
-    ppid: '13482'
-    user: oracle
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/oraagent.bin
-    pid: '14470'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmd.bin
-    pid: '14491'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAAPP
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 1524
+    protocol: tcp
+  discovery_time: '2022-06-15T18:05:12+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    instances:
+    - BSAAPP
+    name: LISTENER_BSAAPP
+  files:
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1
+    subtype: generic
+    type: home
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl
+    subtype: generic
+    type: binary
+  - name: log.xml
+    path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/trace
+    subtype: generic
+    type: log
+  listening_ports:
+  - 1524
+  packages: []
+  process:
+    cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAAPP
       -no_crs_notify -inherit
+    cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+    listening_ports:
+    - 1524
     pid: '14496'
     ppid: '1'
     user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAREP
+  type: Oracle Listener
+  version: []
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 1527
+    protocol: tcp
+  discovery_time: '2022-06-15T18:05:15+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    instances:
+    - BSAREP
+    name: LISTENER_BSAREP
+  files:
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1
+    subtype: generic
+    type: home
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl
+    subtype: generic
+    type: binary
+  - name: log.xml
+    path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/trace
+    subtype: generic
+    type: log
+  listening_ports:
+  - 1527
+  packages: []
+  process:
+    cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAREP
       -no_crs_notify -inherit
+    cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+    listening_ports:
+    - 1527
     pid: '14500'
     ppid: '1'
     user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BNABBDD
+  type: Oracle Listener
+  version: []
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 1523
+    protocol: tcp
+  discovery_time: '2022-06-15T18:05:18+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    instances:
+    - BNABBDD
+    name: LISTENER_BNABBDD
+  files:
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1
+    subtype: generic
+    type: home
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl
+    subtype: generic
+    type: binary
+  - name: log.xml
+    path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/trace
+    subtype: generic
+    type: log
+  listening_ports:
+  - 1523
+  packages: []
+  process:
+    cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BNABBDD
       -no_crs_notify -inherit
+    cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+    listening_ports:
+    - 1523
     pid: '14505'
     ppid: '1'
     user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmlogger.bin
-      -o
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.info
-      -l
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.log
-    pid: '14758'
-    ppid: '14491'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/tnslsnr
+  type: Oracle Listener
+  version: []
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 1521
+    protocol: tcp
+  discovery_time: '2022-06-15T18:05:21+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    instances:
+    - +ASM
+    name: LISTENER
+  files:
+  - path: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    subtype: generic
+    type: home
+  - path: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/lsnrctl
+    subtype: generic
+    type: binary
+  - name: log.xml
+    path: /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/trace
+    subtype: generic
+    type: log
+  listening_ports:
+  - 1521
+  packages: []
+  process:
+    cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/tnslsnr
       LISTENER -no_crs_notify -inherit
+    cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+    listening_ports:
+    - 1521
     pid: '14763'
     ppid: '1'
     user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_ARSYS
+  type: Oracle Listener
+  version: []
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 1522
+    protocol: tcp
+  discovery_time: '2022-06-15T18:05:23+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    instances:
+    - ARSYS
+    name: LISTENER_ARSYS
+  files:
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1
+    subtype: generic
+    type: home
+  - path: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/lsnrctl
+    subtype: generic
+    type: binary
+  - name: log.xml
+    path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/trace
+    subtype: generic
+    type: log
+  listening_ports:
+  - 1522
+  packages: []
+  process:
+    cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_ARSYS
       -no_crs_notify -inherit
+    cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+    listening_ports:
+    - 1522
     pid: '14782'
     ppid: '1'
     user: oragrid
-  - cmdline: >-
-      /usr/local/qualys/cloud-agent/bin/agentid-service -config
-      /etc/qualys/cloud-agent/agentid-service.conf -logdir /var/log/qualys/
-    pid: '14887'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/cssdagent
-    pid: '15030'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ocssd.bin
-    pid: '15057'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_pmon_+ASM
-    pid: '15350'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_psp0_+ASM
-    pid: '15354'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_vktm_+ASM
-    pid: '15357'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_gen0_+ASM
-    pid: '15363'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_mman_+ASM
-    pid: '15365'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_diag_+ASM
-    pid: '15369'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_dia0_+ASM
-    pid: '15371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_dbw0_+ASM
-    pid: '15373'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_lgwr_+ASM
-    pid: '15375'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_ckpt_+ASM
-    pid: '15377'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_smon_+ASM
-    pid: '15379'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_lreg_+ASM
-    pid: '15381'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_pxmn_+ASM
-    pid: '15383'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_rbal_+ASM
-    pid: '15385'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_gmon_+ASM
-    pid: '15387'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_mmon_+ASM
-    pid: '15389'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_mmnl_+ASM
-    pid: '15391'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15491'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15494'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15509'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_asmb_+ASM
-    pid: '15538'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_+asm (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15545'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '15554'
-    ppid: '2'
-    user: root
-  - cmdline: ora_pmon_ARSYS
-    pid: '15612'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_ARSYS
-    pid: '15614'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_ARSYS
-    pid: '15621'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_ARSYS
-    pid: '15625'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_ARSYS
-    pid: '15627'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_ARSYS
-    pid: '15631'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_ARSYS
-    pid: '15633'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_ARSYS
-    pid: '15635'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_ARSYS
-    pid: '15637'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_ARSYS
-    pid: '15639'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_ARSYS
-    pid: '15641'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_ARSYS
-    pid: '15643'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_ARSYS
-    pid: '15645'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_ARSYS
-    pid: '15647'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_ARSYS
-    pid: '15649'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_ARSYS
-    pid: '15651'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_ARSYS
-    pid: '15653'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_ARSYS
-    pid: '15655'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pxmn_ARSYS
-    pid: '15657'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_ARSYS
-    pid: '15659'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_ARSYS
-    pid: '15661'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_ARSYS
-    pid: '15663'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmnl_ARSYS
-    pid: '15667'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15669'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_d000_ARSYS
-    pid: '15674'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_ARSYS
-    pid: '15676'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_ARSYS
-    pid: '15678'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pmon_BSAAPP
-    pid: '15684'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_BSAAPP
-    pid: '15686'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pmon_BNABBDD
-    pid: '15688'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_BNABBDD
-    pid: '15690'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pmon_BSAREP
-    pid: '15692'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_BSAREP
-    pid: '15694'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_BSAAPP
-    pid: '15697'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_BSAAPP
-    pid: '15701'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_BSAAPP
-    pid: '15703'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_BNABBDD
-    pid: '15707'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_BSAAPP
-    pid: '15709'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_BSAAPP
-    pid: '15714'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_BNABBDD
-    pid: '15715'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_BSAREP
-    pid: '15717'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_BSAAPP
-    pid: '15719'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_BNABBDD
-    pid: '15723'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_BSAREP
-    pid: '15725'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_BSAAPP
-    pid: '15727'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_BSAREP
-    pid: '15731'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_BNABBDD
-    pid: '15735'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_BSAAPP
-    pid: '15737'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_BSAREP
-    pid: '15739'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_BNABBDD
-    pid: '15741'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_BSAAPP
-    pid: '15744'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_BSAREP
-    pid: '15746'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_BNABBDD
-    pid: '15747'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_BSAREP
-    pid: '15749'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_BNABBDD
-    pid: '15751'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_BSAAPP
-    pid: '15753'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_BSAREP
-    pid: '15755'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_BNABBDD
-    pid: '15757'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_BSAAPP
-    pid: '15759'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_BSAREP
-    pid: '15761'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_BSAAPP
-    pid: '15763'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_BNABBDD
-    pid: '15765'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_BSAAPP
-    pid: '15767'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_BSAREP
-    pid: '15769'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_BNABBDD
-    pid: '15771'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_BSAAPP
-    pid: '15773'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_BSAREP
-    pid: '15776'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_BNABBDD
-    pid: '15778'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_BSAAPP
-    pid: '15780'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_BSAREP
-    pid: '15782'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_BSAAPP
-    pid: '15784'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pxmn_BSAAPP
-    pid: '15786'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_BSAREP
-    pid: '15788'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_BNABBDD
-    pid: '15790'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_BSAAPP
-    pid: '15792'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_BSAREP
-    pid: '15794'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_BNABBDD
-    pid: '15796'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_BNABBDD
-    pid: '15798'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_BSAAPP
-    pid: '15800'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_BSAREP
-    pid: '15802'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_BNABBDD
-    pid: '15804'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_BSAAPP
-    pid: '15807'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_BSAREP
-    pid: '15808'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_BNABBDD
-    pid: '15810'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_BSAREP
-    pid: '15813'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmnl_BSAAPP
-    pid: '15814'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15816'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_pxmn_BNABBDD
-    pid: '15818'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_d000_BSAAPP
-    pid: '15821'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pxmn_BSAREP
-    pid: '15822'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_BSAAPP
-    pid: '15825'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_BSAREP
-    pid: '15826'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_BNABBDD
-    pid: '15828'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_BSAREP
-    pid: '15830'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_BNABBDD
-    pid: '15832'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_BSAAPP
-    pid: '15834'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_BSAREP
-    pid: '15836'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_BNABBDD
-    pid: '15838'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15840'
-    ppid: '1'
-    user: oracle
-  - cmdline: oracle+ASM_asmb_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15842'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_mmnl_BSAREP
-    pid: '15844'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmnl_BNABBDD
-    pid: '15846'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_d000_BSAREP
-    pid: '15848'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_d000_BNABBDD
-    pid: '15852'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_BSAREP
-    pid: '15854'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_BNABBDD
-    pid: '15856'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_BSAREP
-    pid: '15858'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_BNABBDD
-    pid: '15862'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_ARSYS
-    pid: '15964'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_ARSYS
-    pid: '15966'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_ARSYS
-    pid: '15968'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_ARSYS
-    pid: '15970'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_ARSYS
-    pid: '15972'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_ARSYS
-    pid: '15974'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_ARSYS
-    pid: '15976'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_ARSYS
-    pid: '15978'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_ARSYS
-    pid: '15980'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_ARSYS
-    pid: '15982'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_ARSYS
-    pid: '15984'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_ARSYS
-    pid: '15986'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_ARSYS
-    pid: '15988'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_ARSYS
-    pid: '15990'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_ARSYS
-    pid: '15992'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_BNABBDD
-    pid: '15995'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_BNABBDD
-    pid: '15997'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_BSAREP
-    pid: '15999'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_BSAAPP
-    pid: '16001'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_BNABBDD
-    pid: '16004'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_BSAREP
-    pid: '16005'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_BSAAPP
-    pid: '16007'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_BNABBDD
-    pid: '16010'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_BSAREP
-    pid: '16011'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_BSAAPP
-    pid: '16013'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_BNABBDD
-    pid: '16015'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_BSAREP
-    pid: '16017'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_BNABBDD
-    pid: '16019'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_BSAAPP
-    pid: '16021'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_BSAREP
-    pid: '16023'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_BNABBDD
-    pid: '16027'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_BSAREP
-    pid: '16028'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_BSAAPP
-    pid: '16029'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_BSAREP
-    pid: '16031'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_BSAAPP
-    pid: '16033'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_BNABBDD
-    pid: '16035'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_BSAREP
-    pid: '16037'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_BNABBDD
-    pid: '16039'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_BSAAPP
-    pid: '16041'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_BSAREP
-    pid: '16044'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_BSAAPP
-    pid: '16045'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_BNABBDD
-    pid: '16047'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_BSAREP
-    pid: '16051'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_BNABBDD
-    pid: '16052'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_BSAAPP
-    pid: '16053'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_BSAREP
-    pid: '16057'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_BSAAPP
-    pid: '16058'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_BNABBDD
-    pid: '16059'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_BSAREP
-    pid: '16063'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_BSAAPP
-    pid: '16064'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_BNABBDD
-    pid: '16065'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_BSAREP
-    pid: '16069'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_BNABBDD
-    pid: '16070'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_BSAAPP
-    pid: '16071'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_BSAREP
-    pid: '16075'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_BSAAPP
-    pid: '16076'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_BNABBDD
-    pid: '16077'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_BSAAPP
-    pid: '16079'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_BSAREP
-    pid: '16081'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_BSAAPP
-    pid: '16084'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_BNABBDD
-    pid: '16123'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_ARSYS
-    pid: '16131'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_BNABBDD
-    pid: '16133'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_ARSYS
-    pid: '16141'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_BNABBDD
-    pid: '16145'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_BNABBDD
-    pid: '16151'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_ARSYS
-    pid: '16153'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_ARSYS
-    pid: '16156'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_BNABBDD
-    pid: '16157'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_ARSYS
-    pid: '16161'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_BSAAPP
-    pid: '16167'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_BSAAPP
-    pid: '16173'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_ARSYS
-    pid: '16177'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_BSAAPP
-    pid: '16179'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_BNABBDD
-    pid: '16181'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_BSAAPP
-    pid: '16183'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_BSAREP
-    pid: '16185'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_BSAAPP
-    pid: '16187'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_BSAREP
-    pid: '16189'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_BSAREP
-    pid: '16191'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_BSAREP
-    pid: '16194'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_BSAREP
-    pid: '16196'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_BSAAPP
-    pid: '16198'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_BSAREP
-    pid: '16200'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_ARSYS
-    pid: '16208'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_BNABBDD
-    pid: '16215'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_BSAAPP
-    pid: '16217'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_BSAREP
-    pid: '16253'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_BNABBDD
-    pid: '16285'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_ARSYS
-    pid: '16287'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_BSAAPP
-    pid: '16292'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '16304'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_BSAREP
-    pid: '16309'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_BSAAPP
-    pid: '16318'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_BSAAPP
-    pid: '16320'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_BSAAPP
-    pid: '16322'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_BSAAPP
-    pid: '16324'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_BSAAPP
-    pid: '16328'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_BNABBDD
-    pid: '16330'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_BSAAPP
-    pid: '16332'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_BNABBDD
-    pid: '16334'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_BSAAPP
-    pid: '16336'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_BNABBDD
-    pid: '16338'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_BSAAPP
-    pid: '16340'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_BSAAPP
-    pid: '16343'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_BNABBDD
-    pid: '16344'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_BNABBDD
-    pid: '16346'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_BSAAPP
-    pid: '16348'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_BNABBDD
-    pid: '16351'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_BSAAPP
-    pid: '16352'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_BSAAPP
-    pid: '16354'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_BNABBDD
-    pid: '16356'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_BSAAPP
-    pid: '16361'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_BNABBDD
-    pid: '16363'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_BSAAPP
-    pid: '16365'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_BNABBDD
-    pid: '16367'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_ARSYS
-    pid: '16369'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_BSAAPP
-    pid: '16371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_ARSYS
-    pid: '16373'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_BNABBDD
-    pid: '16375'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_BSAAPP
-    pid: '16377'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_ARSYS
-    pid: '16380'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_BNABBDD
-    pid: '16381'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_BNABBDD
-    pid: '16383'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_BSAAPP
-    pid: '16385'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_ARSYS
-    pid: '16387'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_BSAAPP
-    pid: '16389'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_ARSYS
-    pid: '16391'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_BNABBDD
-    pid: '16393'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_ARSYS
-    pid: '16396'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_BSAAPP
-    pid: '16397'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_BNABBDD
-    pid: '16399'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_BNABBDD
-    pid: '16401'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_ARSYS
-    pid: '16403'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_BSAAPP
-    pid: '16405'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_BSAAPP
-    pid: '16408'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_BNABBDD
-    pid: '16409'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_ARSYS
-    pid: '16411'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_BSAAPP
-    pid: '16413'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_BNABBDD
-    pid: '16415'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_ARSYS
-    pid: '16417'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_BSAAPP
-    pid: '16419'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_ARSYS
-    pid: '16422'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_BNABBDD
-    pid: '16423'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_BSAAPP
-    pid: '16425'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_ARSYS
-    pid: '16428'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_BNABBDD
-    pid: '16429'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_BSAAPP
-    pid: '16431'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_BNABBDD
-    pid: '16434'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_ARSYS
-    pid: '16435'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_BSAAPP
-    pid: '16437'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_ARSYS
-    pid: '16439'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_BNABBDD
-    pid: '16441'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_BSAAPP
-    pid: '16443'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_BNABBDD
-    pid: '16446'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_ARSYS
-    pid: '16447'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_BNABBDD
-    pid: '16449'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_ARSYS
-    pid: '16451'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_BSAAPP
-    pid: '16453'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_ARSYS
-    pid: '16457'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_BNABBDD
-    pid: '16458'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_BSAAPP
-    pid: '16460'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_ARSYS
-    pid: '16462'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_BNABBDD
-    pid: '16464'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_BSAAPP
-    pid: '16466'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_BNABBDD
-    pid: '16468'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_ARSYS
-    pid: '16470'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_BSAAPP
-    pid: '16472'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_BNABBDD
-    pid: '16475'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_ARSYS
-    pid: '16476'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_BSAAPP
-    pid: '16478'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_BNABBDD
-    pid: '16480'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_ARSYS
-    pid: '16482'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_BSAAPP
-    pid: '16484'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_BNABBDD
-    pid: '16486'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_ARSYS
-    pid: '16488'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_BSAAPP
-    pid: '16490'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_ARSYS
-    pid: '16492'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_BNABBDD
-    pid: '16494'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_BSAAPP
-    pid: '16496'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_ARSYS
-    pid: '16498'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_BNABBDD
-    pid: '16500'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_BSAAPP
-    pid: '16502'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_ARSYS
-    pid: '16505'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_BNABBDD
-    pid: '16506'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_BSAAPP
-    pid: '16508'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_ARSYS
-    pid: '16511'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_BNABBDD
-    pid: '16512'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_BSAAPP
-    pid: '16514'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_BNABBDD
-    pid: '16517'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_ARSYS
-    pid: '16518'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_BSAAPP
-    pid: '16520'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_BNABBDD
-    pid: '16523'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_ARSYS
-    pid: '16524'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_BSAAPP
-    pid: '16526'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_BNABBDD
-    pid: '16529'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_ARSYS
-    pid: '16530'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_BSAAPP
-    pid: '16532'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_BNABBDD
-    pid: '16534'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_BSAAPP
-    pid: '16536'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_ARSYS
-    pid: '16538'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_BNABBDD
-    pid: '16540'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_BSAAPP
-    pid: '16542'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_ARSYS
-    pid: '16544'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_BNABBDD
-    pid: '16546'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_BSAAPP
-    pid: '16548'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_ARSYS
-    pid: '16550'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_BNABBDD
-    pid: '16552'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_BSAAPP
-    pid: '16554'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_BNABBDD
-    pid: '16556'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_ARSYS
-    pid: '16558'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_BSAAPP
-    pid: '16560'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_ARSYS
-    pid: '16562'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_BNABBDD
-    pid: '16564'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_BSAAPP
-    pid: '16566'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_ARSYS
-    pid: '16568'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_BNABBDD
-    pid: '16570'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_BSAAPP
-    pid: '16572'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_ARSYS
-    pid: '16574'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_BNABBDD
-    pid: '16576'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_BSAAPP
-    pid: '16579'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_ARSYS
-    pid: '16581'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_BNABBDD
-    pid: '16583'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_BSAAPP
-    pid: '16585'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_ARSYS
-    pid: '16587'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_BNABBDD
-    pid: '16589'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_ARSYS
-    pid: '16591'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_BNABBDD
-    pid: '16593'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_ARSYS
-    pid: '16595'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_BNABBDD
-    pid: '16597'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_ARSYS
-    pid: '16599'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_BNABBDD
-    pid: '16601'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_ARSYS
-    pid: '16603'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_BNABBDD
-    pid: '16605'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_ARSYS
-    pid: '16607'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_ARSYS
-    pid: '16609'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_ARSYS
-    pid: '16611'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_ARSYS
-    pid: '16613'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_ARSYS
-    pid: '16615'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_ARSYS
-    pid: '16617'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_ARSYS
-    pid: '16619'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_ARSYS
-    pid: '16621'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_ARSYS
-    pid: '16623'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '16625'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_BSAAPP
-    pid: '16627'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_BSAAPP
-    pid: '16629'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_BSAAPP
-    pid: '16635'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '16637'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_BNABBDD
-    pid: '16639'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_BNABBDD
-    pid: '16643'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_BSAREP
-    pid: '16645'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_BSAREP
-    pid: '16649'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_BSAREP
-    pid: '16653'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_BNABBDD
-    pid: '16655'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_BSAREP
-    pid: '16657'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_BSAREP
-    pid: '16659'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_ARSYS
-    pid: '16661'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_BSAREP
-    pid: '16663'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_ARSYS
-    pid: '16665'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_BSAREP
-    pid: '16667'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q002_ARSYS
-    pid: '16669'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_BSAREP
-    pid: '16671'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_BSAREP
-    pid: '16673'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_BSAREP
-    pid: '16677'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_ARSYS
-    pid: '16679'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_BSAREP
-    pid: '16681'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_BSAREP
-    pid: '16683'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_BSAREP
-    pid: '16685'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_BSAREP
-    pid: '16687'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_BSAREP
-    pid: '16689'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_BSAREP
-    pid: '16691'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_BSAREP
-    pid: '16693'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_BSAREP
-    pid: '16695'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_BSAREP
-    pid: '16698'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_BSAREP
-    pid: '16700'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_BSAREP
-    pid: '16702'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_BSAREP
-    pid: '16704'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_BSAREP
-    pid: '16706'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_BSAREP
-    pid: '16708'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_BSAREP
-    pid: '16710'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_BSAREP
-    pid: '16712'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_BSAREP
-    pid: '16714'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_BSAREP
-    pid: '16716'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_BSAREP
-    pid: '16718'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_BSAREP
-    pid: '16720'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_BSAREP
-    pid: '16722'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_BSAREP
-    pid: '16724'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_BSAREP
-    pid: '16726'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_BSAREP
-    pid: '16728'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_BSAREP
-    pid: '16730'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_BSAREP
-    pid: '16732'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_BSAREP
-    pid: '16734'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_BSAAPP
-    pid: '16736'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_BSAREP
-    pid: '16738'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_BSAAPP
-    pid: '16740'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_BSAREP
-    pid: '16742'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_BSAAPP
-    pid: '16744'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_BSAREP
-    pid: '16746'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_BSAREP
-    pid: '16748'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_BSAAPP
-    pid: '16750'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_BSAREP
-    pid: '16752'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_BSAAPP
-    pid: '16754'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_BSAREP
-    pid: '16756'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_BSAREP
-    pid: '16758'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q00a_BSAAPP
-    pid: '16760'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_BSAREP
-    pid: '16762'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_BSAREP
-    pid: '16764'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_BSAREP
-    pid: '16766'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_BSAREP
-    pid: '16768'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_BSAREP
-    pid: '16770'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_BSAREP
-    pid: '16772'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_ARSYS
-    pid: '16774'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_ARSYS
-    pid: '16777'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_ARSYS
-    pid: '16779'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_ARSYS
-    pid: '16781'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_ARSYS
-    pid: '16783'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_BNABBDD
-    pid: '16785'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_BNABBDD
-    pid: '16788'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_BNABBDD
-    pid: '16790'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_BNABBDD
-    pid: '16792'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_BNABBDD
-    pid: '16794'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_BSAREP
-    pid: '16797'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_BSAREP
-    pid: '16799'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q002_BSAREP
-    pid: '16801'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '16805'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_BSAREP
-    pid: '16807'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '16837'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_BSAREP
-    pid: '16840'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_BSAREP
-    pid: '16842'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_BSAREP
-    pid: '16844'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_BSAREP
-    pid: '16848'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_BSAREP
-    pid: '16854'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '16951'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '17039'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '17069'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '17109'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '17371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '17411'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '17651'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '17657'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '17796'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '18038'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '19700'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '19811'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '19813'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '20577'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '20645'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '20663'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '20675'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '20679'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '21794'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '21914'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '22175'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22208'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22219'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22258'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22262'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22316'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22318'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22320'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22322'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22324'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22326'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22328'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22330'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22332'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22334'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22336'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22338'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22340'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22342'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22344'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22346'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22348'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22350'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22352'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22354'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22356'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22358'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22360'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22363'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22365'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22368'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22373'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22375'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22379'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22385'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22387'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22393'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22399'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22405'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22411'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22415'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22421'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22425'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22431'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22437'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22443'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22445'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22449'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22451'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22453'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22455'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22458'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22460'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22462'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22464'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22468'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22473'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22477'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22479'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22481'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22483'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22485'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22487'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22489'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22491'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22493'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22495'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22497'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22499'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22501'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22545'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22563'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '32378'
-    ppid: '1'
-    user: oragrid
-  - cmdline: 'sshd: cyberark [priv]'
-    pid: '32623'
-    ppid: '2882'
-    user: root
-  - cmdline: 'sshd: cyberark@pts/1'
-    pid: '32631'
-    ppid: '32623'
-    user: cyberark
-  - cmdline: '-bash'
-    pid: '32632'
-    ppid: '32631'
-    user: cyberark
-  - cmdline: su - root
-    pid: '32668'
-    ppid: '32632'
-    user: cyberark
-  - cmdline: '-bash'
-    pid: '32676'
-    ppid: '32668'
-    user: root
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/sqlplus                                        
-      as sysasm
-    pid: '33023'
-    ppid: '32676'
-    user: root
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '33025'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '34800'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34963'
-    ppid: '2'
-    user: root
-  - cmdline: ora_w004_BSAREP
-    pid: '35257'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w002_BSAAPP
-    pid: '35341'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w003_ARSYS
-    pid: '35409'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_o001_BNABBDD
-    pid: '35698'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o001_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '35700'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_o002_ARSYS
-    pid: '35703'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o002_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '35705'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '36134'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37614'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38019'
-    ppid: '2'
-    user: root
-  - cmdline: ora_w001_BNABBDD
-    pid: '38039'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '38380'
-    ppid: '2'
-    user: root
-  - cmdline: ora_w000_BNABBDD
-    pid: '40559'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '41466'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42316'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51639'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53968'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '55115'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57812'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57921'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58479'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58505'
-    ppid: '2'
-    user: root
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '59259'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '62085'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62951'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '67682'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68499'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68515'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68597'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68768'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68938'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68960'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69565'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '74694'
-    ppid: '2'
-    user: root
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '76012'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '76666'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76667'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76736'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '77158'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79085'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79092'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79256'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79490'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79648'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '79666'
-    ppid: '3539'
-    user: postfix
-  - cmdline: ''
-    pid: '79880'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79915'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79930'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79931'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79933'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80004'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80194'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80196'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80292'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/plugins/oracle.sysman.db.agent.plugin_13.4.1.0.0/scripts/failedLogin.pl
-    pid: '80308'
-    ppid: '13648'
-    user: oracle
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '80326'
-    ppid: '1'
-    user: oragrid
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1655221424
-    pid: '80481'
-    ppid: '2884'
-    user: root
-  - cmdline: 'sshd: cyberark [priv]'
-    pid: '80506'
-    ppid: '2882'
-    user: root
-  - cmdline: 'sshd: cyberark@pts/2'
-    pid: '80508'
-    ppid: '80506'
-    user: cyberark
-  - cmdline: ''
-    pid: '80735'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80741'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80819'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80820'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80821'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80822'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80823'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80824'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80825'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80826'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80827'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80828'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80829'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80830'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80831'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80832'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80833'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80834'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80835'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80836'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80837'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80838'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80839'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80840'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80841'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80842'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80843'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80844'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80845'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80846'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80847'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80848'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80849'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80850'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80851'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80852'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80853'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80854'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80855'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80856'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80857'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80858'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80859'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80860'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80861'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80862'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80863'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80864'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80865'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80866'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /bin/sh -c su - root -c '/bin/sh -c '"'"'echo
-      BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ; /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'"'"''
-      && sleep 0
-    pid: '80972'
-    ppid: '80508'
-    user: cyberark
-  - cmdline: >-
-      su - root -c /bin/sh -c 'echo
-      BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ; /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'
-    pid: '80990'
-    ppid: '80972'
-    user: cyberark
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ;
-      /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
-    pid: '80991'
-    ppid: '80990'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
-    pid: '81026'
-    ppid: '80991'
-    user: root
-  - cmdline: ''
-    pid: '81076'
-    ppid: '2'
-    user: root
-  - cmdline: ora_q003_BNABBDD
-    pid: '85919'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '98298'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w000_ARSYS
-    pid: '105757'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_o002_BSAAPP
-    pid: '121249'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o002_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '121251'
-    ppid: '1'
-    user: oracle
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '123382'
-    ppid: '1'
-    user: oragrid
+  type: Oracle Listener
+  version: []
+mocked_plugin_tasks:
+  Check log_dir is a dir:
+    calls:
+    - expected_args:
+        follow: false
+        get_attributes: true
+        get_mime: true
+        in_docker: true
+        path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/trace
+      plugin_result:
+        failed: false
+        stat:
+          exists: true
+          isdir: true
+    - expected_args:
+        follow: false
+        get_attributes: true
+        get_mime: true
+        in_docker: true
+        path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/trace
+      plugin_result:
+        failed: false
+        stat:
+          exists: true
+          isdir: true
+    - expected_args:
+        follow: false
+        get_attributes: true
+        get_mime: true
+        in_docker: true
+        path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/trace
+      plugin_result:
+        failed: false
+        stat:
+          exists: true
+          isdir: true
+    - expected_args:
+        follow: false
+        get_attributes: true
+        get_mime: true
+        in_docker: true
+        path: /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/trace
+      plugin_result:
+        failed: false
+        stat:
+          exists: true
+          isdir: true
+    - expected_args:
+        follow: false
+        get_attributes: true
+        get_mime: true
+        in_docker: true
+        path: /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/trace
+      plugin_result:
+        failed: false
+        stat:
+          exists: true
+          isdir: true
+  Execute lsnrctl:
+    calls:
+    - plugin_result:
+        failed: false
+        stdout: 'Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml
+
+          (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1524)))
+
+          Services Summary...
+
+          Service "BSAAPP" has 1 instance(s).
+
+          Instance "BSAAPP", status READY, has 1 handler(s) for this service...'
+        stdout_lines:
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsaapp/alert/log.xml
+        - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1524)))
+        - Services Summary...
+        - Service "BSAAPP" has 1 instance(s).
+        - Instance "BSAAPP", status READY, has 1 handler(s) for this service...
+    - plugin_result:
+        failed: false
+        stdout: 'Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml
+
+          (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1527)))
+
+          Services Summary...
+
+          Service "BSAREP" has 1 instance(s).
+
+          Instance "BSAREP", status READY, has 1 handler(s) for this service...'
+        stdout_lines:
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bsarep/alert/log.xml
+        - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1527)))
+        - Services Summary...
+        - Service "BSAREP" has 1 instance(s).
+        - Instance "BSAREP", status READY, has 1 handler(s) for this service...
+    - plugin_result:
+        failed: false
+        stdout: 'Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml
+
+          (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1523)))
+
+          Services Summary...
+
+          Service "BNABBDD" has 1 instance(s).
+
+          Instance "BNABBDD", status READY, has 1 handler(s) for this service...'
+        stdout_lines:
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_bnabbdd/alert/log.xml
+        - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1523)))
+        - Services Summary...
+        - Service "BNABBDD" has 1 instance(s).
+        - Instance "BNABBDD", status READY, has 1 handler(s) for this service...
+    - plugin_result:
+        failed: false
+        stdout: 'Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml
+
+          (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
+
+          Services Summary...
+
+          Service "+ASM" has 1 instance(s).
+
+          Instance "+ASM", status READY, has 1 handler(s) for this service...'
+        stdout_lines:
+        - Listener Log File         /softOracle_local/app/oragrid/diag/tnslsnr/ld1bmb02/listener/alert/log.xml
+        - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
+        - Services Summary...
+        - Service "+ASM" has 1 instance(s).
+        - Instance "+ASM", status READY, has 1 handler(s) for this service...
+    - plugin_result:
+        failed: false
+        stdout: 'Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml
+
+          (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1522)))
+
+          Services Summary...
+
+          Service "ARSYS" has 1 instance(s).
+
+          Instance "ARSYS", status READY, has 1 handler(s) for this service...'
+        stdout_lines:
+        - Listener Log File         /softOracle/app/oracle/diag/tnslsnr/ld1bmb02/listener_arsys/alert/log.xml
+        - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1522)))
+        - Services Summary...
+        - Service "ARSYS" has 1 instance(s).
+        - Instance "ARSYS", status READY, has 1 handler(s) for this service...
+  Read env from process:
+    calls:
+    - expected_args:
+        pid: '14496'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14500'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14505'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+    - expected_args:
+        pid: '14763'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure
+    - expected_args:
+        pid: '14782'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.2/db_1
+packages:
+  AvamarClient:
+  - arch: x86_64
+    epoch: null
+    name: AvamarClient
+    release: '149'
+    source: rpm
+    version: 19.3.100
+  AvamarRMAN:
+  - arch: x86_64
+    epoch: null
+    name: AvamarRMAN
+    release: '149'
+    source: rpm
+    version: 19.3.100
+  BladeLogic_RSCD_Agent:
+  - arch: x86_64
+    epoch: null
+    name: BladeLogic_RSCD_Agent
+    release: '200'
+    source: rpm
+    version: 8.9.04
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
+  NetworkManager:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-config-server:
+  - arch: noarch
+    epoch: 1
+    name: NetworkManager-config-server
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-libnm:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-libnm
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-ppp:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-ppp
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-team:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-team
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-tui:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-tui
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  OpenIPMI:
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
+  OpenIPMI-libs:
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI-libs
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
+  OpenIPMI-modalias:
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI-modalias
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
+  Red_Hat_Enterprise_Linux-Release_Notes-7-en-US:
+  - arch: noarch
+    epoch: null
+    name: Red_Hat_Enterprise_Linux-Release_Notes-7-en-US
+    release: 2.el7
+    source: rpm
+    version: '7'
+  TDP-Oracle:
+  - arch: x86_64
+    epoch: null
+    name: TDP-Oracle
+    release: '0'
+    source: rpm
+    version: 8.1.0
+  TDP-Oracle.Utility:
+  - arch: x86_64
+    epoch: null
+    name: TDP-Oracle.Utility
+    release: '0'
+    source: rpm
+    version: 8.1.0
+  TIVsm-API64:
+  - arch: x86_64
+    epoch: null
+    name: TIVsm-API64
+    release: '0'
+    source: rpm
+    version: 8.1.7
+  TIVsm-BA:
+  - arch: x86_64
+    epoch: null
+    name: TIVsm-BA
+    release: '0'
+    source: rpm
+    version: 8.1.7
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  adcli:
+  - arch: x86_64
+    epoch: null
+    name: adcli
+    release: 9.el7
+    source: rpm
+    version: 0.8.1
+  adobe-mappings-cmap:
+  - arch: noarch
+    epoch: null
+    name: adobe-mappings-cmap
+    release: 3.el7
+    source: rpm
+    version: '20171205'
+  adobe-mappings-cmap-deprecated:
+  - arch: noarch
+    epoch: null
+    name: adobe-mappings-cmap-deprecated
+    release: 3.el7
+    source: rpm
+    version: '20171205'
+  adobe-mappings-pdf:
+  - arch: noarch
+    epoch: null
+    name: adobe-mappings-pdf
+    release: 1.el7
+    source: rpm
+    version: '20180407'
+  aic94xx-firmware:
+  - arch: noarch
+    epoch: null
+    name: aic94xx-firmware
+    release: 6.el7
+    source: rpm
+    version: '30'
+  aide:
+  - arch: x86_64
+    epoch: null
+    name: aide
+    release: 13.el7_9.1
+    source: rpm
+    version: 0.15.1
+  alsa-firmware:
+  - arch: noarch
+    epoch: null
+    name: alsa-firmware
+    release: 2.el7
+    source: rpm
+    version: 1.0.28
+  alsa-lib:
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
+  alsa-tools-firmware:
+  - arch: x86_64
+    epoch: null
+    name: alsa-tools-firmware
+    release: 1.el7
+    source: rpm
+    version: 1.1.0
+  at:
+  - arch: x86_64
+    epoch: null
+    name: at
+    release: 24.el7
+    source: rpm
+    version: 3.1.13
+  atk:
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs:
+  - arch: i686
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autofs:
+  - arch: x86_64
+    epoch: 1
+    name: autofs
+    release: 106.el7
+    source: rpm
+    version: 5.0.7
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  avahi-autoipd:
+  - arch: x86_64
+    epoch: null
+    name: avahi-autoipd
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  avahi-libs:
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
+  bash-completion:
+  - arch: noarch
+    epoch: 1
+    name: bash-completion
+    release: 6.el7
+    source: rpm
+    version: '2.1'
+  bc:
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
+  biosdevname:
+  - arch: x86_64
+    epoch: null
+    name: biosdevname
+    release: 2.el7
+    source: rpm
+    version: 0.7.3
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2:
+  - arch: x86_64
+    epoch: null
+    name: bzip2
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  bzip2-libs:
+  - arch: i686
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  c-ares:
+  - arch: x86_64
+    epoch: null
+    name: c-ares
+    release: 3.el7
+    source: rpm
+    version: 1.10.0
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  cairo:
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
+  cfg2html:
+  - arch: noarch
+    epoch: null
+    name: cfg2html
+    release: '151.1'
+    source: rpm
+    version: '6.30'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  compat-libcap1:
+  - arch: x86_64
+    epoch: null
+    name: compat-libcap1
+    release: 7.el7
+    source: rpm
+    version: '1.10'
+  compat-libstdc++-33:
+  - arch: i686
+    epoch: null
+    name: compat-libstdc++-33
+    release: 72.el7
+    source: rpm
+    version: 3.2.3
+  - arch: x86_64
+    epoch: null
+    name: compat-libstdc++-33
+    release: 72.el7
+    source: rpm
+    version: 3.2.3
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  - arch: i686
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.3
+  cups-client:
+  - arch: x86_64
+    epoch: 1
+    name: cups-client
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
+  cups-libs:
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-gssapi:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-gssapi
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  dejavu-fonts-common:
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  dejavu-sans-fonts:
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  desktop-file-utils:
+  - arch: x86_64
+    epoch: null
+    name: desktop-file-utils
+    release: 2.el7
+    source: rpm
+    version: '0.23'
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
+  device-mapper-event:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
+  device-mapper-event-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
+  device-mapper-multipath:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-multipath
+    release: 127.el7
+    source: rpm
+    version: 0.4.9
+  device-mapper-multipath-libs:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-multipath-libs
+    release: 127.el7
+    source: rpm
+    version: 0.4.9
+  device-mapper-persistent-data:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 1.el7
+    source: rpm
+    version: 0.8.5
+  dhclient:
+  - arch: x86_64
+    epoch: 12
+    name: dhclient
+    release: 83.el7_9.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7_9.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7_9.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 3.el7
+    source: rpm
+    version: '3.2'
+  dnsmasq:
+  - arch: x86_64
+    epoch: null
+    name: dnsmasq
+    release: 16.el7_9.1
+    source: rpm
+    version: '2.76'
+  dosfstools:
+  - arch: x86_64
+    epoch: null
+    name: dosfstools
+    release: 10.el7
+    source: rpm
+    version: 3.0.20
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 564.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 564.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 564.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  ebtables:
+  - arch: x86_64
+    epoch: null
+    name: ebtables
+    release: 16.el7
+    source: rpm
+    version: 2.0.10
+  ed:
+  - arch: x86_64
+    epoch: null
+    name: ed
+    release: 4.el7
+    source: rpm
+    version: '1.9'
+  efibootmgr:
+  - arch: x86_64
+    epoch: null
+    name: efibootmgr
+    release: 2.el7
+    source: rpm
+    version: '17'
+  efivar-libs:
+  - arch: x86_64
+    epoch: null
+    name: efivar-libs
+    release: 12.el7
+    source: rpm
+    version: '36'
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: i686
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  - arch: i686
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  emacs-common:
+  - arch: x86_64
+    epoch: 1
+    name: emacs-common
+    release: 23.el7
+    source: rpm
+    version: '24.3'
+  emacs-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: emacs-filesystem
+    release: 23.el7
+    source: rpm
+    version: '24.3'
+  emacs-nox:
+  - arch: x86_64
+    epoch: 1
+    name: emacs-nox
+    release: 23.el7
+    source: rpm
+    version: '24.3'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 14.el7_9
+    source: rpm
+    version: 2.1.0
+  expect:
+  - arch: x86_64
+    epoch: null
+    name: expect
+    release: 14.el7_1
+    source: rpm
+    version: '5.45'
+  falcon-sensor:
+  - arch: x86_64
+    epoch: null
+    name: falcon-sensor
+    release: 10402.el7
+    source: rpm
+    version: 5.38.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 6.8.8
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  finger:
+  - arch: x86_64
+    epoch: null
+    name: finger
+    release: 52.el7
+    source: rpm
+    version: '0.17'
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  firewalld:
+  - arch: noarch
+    epoch: null
+    name: firewalld
+    release: 2.el7_7.1
+    source: rpm
+    version: 0.6.3
+  firewalld-filesystem:
+  - arch: noarch
+    epoch: null
+    name: firewalld-filesystem
+    release: 2.el7_7.1
+    source: rpm
+    version: 0.6.3
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  foomatic-filters:
+  - arch: x86_64
+    epoch: null
+    name: foomatic-filters
+    release: 9.el7
+    source: rpm
+    version: 4.0.9
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  ftp:
+  - arch: x86_64
+    epoch: null
+    name: ftp
+    release: 67.el7
+    source: rpm
+    version: '0.17'
+  fxload:
+  - arch: x86_64
+    epoch: null
+    name: fxload
+    release: 16.el7
+    source: rpm
+    version: '2002_04_11'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdbm-devel:
+  - arch: x86_64
+    epoch: null
+    name: gdbm-devel
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  ghostscript:
+  - arch: x86_64
+    epoch: null
+    name: ghostscript
+    release: 2.el7_7.3
+    source: rpm
+    version: '9.25'
+  ghostscript-fonts:
+  - arch: noarch
+    epoch: null
+    name: ghostscript-fonts
+    release: 32.el7
+    source: rpm
+    version: '5.50'
+  glib-networking:
+  - arch: x86_64
+    epoch: null
+    name: glib-networking
+    release: 1.el7
+    source: rpm
+    version: 2.56.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc-devel
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gnutls:
+  - arch: x86_64
+    epoch: null
+    name: gnutls
+    release: 9.el7_6
+    source: rpm
+    version: 3.3.29
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 45700c69
+    source: rpm
+    version: 2fa658e0
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 4ae0493b
+    source: rpm
+    version: fd431d51
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-efi-x64:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-efi-x64
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-efi-x64-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-efi-x64-modules
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gsettings-desktop-schemas:
+  - arch: x86_64
+    epoch: null
+    name: gsettings-desktop-schemas
+    release: 3.el7
+    source: rpm
+    version: 3.28.0
+  gskcrypt64:
+  - arch: x86_64
+    epoch: null
+    name: gskcrypt64
+    release: '55.2'
+    source: rpm
+    version: '8.0'
+  gskssl64:
+  - arch: x86_64
+    epoch: null
+    name: gskssl64
+    release: '55.2'
+    source: rpm
+    version: '8.0'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 26.el7
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 5.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hesiod:
+  - arch: x86_64
+    epoch: null
+    name: hesiod
+    release: 3.el7
+    source: rpm
+    version: 3.2.1
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  http-parser:
+  - arch: x86_64
+    epoch: null
+    name: http-parser
+    release: 8.el7_7.2
+    source: rpm
+    version: 2.7.1
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.3.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.47
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iometrics-agent-plugin-oracle-lib-connector:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-lib-connector
+    release: '25'
+    source: rpm
+    version: 18.5.0_1.11.3
+  iometrics-agent-plugin-oracle-libs:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-libs
+    release: '1'
+    source: rpm
+    version: 18.5.0
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  ipmitool:
+  - arch: x86_64
+    epoch: null
+    name: ipmitool
+    release: 9.el7_7
+    source: rpm
+    version: 1.8.18
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 25.el7
+    source: rpm
+    version: 4.11.0
+  iprutils:
+  - arch: x86_64
+    epoch: null
+    name: iprutils
+    release: 2.el7
+    source: rpm
+    version: 2.4.17.1
+  ipset:
+  - arch: x86_64
+    epoch: null
+    name: ipset
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 33.el7
+    source: rpm
+    version: 1.4.21
+  iptables-services:
+  - arch: x86_64
+    epoch: null
+    name: iptables-services
+    release: 33.el7
+    source: rpm
+    version: 1.4.21
+  iptraf-ng:
+  - arch: x86_64
+    epoch: null
+    name: iptraf-ng
+    release: 7.el7
+    source: rpm
+    version: 1.1.4
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  ivtv-firmware:
+  - arch: noarch
+    epoch: 2
+    name: ivtv-firmware
+    release: 26.el7
+    source: rpm
+    version: '20080701'
+  iwl100-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl100-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
+  iwl1000-firmware:
+  - arch: noarch
+    epoch: 1
+    name: iwl1000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
+  iwl105-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl105-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl135-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl135-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl2000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl2000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl2030-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl2030-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl3160-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl3160-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
+  iwl3945-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl3945-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 15.32.2.9
+  iwl4965-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl4965-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 228.61.2.24
+  iwl5000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl5000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.83.5.1_1
+  iwl5150-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl5150-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.24.2.2
+  iwl6000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 9.221.4.1
+  iwl6000g2a-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2a-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl6000g2b-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2b-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl6050-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6050-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 41.28.5.1
+  iwl7260-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7260-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 33.el7
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 25.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 25.el7
+    source: rpm
+    version: '20'
+  kmod-oracleasm:
+  - arch: x86_64
+    epoch: null
+    name: kmod-oracleasm
+    release: 26.el7
+    source: rpm
+    version: 2.0.8
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 127.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  krb5-workstation:
+  - arch: x86_64
+    epoch: null
+    name: krb5-workstation
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  ksh:
+  - arch: x86_64
+    epoch: null
+    name: ksh
+    release: 142.el7
+    source: rpm
+    version: '20120801'
+  lcms2:
+  - arch: x86_64
+    epoch: null
+    name: lcms2
+    release: 3.el7
+    source: rpm
+    version: '2.6'
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: i686
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  - arch: i686
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: i686
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  - arch: i686
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXmu:
+  - arch: x86_64
+    epoch: null
+    name: libXmu
+    release: 2.el7
+    source: rpm
+    version: 1.1.2
+  libXp:
+  - arch: x86_64
+    epoch: null
+    name: libXp
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.2
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXt:
+  - arch: x86_64
+    epoch: null
+    name: libXt
+    release: 3.el7
+    source: rpm
+    version: 1.1.5
+  libXtst:
+  - arch: i686
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXv:
+  - arch: x86_64
+    epoch: null
+    name: libXv
+    release: 1.el7
+    source: rpm
+    version: 1.0.11
+  libXxf86dga:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86dga
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.4
+  libXxf86misc:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86misc
+    release: 7.1.el7
+    source: rpm
+    version: 1.0.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: i686
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libaio-devel:
+  - arch: i686
+    epoch: null
+    name: libaio-devel
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  - arch: x86_64
+    epoch: null
+    name: libaio-devel
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: i686
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: i686
+    epoch: null
+    name: libcap
+    release: 10.el7
+    source: rpm
+    version: '2.22'
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 10.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  - arch: i686
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcgroup-tools:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup-tools
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  - arch: i686
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-devel:
+  - arch: x86_64
+    epoch: null
+    name: libdb-devel
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdhash:
+  - arch: x86_64
+    epoch: null
+    name: libdhash
+    release: 32.el7
+    source: rpm
+    version: 0.5.0
+  libdmx:
+  - arch: x86_64
+    epoch: null
+    name: libdmx
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  - arch: i686
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  - arch: i686
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libgs:
+  - arch: x86_64
+    epoch: null
+    name: libgs
+    release: 2.el7_7.3
+    source: rpm
+    version: '9.25'
+  libgudev1:
+  - arch: x86_64
+    epoch: null
+    name: libgudev1
+    release: 78.el7
+    source: rpm
+    version: '219'
+  libhugetlbfs:
+  - arch: x86_64
+    epoch: null
+    name: libhugetlbfs
+    release: 13.el7
+    source: rpm
+    version: '2.16'
+  libhugetlbfs-utils:
+  - arch: x86_64
+    epoch: null
+    name: libhugetlbfs-utils
+    release: 13.el7
+    source: rpm
+    version: '2.16'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libipa_hbac:
+  - arch: x86_64
+    epoch: null
+    name: libipa_hbac
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libkadm5:
+  - arch: x86_64
+    epoch: null
+    name: libkadm5
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  libldb:
+  - arch: x86_64
+    epoch: null
+    name: libldb
+    release: 2.el7_9
+    source: rpm
+    version: 1.5.4
+  liblockfile:
+  - arch: x86_64
+    epoch: null
+    name: liblockfile
+    release: 17.el7
+    source: rpm
+    version: '1.08'
+  libmng:
+  - arch: x86_64
+    epoch: null
+    name: libmng
+    release: 14.el7
+    source: rpm
+    version: 1.0.10
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmodman:
+  - arch: x86_64
+    epoch: null
+    name: libmodman
+    release: 8.el7
+    source: rpm
+    version: 2.0.1
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl:
+  - arch: x86_64
+    epoch: null
+    name: libnl
+    release: 3.el7
+    source: rpm
+    version: 1.1.4
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpaper:
+  - arch: x86_64
+    epoch: null
+    name: libpaper
+    release: 8.el7
+    source: rpm
+    version: 1.1.24
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 11.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpng12:
+  - arch: x86_64
+    epoch: null
+    name: libpng12
+    release: 10.el7
+    source: rpm
+    version: 1.2.50
+  libproxy:
+  - arch: x86_64
+    epoch: null
+    name: libproxy
+    release: 11.el7
+    source: rpm
+    version: 0.4.11
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  libsmbclient:
+  - arch: x86_64
+    epoch: 0
+    name: libsmbclient
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  libsoup:
+  - arch: x86_64
+    epoch: null
+    name: libsoup
+    release: 2.el7
+    source: rpm
+    version: 2.62.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libsss_autofs:
+  - arch: x86_64
+    epoch: null
+    name: libsss_autofs
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libsss_certmap:
+  - arch: x86_64
+    epoch: null
+    name: libsss_certmap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libsss_idmap:
+  - arch: x86_64
+    epoch: null
+    name: libsss_idmap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libsss_nss_idmap:
+  - arch: x86_64
+    epoch: null
+    name: libsss_nss_idmap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libsss_sudo:
+  - arch: x86_64
+    epoch: null
+    name: libsss_sudo
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++-devel
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtalloc:
+  - arch: x86_64
+    epoch: null
+    name: libtalloc
+    release: 1.el7
+    source: rpm
+    version: 2.1.16
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libtdb:
+  - arch: x86_64
+    epoch: null
+    name: libtdb
+    release: 1.el7
+    source: rpm
+    version: 1.3.18
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 9.el7
+    source: rpm
+    version: '1.27'
+  libtevent:
+  - arch: x86_64
+    epoch: null
+    name: libtevent
+    release: 1.el7
+    source: rpm
+    version: 0.9.39
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-tevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-tevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwbclient:
+  - arch: x86_64
+    epoch: 0
+    name: libwbclient
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  - arch: i686
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lm_sensors:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 13.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lsscsi:
+  - arch: x86_64
+    epoch: null
+    name: lsscsi
+    release: 6.el7
+    source: rpm
+    version: '0.27'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 2.el7
+    source: rpm
+    version: 2.02.185
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 2.el7
+    source: rpm
+    version: 2.02.185
+  lz4:
+  - arch: i686
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m2crypto:
+  - arch: x86_64
+    epoch: null
+    name: m2crypto
+    release: 17.el7
+    source: rpm
+    version: 0.21.1
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  mailx:
+  - arch: x86_64
+    epoch: null
+    name: mailx
+    release: 19.el7
+    source: rpm
+    version: '12.5'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
+  mesa-libGLU:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGLU
+    release: 4.el7
+    source: rpm
+    version: 9.0.0
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mlocate:
+  - arch: x86_64
+    epoch: null
+    name: mlocate
+    release: 8.el7
+    source: rpm
+    version: '0.26'
+  mokutil:
+  - arch: x86_64
+    epoch: null
+    name: mokutil
+    release: 8.el7_8
+    source: rpm
+    version: '15'
+  motif:
+  - arch: x86_64
+    epoch: null
+    name: motif
+    release: 14.el7_5
+    source: rpm
+    version: 2.3.4
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-utils:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-utils
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  nettle:
+  - arch: x86_64
+    epoch: null
+    name: nettle
+    release: 9.el7_9
+    source: rpm
+    version: 2.7.1
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.65.el7
+    source: rpm
+    version: 1.3.0
+  nscd:
+  - arch: x86_64
+    epoch: null
+    name: nscd
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7_8.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7_8.2
+    source: rpm
+    version: 4.2.6p5
+  numactl:
+  - arch: x86_64
+    epoch: null
+    name: numactl
+    release: 3.el7
+    source: rpm
+    version: 2.0.12
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.12
+  numad:
+  - arch: x86_64
+    epoch: null
+    name: numad
+    release: 18.20150602git.el7
+    source: rpm
+    version: '0.5'
+  oddjob:
+  - arch: x86_64
+    epoch: null
+    name: oddjob
+    release: 4.el7
+    source: rpm
+    version: 0.31.5
+  oddjob-mkhomedir:
+  - arch: x86_64
+    epoch: null
+    name: oddjob-mkhomedir
+    release: 4.el7
+    source: rpm
+    version: 0.31.5
+  openjpeg2:
+  - arch: x86_64
+    epoch: null
+    name: openjpeg2
+    release: 3.el7_7
+    source: rpm
+    version: 2.3.1
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 25.el7_9
+    source: rpm
+    version: 2.4.44
+  openldap-clients:
+  - arch: x86_64
+    epoch: null
+    name: openldap-clients
+    release: 25.el7_9
+    source: rpm
+    version: 2.4.44
+  openscap:
+  - arch: x86_64
+    epoch: null
+    name: openscap
+    release: 4.el7
+    source: rpm
+    version: 1.2.17
+  openscap-scanner:
+  - arch: x86_64
+    epoch: null
+    name: openscap-scanner
+    release: 4.el7
+    source: rpm
+    version: 1.2.17
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 25.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 25.el7_9
+    source: rpm
+    version: 1.0.2k
+  oracleasm-support:
+  - arch: x86_64
+    epoch: null
+    name: oracleasm-support
+    release: 3.el7
+    source: rpm
+    version: 2.1.8
+  oracleasmlib:
+  - arch: x86_64
+    epoch: null
+    name: oracleasmlib
+    release: 1.el7
+    source: rpm
+    version: 2.0.12
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  - arch: i686
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  pam-devel:
+  - arch: x86_64
+    epoch: null
+    name: pam-devel
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 31.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 5.el7
+    source: rpm
+    version: '0.79'
+  patch:
+  - arch: x86_64
+    epoch: null
+    name: patch
+    release: 12.el7_7
+    source: rpm
+    version: 2.7.1
+  pciutils:
+  - arch: x86_64
+    epoch: null
+    name: pciutils
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: i686
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-B-Lint:
+  - arch: noarch
+    epoch: null
+    name: perl-B-Lint
+    release: 3.el7
+    source: rpm
+    version: '1.17'
+  perl-Business-ISBN:
+  - arch: noarch
+    epoch: null
+    name: perl-Business-ISBN
+    release: 2.el7
+    source: rpm
+    version: '2.06'
+  perl-Business-ISBN-Data:
+  - arch: noarch
+    epoch: null
+    name: perl-Business-ISBN-Data
+    release: 2.el7
+    source: rpm
+    version: '20120719.001'
+  perl-CGI:
+  - arch: noarch
+    epoch: null
+    name: perl-CGI
+    release: 4.el7
+    source: rpm
+    version: '3.63'
+  perl-CPAN:
+  - arch: noarch
+    epoch: 0
+    name: perl-CPAN
+    release: 299.el7_9
+    source: rpm
+    version: '1.9800'
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Class-ISA:
+  - arch: noarch
+    epoch: null
+    name: perl-Class-ISA
+    release: 1010.el7
+    source: rpm
+    version: '0.36'
+  perl-Compress-Raw-Bzip2:
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
+  perl-Compress-Raw-Zlib:
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Digest:
+  - arch: noarch
+    epoch: null
+    name: perl-Digest
+    release: 245.el7
+    source: rpm
+    version: '1.17'
+  perl-Digest-MD5:
+  - arch: x86_64
+    epoch: null
+    name: perl-Digest-MD5
+    release: 3.el7
+    source: rpm
+    version: '2.52'
+  perl-Digest-SHA:
+  - arch: x86_64
+    epoch: 1
+    name: perl-Digest-SHA
+    release: 4.el7
+    source: rpm
+    version: '5.85'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Encode-Locale:
+  - arch: noarch
+    epoch: null
+    name: perl-Encode-Locale
+    release: 5.el7
+    source: rpm
+    version: '1.03'
+  perl-Env:
+  - arch: noarch
+    epoch: null
+    name: perl-Env
+    release: 2.el7
+    source: rpm
+    version: '1.04'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-ExtUtils-Install:
+  - arch: noarch
+    epoch: 0
+    name: perl-ExtUtils-Install
+    release: 299.el7_9
+    source: rpm
+    version: '1.58'
+  perl-ExtUtils-MakeMaker:
+  - arch: noarch
+    epoch: null
+    name: perl-ExtUtils-MakeMaker
+    release: 3.el7
+    source: rpm
+    version: '6.68'
+  perl-ExtUtils-Manifest:
+  - arch: noarch
+    epoch: null
+    name: perl-ExtUtils-Manifest
+    release: 244.el7
+    source: rpm
+    version: '1.61'
+  perl-ExtUtils-ParseXS:
+  - arch: noarch
+    epoch: 1
+    name: perl-ExtUtils-ParseXS
+    release: 3.el7
+    source: rpm
+    version: '3.18'
+  perl-FCGI:
+  - arch: x86_64
+    epoch: 1
+    name: perl-FCGI
+    release: 8.el7
+    source: rpm
+    version: '0.74'
+  perl-File-CheckTree:
+  - arch: noarch
+    epoch: null
+    name: perl-File-CheckTree
+    release: 3.el7
+    source: rpm
+    version: '4.42'
+  perl-File-Listing:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Listing
+    release: 7.el7
+    source: rpm
+    version: '6.04'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTML-Parser:
+  - arch: x86_64
+    epoch: null
+    name: perl-HTML-Parser
+    release: 4.el7
+    source: rpm
+    version: '3.71'
+  perl-HTML-Tagset:
+  - arch: noarch
+    epoch: null
+    name: perl-HTML-Tagset
+    release: 15.el7
+    source: rpm
+    version: '3.20'
+  perl-HTTP-Cookies:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Cookies
+    release: 5.el7
+    source: rpm
+    version: '6.01'
+  perl-HTTP-Daemon:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Daemon
+    release: 8.el7
+    source: rpm
+    version: '6.01'
+  perl-HTTP-Date:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Date
+    release: 8.el7
+    source: rpm
+    version: '6.02'
+  perl-HTTP-Message:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Message
+    release: 6.el7
+    source: rpm
+    version: '6.06'
+  perl-HTTP-Negotiate:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Negotiate
+    release: 5.el7
+    source: rpm
+    version: '6.01'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-IO-Compress:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
+  perl-IO-HTML:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-HTML
+    release: 2.el7
+    source: rpm
+    version: '1.00'
+  perl-IO-Socket-IP:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Socket-IP
+    release: 5.el7
+    source: rpm
+    version: '0.21'
+  perl-IO-Socket-SSL:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Socket-SSL
+    release: 7.el7
+    source: rpm
+    version: '1.94'
+  perl-LWP-MediaTypes:
+  - arch: noarch
+    epoch: null
+    name: perl-LWP-MediaTypes
+    release: 2.el7
+    source: rpm
+    version: '6.02'
+  perl-Locale-Codes:
+  - arch: noarch
+    epoch: null
+    name: perl-Locale-Codes
+    release: 2.el7
+    source: rpm
+    version: '3.26'
+  perl-Locale-Maketext:
+  - arch: noarch
+    epoch: null
+    name: perl-Locale-Maketext
+    release: 3.el7
+    source: rpm
+    version: '1.23'
+  perl-Module-Pluggable:
+  - arch: noarch
+    epoch: 1
+    name: perl-Module-Pluggable
+    release: 3.el7
+    source: rpm
+    version: '4.8'
+  perl-Mozilla-CA:
+  - arch: noarch
+    epoch: null
+    name: perl-Mozilla-CA
+    release: 5.el7
+    source: rpm
+    version: '20130114'
+  perl-Net-HTTP:
+  - arch: noarch
+    epoch: null
+    name: perl-Net-HTTP
+    release: 2.el7
+    source: rpm
+    version: '6.06'
+  perl-Net-LibIDN:
+  - arch: x86_64
+    epoch: null
+    name: perl-Net-LibIDN
+    release: 15.el7
+    source: rpm
+    version: '0.12'
+  perl-Net-SSLeay:
+  - arch: x86_64
+    epoch: null
+    name: perl-Net-SSLeay
+    release: 6.el7
+    source: rpm
+    version: '1.55'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Checker:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Checker
+    release: 2.el7
+    source: rpm
+    version: '1.60'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-LaTeX:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-LaTeX
+    release: 2.el7
+    source: rpm
+    version: '0.61'
+  perl-Pod-Parser:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Parser
+    release: 2.el7
+    source: rpm
+    version: '1.61'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Plainer:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Plainer
+    release: 4.el7
+    source: rpm
+    version: '1.03'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 4.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Sys-Syslog:
+  - arch: x86_64
+    epoch: null
+    name: perl-Sys-Syslog
+    release: 3.el7
+    source: rpm
+    version: '0.33'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Test-Simple:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Simple
+    release: 243.el7
+    source: rpm
+    version: '0.98'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Text-Soundex:
+  - arch: x86_64
+    epoch: null
+    name: perl-Text-Soundex
+    release: 4.el7
+    source: rpm
+    version: '3.04'
+  perl-Text-Unidecode:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-Unidecode
+    release: 20.el7
+    source: rpm
+    version: '0.04'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-TimeDate:
+  - arch: noarch
+    epoch: 1
+    name: perl-TimeDate
+    release: 2.el7
+    source: rpm
+    version: '2.30'
+  perl-URI:
+  - arch: noarch
+    epoch: null
+    name: perl-URI
+    release: 9.el7
+    source: rpm
+    version: '1.60'
+  perl-WWW-RobotRules:
+  - arch: noarch
+    epoch: null
+    name: perl-WWW-RobotRules
+    release: 5.el7
+    source: rpm
+    version: '6.02'
+  perl-XML-LibXML:
+  - arch: x86_64
+    epoch: 1
+    name: perl-XML-LibXML
+    release: 5.el7
+    source: rpm
+    version: '2.0018'
+  perl-XML-NamespaceSupport:
+  - arch: noarch
+    epoch: null
+    name: perl-XML-NamespaceSupport
+    release: 10.el7
+    source: rpm
+    version: '1.11'
+  perl-XML-SAX:
+  - arch: noarch
+    epoch: null
+    name: perl-XML-SAX
+    release: 9.el7
+    source: rpm
+    version: '0.99'
+  perl-XML-SAX-Base:
+  - arch: noarch
+    epoch: null
+    name: perl-XML-SAX-Base
+    release: 7.el7
+    source: rpm
+    version: '1.08'
+  perl-autodie:
+  - arch: noarch
+    epoch: null
+    name: perl-autodie
+    release: 2.el7
+    source: rpm
+    version: '2.16'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-devel:
+  - arch: x86_64
+    epoch: 4
+    name: perl-devel
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-libwww-perl:
+  - arch: noarch
+    epoch: null
+    name: perl-libwww-perl
+    release: 2.el7
+    source: rpm
+    version: '6.05'
+  perl-local-lib:
+  - arch: noarch
+    epoch: null
+    name: perl-local-lib
+    release: 4.el7
+    source: rpm
+    version: '1.008010'
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  plymouth:
+  - arch: x86_64
+    epoch: null
+    name: plymouth
+    release: 0.32.20140113.el7
+    source: rpm
+    version: 0.8.9
+  plymouth-core-libs:
+  - arch: x86_64
+    epoch: null
+    name: plymouth-core-libs
+    release: 0.32.20140113.el7
+    source: rpm
+    version: 0.8.9
+  plymouth-scripts:
+  - arch: x86_64
+    epoch: null
+    name: plymouth-scripts
+    release: 0.32.20140113.el7
+    source: rpm
+    version: 0.8.9
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 33.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 33.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  poppler-data:
+  - arch: noarch
+    epoch: null
+    name: poppler-data
+    release: 3.el7
+    source: rpm
+    version: 0.4.6
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  powertop:
+  - arch: x86_64
+    epoch: null
+    name: powertop
+    release: 1.el7
+    source: rpm
+    version: '2.9'
+  ppp:
+  - arch: x86_64
+    epoch: null
+    name: ppp
+    release: 34.el7_7
+    source: rpm
+    version: 2.4.5
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 26.el7
+    source: rpm
+    version: 3.3.10
+  psmisc:
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 16.el7
+    source: rpm
+    version: '22.20'
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pyOpenSSL:
+  - arch: x86_64
+    epoch: null
+    name: pyOpenSSL
+    release: 4.el7
+    source: rpm
+    version: 0.13.1
+  pygobject2:
+  - arch: x86_64
+    epoch: null
+    name: pygobject2
+    release: 11.el7
+    source: rpm
+    version: 2.28.6
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyldb:
+  - arch: x86_64
+    epoch: null
+    name: pyldb
+    release: 2.el7_9
+    source: rpm
+    version: 1.5.4
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyparsing:
+  - arch: noarch
+    epoch: null
+    name: pyparsing
+    release: 9.el7
+    source: rpm
+    version: 1.5.6
+  pytalloc:
+  - arch: x86_64
+    epoch: null
+    name: pytalloc
+    release: 1.el7
+    source: rpm
+    version: 2.1.16
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-dateutil:
+  - arch: noarch
+    epoch: null
+    name: python-dateutil
+    release: 7.el7
+    source: rpm
+    version: '1.5'
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-dmidecode:
+  - arch: x86_64
+    epoch: null
+    name: python-dmidecode
+    release: 3.el7
+    source: rpm
+    version: 3.12.2
+  python-ethtool:
+  - arch: x86_64
+    epoch: null
+    name: python-ethtool
+    release: 8.el7
+    source: rpm
+    version: '0.8'
+  python-firewall:
+  - arch: noarch
+    epoch: null
+    name: python-firewall
+    release: 2.el7_7.1
+    source: rpm
+    version: 0.6.3
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-gudev:
+  - arch: x86_64
+    epoch: null
+    name: python-gudev
+    release: 7.el7
+    source: rpm
+    version: '147.2'
+  python-hwdata:
+  - arch: noarch
+    epoch: null
+    name: python-hwdata
+    release: 4.el7
+    source: rpm
+    version: 1.7.3
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-inotify:
+  - arch: noarch
+    epoch: null
+    name: python-inotify
+    release: 4.el7
+    source: rpm
+    version: 0.9.4
+  python-ipaddr:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddr
+    release: 2.el7
+    source: rpm
+    version: 2.1.11
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-magic:
+  - arch: noarch
+    epoch: null
+    name: python-magic
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-slip:
+  - arch: noarch
+    epoch: null
+    name: python-slip
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-slip-dbus:
+  - arch: noarch
+    epoch: null
+    name: python-slip-dbus
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-sssdconfig:
+  - arch: noarch
+    epoch: null
+    name: python-sssdconfig
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  python-syspurpose:
+  - arch: x86_64
+    epoch: null
+    name: python-syspurpose
+    release: 3.el7_7
+    source: rpm
+    version: 1.24.13
+  python-tdb:
+  - arch: x86_64
+    epoch: null
+    name: python-tdb
+    release: 1.el7
+    source: rpm
+    version: 1.3.18
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python2-futures:
+  - arch: noarch
+    epoch: null
+    name: python2-futures
+    release: 5.el7
+    source: rpm
+    version: 3.1.1
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_8
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  qt:
+  - arch: x86_64
+    epoch: 1
+    name: qt
+    release: 9.el7_9
+    source: rpm
+    version: 4.8.7
+  qt-settings:
+  - arch: noarch
+    epoch: null
+    name: qt-settings
+    release: 23.10.el7_7
+    source: rpm
+    version: '19'
+  qt-x11:
+  - arch: x86_64
+    epoch: 1
+    name: qt-x11
+    release: 9.el7_9
+    source: rpm
+    version: 4.8.7
+  qt3:
+  - arch: x86_64
+    epoch: null
+    name: qt3
+    release: 51.el7
+    source: rpm
+    version: 3.3.8b
+  qualys-cloud-agent:
+  - arch: x86_64
+    epoch: null
+    name: qualys-cloud-agent
+    release: '49'
+    source: rpm
+    version: 4.8.0
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  rdma-core:
+  - arch: i686
+    epoch: null
+    name: rdma-core
+    release: 3.el7
+    source: rpm
+    version: '22.1'
+  - arch: x86_64
+    epoch: null
+    name: rdma-core
+    release: 3.el7
+    source: rpm
+    version: '22.1'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  realmd:
+  - arch: x86_64
+    epoch: null
+    name: realmd
+    release: 11.el7
+    source: rpm
+    version: 0.16.1
+  redhat-logos:
+  - arch: noarch
+    epoch: null
+    name: redhat-logos
+    release: 1.el7
+    source: rpm
+    version: 70.7.0
+  redhat-lsb:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-core:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-core
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-cxx:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-cxx
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-desktop:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-desktop
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-languages:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-languages
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-printing:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-printing
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-submod-multimedia:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-submod-multimedia
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-submod-security:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-submod-security
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-release-server:
+  - arch: x86_64
+    epoch: null
+    name: redhat-release-server
+    release: 10.el7
+    source: rpm
+    version: '7.7'
+  redhat-support-lib-python:
+  - arch: noarch
+    epoch: null
+    name: redhat-support-lib-python
+    release: 6.el7
+    source: rpm
+    version: 0.9.7
+  redhat-support-tool:
+  - arch: noarch
+    epoch: null
+    name: redhat-support-tool
+    release: 1.el7
+    source: rpm
+    version: 0.9.11
+  rhn-client-tools:
+  - arch: x86_64
+    epoch: null
+    name: rhn-client-tools
+    release: 24.el7
+    source: rpm
+    version: 2.0.2
+  rhnlib:
+  - arch: noarch
+    epoch: null
+    name: rhnlib
+    release: 8.el7
+    source: rpm
+    version: 2.5.65
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
+    name: rpcbind
+    release: 48.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 52.el7
+    source: rpm
+    version: 8.24.0
+  samba-client-libs:
+  - arch: x86_64
+    epoch: 0
+    name: samba-client-libs
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  samba-common:
+  - arch: noarch
+    epoch: 0
+    name: samba-common
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  samba-common-libs:
+  - arch: x86_64
+    epoch: 0
+    name: samba-common-libs
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  samba-common-tools:
+  - arch: x86_64
+    epoch: 0
+    name: samba-common-tools
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  samba-libs:
+  - arch: x86_64
+    epoch: 0
+    name: samba-libs
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  scap-security-guide:
+  - arch: noarch
+    epoch: null
+    name: scap-security-guide
+    release: 13.el7
+    source: rpm
+    version: 0.1.43
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 252.el7.1
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 252.el7.1
+    source: rpm
+    version: 3.13.1
+  setools-console:
+  - arch: x86_64
+    epoch: null
+    name: setools-console
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 18.el7_7.1
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 18.el7_7.1
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  shim-unsigned:
+  - arch: x86_64
+    epoch: null
+    name: shim-unsigned
+    release: 1.el7
+    source: rpm
+    version: '0.9'
+  shim-x64:
+  - arch: x86_64
+    epoch: null
+    name: shim-x64
+    release: 8.el7_8
+    source: rpm
+    version: '15'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smartmontools:
+  - arch: x86_64
+    epoch: 1
+    name: smartmontools
+    release: 1.el7
+    source: rpm
+    version: '7.0'
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sos:
+  - arch: noarch
+    epoch: null
+    name: sos
+    release: 6.el7_7
+    source: rpm
+    version: '3.7'
+  spax:
+  - arch: x86_64
+    epoch: null
+    name: spax
+    release: 13.el7
+    source: rpm
+    version: 1.5.2
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sssd:
+  - arch: x86_64
+    epoch: null
+    name: sssd
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-ad:
+  - arch: x86_64
+    epoch: null
+    name: sssd-ad
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-client:
+  - arch: x86_64
+    epoch: null
+    name: sssd-client
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-common:
+  - arch: x86_64
+    epoch: null
+    name: sssd-common
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-common-pac:
+  - arch: x86_64
+    epoch: null
+    name: sssd-common-pac
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-ipa:
+  - arch: x86_64
+    epoch: null
+    name: sssd-ipa
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-krb5:
+  - arch: x86_64
+    epoch: null
+    name: sssd-krb5
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-krb5-common:
+  - arch: x86_64
+    epoch: null
+    name: sssd-krb5-common
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-ldap:
+  - arch: x86_64
+    epoch: null
+    name: sssd-ldap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-proxy:
+  - arch: x86_64
+    epoch: null
+    name: sssd-proxy
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 9.el7
+    source: rpm
+    version: '4.12'
+  subscription-manager:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager
+    release: 1.el7
+    source: rpm
+    version: 1.24.26
+  subscription-manager-rhsm:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm
+    release: 1.el7
+    source: rpm
+    version: 1.24.26
+  subscription-manager-rhsm-certificates:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm-certificates
+    release: 1.el7
+    source: rpm
+    version: 1.24.26
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.1
+    source: rpm
+    version: 1.8.23
+  sysfsutils:
+  - arch: x86_64
+    epoch: null
+    name: sysfsutils
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 18.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7
+    source: rpm
+    version: '219'
+  - arch: i686
+    epoch: null
+    name: systemd-libs
+    release: 78.el7
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7
+    source: rpm
+    version: '219'
+  systemtap-sdt-devel:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-sdt-devel
+    release: 9.el7
+    source: rpm
+    version: '4.0'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcl:
+  - arch: x86_64
+    epoch: 1
+    name: tcl
+    release: 8.el7
+    source: rpm
+    version: 8.5.13
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 9.el7
+    source: rpm
+    version: '1.27'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 65.el7_8
+    source: rpm
+    version: '0.17'
+  time:
+  - arch: x86_64
+    epoch: null
+    name: time
+    release: 45.el7
+    source: rpm
+    version: '1.7'
+  tk:
+  - arch: x86_64
+    epoch: 1
+    name: tk
+    release: 6.el7
+    source: rpm
+    version: 8.5.13
+  traceroute:
+  - arch: x86_64
+    epoch: 3
+    name: traceroute
+    release: 2.el7
+    source: rpm
+    version: 2.0.22
+  tree:
+  - arch: x86_64
+    epoch: null
+    name: tree
+    release: 10.el7
+    source: rpm
+    version: 1.6.0
+  trousers:
+  - arch: x86_64
+    epoch: null
+    name: trousers
+    release: 2.el7
+    source: rpm
+    version: 0.3.14
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 5.el7_7.1
+    source: rpm
+    version: 2.11.0
+  tuned-utils:
+  - arch: noarch
+    epoch: null
+    name: tuned-utils
+    release: 5.el7_7.1
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019c
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
+  urw-base35-bookman-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-bookman-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-c059-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-c059-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-d050000l-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-d050000l-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-fonts-common:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-fonts-common
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-gothic-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-gothic-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-nimbus-mono-ps-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-nimbus-mono-ps-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-nimbus-roman-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-nimbus-roman-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-nimbus-sans-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-nimbus-sans-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-p052-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-p052-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-standard-symbols-ps-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-standard-symbols-ps-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-z003-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-z003-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  usermode:
+  - arch: x86_64
+    epoch: null
+    name: usermode
+    release: 6.el7
+    source: rpm
+    version: '1.111'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xdg-utils:
+  - arch: noarch
+    epoch: null
+    name: xdg-utils
+    release: 0.17.20120809git.el7
+    source: rpm
+    version: 1.1.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 20.el7
+    source: rpm
+    version: 4.5.0
+  xinetd:
+  - arch: x86_64
+    epoch: 2
+    name: xinetd
+    release: 13.el7
+    source: rpm
+    version: 2.3.15
+  xml-common:
+  - arch: noarch
+    epoch: null
+    name: xml-common
+    release: 39.el7
+    source: rpm
+    version: 0.6.3
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-server-utils:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-server-utils
+    release: 20.el7
+    source: rpm
+    version: '7.7'
+  xorg-x11-utils:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-utils
+    release: 23.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-xauth:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-xauth
+    release: 1.el7
+    source: rpm
+    version: 1.0.9
+  xorg-x11-xbitmaps:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-xbitmaps
+    release: 6.el7
+    source: rpm
+    version: 1.1.1
+  xorg-x11-xinit:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-xinit
+    release: 2.el7
+    source: rpm
+    version: 1.3.4
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  - arch: i686
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 163.el7
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 52.el7
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: i686
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '54'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '64'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '66'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '67'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '71'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '72'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '73'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '74'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '77'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '78'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '82'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '84'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '86'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '88'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '89'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '90'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '91'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '92'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '93'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '94'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '95'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '96'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '97'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '98'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '99'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '105'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '106'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '107'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '108'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '118'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '119'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '121'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '123'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '137'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '176'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '365'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '366'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '367'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '369'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '370'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '371'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '373'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '413'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '414'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '512'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '612'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '613'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '624'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '625'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '638'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '639'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '640'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '641'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '642'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '643'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '644'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '645'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '646'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '647'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '648'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '649'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '732'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '765'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '768'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '810'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '811'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '812'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '813'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '814'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1167'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1168'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1169'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1170'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1171'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1172'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1184'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1185'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1186'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1188'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1195'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1196'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1197'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1198'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1199'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1200'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1201'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1202'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1204'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1205'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1207'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1208'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1210'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1211'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1213'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1214'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1217'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1218'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1219'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1222'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1224'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1225'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1227'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1228'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1237'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1238'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1240'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1241'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1243'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1244'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1246'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1247'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1258'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1259'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1260'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1261'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1262'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1263'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1271'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1273'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1275'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1277'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1278'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1279'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1280'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1281'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1282'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1297'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1301'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1302'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1303'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1304'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1311'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1312'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1315'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1321'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1322'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1324'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1325'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1326'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1329'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1330'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1331'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1332'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1333'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1334'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1335'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1350'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1351'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1353'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1354'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1355'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1356'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1357'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1358'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1359'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1360'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1361'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1362'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1363'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1364'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1365'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1366'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1367'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1368'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1370'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1371'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1372'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1373'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1374'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1375'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1385'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1386'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1387'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1388'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1389'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1401'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1402'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1403'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1404'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1405'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1406'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1413'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1414'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1415'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1416'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1417'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1418'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1419'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1420'
+  ppid: '2'
+  user: root
+- cmdline: /opt/CrowdStrike/falcond
+  cwd: /opt/CrowdStrike/
+  pid: '1436'
+  ppid: '1'
+  user: root
+- cmdline: falcon-sensor
+  cwd: /
+  pid: '1438'
+  ppid: '1436'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '1448'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '1494'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '1499'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '1500'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/ntpd -u ntp:ntp -u ntp:ntp -p /var/run/ntpd.pid -g
+  cwd: /usr/sbin/
+  pid: '1514'
+  ppid: '1'
+  user: ntp
+- cmdline: /usr/sbin/NetworkManager --no-daemon
+  cwd: /usr/sbin/
+  pid: '1516'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sssd -i --logger=files
+  cwd: /usr/sbin/
+  pid: '1520'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '1564'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/nscd
+  cwd: /usr/sbin/
+  pid: '1597'
+  ppid: '1'
+  user: nscd
+- cmdline: /usr/libexec/sssd/sssd_be --domain ES.WCORP.CARREFOUR.COM --uid 0 --gid
+    0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2392'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/local/avamar/bin/avagent.bin --bindir="/usr/local/avamar/bin" --vardir="/usr/local/avamar/var"
+    --sysdir="/usr/local/avamar/etc" --logfile="/usr/local/avamar/var/avagent.log"
+  cwd: /usr/local/avamar/bin/
+  pid: '2479'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/vmtoolsd
+  cwd: /usr/sbin/
+  pid: '2490'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/vmware-vgauth/VGAuthService -s
+  cwd: /usr/lib/vmware-vgauth/
+  pid: '2583'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2697'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/libexec/sssd/sssd_pam --uid 0 --gid 0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2698'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/libexec/sssd/sssd_pac --uid 0 --gid 0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2699'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '2722'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/atd -f
+  cwd: /usr/sbin/
+  pid: '2731'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '2735'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '2743'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '2882'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '2884'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '2888'
+  ppid: '1'
+  user: root
+- cmdline: /usr/share/filebeat/bin/filebeat -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '2891'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh /etc/init.d/init.ohasd run >/dev/null 2>&1 </dev/null
+  cwd: /bin/
+  pid: '2892'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '2893'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/qualys/cloud-agent/bin/qualys-cloud-agent
+  cwd: /usr/local/qualys/cloud-agent/bin/
+  pid: '2907'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/rhsmcertd
+  cwd: /usr/bin/
+  pid: '2909'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/xinetd -stayalive -pidfile /var/run/xinetd.pid
+  cwd: /usr/sbin/
+  pid: '2919'
+  ppid: '1'
+  user: root
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm.opt
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '3268'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3451'
+  ppid: '2'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '3539'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '3568'
+  ppid: '3539'
+  user: postfix
+- cmdline: bin/rscw
+  cwd: bin/
+  pid: '4017'
+  ppid: '1'
+  user: root
+- cmdline: bin/rscd
+  cwd: bin/
+  pid: '4019'
+  ppid: '4017'
+  user: root
+- cmdline: bin/rscd
+  cwd: bin/
+  pid: '4020'
+  ppid: '4017'
+  user: root
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_ARSYS.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '5787'
+  ppid: '1'
+  user: root
+- cmdline: ora_o001_BSAREP
+  cwd: /
+  pid: '7109'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o001_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '7111'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_w005_BSAREP
+  cwd: /
+  pid: '8166'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w004_BSAAPP
+  cwd: /
+  pid: '8584'
+  ppid: '1'
+  user: oragrid
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BNABBDD.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '9365'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10723'
+  ppid: '2'
+  user: root
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '11271'
+  ppid: '1'
+  user: oragrid
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAAPP.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '11643'
+  ppid: '1'
+  user: root
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAREP.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '12211'
+  ppid: '1'
+  user: root
+- cmdline: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/perl
+    /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/bin/emwd.pl
+    agent /softOracle/app/oracle/product/12.1.0.4/agentes/gcinst/sysman/log/emagent.nohup
+  cwd: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/
+  pid: '13389'
+  ppid: '1'
+  user: oracle
+- cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
+    /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/bin/emwd.pl
+    agent /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_inst/sysman/log/emagent.nohup
+  cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/
+  pid: '13482'
+  ppid: '1'
+  user: oracle
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ohasd.bin
+    reboot
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '13578'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdk/bin/java
+    -Xmx128M -XX:MaxPermSize=96M -server -Djava.security.egd=file:///dev/./urandom
+    -Dsun.lang.ClassLoader.allowArraySyntax=true -XX:+UseLinuxPosixThreadCPUClocks
+    -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -Dwatchdog.pid=13389
+    -cp /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdbc/lib/ojdbc5.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.http_client_11.1.1.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/xmlparserv2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/jsch.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/optic.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.dms_11.1.1/dms.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK.jar
+    oracle.sysman.gcagent.tmmain.TMMain
+  cwd: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdk/bin/
+  pid: '13590'
+  ppid: '13389'
+  user: oracle
+- cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/jdk/bin/java
+    -Xmx128M -XX:MaxMetaspaceSize=224M -server -Djava.security.egd=file:///dev/./urandom
+    -Dsun.lang.ClassLoader.allowArraySyntax=true -XX:-UseLargePages -XX:+UseLinuxPosixThreadCPUClocks
+    -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -DHTTPClient.dontSeekTerminatingChunk=true
+    -Dwatchdog.pid=13482 -cp /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jdbc/lib/ojdbc7.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/jsch-0.1.54.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/com.oracle.http_client.http_client.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.xdk/xmlparserv2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.dms/dms.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/lib/optic.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK.jar
+    oracle.sysman.gcagent.tmmain.TMMain
+  cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/jdk/bin/
+  pid: '13648'
+  ppid: '13482'
+  user: oracle
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/oraagent.bin
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14470'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmd.bin
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14491'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAAPP
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14496'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAREP
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14500'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BNABBDD
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14505'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmlogger.bin
+    -o /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.info
+    -l /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.log
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14758'
+  ppid: '14491'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/tnslsnr
+    LISTENER -no_crs_notify -inherit
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14763'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_ARSYS
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14782'
+  ppid: '1'
+  user: oragrid
+- cmdline: /usr/local/qualys/cloud-agent/bin/agentid-service -config /etc/qualys/cloud-agent/agentid-service.conf
+    -logdir /var/log/qualys/
+  cwd: /usr/local/qualys/cloud-agent/bin/
+  pid: '14887'
+  ppid: '1'
+  user: root
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/cssdagent
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '15030'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ocssd.bin
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '15057'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_pmon_+ASM
+  cwd: /
+  pid: '15350'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_psp0_+ASM
+  cwd: /
+  pid: '15354'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_vktm_+ASM
+  cwd: /
+  pid: '15357'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_gen0_+ASM
+  cwd: /
+  pid: '15363'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_mman_+ASM
+  cwd: /
+  pid: '15365'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_diag_+ASM
+  cwd: /
+  pid: '15369'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_dia0_+ASM
+  cwd: /
+  pid: '15371'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_dbw0_+ASM
+  cwd: /
+  pid: '15373'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_lgwr_+ASM
+  cwd: /
+  pid: '15375'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_ckpt_+ASM
+  cwd: /
+  pid: '15377'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_smon_+ASM
+  cwd: /
+  pid: '15379'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_lreg_+ASM
+  cwd: /
+  pid: '15381'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_pxmn_+ASM
+  cwd: /
+  pid: '15383'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_rbal_+ASM
+  cwd: /
+  pid: '15385'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_gmon_+ASM
+  cwd: /
+  pid: '15387'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_mmon_+ASM
+  cwd: /
+  pid: '15389'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_mmnl_+ASM
+  cwd: /
+  pid: '15391'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15491'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15494'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15509'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_asmb_+ASM
+  cwd: /
+  pid: '15538'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_+asm (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15545'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '15554'
+  ppid: '2'
+  user: root
+- cmdline: ora_pmon_ARSYS
+  cwd: /
+  pid: '15612'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_ARSYS
+  cwd: /
+  pid: '15614'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_ARSYS
+  cwd: /
+  pid: '15621'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_ARSYS
+  cwd: /
+  pid: '15625'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_ARSYS
+  cwd: /
+  pid: '15627'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_ARSYS
+  cwd: /
+  pid: '15631'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_ARSYS
+  cwd: /
+  pid: '15633'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_ARSYS
+  cwd: /
+  pid: '15635'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_ARSYS
+  cwd: /
+  pid: '15637'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_ARSYS
+  cwd: /
+  pid: '15639'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_ARSYS
+  cwd: /
+  pid: '15641'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_ARSYS
+  cwd: /
+  pid: '15643'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_ARSYS
+  cwd: /
+  pid: '15645'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_ARSYS
+  cwd: /
+  pid: '15647'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_ARSYS
+  cwd: /
+  pid: '15649'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_ARSYS
+  cwd: /
+  pid: '15651'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_ARSYS
+  cwd: /
+  pid: '15653'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_ARSYS
+  cwd: /
+  pid: '15655'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pxmn_ARSYS
+  cwd: /
+  pid: '15657'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_ARSYS
+  cwd: /
+  pid: '15659'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_ARSYS
+  cwd: /
+  pid: '15661'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_ARSYS
+  cwd: /
+  pid: '15663'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmnl_ARSYS
+  cwd: /
+  pid: '15667'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15669'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_d000_ARSYS
+  cwd: /
+  pid: '15674'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_ARSYS
+  cwd: /
+  pid: '15676'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_ARSYS
+  cwd: /
+  pid: '15678'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pmon_BSAAPP
+  cwd: /
+  pid: '15684'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_BSAAPP
+  cwd: /
+  pid: '15686'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pmon_BNABBDD
+  cwd: /
+  pid: '15688'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_BNABBDD
+  cwd: /
+  pid: '15690'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pmon_BSAREP
+  cwd: /
+  pid: '15692'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_BSAREP
+  cwd: /
+  pid: '15694'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_BSAAPP
+  cwd: /
+  pid: '15697'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_BSAAPP
+  cwd: /
+  pid: '15701'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_BSAAPP
+  cwd: /
+  pid: '15703'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_BNABBDD
+  cwd: /
+  pid: '15707'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_BSAAPP
+  cwd: /
+  pid: '15709'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_BSAAPP
+  cwd: /
+  pid: '15714'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_BNABBDD
+  cwd: /
+  pid: '15715'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_BSAREP
+  cwd: /
+  pid: '15717'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_BSAAPP
+  cwd: /
+  pid: '15719'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_BNABBDD
+  cwd: /
+  pid: '15723'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_BSAREP
+  cwd: /
+  pid: '15725'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_BSAAPP
+  cwd: /
+  pid: '15727'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_BSAREP
+  cwd: /
+  pid: '15731'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_BNABBDD
+  cwd: /
+  pid: '15735'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_BSAAPP
+  cwd: /
+  pid: '15737'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_BSAREP
+  cwd: /
+  pid: '15739'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_BNABBDD
+  cwd: /
+  pid: '15741'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_BSAAPP
+  cwd: /
+  pid: '15744'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_BSAREP
+  cwd: /
+  pid: '15746'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_BNABBDD
+  cwd: /
+  pid: '15747'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_BSAREP
+  cwd: /
+  pid: '15749'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_BNABBDD
+  cwd: /
+  pid: '15751'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_BSAAPP
+  cwd: /
+  pid: '15753'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_BSAREP
+  cwd: /
+  pid: '15755'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_BNABBDD
+  cwd: /
+  pid: '15757'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_BSAAPP
+  cwd: /
+  pid: '15759'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_BSAREP
+  cwd: /
+  pid: '15761'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_BSAAPP
+  cwd: /
+  pid: '15763'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_BNABBDD
+  cwd: /
+  pid: '15765'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_BSAAPP
+  cwd: /
+  pid: '15767'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_BSAREP
+  cwd: /
+  pid: '15769'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_BNABBDD
+  cwd: /
+  pid: '15771'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_BSAAPP
+  cwd: /
+  pid: '15773'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_BSAREP
+  cwd: /
+  pid: '15776'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_BNABBDD
+  cwd: /
+  pid: '15778'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_BSAAPP
+  cwd: /
+  pid: '15780'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_BSAREP
+  cwd: /
+  pid: '15782'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_BSAAPP
+  cwd: /
+  pid: '15784'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pxmn_BSAAPP
+  cwd: /
+  pid: '15786'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_BSAREP
+  cwd: /
+  pid: '15788'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_BNABBDD
+  cwd: /
+  pid: '15790'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_BSAAPP
+  cwd: /
+  pid: '15792'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_BSAREP
+  cwd: /
+  pid: '15794'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_BNABBDD
+  cwd: /
+  pid: '15796'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_BNABBDD
+  cwd: /
+  pid: '15798'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_BSAAPP
+  cwd: /
+  pid: '15800'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_BSAREP
+  cwd: /
+  pid: '15802'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_BNABBDD
+  cwd: /
+  pid: '15804'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_BSAAPP
+  cwd: /
+  pid: '15807'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_BSAREP
+  cwd: /
+  pid: '15808'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_BNABBDD
+  cwd: /
+  pid: '15810'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_BSAREP
+  cwd: /
+  pid: '15813'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmnl_BSAAPP
+  cwd: /
+  pid: '15814'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15816'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_pxmn_BNABBDD
+  cwd: /
+  pid: '15818'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_d000_BSAAPP
+  cwd: /
+  pid: '15821'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pxmn_BSAREP
+  cwd: /
+  pid: '15822'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_BSAAPP
+  cwd: /
+  pid: '15825'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_BSAREP
+  cwd: /
+  pid: '15826'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_BNABBDD
+  cwd: /
+  pid: '15828'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_BSAREP
+  cwd: /
+  pid: '15830'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_BNABBDD
+  cwd: /
+  pid: '15832'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_BSAAPP
+  cwd: /
+  pid: '15834'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_BSAREP
+  cwd: /
+  pid: '15836'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_BNABBDD
+  cwd: /
+  pid: '15838'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15840'
+  ppid: '1'
+  user: oracle
+- cmdline: oracle+ASM_asmb_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15842'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_mmnl_BSAREP
+  cwd: /
+  pid: '15844'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmnl_BNABBDD
+  cwd: /
+  pid: '15846'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_d000_BSAREP
+  cwd: /
+  pid: '15848'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_d000_BNABBDD
+  cwd: /
+  pid: '15852'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_BSAREP
+  cwd: /
+  pid: '15854'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_BNABBDD
+  cwd: /
+  pid: '15856'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_BSAREP
+  cwd: /
+  pid: '15858'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_BNABBDD
+  cwd: /
+  pid: '15862'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_ARSYS
+  cwd: /
+  pid: '15964'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_ARSYS
+  cwd: /
+  pid: '15966'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_ARSYS
+  cwd: /
+  pid: '15968'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_ARSYS
+  cwd: /
+  pid: '15970'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_ARSYS
+  cwd: /
+  pid: '15972'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_ARSYS
+  cwd: /
+  pid: '15974'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_ARSYS
+  cwd: /
+  pid: '15976'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_ARSYS
+  cwd: /
+  pid: '15978'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_ARSYS
+  cwd: /
+  pid: '15980'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_ARSYS
+  cwd: /
+  pid: '15982'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_ARSYS
+  cwd: /
+  pid: '15984'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_ARSYS
+  cwd: /
+  pid: '15986'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_ARSYS
+  cwd: /
+  pid: '15988'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_ARSYS
+  cwd: /
+  pid: '15990'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_ARSYS
+  cwd: /
+  pid: '15992'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_BNABBDD
+  cwd: /
+  pid: '15995'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_BNABBDD
+  cwd: /
+  pid: '15997'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_BSAREP
+  cwd: /
+  pid: '15999'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_BSAAPP
+  cwd: /
+  pid: '16001'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_BNABBDD
+  cwd: /
+  pid: '16004'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_BSAREP
+  cwd: /
+  pid: '16005'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_BSAAPP
+  cwd: /
+  pid: '16007'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_BNABBDD
+  cwd: /
+  pid: '16010'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_BSAREP
+  cwd: /
+  pid: '16011'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_BSAAPP
+  cwd: /
+  pid: '16013'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_BNABBDD
+  cwd: /
+  pid: '16015'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_BSAREP
+  cwd: /
+  pid: '16017'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_BNABBDD
+  cwd: /
+  pid: '16019'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_BSAAPP
+  cwd: /
+  pid: '16021'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_BSAREP
+  cwd: /
+  pid: '16023'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_BNABBDD
+  cwd: /
+  pid: '16027'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_BSAREP
+  cwd: /
+  pid: '16028'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_BSAAPP
+  cwd: /
+  pid: '16029'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_BSAREP
+  cwd: /
+  pid: '16031'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_BSAAPP
+  cwd: /
+  pid: '16033'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_BNABBDD
+  cwd: /
+  pid: '16035'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_BSAREP
+  cwd: /
+  pid: '16037'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_BNABBDD
+  cwd: /
+  pid: '16039'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_BSAAPP
+  cwd: /
+  pid: '16041'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_BSAREP
+  cwd: /
+  pid: '16044'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_BSAAPP
+  cwd: /
+  pid: '16045'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_BNABBDD
+  cwd: /
+  pid: '16047'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_BSAREP
+  cwd: /
+  pid: '16051'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_BNABBDD
+  cwd: /
+  pid: '16052'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_BSAAPP
+  cwd: /
+  pid: '16053'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_BSAREP
+  cwd: /
+  pid: '16057'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_BSAAPP
+  cwd: /
+  pid: '16058'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_BNABBDD
+  cwd: /
+  pid: '16059'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_BSAREP
+  cwd: /
+  pid: '16063'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_BSAAPP
+  cwd: /
+  pid: '16064'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_BNABBDD
+  cwd: /
+  pid: '16065'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_BSAREP
+  cwd: /
+  pid: '16069'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_BNABBDD
+  cwd: /
+  pid: '16070'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_BSAAPP
+  cwd: /
+  pid: '16071'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_BSAREP
+  cwd: /
+  pid: '16075'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_BSAAPP
+  cwd: /
+  pid: '16076'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_BNABBDD
+  cwd: /
+  pid: '16077'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_BSAAPP
+  cwd: /
+  pid: '16079'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_BSAREP
+  cwd: /
+  pid: '16081'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_BSAAPP
+  cwd: /
+  pid: '16084'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_BNABBDD
+  cwd: /
+  pid: '16123'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_ARSYS
+  cwd: /
+  pid: '16131'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_BNABBDD
+  cwd: /
+  pid: '16133'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_ARSYS
+  cwd: /
+  pid: '16141'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_BNABBDD
+  cwd: /
+  pid: '16145'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_BNABBDD
+  cwd: /
+  pid: '16151'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_ARSYS
+  cwd: /
+  pid: '16153'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_ARSYS
+  cwd: /
+  pid: '16156'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_BNABBDD
+  cwd: /
+  pid: '16157'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_ARSYS
+  cwd: /
+  pid: '16161'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_BSAAPP
+  cwd: /
+  pid: '16167'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_BSAAPP
+  cwd: /
+  pid: '16173'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_ARSYS
+  cwd: /
+  pid: '16177'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_BSAAPP
+  cwd: /
+  pid: '16179'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_BNABBDD
+  cwd: /
+  pid: '16181'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_BSAAPP
+  cwd: /
+  pid: '16183'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_BSAREP
+  cwd: /
+  pid: '16185'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_BSAAPP
+  cwd: /
+  pid: '16187'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_BSAREP
+  cwd: /
+  pid: '16189'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_BSAREP
+  cwd: /
+  pid: '16191'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_BSAREP
+  cwd: /
+  pid: '16194'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_BSAREP
+  cwd: /
+  pid: '16196'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_BSAAPP
+  cwd: /
+  pid: '16198'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_BSAREP
+  cwd: /
+  pid: '16200'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_ARSYS
+  cwd: /
+  pid: '16208'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_BNABBDD
+  cwd: /
+  pid: '16215'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_BSAAPP
+  cwd: /
+  pid: '16217'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_BSAREP
+  cwd: /
+  pid: '16253'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_BNABBDD
+  cwd: /
+  pid: '16285'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_ARSYS
+  cwd: /
+  pid: '16287'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_BSAAPP
+  cwd: /
+  pid: '16292'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '16304'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_BSAREP
+  cwd: /
+  pid: '16309'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_BSAAPP
+  cwd: /
+  pid: '16318'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_BSAAPP
+  cwd: /
+  pid: '16320'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_BSAAPP
+  cwd: /
+  pid: '16322'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_BSAAPP
+  cwd: /
+  pid: '16324'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_BSAAPP
+  cwd: /
+  pid: '16328'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_BNABBDD
+  cwd: /
+  pid: '16330'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_BSAAPP
+  cwd: /
+  pid: '16332'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_BNABBDD
+  cwd: /
+  pid: '16334'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_BSAAPP
+  cwd: /
+  pid: '16336'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_BNABBDD
+  cwd: /
+  pid: '16338'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_BSAAPP
+  cwd: /
+  pid: '16340'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_BSAAPP
+  cwd: /
+  pid: '16343'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_BNABBDD
+  cwd: /
+  pid: '16344'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_BNABBDD
+  cwd: /
+  pid: '16346'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_BSAAPP
+  cwd: /
+  pid: '16348'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_BNABBDD
+  cwd: /
+  pid: '16351'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_BSAAPP
+  cwd: /
+  pid: '16352'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_BSAAPP
+  cwd: /
+  pid: '16354'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_BNABBDD
+  cwd: /
+  pid: '16356'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_BSAAPP
+  cwd: /
+  pid: '16361'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_BNABBDD
+  cwd: /
+  pid: '16363'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_BSAAPP
+  cwd: /
+  pid: '16365'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_BNABBDD
+  cwd: /
+  pid: '16367'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_ARSYS
+  cwd: /
+  pid: '16369'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_BSAAPP
+  cwd: /
+  pid: '16371'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_ARSYS
+  cwd: /
+  pid: '16373'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_BNABBDD
+  cwd: /
+  pid: '16375'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_BSAAPP
+  cwd: /
+  pid: '16377'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_ARSYS
+  cwd: /
+  pid: '16380'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_BNABBDD
+  cwd: /
+  pid: '16381'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_BNABBDD
+  cwd: /
+  pid: '16383'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_BSAAPP
+  cwd: /
+  pid: '16385'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_ARSYS
+  cwd: /
+  pid: '16387'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_BSAAPP
+  cwd: /
+  pid: '16389'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_ARSYS
+  cwd: /
+  pid: '16391'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_BNABBDD
+  cwd: /
+  pid: '16393'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_ARSYS
+  cwd: /
+  pid: '16396'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_BSAAPP
+  cwd: /
+  pid: '16397'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_BNABBDD
+  cwd: /
+  pid: '16399'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_BNABBDD
+  cwd: /
+  pid: '16401'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_ARSYS
+  cwd: /
+  pid: '16403'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_BSAAPP
+  cwd: /
+  pid: '16405'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_BSAAPP
+  cwd: /
+  pid: '16408'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_BNABBDD
+  cwd: /
+  pid: '16409'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_ARSYS
+  cwd: /
+  pid: '16411'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_BSAAPP
+  cwd: /
+  pid: '16413'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_BNABBDD
+  cwd: /
+  pid: '16415'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_ARSYS
+  cwd: /
+  pid: '16417'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_BSAAPP
+  cwd: /
+  pid: '16419'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_ARSYS
+  cwd: /
+  pid: '16422'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_BNABBDD
+  cwd: /
+  pid: '16423'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_BSAAPP
+  cwd: /
+  pid: '16425'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_ARSYS
+  cwd: /
+  pid: '16428'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_BNABBDD
+  cwd: /
+  pid: '16429'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_BSAAPP
+  cwd: /
+  pid: '16431'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_BNABBDD
+  cwd: /
+  pid: '16434'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_ARSYS
+  cwd: /
+  pid: '16435'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_BSAAPP
+  cwd: /
+  pid: '16437'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_ARSYS
+  cwd: /
+  pid: '16439'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_BNABBDD
+  cwd: /
+  pid: '16441'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_BSAAPP
+  cwd: /
+  pid: '16443'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_BNABBDD
+  cwd: /
+  pid: '16446'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_ARSYS
+  cwd: /
+  pid: '16447'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_BNABBDD
+  cwd: /
+  pid: '16449'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_ARSYS
+  cwd: /
+  pid: '16451'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_BSAAPP
+  cwd: /
+  pid: '16453'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_ARSYS
+  cwd: /
+  pid: '16457'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_BNABBDD
+  cwd: /
+  pid: '16458'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_BSAAPP
+  cwd: /
+  pid: '16460'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_ARSYS
+  cwd: /
+  pid: '16462'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_BNABBDD
+  cwd: /
+  pid: '16464'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_BSAAPP
+  cwd: /
+  pid: '16466'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_BNABBDD
+  cwd: /
+  pid: '16468'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_ARSYS
+  cwd: /
+  pid: '16470'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_BSAAPP
+  cwd: /
+  pid: '16472'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_BNABBDD
+  cwd: /
+  pid: '16475'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_ARSYS
+  cwd: /
+  pid: '16476'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_BSAAPP
+  cwd: /
+  pid: '16478'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_BNABBDD
+  cwd: /
+  pid: '16480'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_ARSYS
+  cwd: /
+  pid: '16482'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_BSAAPP
+  cwd: /
+  pid: '16484'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_BNABBDD
+  cwd: /
+  pid: '16486'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_ARSYS
+  cwd: /
+  pid: '16488'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_BSAAPP
+  cwd: /
+  pid: '16490'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_ARSYS
+  cwd: /
+  pid: '16492'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_BNABBDD
+  cwd: /
+  pid: '16494'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_BSAAPP
+  cwd: /
+  pid: '16496'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_ARSYS
+  cwd: /
+  pid: '16498'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_BNABBDD
+  cwd: /
+  pid: '16500'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_BSAAPP
+  cwd: /
+  pid: '16502'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_ARSYS
+  cwd: /
+  pid: '16505'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_BNABBDD
+  cwd: /
+  pid: '16506'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_BSAAPP
+  cwd: /
+  pid: '16508'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_ARSYS
+  cwd: /
+  pid: '16511'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_BNABBDD
+  cwd: /
+  pid: '16512'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_BSAAPP
+  cwd: /
+  pid: '16514'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_BNABBDD
+  cwd: /
+  pid: '16517'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_ARSYS
+  cwd: /
+  pid: '16518'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_BSAAPP
+  cwd: /
+  pid: '16520'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_BNABBDD
+  cwd: /
+  pid: '16523'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_ARSYS
+  cwd: /
+  pid: '16524'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_BSAAPP
+  cwd: /
+  pid: '16526'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_BNABBDD
+  cwd: /
+  pid: '16529'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_ARSYS
+  cwd: /
+  pid: '16530'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_BSAAPP
+  cwd: /
+  pid: '16532'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_BNABBDD
+  cwd: /
+  pid: '16534'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_BSAAPP
+  cwd: /
+  pid: '16536'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_ARSYS
+  cwd: /
+  pid: '16538'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_BNABBDD
+  cwd: /
+  pid: '16540'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_BSAAPP
+  cwd: /
+  pid: '16542'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_ARSYS
+  cwd: /
+  pid: '16544'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_BNABBDD
+  cwd: /
+  pid: '16546'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_BSAAPP
+  cwd: /
+  pid: '16548'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_ARSYS
+  cwd: /
+  pid: '16550'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_BNABBDD
+  cwd: /
+  pid: '16552'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_BSAAPP
+  cwd: /
+  pid: '16554'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_BNABBDD
+  cwd: /
+  pid: '16556'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_ARSYS
+  cwd: /
+  pid: '16558'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_BSAAPP
+  cwd: /
+  pid: '16560'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_ARSYS
+  cwd: /
+  pid: '16562'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_BNABBDD
+  cwd: /
+  pid: '16564'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_BSAAPP
+  cwd: /
+  pid: '16566'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_ARSYS
+  cwd: /
+  pid: '16568'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_BNABBDD
+  cwd: /
+  pid: '16570'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_BSAAPP
+  cwd: /
+  pid: '16572'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_ARSYS
+  cwd: /
+  pid: '16574'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_BNABBDD
+  cwd: /
+  pid: '16576'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_BSAAPP
+  cwd: /
+  pid: '16579'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_ARSYS
+  cwd: /
+  pid: '16581'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_BNABBDD
+  cwd: /
+  pid: '16583'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_BSAAPP
+  cwd: /
+  pid: '16585'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_ARSYS
+  cwd: /
+  pid: '16587'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_BNABBDD
+  cwd: /
+  pid: '16589'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_ARSYS
+  cwd: /
+  pid: '16591'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_BNABBDD
+  cwd: /
+  pid: '16593'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_ARSYS
+  cwd: /
+  pid: '16595'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_BNABBDD
+  cwd: /
+  pid: '16597'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_ARSYS
+  cwd: /
+  pid: '16599'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_BNABBDD
+  cwd: /
+  pid: '16601'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_ARSYS
+  cwd: /
+  pid: '16603'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_BNABBDD
+  cwd: /
+  pid: '16605'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_ARSYS
+  cwd: /
+  pid: '16607'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_ARSYS
+  cwd: /
+  pid: '16609'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_ARSYS
+  cwd: /
+  pid: '16611'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_ARSYS
+  cwd: /
+  pid: '16613'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_ARSYS
+  cwd: /
+  pid: '16615'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_ARSYS
+  cwd: /
+  pid: '16617'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_ARSYS
+  cwd: /
+  pid: '16619'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_ARSYS
+  cwd: /
+  pid: '16621'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_ARSYS
+  cwd: /
+  pid: '16623'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '16625'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_BSAAPP
+  cwd: /
+  pid: '16627'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_BSAAPP
+  cwd: /
+  pid: '16629'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_BSAAPP
+  cwd: /
+  pid: '16635'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '16637'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_BNABBDD
+  cwd: /
+  pid: '16639'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_BNABBDD
+  cwd: /
+  pid: '16643'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_BSAREP
+  cwd: /
+  pid: '16645'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_BSAREP
+  cwd: /
+  pid: '16649'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_BSAREP
+  cwd: /
+  pid: '16653'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_BNABBDD
+  cwd: /
+  pid: '16655'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_BSAREP
+  cwd: /
+  pid: '16657'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_BSAREP
+  cwd: /
+  pid: '16659'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_ARSYS
+  cwd: /
+  pid: '16661'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_BSAREP
+  cwd: /
+  pid: '16663'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_ARSYS
+  cwd: /
+  pid: '16665'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_BSAREP
+  cwd: /
+  pid: '16667'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q002_ARSYS
+  cwd: /
+  pid: '16669'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_BSAREP
+  cwd: /
+  pid: '16671'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_BSAREP
+  cwd: /
+  pid: '16673'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_BSAREP
+  cwd: /
+  pid: '16677'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_ARSYS
+  cwd: /
+  pid: '16679'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_BSAREP
+  cwd: /
+  pid: '16681'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_BSAREP
+  cwd: /
+  pid: '16683'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_BSAREP
+  cwd: /
+  pid: '16685'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_BSAREP
+  cwd: /
+  pid: '16687'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_BSAREP
+  cwd: /
+  pid: '16689'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_BSAREP
+  cwd: /
+  pid: '16691'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_BSAREP
+  cwd: /
+  pid: '16693'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_BSAREP
+  cwd: /
+  pid: '16695'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_BSAREP
+  cwd: /
+  pid: '16698'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_BSAREP
+  cwd: /
+  pid: '16700'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_BSAREP
+  cwd: /
+  pid: '16702'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_BSAREP
+  cwd: /
+  pid: '16704'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_BSAREP
+  cwd: /
+  pid: '16706'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_BSAREP
+  cwd: /
+  pid: '16708'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_BSAREP
+  cwd: /
+  pid: '16710'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_BSAREP
+  cwd: /
+  pid: '16712'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_BSAREP
+  cwd: /
+  pid: '16714'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_BSAREP
+  cwd: /
+  pid: '16716'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_BSAREP
+  cwd: /
+  pid: '16718'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_BSAREP
+  cwd: /
+  pid: '16720'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_BSAREP
+  cwd: /
+  pid: '16722'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_BSAREP
+  cwd: /
+  pid: '16724'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_BSAREP
+  cwd: /
+  pid: '16726'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_BSAREP
+  cwd: /
+  pid: '16728'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_BSAREP
+  cwd: /
+  pid: '16730'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_BSAREP
+  cwd: /
+  pid: '16732'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_BSAREP
+  cwd: /
+  pid: '16734'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_BSAAPP
+  cwd: /
+  pid: '16736'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_BSAREP
+  cwd: /
+  pid: '16738'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_BSAAPP
+  cwd: /
+  pid: '16740'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_BSAREP
+  cwd: /
+  pid: '16742'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_BSAAPP
+  cwd: /
+  pid: '16744'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_BSAREP
+  cwd: /
+  pid: '16746'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_BSAREP
+  cwd: /
+  pid: '16748'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_BSAAPP
+  cwd: /
+  pid: '16750'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_BSAREP
+  cwd: /
+  pid: '16752'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_BSAAPP
+  cwd: /
+  pid: '16754'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_BSAREP
+  cwd: /
+  pid: '16756'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_BSAREP
+  cwd: /
+  pid: '16758'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q00a_BSAAPP
+  cwd: /
+  pid: '16760'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_BSAREP
+  cwd: /
+  pid: '16762'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_BSAREP
+  cwd: /
+  pid: '16764'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_BSAREP
+  cwd: /
+  pid: '16766'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_BSAREP
+  cwd: /
+  pid: '16768'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_BSAREP
+  cwd: /
+  pid: '16770'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_BSAREP
+  cwd: /
+  pid: '16772'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_ARSYS
+  cwd: /
+  pid: '16774'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_ARSYS
+  cwd: /
+  pid: '16777'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_ARSYS
+  cwd: /
+  pid: '16779'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_ARSYS
+  cwd: /
+  pid: '16781'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_ARSYS
+  cwd: /
+  pid: '16783'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_BNABBDD
+  cwd: /
+  pid: '16785'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_BNABBDD
+  cwd: /
+  pid: '16788'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_BNABBDD
+  cwd: /
+  pid: '16790'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_BNABBDD
+  cwd: /
+  pid: '16792'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_BNABBDD
+  cwd: /
+  pid: '16794'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_BSAREP
+  cwd: /
+  pid: '16797'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_BSAREP
+  cwd: /
+  pid: '16799'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q002_BSAREP
+  cwd: /
+  pid: '16801'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '16805'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_BSAREP
+  cwd: /
+  pid: '16807'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '16837'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_BSAREP
+  cwd: /
+  pid: '16840'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_BSAREP
+  cwd: /
+  pid: '16842'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_BSAREP
+  cwd: /
+  pid: '16844'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_BSAREP
+  cwd: /
+  pid: '16848'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_BSAREP
+  cwd: /
+  pid: '16854'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '16951'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '17039'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '17069'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '17109'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '17371'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '17411'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '17651'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '17657'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '17796'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '18038'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '19700'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '19811'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '19813'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '20577'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '20645'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '20663'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '20675'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '20679'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '21794'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '21914'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '22175'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22208'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22219'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22258'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22262'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22316'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22318'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22320'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22322'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22324'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22326'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22328'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22330'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22332'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22334'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22336'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22338'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22340'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22342'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22344'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22346'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22348'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22350'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22352'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22354'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22356'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22358'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22360'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22363'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22365'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22368'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22371'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22373'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22375'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22379'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22385'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22387'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22393'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22399'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22405'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22411'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22415'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22421'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22425'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22431'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22437'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22443'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22445'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22449'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22451'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22453'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22455'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22458'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22460'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22462'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22464'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22468'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22473'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22477'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22479'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22481'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22483'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22485'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22487'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22489'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22491'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22493'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22495'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22497'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22499'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22501'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22545'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22563'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '32378'
+  ppid: '1'
+  user: oragrid
+- cmdline: 'sshd: cyberark [priv]'
+  cwd: /
+  pid: '32623'
+  ppid: '2882'
+  user: root
+- cmdline: 'sshd: cyberark@pts/1'
+  cwd: /
+  pid: '32631'
+  ppid: '32623'
+  user: cyberark
+- cmdline: -bash
+  cwd: /
+  pid: '32632'
+  ppid: '32631'
+  user: cyberark
+- cmdline: su - root
+  cwd: /
+  pid: '32668'
+  ppid: '32632'
+  user: cyberark
+- cmdline: -bash
+  cwd: /
+  pid: '32676'
+  ppid: '32668'
+  user: root
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/sqlplus                                         as
+    sysasm
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '33023'
+  ppid: '32676'
+  user: root
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '33025'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '34800'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34963'
+  ppid: '2'
+  user: root
+- cmdline: ora_w004_BSAREP
+  cwd: /
+  pid: '35257'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w002_BSAAPP
+  cwd: /
+  pid: '35341'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w003_ARSYS
+  cwd: /
+  pid: '35409'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_o001_BNABBDD
+  cwd: /
+  pid: '35698'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o001_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '35700'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_o002_ARSYS
+  cwd: /
+  pid: '35703'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o002_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '35705'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '36134'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37614'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38019'
+  ppid: '2'
+  user: root
+- cmdline: ora_w001_BNABBDD
+  cwd: /
+  pid: '38039'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '38380'
+  ppid: '2'
+  user: root
+- cmdline: ora_w000_BNABBDD
+  cwd: /
+  pid: '40559'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '41466'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51639'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53968'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '55115'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57812'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57921'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58479'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58505'
+  ppid: '2'
+  user: root
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '59259'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '62085'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62951'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '67682'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68499'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68515'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68597'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68768'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68938'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68960'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69565'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '74694'
+  ppid: '2'
+  user: root
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '76012'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '76666'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76667'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76736'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '77158'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79085'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79092'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79256'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79490'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79648'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '79666'
+  ppid: '3539'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '79880'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79915'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79930'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79931'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79933'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80004'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80194'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80196'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80292'
+  ppid: '2'
+  user: root
+- cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
+    /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/plugins/oracle.sysman.db.agent.plugin_13.4.1.0.0/scripts/failedLogin.pl
+  cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/
+  pid: '80308'
+  ppid: '13648'
+  user: oracle
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '80326'
+  ppid: '1'
+  user: oragrid
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1655221424
+  cwd: /usr/lib64/sa/
+  pid: '80481'
+  ppid: '2884'
+  user: root
+- cmdline: 'sshd: cyberark [priv]'
+  cwd: /
+  pid: '80506'
+  ppid: '2882'
+  user: root
+- cmdline: 'sshd: cyberark@pts/2'
+  cwd: /
+  pid: '80508'
+  ppid: '80506'
+  user: cyberark
+- cmdline: ''
+  cwd: /
+  pid: '80735'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80741'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80819'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80820'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80821'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80822'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80823'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80824'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80825'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80826'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80827'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80828'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80829'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80830'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80831'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80832'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80833'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80834'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80835'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80836'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80837'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80838'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80839'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80840'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80841'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80842'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80843'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80844'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80845'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80846'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80847'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80848'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80849'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80850'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80851'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80852'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80853'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80854'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80855'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80856'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80857'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80858'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80859'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80860'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80861'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80862'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80863'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80864'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80865'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80866'
+  ppid: '2'
+  user: root
+- cmdline: /bin/sh -c su - root -c '/bin/sh -c '"'"'echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve
+    ; /usr/bin/python /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'"'"''
+    && sleep 0
+  cwd: /bin/
+  pid: '80972'
+  ppid: '80508'
+  user: cyberark
+- cmdline: su - root -c /bin/sh -c 'echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve
+    ; /usr/bin/python /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'
+  cwd: /
+  pid: '80990'
+  ppid: '80972'
+  user: cyberark
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ; /usr/bin/python
+    /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '80991'
+  ppid: '80990'
+  user: root
+- cmdline: /usr/bin/python /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '81026'
+  ppid: '80991'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81076'
+  ppid: '2'
+  user: root
+- cmdline: ora_q003_BNABBDD
+  cwd: /
+  pid: '85919'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '98298'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w000_ARSYS
+  cwd: /
+  pid: '105757'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_o002_BSAAPP
+  cwd: /
+  pid: '121249'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o002_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '121251'
+  ppid: '1'
+  user: oracle
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '123382'
+  ppid: '1'
+  user: oragrid
+software_list:
+- cmd_regexp: tnslsnr
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/oracle_listener.yaml'
+    name: Include Oracle Listener specific plugins
+  name: Oracle Listener
+  process_type: parent
+  return_children: false
+  return_packages: true
+  vars: {}
 tcp_listen:
-  - address: 0.0.0.0
-    name: java
-    pid: 13648
-    port: 47632
-    protocol: tcp
-    stime: 'Thu May 12 19:11:16 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_BSAR
-    pid: 15848
-    port: 24016
-    protocol: tcp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 192.168.25.186
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 192.168.22.25
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 192.168.28.229
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14763
-    port: 1521
-    protocol: tcp
-    stime: 'Thu May 12 19:11:29 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14782
-    port: 1522
-    protocol: tcp
-    stime: 'Thu May 12 19:11:29 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14505
-    port: 1523
-    protocol: tcp
-    stime: 'Thu May 12 19:11:28 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14496
-    port: 1524
-    protocol: tcp
-    stime: 'Thu May 12 19:11:27 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: sshd
-    pid: 2882
-    port: 22
-    protocol: tcp
-    stime: 'Thu May 12 19:10:27 2022'
-    user: root
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14500
-    port: 1527
-    protocol: tcp
-    stime: 'Thu May 12 19:11:27 2022'
-    user: oragrid
-  - address: 127.0.0.1
-    name: master
-    pid: 3539
-    port: 25
-    protocol: tcp
-    stime: 'Thu May 12 19:10:28 2022'
-    user: root
-  - address: 0.0.0.0
-    name: dsmc
-    pid: 3268
-    port: 1501
-    protocol: tcp
-    stime: 'Thu May 12 19:10:28 2022'
-    user: root
-  - address: 127.0.0.1
-    name: oraagent.bin
-    pid: 14470
-    port: 2016
-    protocol: tcp
-    stime: 'Thu May 12 19:11:27 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: java
-    pid: 13590
-    port: 3872
-    protocol: tcp
-    stime: 'Thu May 12 19:11:14 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: java
-    pid: 13648
-    port: 3873
-    protocol: tcp
-    stime: 'Thu May 12 19:11:16 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_ARSY
-    pid: 15674
-    port: 20266
-    protocol: tcp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_BSAA
-    pid: 15821
-    port: 20267
-    protocol: tcp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_BNAB
-    pid: 15852
-    port: 13966
-    protocol: tcp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Thu May 12 19:10:02 2022'
-    user: root
-  - address: '::'
-    name: avagent.bin
-    pid: 2479
-    port: 30002
-    protocol: tcp
-    stime: 'Thu May 12 19:10:25 2022'
-    user: root
-  - address: '::'
-    name: avagent.bin
-    pid: 2479
-    port: 28002
-    protocol: tcp
-    stime: 'Thu May 12 19:10:25 2022'
-    user: root
-  - address: 127.0.0.1
-    name: avagent.bin
-    pid: 2479
-    port: 30984
-    protocol: tcp
-    stime: 'Thu May 12 19:10:25 2022'
-    user: root
-  - address: '::'
-    name: bin/rscd
-    pid: 4020
-    port: 4750
-    protocol: tcp
-    stime: 'Thu May 12 19:10:29 2022'
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 1564
-    port: 111
-    protocol: tcp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: java
+  pid: 13648
+  port: 47632
+  protocol: tcp
+  stime: Thu May 12 19:11:16 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_BSAR
+  pid: 15848
+  port: 24016
+  protocol: tcp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 192.168.25.186
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 192.168.22.25
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 192.168.28.229
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 127.0.0.1
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14763
+  port: 1521
+  protocol: tcp
+  stime: Thu May 12 19:11:29 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14782
+  port: 1522
+  protocol: tcp
+  stime: Thu May 12 19:11:29 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14505
+  port: 1523
+  protocol: tcp
+  stime: Thu May 12 19:11:28 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14496
+  port: 1524
+  protocol: tcp
+  stime: Thu May 12 19:11:27 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: sshd
+  pid: 2882
+  port: 22
+  protocol: tcp
+  stime: Thu May 12 19:10:27 2022
+  user: root
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14500
+  port: 1527
+  protocol: tcp
+  stime: Thu May 12 19:11:27 2022
+  user: oragrid
+- address: 127.0.0.1
+  name: master
+  pid: 3539
+  port: 25
+  protocol: tcp
+  stime: Thu May 12 19:10:28 2022
+  user: root
+- address: 0.0.0.0
+  name: dsmc
+  pid: 3268
+  port: 1501
+  protocol: tcp
+  stime: Thu May 12 19:10:28 2022
+  user: root
+- address: 127.0.0.1
+  name: oraagent.bin
+  pid: 14470
+  port: 2016
+  protocol: tcp
+  stime: Thu May 12 19:11:27 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: java
+  pid: 13590
+  port: 3872
+  protocol: tcp
+  stime: Thu May 12 19:11:14 2022
+  user: oracle
+- address: 0.0.0.0
+  name: java
+  pid: 13648
+  port: 3873
+  protocol: tcp
+  stime: Thu May 12 19:11:16 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_ARSY
+  pid: 15674
+  port: 20266
+  protocol: tcp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_BSAA
+  pid: 15821
+  port: 20267
+  protocol: tcp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_BNAB
+  pid: 15852
+  port: 13966
+  protocol: tcp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Thu May 12 19:10:02 2022
+  user: root
+- address: '::'
+  name: avagent.bin
+  pid: 2479
+  port: 30002
+  protocol: tcp
+  stime: Thu May 12 19:10:25 2022
+  user: root
+- address: '::'
+  name: avagent.bin
+  pid: 2479
+  port: 28002
+  protocol: tcp
+  stime: Thu May 12 19:10:25 2022
+  user: root
+- address: 127.0.0.1
+  name: avagent.bin
+  pid: 2479
+  port: 30984
+  protocol: tcp
+  stime: Thu May 12 19:10:25 2022
+  user: root
+- address: '::'
+  name: bin/rscd
+  pid: 4020
+  port: 4750
+  protocol: tcp
+  stime: Thu May 12 19:10:29 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 1564
+  port: 111
+  protocol: tcp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc
 udp_listen:
-  - address: 127.0.0.1
-    name: ora_s000_BNAB
-    pid: 15862
-    port: 9756
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: rsyslogd
-    pid: 2888
-    port: 10583
-    protocol: udp
-    stime: 'Thu May 12 19:10:27 2022'
-    user: root
-  - address: 127.0.0.1
-    name: ora_d000_BNAB
-    pid: 15852
-    port: 43469
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_lreg_BNAB
-    pid: 15810
-    port: 43845
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_s000_ARSY
-    pid: 15676
-    port: 46109
-    protocol: udp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_s000_BSAA
-    pid: 15825
-    port: 15051
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_d000_BSAR
-    pid: 15848
-    port: 18969
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_s000_BSAR
-    pid: 15858
-    port: 52283
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ohasd.bin
-    pid: 13578
-    port: 53703
-    protocol: udp
-    stime: 'Thu May 12 19:11:11 2022'
-    user: oragrid
-  - address: 127.0.0.1
-    name: asm_lreg_+ASM
-    pid: 15381
-    port: 23389
-    protocol: udp
-    stime: 'Thu May 12 19:12:03 2022'
-    user: oragrid
-  - address: 127.0.0.1
-    name: ora_lreg_ARSY
-    pid: 15655
-    port: 57074
-    protocol: udp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_d000_BSAA
-    pid: 15821
-    port: 26201
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_lreg_BSAR
-    pid: 15813
-    port: 60678
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_d000_ARSY
-    pid: 15674
-    port: 62388
-    protocol: udp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Thu May 12 19:10:02 2022'
-    user: root
-  - address: 192.168.25.186
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 192.168.22.25
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 192.168.28.229
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 127.0.0.1
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 0.0.0.0
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 1564
-    port: 850
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
-  - address: 127.0.0.1
-    name: ora_lreg_BSAA
-    pid: 15784
-    port: 34911
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: java
-    pid: 13648
-    port: 3873
-    protocol: udp
-    stime: 'Thu May 12 19:11:16 2022'
-    user: oracle
-  - address: '::'
-    name: rpcbind
-    pid: 1564
-    port: 111
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
-  - address: '::'
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: '::'
-    name: rpcbind
-    pid: 1564
-    port: 850
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
+- address: 127.0.0.1
+  name: ora_s000_BNAB
+  pid: 15862
+  port: 9756
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: rsyslogd
+  pid: 2888
+  port: 10583
+  protocol: udp
+  stime: Thu May 12 19:10:27 2022
+  user: root
+- address: 127.0.0.1
+  name: ora_d000_BNAB
+  pid: 15852
+  port: 43469
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_lreg_BNAB
+  pid: 15810
+  port: 43845
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_s000_ARSY
+  pid: 15676
+  port: 46109
+  protocol: udp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_s000_BSAA
+  pid: 15825
+  port: 15051
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_d000_BSAR
+  pid: 15848
+  port: 18969
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_s000_BSAR
+  pid: 15858
+  port: 52283
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ohasd.bin
+  pid: 13578
+  port: 53703
+  protocol: udp
+  stime: Thu May 12 19:11:11 2022
+  user: oragrid
+- address: 127.0.0.1
+  name: asm_lreg_+ASM
+  pid: 15381
+  port: 23389
+  protocol: udp
+  stime: Thu May 12 19:12:03 2022
+  user: oragrid
+- address: 127.0.0.1
+  name: ora_lreg_ARSY
+  pid: 15655
+  port: 57074
+  protocol: udp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_d000_BSAA
+  pid: 15821
+  port: 26201
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_lreg_BSAR
+  pid: 15813
+  port: 60678
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_d000_ARSY
+  pid: 15674
+  port: 62388
+  protocol: udp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Thu May 12 19:10:02 2022
+  user: root
+- address: 192.168.25.186
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 192.168.22.25
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 192.168.28.229
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 127.0.0.1
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 0.0.0.0
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 1564
+  port: 850
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc
+- address: 127.0.0.1
+  name: ora_lreg_BSAA
+  pid: 15784
+  port: 34911
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: java
+  pid: 13648
+  port: 3873
+  protocol: udp
+  stime: Thu May 12 19:11:16 2022
+  user: oracle
+- address: '::'
+  name: rpcbind
+  pid: 1564
+  port: 111
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc
+- address: '::'
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: '::'
+  name: rpcbind
+  pid: 1564
+  port: 850
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/oracle_listener/oracle_listener21_centos7.9.yaml
+++ b/tests/unit/plugins/action/auto/resources/oracle_listener/oracle_listener21_centos7.9.yaml
@@ -1,30 +1,263 @@
----
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - analyzer
+    - -c
+    - /etc/iometrics/skydive/skydive.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - analyzer
+      - -c
+      - /etc/iometrics/skydive/skydive.yml
+      Domainname: ''
+      Entrypoint:
+      - /usr/local/bin/skydive
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      ExposedPorts:
+        8082/tcp: {}
+      Hostname: test-ram-norm01.novalocal
+      Image: nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-4
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/iometrics/skydive/skydive.yml: {}
+        /var/lib/skydive: {}
+      WorkingDir: ''
+    Created: '2022-02-11T16:39:16.436847232Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631-init/diff:/var/lib/docker/overlay2/98c8fc8a1198391d57b52bfc7481b12d8fcb3f1460fa681558aaa7306730bd9a/diff:/var/lib/docker/overlay2/9b3407fa7b3cf45082812007500f2249298b9522aeeb6b5e8c324eb8e7291ad5/diff:/var/lib/docker/overlay2/2a70d40f778c8683b234911bdff488726b2d1931d804bca86b612015cabbcfec/diff
+        MergedDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/merged
+        UpperDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/diff
+        WorkDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/iometrics/skydive/:/var/lib/skydive:rw
+      - /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hostname
+    HostsPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hosts
+    Id: 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
+    Image: sha256:7b966f2ba2092efb97f038f14563b84b32e98879ad8d52189af823c594b185ed
+    LogPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/iometrics/skydive/skydive.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics/skydive/skydive.yml
+      Type: bind
+    - Destination: /var/lib/skydive
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/iometrics/skydive
+      Type: bind
+    Name: /skydive-analyzer
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 36711925279b4b1ac03d5cdb68a3d4d765d86759714aaae8c976b8bce04ce890
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 6e919553642bae0550eee9382a797f886036f8f6f296d65183121041f1da3b83
+      Ports: {}
+      SandboxID: be98496481fa878c6ad9f140fbcae075d3bccea63ad36757fecf011ab94b6dd3
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/local/bin/skydive
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T14:45:04.915207484Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1512
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:45:08.126872087Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 5500
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 1539
+    protocol: tcp
+  discovery_time: '2022-06-15T17:43:13+02:00'
+  extra_data:
+    ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
+    instances:
+    - XE
+    name: LISTENER
+  files:
+  - path: /opt/oracle/product/21c/dbhomeXE
+    subtype: generic
+    type: home
+  - path: /opt/oracle/product/21c/dbhomeXE/bin/lsnrctl
+    subtype: generic
+    type: binary
+  - name: log.xml
+    path: /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/trace
+    subtype: generic
+    type: log
+  listening_ports:
+  - 1539
+  packages: []
+  process:
+    cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
+    cwd: /opt/oracle/product/21c/dbhomeXE/bin/
+    listening_ports:
+    - 1539
+    - 5500
+    pid: '22926'
+    ppid: '1'
+    user: oracle
+  type: Oracle Listener
+  version: []
 mocked_plugin_tasks:
-  Read env from process:
+  Check log_dir is a dir:
     expected_args:
-      pid: '22926'
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/trace
     plugin_result:
       failed: false
-      parsed:
-        "XDG_SESSION_ID": "c3"
-        "LISTENER_NAME": "LISTENER"
-        "TEMPLATE_NAME": "XE_Database.dbc"
-        "SHELL": "/bin/bash"
-        "USER": "oracle"
-        "ORACLE_SID": "XE"
-        "PDB_NAME": "XEPDB1"
-        "CREATE_AS_CDB": "true"
-        "PATH": "/opt/oracle/product/21c/dbhomeXE/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
-        "_": "/opt/oracle/product/21c/dbhomeXE/bin/lsnrctl"
-        "PWD": "/"
-        "LANG": "en_US.UTF-8"
-        "NUMBER_OF_PDBS": "1"
-        "HOME": "/home/oracle"
-        "SHLVL": "2"
-        "LOGNAME": "oracle"
-        "XDG_RUNTIME_DIR": "/run/user/54321"
-        "ORACLE_HOME": "/opt/oracle/product/21c/dbhomeXE"
-        "ORA_NET2_DESC": "7,10"
+      stat:
+        exists: true
+        isdir: true
+        path: /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/trace
   Execute lsnrctl:
     expected_args:
       argv: null
@@ -32,4702 +265,4586 @@ mocked_plugin_tasks:
       in_docker: true
     expected_attributes:
       environment:
-        ORACLE_HOME: "/opt/oracle/product/21c/dbhomeXE"
-        TNS_ADMIN: "/opt/oracle/product/21c/dbhomeXE/network/admin"
+        ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
+        TNS_ADMIN: /opt/oracle/product/21c/dbhomeXE/network/admin
       register: any
       when: any
     plugin_result:
       failed: false
-      stdout: |-
-        
-        LSNRCTL for Linux: Version 21.0.0.0.0 - Production on 15-JUN-2022 15:15:33
-        
-        Copyright (c) 1991, 2021, Oracle.  All rights reserved.
-        
-        Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=test-ram-norm01.novalocal)(PORT=1539)))
-        STATUS of the LISTENER
-        ------------------------
-        Alias                     LISTENER
-        Version                   TNSLSNR for Linux: Version 21.0.0.0.0 - Production
-        Start Date                09-JUN-2022 09:15:35
-        Uptime                    6 days 5 hr. 59 min. 57 sec
-        Trace Level               off
-        Security                  ON: Local OS Authentication
-        SNMP                      OFF
-        Default Service           XE
-        Listener Parameter File   /opt/oracle/homes/OraDBHome21cXE/network/admin/listener.ora
-        Listener Log File         /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/alert/log.xml
-        Listening Endpoints Summary...
-          (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1539)))
-          (DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))
-          (DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=localhost)(PORT=5500))(Security=(my_wallet_directory=/opt/oracle/homes/OraDBHome21cXE/admin/XE/xdb_wallet))(Presentation=HTTP)(Session=RAW))
-        Services Summary...
-        Service "XE" has 1 instance(s).
-          Instance "XE", status READY, has 1 handler(s) for this service...
-        Service "XEXDB" has 1 instance(s).
-          Instance "XE", status READY, has 1 handler(s) for this service...
-        Service "d6e0afed43d66145e055000000000001" has 1 instance(s).
-          Instance "XE", status READY, has 1 handler(s) for this service...
-        Service "xepdb1" has 1 instance(s).
-          Instance "XE", status READY, has 1 handler(s) for this service...
-        The command completed successfully
+      stdout: "\nLSNRCTL for Linux: Version 21.0.0.0.0 - Production on 15-JUN-2022\
+        \ 15:15:33\n\nCopyright (c) 1991, 2021, Oracle.  All rights reserved.\n\n\
+        Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=test-ram-norm01.novalocal)(PORT=1539)))\n\
+        STATUS of the LISTENER\n------------------------\nAlias                  \
+        \   LISTENER\nVersion                   TNSLSNR for Linux: Version 21.0.0.0.0\
+        \ - Production\nStart Date                09-JUN-2022 09:15:35\nUptime   \
+        \                 6 days 5 hr. 59 min. 57 sec\nTrace Level               off\n\
+        Security                  ON: Local OS Authentication\nSNMP              \
+        \        OFF\nDefault Service           XE\nListener Parameter File   /opt/oracle/homes/OraDBHome21cXE/network/admin/listener.ora\n\
+        Listener Log File         /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/alert/log.xml\n\
+        Listening Endpoints Summary...\n  (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1539)))\n\
+        \  (DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))\n  (DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=localhost)(PORT=5500))(Security=(my_wallet_directory=/opt/oracle/homes/OraDBHome21cXE/admin/XE/xdb_wallet))(Presentation=HTTP)(Session=RAW))\n\
+        Services Summary...\nService \"XE\" has 1 instance(s).\n  Instance \"XE\"\
+        , status READY, has 1 handler(s) for this service...\nService \"XEXDB\" has\
+        \ 1 instance(s).\n  Instance \"XE\", status READY, has 1 handler(s) for this\
+        \ service...\nService \"d6e0afed43d66145e055000000000001\" has 1 instance(s).\n\
+        \  Instance \"XE\", status READY, has 1 handler(s) for this service...\nService\
+        \ \"xepdb1\" has 1 instance(s).\n  Instance \"XE\", status READY, has 1 handler(s)\
+        \ for this service...\nThe command completed successfully"
       stdout_lines:
-        - ''
-        - LSNRCTL for Linux: Version 21.0.0.0.0 - Production on 15-JUN-2022 15:15:33
-        - ''
-        - Copyright (c) 1991, 2021, Oracle.  All rights reserved.
-        - ''
-        - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=test-ram-norm01.novalocal)(PORT=1539)))
-        - STATUS of the LISTENER
-        - ------------------------
-        - Alias                     LISTENER
-        - Version                   TNSLSNR for Linux: Version 21.0.0.0.0 - Production
-        - Start Date                09-JUN-2022 09:15:35
-        - Uptime                    6 days 5 hr. 59 min. 57 sec
-        - Trace Level               off
-        - Security                  ON: Local OS Authentication
-        - SNMP                      OFF
-        - Default Service           XE
-        - Listener Parameter File   /opt/oracle/homes/OraDBHome21cXE/network/admin/listener.ora
-        - Listener Log File         /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/alert/log.xml
-        - Listening Endpoints Summary...
-        - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1539)))
-        - (DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))
-        - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=localhost)(PORT=5500))(Security=(my_wallet_directory=/opt/oracle/homes/OraDBHome21cXE/admin/XE/xdb_wallet))(Presentation=HTTP)(Session=RAW))
-        - Services Summary...
-        - Service "XE" has 1 instance(s).
-        - Instance "XE", status READY, has 1 handler(s) for this service...
-        - Service "XEXDB" has 1 instance(s).
-        - Instance "XE", status READY, has 1 handler(s) for this service...
-        - Service "d6e0afed43d66145e055000000000001" has 1 instance(s).
-        - Instance "XE", status READY, has 1 handler(s) for this service...
-        - Service "xepdb1" has 1 instance(s).
-        - Instance "XE", status READY, has 1 handler(s) for this service...
-        - The command completed successfully
-
-  Check log_dir is a dir:
+      - ''
+      - LSNRCTL for Linux: Version 21.0.0.0.0 - Production on 15-JUN-2022 15:15:33
+      - ''
+      - Copyright (c) 1991, 2021, Oracle.  All rights reserved.
+      - ''
+      - Connecting to (DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=test-ram-norm01.novalocal)(PORT=1539)))
+      - STATUS of the LISTENER
+      - '------------------------'
+      - Alias                     LISTENER
+      - Version                   TNSLSNR for Linux: Version 21.0.0.0.0 - Production
+      - Start Date                09-JUN-2022 09:15:35
+      - Uptime                    6 days 5 hr. 59 min. 57 sec
+      - Trace Level               off
+      - Security                  ON: Local OS Authentication
+      - SNMP                      OFF
+      - Default Service           XE
+      - Listener Parameter File   /opt/oracle/homes/OraDBHome21cXE/network/admin/listener.ora
+      - Listener Log File         /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/alert/log.xml
+      - Listening Endpoints Summary...
+      - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1539)))
+      - (DESCRIPTION=(ADDRESS=(PROTOCOL=ipc)(KEY=EXTPROC1521)))
+      - (DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=localhost)(PORT=5500))(Security=(my_wallet_directory=/opt/oracle/homes/OraDBHome21cXE/admin/XE/xdb_wallet))(Presentation=HTTP)(Session=RAW))
+      - Services Summary...
+      - Service "XE" has 1 instance(s).
+      - Instance "XE", status READY, has 1 handler(s) for this service...
+      - Service "XEXDB" has 1 instance(s).
+      - Instance "XE", status READY, has 1 handler(s) for this service...
+      - Service "d6e0afed43d66145e055000000000001" has 1 instance(s).
+      - Instance "XE", status READY, has 1 handler(s) for this service...
+      - Service "xepdb1" has 1 instance(s).
+      - Instance "XE", status READY, has 1 handler(s) for this service...
+      - The command completed successfully
+  Read env from process:
     expected_args:
-      path: /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/trace
-      follow: false
-      get_attributes: true
-      get_mime: true
-      in_docker: true
+      pid: '22926'
     plugin_result:
       failed: false
-      stat:
-        exists: true
-        isdir: true
-        path: /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/trace
-
-expected_result:
-  - bindings:
-      - address: '::'
-        class: 'service'
-        port: 5500
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 1539
-        protocol: 'tcp'
-    extra_data:
-      ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
-      instances:
-        - XE
-      name: LISTENER
-    files:
-      - path: /opt/oracle/product/21c/dbhomeXE
-        subtype: generic
-        type: home
-      - path: /opt/oracle/product/21c/dbhomeXE/bin/lsnrctl
-        subtype: generic
-        type: binary
-      - path: /opt/oracle/diag/tnslsnr/test-ram-norm01/listener/trace
-        name: log.xml
-        subtype: generic
-        type: log
-    discovery_time: '2022-06-15T17:43:13+02:00'
-    listening_ports:
-      - 1539
-    packages: [ ]
-    process:
-      cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
-      listening_ports:
-        - 1539
-        - 5500
-      pid: '22926'
-      ppid: '1'
-      user: oracle
-    type: Oracle Listener
-    version: [ ]
-
-software_list:
-  - name: Oracle Listener
-    cmd_regexp: "tnslsnr"
-    process_type: parent
-    return_children: false
-    return_packages: true
-    vars: { }
-    custom_tasks:
-      - name: Include Oracle Listener specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/oracle_listener.yaml"
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - analyzer
-        - '-c'
-        - /etc/iometrics/skydive/skydive.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - analyzer
-          - '-c'
-          - /etc/iometrics/skydive/skydive.yml
-        Domainname: ''
-        Entrypoint:
-          - /usr/local/bin/skydive
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-        ExposedPorts:
-          8082/tcp: {}
-        Hostname: test-ram-norm01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-4'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/iometrics/skydive/skydive.yml: {}
-          /var/lib/skydive: {}
-        WorkingDir: ''
-      Created: '2022-02-11T16:39:16.436847232Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631-init/diff:/var/lib/docker/overlay2/98c8fc8a1198391d57b52bfc7481b12d8fcb3f1460fa681558aaa7306730bd9a/diff:/var/lib/docker/overlay2/9b3407fa7b3cf45082812007500f2249298b9522aeeb6b5e8c324eb8e7291ad5/diff:/var/lib/docker/overlay2/2a70d40f778c8683b234911bdff488726b2d1931d804bca86b612015cabbcfec/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/iometrics/skydive/:/var/lib/skydive:rw'
-          - >-
-            /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hosts
-      Id: 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
-      Image: 'sha256:7b966f2ba2092efb97f038f14563b84b32e98879ad8d52189af823c594b185ed'
-      LogPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/iometrics/skydive/skydive.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics/skydive/skydive.yml
-          Type: bind
-        - Destination: /var/lib/skydive
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/iometrics/skydive
-          Type: bind
-      Name: /skydive-analyzer
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 36711925279b4b1ac03d5cdb68a3d4d765d86759714aaae8c976b8bce04ce890
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 6e919553642bae0550eee9382a797f886036f8f6f296d65183121041f1da3b83
-        Ports: {}
-        SandboxID: be98496481fa878c6ad9f140fbcae075d3bccea63ad36757fecf011ab94b6dd3
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/local/bin/skydive
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T14:45:04.915207484Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1512
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:45:08.126872087Z'
-        Status: running
+      parsed:
+        CREATE_AS_CDB: 'true'
+        HOME: /home/oracle
+        LANG: en_US.UTF-8
+        LISTENER_NAME: LISTENER
+        LOGNAME: oracle
+        NUMBER_OF_PDBS: '1'
+        ORACLE_HOME: /opt/oracle/product/21c/dbhomeXE
+        ORACLE_SID: XE
+        ORA_NET2_DESC: 7,10
+        PATH: /opt/oracle/product/21c/dbhomeXE/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+        PDB_NAME: XEPDB1
+        PWD: /
+        SHELL: /bin/bash
+        SHLVL: '2'
+        TEMPLATE_NAME: XE_Database.dbc
+        USER: oracle
+        XDG_RUNTIME_DIR: /run/user/54321
+        XDG_SESSION_ID: c3
+        _: /opt/oracle/product/21c/dbhomeXE/bin/lsnrctl
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   apache-commons-collections:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-collections
-      release: 22.el7_2
-      source: rpm
-      version: 3.2.1
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
   apache-commons-daemon:
-    - arch: x86_64
-      epoch: null
-      name: apache-commons-daemon
-      release: 7.el7
-      source: rpm
-      version: 1.0.13
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
   apache-commons-dbcp:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-dbcp
-      release: 17.el7
-      source: rpm
-      version: '1.4'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
   apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
   apache-commons-pool:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-pool
-      release: 9.el7
-      source: rpm
-      version: '1.6'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
   avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 35.el7_9
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 35.el7_9
+    source: rpm
+    version: 4.2.46
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 72.el7_9
-      source: rpm
-      version: 2021.2.50
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 72.el7_9
+    source: rpm
+    version: 2021.2.50
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 7.el7.centos.5
-      source: rpm
-      version: '19.4'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 7.el7.centos.5
+    source: rpm
+    version: '19.4'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.4.12
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.4.12
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: i686
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: i686
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-ce-rootless-extras:
-    - arch: x86_64
-      epoch: 0
-      name: docker-ce-rootless-extras
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-scan-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-scan-plugin
-      release: 3.el7
-      source: rpm
-      version: 0.12.0
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  ecj:
-    - arch: x86_64
-      epoch: 1
-      name: ecj
-      release: 3.el7
-      source: rpm
-      version: 4.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '14'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
-  fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  geronimo-jta:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jta
-      release: 17.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 467e318a
-      source: rpm
-      version: 00f97f56
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iometrics-agent-plugin-oracle-lib-connector:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-lib-connector
-      release: '25'
-      source: rpm
-      version: 18.5.0_1.11.3
-  iometrics-agent-plugin-oracle-libs:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-libs
-      release: '1'
-      source: rpm
-      version: 18.5.0
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-taglibs-standard:
-    - arch: noarch
-      epoch: 0
-      name: jakarta-taglibs-standard
-      release: 14.el7_1
-      source: rpm
-      version: 1.1.2
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.3
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: i686
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 135.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: i686
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  ksh:
-    - arch: x86_64
-      epoch: null
-      name: ksh
-      release: 143.el7_9
-      source: rpm
-      version: '20120801'
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXmu:
-    - arch: x86_64
-      epoch: null
-      name: libXmu
-      release: 2.el7
-      source: rpm
-      version: 1.1.2
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXt:
-    - arch: x86_64
-      epoch: null
-      name: libXt
-      release: 3.el7
-      source: rpm
-      version: 1.1.5
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXv:
-    - arch: x86_64
-      epoch: null
-      name: libXv
-      release: 1.el7
-      source: rpm
-      version: 1.0.11
-  libXxf86dga:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86dga
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.4
-  libXxf86misc:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86misc
-      release: 7.1.el7
-      source: rpm
-      version: 1.0.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-    - arch: i686
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: i686
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdmx:
-    - arch: x86_64
-      epoch: null
-      name: libdmx
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: i686
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-    - arch: i686
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 18.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  mailx:
-    - arch: x86_64
-      epoch: null
-      name: mailx
-      release: 19.el7
-      source: rpm
-      version: '12.5'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-    - arch: i686
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7.2
-      source: rpm
-      version: 1.3.0
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: i686
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-    - arch: i686
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-    - arch: i686
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-    - arch: i686
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  oracle-database-preinstall-21c:
-    - arch: x86_64
-      epoch: null
-      name: oracle-database-preinstall-21c
-      release: 1.el7
-      source: rpm
-      version: '1.0'
-  oracle-database-xe-21c:
-    - arch: x86_64
-      epoch: null
-      name: oracle-database-xe-21c
-      release: '1'
-      source: rpm
-      version: '1.0'
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: i686
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql:
-    - arch: x86_64
-      epoch: null
-      name: postgresql
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-contrib
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-    - arch: i686
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-server
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 17.el7
-      source: rpm
-      version: '22.20'
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 10.el7
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: i686
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redis:
-    - arch: x86_64
-      epoch: null
-      name: redis
-      release: 1.el7.remi
-      source: rpm
-      version: 6.2.6
-  remi-release:
-    - arch: noarch
-      epoch: null
-      name: remi-release
-      release: 2.el7.remi
-      source: rpm
-      version: '7.9'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9.1
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  smartmontools:
-    - arch: x86_64
-      epoch: 1
-      name: smartmontools
-      release: 2.el7
-      source: rpm
-      version: '7.0'
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: i686
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.2
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  tomcat:
-    - arch: noarch
-      epoch: 0
-      name: tomcat
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-admin-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-admin-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-docs-webapp:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-docs-webapp
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-el-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-el-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-javadoc:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-javadoc
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-jsp-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-jsp-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-lib:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-lib
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 24.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  uuid:
-    - arch: x86_64
-      epoch: null
-      name: uuid
-      release: 26.el7
-      source: rpm
-      version: 1.6.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7_9.1
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-utils
-      release: 23.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-xauth:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-xauth
-      release: 1.el7
-      source: rpm
-      version: 1.0.9
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-    - arch: i686
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '127'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '194'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '195'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '267'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '273'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '294'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '411'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '453'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '481'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '486'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '515'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '551'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '552'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '566'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/smartd -n -q never
-    pid: '567'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '570'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '573'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '584'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '594'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H test-ram-norm01 eth0
-    pid: '826'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/lib/jvm/jre/bin/java
-      -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
-      -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050
-      -Dcom.sun.management.jmxremote.rmi.port=8050
-      -Dcom.sun.management.jmxremote.ssl=false
-      -Dcom.sun.management.jmxremote.authenticate=false
-      -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath
-      /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
-      -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat
-      -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp
-      -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      org.apache.catalina.startup.Bootstrap start
-    pid: '881'
-    ppid: '1'
-    user: tomcat
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '883'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '902'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1058'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1063'
-    ppid: '1058'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1103'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1105'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml
-      -path.home /usr/share/filebeat -path.config /etc/filebeat -path.data
-      /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '1106'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/redis-server 127.0.0.1:6379'
-    pid: '1109'
-    ppid: '1'
-    user: redis
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1110'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1114'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1115'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1116'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9 -address
-      /run/containerd/containerd.sock
-    pid: '1494'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
-    pid: '1512'
-    ppid: '1494'
-    user: root
-  - cmdline: /usr/bin/docker start -a skydive-analyzer
-    pid: '1561'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/postgres -D /var/lib/pgsql/data -p 5432
-    pid: '7291'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: logger process'
-    pid: '7292'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: checkpointer process'
-    pid: '7294'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: writer process'
-    pid: '7295'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: wal writer process'
-    pid: '7296'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: autovacuum launcher process'
-    pid: '7297'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: stats collector process'
-    pid: '7298'
-    ppid: '7291'
-    user: postgres
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '14440'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: postgres datadope [local] idle'
-    pid: '14511'
-    ppid: '7291'
-    user: postgres
-  - cmdline: pickup -l -t unix -u
-    pid: '18090'
-    ppid: '1058'
-    user: postfix
-  - cmdline: ''
-    pid: '18693'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '22473'
-    ppid: '1103'
-    user: root
-  - cmdline: 'sshd: centos@pts/2'
-    pid: '22476'
-    ppid: '22473'
-    user: centos
-  - cmdline: '-bash'
-    pid: '22477'
-    ppid: '22476'
-    user: centos
-  - cmdline: sudo su -
-    pid: '22499'
-    ppid: '22477'
-    user: root
-  - cmdline: su -
-    pid: '22500'
-    ppid: '22499'
-    user: root
-  - cmdline: '-bash'
-    pid: '22501'
-    ppid: '22500'
-    user: root
-  - cmdline: ''
-    pid: '22846'
-    ppid: '2'
-    user: root
-  - cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
-    pid: '22926'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pmon_XE
-    pid: '22942'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_clmn_XE
-    pid: '22946'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_psp0_XE
-    pid: '22950'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vktm_XE
-    pid: '22954'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen0_XE
-    pid: '22961'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mman_XE
-    pid: '22967'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen1_XE
-    pid: '22971'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen2_XE
-    pid: '22973'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vosd_XE
-    pid: '22975'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_diag_XE
-    pid: '22979'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_ofsd_XE
-    pid: '22985'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dbrm_XE
-    pid: '22990'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vkrm_XE
-    pid: '22993'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_svcb_XE
-    pid: '22996'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pman_XE
-    pid: '23001'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dia0_XE
-    pid: '23004'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dbw0_XE
-    pid: '23008'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_lgwr_XE
-    pid: '23012'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_ckpt_XE
-    pid: '23015'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_smon_XE
-    pid: '23020'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_smco_XE
-    pid: '23023'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_reco_XE
-    pid: '23030'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_lreg_XE
-    pid: '23033'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pxmn_XE
-    pid: '23035'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mmon_XE
-    pid: '23041'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mmnl_XE
-    pid: '23045'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_bg00_XE
-    pid: '23049'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_d000_XE
-    pid: '23051'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w000_XE
-    pid: '23054'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_bg01_XE
-    pid: '23058'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_s000_XE
-    pid: '23060'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w001_XE
-    pid: '23063'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tmon_XE
-    pid: '23068'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt00_XE
-    pid: '23074'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt01_XE
-    pid: '23076'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt02_XE
-    pid: '23078'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_rcbg_XE
-    pid: '23098'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_aqpc_XE
-    pid: '23109'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w002_XE
-    pid: '23114'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w003_XE
-    pid: '23120'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w004_XE
-    pid: '23299'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_cjq0_XE
-    pid: '23309'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_qm02_XE
-    pid: '23311'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_q003_XE
-    pid: '23318'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_q005_XE
-    pid: '23374'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_cl00_XE
-    pid: '23486'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_m004_XE
-    pid: '24070'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w005_XE
-    pid: '24218'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w006_XE
-    pid: '24731'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w007_XE
-    pid: '24736'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_m000_XE
-    pid: '26069'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_m003_XE
-    pid: '26855'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '27532'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28851'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29511'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654769069
-    pid: '30393'
-    ppid: '14440'
-    user: root
-  - cmdline: xe_m002_XE
-    pid: '30487'
-    ppid: '1'
-    user: oracle
-  - cmdline: 'sshd: centos [priv]'
-    pid: '30501'
-    ppid: '1103'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '30503'
-    ppid: '30501'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '30659'
-    ppid: '30503'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
-    pid: '30672'
-    ppid: '30659'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
-    pid: '30673'
-    ppid: '30672'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
-    pid: '30674'
-    ppid: '30673'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: postgres
-    pid: 7291
-    port: 5432
-    protocol: tcp
-    stime: 'Fri Jun  3 09:22:29 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1058
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:01 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 1512
-    port: 12379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 1512
-    port: 12380
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: 192.168.0.26
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: 127.0.0.1
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1103
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: root
-  - address: '::1'
-    name: postgres
-    pid: 7291
-    port: 5432
-    protocol: tcp
-    stime: 'Fri Jun  3 09:22:29 2022'
-    user: postgres
-  - address: '::1'
-    name: master
-    pid: 1058
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:01 2022'
-    user: root
-  - address: '::'
-    name: tnslsnr
-    pid: 22926
-    port: 5500
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:34 2022'
-    user: oracle
-  - address: '::'
-    name: java
-    pid: 881
-    port: 11870
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 4000
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: tnslsnr
-    pid: 22926
-    port: 1539
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:34 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: java
-    pid: 881
-    port: 8005
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8009
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: xe_d000_XE
-    pid: 23051
-    port: 21899
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::1'
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8080
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8081
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8082
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8050
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: sshd
-    pid: 1103
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: root
-udp_listen:
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 584
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:54 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 566
-    port: 719
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 826
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: root
-  - address: 0.0.0.0
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-ce-rootless-extras:
+  - arch: x86_64
+    epoch: 0
+    name: docker-ce-rootless-extras
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-scan-plugin:
+  - arch: x86_64
+    epoch: 0
+    name: docker-scan-plugin
+    release: 3.el7
+    source: rpm
+    version: 0.12.0
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '14'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  fuse-overlayfs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
+  fuse3-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 467e318a
+    source: rpm
+    version: 00f97f56
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iometrics-agent-plugin-oracle-lib-connector:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-lib-connector
+    release: '25'
+    source: rpm
+    version: 18.5.0_1.11.3
+  iometrics-agent-plugin-oracle-libs:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-libs
+    release: '1'
+    source: rpm
+    version: 18.5.0
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.3
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: i686
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 135.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: i686
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  ksh:
+  - arch: x86_64
+    epoch: null
+    name: ksh
+    release: 143.el7_9
+    source: rpm
+    version: '20120801'
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXmu:
+  - arch: x86_64
+    epoch: null
+    name: libXmu
+    release: 2.el7
+    source: rpm
+    version: 1.1.2
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXt:
+  - arch: x86_64
+    epoch: null
+    name: libXt
+    release: 3.el7
+    source: rpm
+    version: 1.1.5
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXv:
+  - arch: x86_64
+    epoch: null
+    name: libXv
+    release: 1.el7
+    source: rpm
+    version: 1.0.11
+  libXxf86dga:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86dga
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.4
+  libXxf86misc:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86misc
+    release: 7.1.el7
+    source: rpm
+    version: 1.0.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  - arch: i686
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: i686
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdmx:
+  - arch: x86_64
+    epoch: null
+    name: libdmx
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: i686
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  - arch: i686
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 18.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  mailx:
+  - arch: x86_64
+    epoch: null
+    name: mailx
+    release: 19.el7
+    source: rpm
+    version: '12.5'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  - arch: i686
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7.2
+    source: rpm
+    version: 1.3.0
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: i686
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  - arch: i686
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  - arch: i686
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  - arch: i686
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  oracle-database-preinstall-21c:
+  - arch: x86_64
+    epoch: null
+    name: oracle-database-preinstall-21c
+    release: 1.el7
+    source: rpm
+    version: '1.0'
+  oracle-database-xe-21c:
+  - arch: x86_64
+    epoch: null
+    name: oracle-database-xe-21c
+    release: '1'
+    source: rpm
+    version: '1.0'
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: i686
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql:
+  - arch: x86_64
+    epoch: null
+    name: postgresql
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-contrib
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  - arch: i686
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-server
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  psmisc:
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 17.el7
+    source: rpm
+    version: '22.20'
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 10.el7
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: i686
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redis:
+  - arch: x86_64
+    epoch: null
+    name: redis
+    release: 1.el7.remi
+    source: rpm
+    version: 6.2.6
+  remi-release:
+  - arch: noarch
+    epoch: null
+    name: remi-release
+    release: 2.el7.remi
+    source: rpm
+    version: '7.9'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 566
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 584
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:54 2022'
-    user: chrony
-  - address: '::1'
-    name: xe_lreg_XE
-    pid: 23033
-    port: 33176
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 719
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::1'
-    name: xe_s000_XE
-    pid: 23060
-    port: 64452
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:38 2022'
-    user: oracle
-  - address: '::1'
-    name: xe_d000_XE
-    pid: 23051
-    port: 32251
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8081
-    protocol: udp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9.1
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  smartmontools:
+  - arch: x86_64
+    epoch: 1
+    name: smartmontools
+    release: 2.el7
+    source: rpm
+    version: '7.0'
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: i686
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.2
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-docs-webapp:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-docs-webapp
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-javadoc:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-javadoc
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 24.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  uuid:
+  - arch: x86_64
+    epoch: null
+    name: uuid
+    release: 26.el7
+    source: rpm
+    version: 1.6.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7_9.1
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-utils:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-utils
+    release: 23.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-xauth:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-xauth
+    release: 1.el7
+    source: rpm
+    version: 1.0.9
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+  - arch: i686
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '127'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '194'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '195'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '273'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '411'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '453'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '481'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '486'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '515'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '551'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '552'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '566'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/smartd -n -q never
+  cwd: /usr/sbin/
+  pid: '567'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '570'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '573'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '584'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '594'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H test-ram-norm01 eth0
+  cwd: /sbin/
+  pid: '826'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+    -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050 -Dcom.sun.management.jmxremote.rmi.port=8050
+    -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
+    -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+    -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+    -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+    start
+  cwd: /usr/lib/jvm/jre/bin/
+  pid: '881'
+  ppid: '1'
+  user: tomcat
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '883'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '902'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1058'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1063'
+  ppid: '1058'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1103'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1105'
+  ppid: '1'
+  user: root
+- cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '1106'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/redis-server 127.0.0.1:6379
+  cwd: /usr/bin/
+  pid: '1109'
+  ppid: '1'
+  user: redis
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1110'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1114'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1115'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1116'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1494'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
+  cwd: /usr/local/bin/
+  pid: '1512'
+  ppid: '1494'
+  user: root
+- cmdline: /usr/bin/docker start -a skydive-analyzer
+  cwd: /usr/bin/
+  pid: '1561'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/postgres -D /var/lib/pgsql/data -p 5432
+  cwd: /usr/bin/
+  pid: '7291'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: logger process'
+  cwd: /
+  pid: '7292'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: checkpointer process'
+  cwd: /
+  pid: '7294'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: writer process'
+  cwd: /
+  pid: '7295'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: wal writer process'
+  cwd: /
+  pid: '7296'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: autovacuum launcher process'
+  cwd: /
+  pid: '7297'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: stats collector process'
+  cwd: /
+  pid: '7298'
+  ppid: '7291'
+  user: postgres
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '14440'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: postgres datadope [local] idle'
+  cwd: /
+  pid: '14511'
+  ppid: '7291'
+  user: postgres
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '18090'
+  ppid: '1058'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '18693'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '22473'
+  ppid: '1103'
+  user: root
+- cmdline: 'sshd: centos@pts/2'
+  cwd: /
+  pid: '22476'
+  ppid: '22473'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '22477'
+  ppid: '22476'
+  user: centos
+- cmdline: sudo su -
+  cwd: /
+  pid: '22499'
+  ppid: '22477'
+  user: root
+- cmdline: su -
+  cwd: /
+  pid: '22500'
+  ppid: '22499'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '22501'
+  ppid: '22500'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22846'
+  ppid: '2'
+  user: root
+- cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
+  cwd: /opt/oracle/product/21c/dbhomeXE/bin/
+  pid: '22926'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pmon_XE
+  cwd: /
+  pid: '22942'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_clmn_XE
+  cwd: /
+  pid: '22946'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_psp0_XE
+  cwd: /
+  pid: '22950'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vktm_XE
+  cwd: /
+  pid: '22954'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen0_XE
+  cwd: /
+  pid: '22961'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mman_XE
+  cwd: /
+  pid: '22967'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen1_XE
+  cwd: /
+  pid: '22971'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen2_XE
+  cwd: /
+  pid: '22973'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vosd_XE
+  cwd: /
+  pid: '22975'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_diag_XE
+  cwd: /
+  pid: '22979'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_ofsd_XE
+  cwd: /
+  pid: '22985'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dbrm_XE
+  cwd: /
+  pid: '22990'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vkrm_XE
+  cwd: /
+  pid: '22993'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_svcb_XE
+  cwd: /
+  pid: '22996'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pman_XE
+  cwd: /
+  pid: '23001'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dia0_XE
+  cwd: /
+  pid: '23004'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dbw0_XE
+  cwd: /
+  pid: '23008'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_lgwr_XE
+  cwd: /
+  pid: '23012'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_ckpt_XE
+  cwd: /
+  pid: '23015'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_smon_XE
+  cwd: /
+  pid: '23020'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_smco_XE
+  cwd: /
+  pid: '23023'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_reco_XE
+  cwd: /
+  pid: '23030'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_lreg_XE
+  cwd: /
+  pid: '23033'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pxmn_XE
+  cwd: /
+  pid: '23035'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mmon_XE
+  cwd: /
+  pid: '23041'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mmnl_XE
+  cwd: /
+  pid: '23045'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_bg00_XE
+  cwd: /
+  pid: '23049'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_d000_XE
+  cwd: /
+  pid: '23051'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w000_XE
+  cwd: /
+  pid: '23054'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_bg01_XE
+  cwd: /
+  pid: '23058'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_s000_XE
+  cwd: /
+  pid: '23060'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w001_XE
+  cwd: /
+  pid: '23063'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tmon_XE
+  cwd: /
+  pid: '23068'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt00_XE
+  cwd: /
+  pid: '23074'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt01_XE
+  cwd: /
+  pid: '23076'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt02_XE
+  cwd: /
+  pid: '23078'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_rcbg_XE
+  cwd: /
+  pid: '23098'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_aqpc_XE
+  cwd: /
+  pid: '23109'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w002_XE
+  cwd: /
+  pid: '23114'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w003_XE
+  cwd: /
+  pid: '23120'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w004_XE
+  cwd: /
+  pid: '23299'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_cjq0_XE
+  cwd: /
+  pid: '23309'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_qm02_XE
+  cwd: /
+  pid: '23311'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_q003_XE
+  cwd: /
+  pid: '23318'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_q005_XE
+  cwd: /
+  pid: '23374'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_cl00_XE
+  cwd: /
+  pid: '23486'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_m004_XE
+  cwd: /
+  pid: '24070'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w005_XE
+  cwd: /
+  pid: '24218'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w006_XE
+  cwd: /
+  pid: '24731'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w007_XE
+  cwd: /
+  pid: '24736'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_m000_XE
+  cwd: /
+  pid: '26069'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_m003_XE
+  cwd: /
+  pid: '26855'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '27532'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28851'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29511'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654769069
+  cwd: /usr/lib64/sa/
+  pid: '30393'
+  ppid: '14440'
+  user: root
+- cmdline: xe_m002_XE
+  cwd: /
+  pid: '30487'
+  ppid: '1'
+  user: oracle
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '30501'
+  ppid: '1103'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '30503'
+  ppid: '30501'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '30659'
+  ppid: '30503'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '30672'
+  ppid: '30659'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-goiszuyxzjhvlqbnwuwkryceqqdvlzyl ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '30673'
+  ppid: '30672'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654769106.30796-59484-219491293419514/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '30674'
+  ppid: '30673'
+  user: root
+software_list:
+- cmd_regexp: tnslsnr
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/oracle_listener.yaml'
+    name: Include Oracle Listener specific plugins
+  name: Oracle Listener
+  process_type: parent
+  return_children: false
+  return_packages: true
+  vars: {}
+tcp_listen:
+- address: 127.0.0.1
+  name: postgres
+  pid: 7291
+  port: 5432
+  protocol: tcp
+  stime: Fri Jun  3 09:22:29 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1058
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 14:45:01 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 1512
+  port: 12379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 1512
+  port: 12380
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: 192.168.0.26
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: 127.0.0.1
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: 0.0.0.0
+  name: sshd
+  pid: 1103
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: root
+- address: ::1
+  name: postgres
+  pid: 7291
+  port: 5432
+  protocol: tcp
+  stime: Fri Jun  3 09:22:29 2022
+  user: postgres
+- address: ::1
+  name: master
+  pid: 1058
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 14:45:01 2022
+  user: root
+- address: '::'
+  name: tnslsnr
+  pid: 22926
+  port: 5500
+  protocol: tcp
+  stime: Thu Jun  9 09:15:34 2022
+  user: oracle
+- address: '::'
+  name: java
+  pid: 881
+  port: 11870
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 4000
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: tnslsnr
+  pid: 22926
+  port: 1539
+  protocol: tcp
+  stime: Thu Jun  9 09:15:34 2022
+  user: oracle
+- address: 127.0.0.1
+  name: java
+  pid: 881
+  port: 8005
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 881
+  port: 8009
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: xe_d000_XE
+  pid: 23051
+  port: 21899
+  protocol: tcp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: ::1
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8080
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8081
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 881
+  port: 8082
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 881
+  port: 8050
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: sshd
+  pid: 1103
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: root
+udp_listen:
+- address: 127.0.0.1
+  name: chronyd
+  pid: 584
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 14:44:54 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 719
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 826
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 14:44:59 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 584
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 14:44:54 2022
+  user: chrony
+- address: ::1
+  name: xe_lreg_XE
+  pid: 23033
+  port: 33176
+  protocol: udp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 719
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: ::1
+  name: xe_s000_XE
+  pid: 23060
+  port: 64452
+  protocol: udp
+  stime: Thu Jun  9 09:15:38 2022
+  user: oracle
+- address: ::1
+  name: xe_d000_XE
+  pid: 23051
+  port: 32251
+  protocol: udp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8081
+  protocol: udp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/oracle_management_agent/oracle_management_agent12_centos7.7_5instances.yaml
+++ b/tests/unit/plugins/action/auto/resources/oracle_management_agent/oracle_management_agent12_centos7.7_5instances.yaml
@@ -1,10140 +1,11127 @@
-mocked_plugin_tasks:
-  Read env from process:
-    calls:
-      - expected_args:
-          pid: '13389'
-        plugin_result:
-          failed: false
-          parsed:
-            "ORACLE_HOME": "/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0"
-      - expected_args:
-          pid: '13482'
-        plugin_result:
-          failed: false
-          parsed:
-            "ORACLE_HOME": "/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0"
-
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 3872
-        protocol: 'tcp'
-    extra_data:
-      ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0
-    files:
-      - path: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0
-        subtype: generic
-        type: home
-    discovery_time: '2022-06-15T18:05:12+02:00'
-    listening_ports: [ 3872 ]
-    packages: [ ]
-    process:
-      cmdline: >-
-        /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/perl
-        /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/bin/emwd.pl
-        agent
-        /softOracle/app/oracle/product/12.1.0.4/agentes/gcinst/sysman/log/emagent.nohup
-      pid: '13389'
-      ppid: '1'
-      user: oracle
-    type: Oracle Management Agent
-    version:
-      - number: 12.1.0.4.0
-        type: file
-  - bindings:
-    - address: '0.0.0.0'
-      class: 'service'
-      port: 47632
-      protocol: 'tcp'
-    - address: '0.0.0.0'
-      class: 'service'
-      port: 3873
-      protocol: 'tcp'
-    - address: '0.0.0.0'
-      class: 'service'
-      port: 3873
-      protocol: 'udp'
-    extra_data:
-      ORACLE_HOME: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0
-    files:
-      - path: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0
-        subtype: generic
-        type: home
-    discovery_time: '2022-06-15T18:05:15+02:00'
-    listening_ports: [ 3873, 47632 ]
-    packages: [ ]
-    process:
-      cmdline: >-
-        /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
-        /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/bin/emwd.pl
-        agent
-        /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_inst/sysman/log/emagent.nohup
-      pid: '13482'
-      ppid: '1'
-      user: oracle
-    type: Oracle Management Agent
-    version:
-      - number: 13.4.0.0.0
-        type: file
-
-software_list:
-  - name: Oracle Management Agent
-    cmd_regexp: "emwd.pl agent"
-    process_type: parent
-    return_children: false
-    return_packages: true
-    vars: { }
-    custom_tasks:
-      - name: Include Oracle Management Agent specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/oracle_management_agent.yaml"
-
 dockers:
-  containers: [ ]
-packages:
-  AvamarClient:
-    - arch: x86_64
-      epoch: null
-      name: AvamarClient
-      release: '149'
-      source: rpm
-      version: 19.3.100
-  AvamarRMAN:
-    - arch: x86_64
-      epoch: null
-      name: AvamarRMAN
-      release: '149'
-      source: rpm
-      version: 19.3.100
-  BladeLogic_RSCD_Agent:
-    - arch: x86_64
-      epoch: null
-      name: BladeLogic_RSCD_Agent
-      release: '200'
-      source: rpm
-      version: 8.9.04
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
-  NetworkManager:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-config-server:
-    - arch: noarch
-      epoch: 1
-      name: NetworkManager-config-server
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-libnm:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-libnm
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-ppp:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-ppp
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-team:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-team
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  NetworkManager-tui:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-tui
-      release: 1.el7
-      source: rpm
-      version: 1.18.8
-  OpenIPMI:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
-  OpenIPMI-libs:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI-libs
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
-  OpenIPMI-modalias:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI-modalias
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
-  Red_Hat_Enterprise_Linux-Release_Notes-7-en-US:
-    - arch: noarch
-      epoch: null
-      name: Red_Hat_Enterprise_Linux-Release_Notes-7-en-US
-      release: 2.el7
-      source: rpm
-      version: '7'
-  TDP-Oracle:
-    - arch: x86_64
-      epoch: null
-      name: TDP-Oracle
-      release: '0'
-      source: rpm
-      version: 8.1.0
-  TDP-Oracle.Utility:
-    - arch: x86_64
-      epoch: null
-      name: TDP-Oracle.Utility
-      release: '0'
-      source: rpm
-      version: 8.1.0
-  TIVsm-API64:
-    - arch: x86_64
-      epoch: null
-      name: TIVsm-API64
-      release: '0'
-      source: rpm
-      version: 8.1.7
-  TIVsm-BA:
-    - arch: x86_64
-      epoch: null
-      name: TIVsm-BA
-      release: '0'
-      source: rpm
-      version: 8.1.7
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  adcli:
-    - arch: x86_64
-      epoch: null
-      name: adcli
-      release: 9.el7
-      source: rpm
-      version: 0.8.1
-  adobe-mappings-cmap:
-    - arch: noarch
-      epoch: null
-      name: adobe-mappings-cmap
-      release: 3.el7
-      source: rpm
-      version: '20171205'
-  adobe-mappings-cmap-deprecated:
-    - arch: noarch
-      epoch: null
-      name: adobe-mappings-cmap-deprecated
-      release: 3.el7
-      source: rpm
-      version: '20171205'
-  adobe-mappings-pdf:
-    - arch: noarch
-      epoch: null
-      name: adobe-mappings-pdf
-      release: 1.el7
-      source: rpm
-      version: '20180407'
-  aic94xx-firmware:
-    - arch: noarch
-      epoch: null
-      name: aic94xx-firmware
-      release: 6.el7
-      source: rpm
-      version: '30'
-  aide:
-    - arch: x86_64
-      epoch: null
-      name: aide
-      release: 13.el7_9.1
-      source: rpm
-      version: 0.15.1
-  alsa-firmware:
-    - arch: noarch
-      epoch: null
-      name: alsa-firmware
-      release: 2.el7
-      source: rpm
-      version: 1.0.28
-  alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
-  alsa-tools-firmware:
-    - arch: x86_64
-      epoch: null
-      name: alsa-tools-firmware
-      release: 1.el7
-      source: rpm
-      version: 1.1.0
-  at:
-    - arch: x86_64
-      epoch: null
-      name: at
-      release: 24.el7
-      source: rpm
-      version: 3.1.13
-  atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs:
-    - arch: i686
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autofs:
-    - arch: x86_64
-      epoch: 1
-      name: autofs
-      release: 106.el7
-      source: rpm
-      version: 5.0.7
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  avahi-autoipd:
-    - arch: x86_64
-      epoch: null
-      name: avahi-autoipd
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
-  avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
-  bash-completion:
-    - arch: noarch
-      epoch: 1
-      name: bash-completion
-      release: 6.el7
-      source: rpm
-      version: '2.1'
-  bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
-  biosdevname:
-    - arch: x86_64
-      epoch: null
-      name: biosdevname
-      release: 2.el7
-      source: rpm
-      version: 0.7.3
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2:
-    - arch: x86_64
-      epoch: null
-      name: bzip2
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  bzip2-libs:
-    - arch: i686
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  c-ares:
-    - arch: x86_64
-      epoch: null
-      name: c-ares
-      release: 3.el7
-      source: rpm
-      version: 1.10.0
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
-  cfg2html:
-    - arch: noarch
-      epoch: null
-      name: cfg2html
-      release: '151.1'
-      source: rpm
-      version: '6.30'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  compat-libcap1:
-    - arch: x86_64
-      epoch: null
-      name: compat-libcap1
-      release: 7.el7
-      source: rpm
-      version: '1.10'
-  compat-libstdc++-33:
-    - arch: i686
-      epoch: null
-      name: compat-libstdc++-33
-      release: 72.el7
-      source: rpm
-      version: 3.2.3
-    - arch: x86_64
-      epoch: null
-      name: compat-libstdc++-33
-      release: 72.el7
-      source: rpm
-      version: 3.2.3
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
-  cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-    - arch: i686
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.3
-  cups-client:
-    - arch: x86_64
-      epoch: 1
-      name: cups-client
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
-  cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-gssapi:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-gssapi
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 24.el7_9
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  desktop-file-utils:
-    - arch: x86_64
-      epoch: null
-      name: desktop-file-utils
-      release: 2.el7
-      source: rpm
-      version: '0.23'
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
-  device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
-  device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 2.el7
-      source: rpm
-      version: 1.02.158
-  device-mapper-multipath:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-multipath
-      release: 127.el7
-      source: rpm
-      version: 0.4.9
-  device-mapper-multipath-libs:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-multipath-libs
-      release: 127.el7
-      source: rpm
-      version: 0.4.9
-  device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 1.el7
-      source: rpm
-      version: 0.8.5
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7_9.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7_9.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7_9.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 3.el7
-      source: rpm
-      version: '3.2'
-  dnsmasq:
-    - arch: x86_64
-      epoch: null
-      name: dnsmasq
-      release: 16.el7_9.1
-      source: rpm
-      version: '2.76'
-  dosfstools:
-    - arch: x86_64
-      epoch: null
-      name: dosfstools
-      release: 10.el7
-      source: rpm
-      version: 3.0.20
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 564.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 564.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 564.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  ebtables:
-    - arch: x86_64
-      epoch: null
-      name: ebtables
-      release: 16.el7
-      source: rpm
-      version: 2.0.10
-  ed:
-    - arch: x86_64
-      epoch: null
-      name: ed
-      release: 4.el7
-      source: rpm
-      version: '1.9'
-  efibootmgr:
-    - arch: x86_64
-      epoch: null
-      name: efibootmgr
-      release: 2.el7
-      source: rpm
-      version: '17'
-  efivar-libs:
-    - arch: x86_64
-      epoch: null
-      name: efivar-libs
-      release: 12.el7
-      source: rpm
-      version: '36'
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: i686
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-    - arch: i686
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.176'
-  emacs-common:
-    - arch: x86_64
-      epoch: 1
-      name: emacs-common
-      release: 23.el7
-      source: rpm
-      version: '24.3'
-  emacs-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: emacs-filesystem
-      release: 23.el7
-      source: rpm
-      version: '24.3'
-  emacs-nox:
-    - arch: x86_64
-      epoch: 1
-      name: emacs-nox
-      release: 23.el7
-      source: rpm
-      version: '24.3'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 14.el7_9
-      source: rpm
-      version: 2.1.0
-  expect:
-    - arch: x86_64
-      epoch: null
-      name: expect
-      release: 14.el7_1
-      source: rpm
-      version: '5.45'
-  falcon-sensor:
-    - arch: x86_64
-      epoch: null
-      name: falcon-sensor
-      release: 10402.el7
-      source: rpm
-      version: 5.38.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 6.8.8
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  finger:
-    - arch: x86_64
-      epoch: null
-      name: finger
-      release: 52.el7
-      source: rpm
-      version: '0.17'
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  firewalld:
-    - arch: noarch
-      epoch: null
-      name: firewalld
-      release: 2.el7_7.1
-      source: rpm
-      version: 0.6.3
-  firewalld-filesystem:
-    - arch: noarch
-      epoch: null
-      name: firewalld-filesystem
-      release: 2.el7_7.1
-      source: rpm
-      version: 0.6.3
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  foomatic-filters:
-    - arch: x86_64
-      epoch: null
-      name: foomatic-filters
-      release: 9.el7
-      source: rpm
-      version: 4.0.9
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  ftp:
-    - arch: x86_64
-      epoch: null
-      name: ftp
-      release: 67.el7
-      source: rpm
-      version: '0.17'
-  fxload:
-    - arch: x86_64
-      epoch: null
-      name: fxload
-      release: 16.el7
-      source: rpm
-      version: '2002_04_11'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdbm-devel:
-    - arch: x86_64
-      epoch: null
-      name: gdbm-devel
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  ghostscript:
-    - arch: x86_64
-      epoch: null
-      name: ghostscript
-      release: 2.el7_7.3
-      source: rpm
-      version: '9.25'
-  ghostscript-fonts:
-    - arch: noarch
-      epoch: null
-      name: ghostscript-fonts
-      release: 32.el7
-      source: rpm
-      version: '5.50'
-  glib-networking:
-    - arch: x86_64
-      epoch: null
-      name: glib-networking
-      release: 1.el7
-      source: rpm
-      version: 2.56.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc-devel
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gnutls:
-    - arch: x86_64
-      epoch: null
-      name: gnutls
-      release: 9.el7_6
-      source: rpm
-      version: 3.3.29
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 45700c69
-      source: rpm
-      version: 2fa658e0
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 4ae0493b
-      source: rpm
-      version: fd431d51
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-efi-x64:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-efi-x64
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-efi-x64-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-efi-x64-modules
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7_9.6
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gsettings-desktop-schemas:
-    - arch: x86_64
-      epoch: null
-      name: gsettings-desktop-schemas
-      release: 3.el7
-      source: rpm
-      version: 3.28.0
-  gskcrypt64:
-    - arch: x86_64
-      epoch: null
-      name: gskcrypt64
-      release: '55.2'
-      source: rpm
-      version: '8.0'
-  gskssl64:
-    - arch: x86_64
-      epoch: null
-      name: gskssl64
-      release: '55.2'
-      source: rpm
-      version: '8.0'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 26.el7
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 5.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hesiod:
-    - arch: x86_64
-      epoch: null
-      name: hesiod
-      release: 3.el7
-      source: rpm
-      version: 3.2.1
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  http-parser:
-    - arch: x86_64
-      epoch: null
-      name: http-parser
-      release: 8.el7_7.2
-      source: rpm
-      version: 2.7.1
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.3.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.47
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iometrics-agent-plugin-oracle-lib-connector:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-lib-connector
-      release: '25'
-      source: rpm
-      version: 18.5.0_1.11.3
-  iometrics-agent-plugin-oracle-libs:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-libs
-      release: '1'
-      source: rpm
-      version: 18.5.0
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  ipmitool:
-    - arch: x86_64
-      epoch: null
-      name: ipmitool
-      release: 9.el7_7
-      source: rpm
-      version: 1.8.18
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 25.el7
-      source: rpm
-      version: 4.11.0
-  iprutils:
-    - arch: x86_64
-      epoch: null
-      name: iprutils
-      release: 2.el7
-      source: rpm
-      version: 2.4.17.1
-  ipset:
-    - arch: x86_64
-      epoch: null
-      name: ipset
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 33.el7
-      source: rpm
-      version: 1.4.21
-  iptables-services:
-    - arch: x86_64
-      epoch: null
-      name: iptables-services
-      release: 33.el7
-      source: rpm
-      version: 1.4.21
-  iptraf-ng:
-    - arch: x86_64
-      epoch: null
-      name: iptraf-ng
-      release: 7.el7
-      source: rpm
-      version: 1.1.4
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  ivtv-firmware:
-    - arch: noarch
-      epoch: 2
-      name: ivtv-firmware
-      release: 26.el7
-      source: rpm
-      version: '20080701'
-  iwl100-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl100-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
-  iwl1000-firmware:
-    - arch: noarch
-      epoch: 1
-      name: iwl1000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
-  iwl105-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl105-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl135-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl135-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl2000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl2030-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2030-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl3160-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3160-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
-  iwl3945-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3945-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 15.32.2.9
-  iwl4965-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl4965-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 228.61.2.24
-  iwl5000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.83.5.1_1
-  iwl5150-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5150-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.24.2.2
-  iwl6000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 9.221.4.1
-  iwl6000g2a-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2a-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl6000g2b-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2b-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl6050-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6050-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 41.28.5.1
-  iwl7260-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7260-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.59.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 33.el7
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 25.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 25.el7
-      source: rpm
-      version: '20'
-  kmod-oracleasm:
-    - arch: x86_64
-      epoch: null
-      name: kmod-oracleasm
-      release: 26.el7
-      source: rpm
-      version: 2.0.8
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 127.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  krb5-workstation:
-    - arch: x86_64
-      epoch: null
-      name: krb5-workstation
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  ksh:
-    - arch: x86_64
-      epoch: null
-      name: ksh
-      release: 142.el7
-      source: rpm
-      version: '20120801'
-  lcms2:
-    - arch: x86_64
-      epoch: null
-      name: lcms2
-      release: 3.el7
-      source: rpm
-      version: '2.6'
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: i686
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-    - arch: i686
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: i686
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-    - arch: i686
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXmu:
-    - arch: x86_64
-      epoch: null
-      name: libXmu
-      release: 2.el7
-      source: rpm
-      version: 1.1.2
-  libXp:
-    - arch: x86_64
-      epoch: null
-      name: libXp
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.2
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXt:
-    - arch: x86_64
-      epoch: null
-      name: libXt
-      release: 3.el7
-      source: rpm
-      version: 1.1.5
-  libXtst:
-    - arch: i686
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXv:
-    - arch: x86_64
-      epoch: null
-      name: libXv
-      release: 1.el7
-      source: rpm
-      version: 1.0.11
-  libXxf86dga:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86dga
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.4
-  libXxf86misc:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86misc
-      release: 7.1.el7
-      source: rpm
-      version: 1.0.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: i686
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libaio-devel:
-    - arch: i686
-      epoch: null
-      name: libaio-devel
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-    - arch: x86_64
-      epoch: null
-      name: libaio-devel
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: i686
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: i686
-      epoch: null
-      name: libcap
-      release: 10.el7
-      source: rpm
-      version: '2.22'
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 10.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-    - arch: i686
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcgroup-tools:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup-tools
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-    - arch: i686
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-devel:
-    - arch: x86_64
-      epoch: null
-      name: libdb-devel
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdhash:
-    - arch: x86_64
-      epoch: null
-      name: libdhash
-      release: 32.el7
-      source: rpm
-      version: 0.5.0
-  libdmx:
-    - arch: x86_64
-      epoch: null
-      name: libdmx
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-    - arch: i686
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-    - arch: i686
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libgs:
-    - arch: x86_64
-      epoch: null
-      name: libgs
-      release: 2.el7_7.3
-      source: rpm
-      version: '9.25'
-  libgudev1:
-    - arch: x86_64
-      epoch: null
-      name: libgudev1
-      release: 78.el7
-      source: rpm
-      version: '219'
-  libhugetlbfs:
-    - arch: x86_64
-      epoch: null
-      name: libhugetlbfs
-      release: 13.el7
-      source: rpm
-      version: '2.16'
-  libhugetlbfs-utils:
-    - arch: x86_64
-      epoch: null
-      name: libhugetlbfs-utils
-      release: 13.el7
-      source: rpm
-      version: '2.16'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libipa_hbac:
-    - arch: x86_64
-      epoch: null
-      name: libipa_hbac
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libkadm5:
-    - arch: x86_64
-      epoch: null
-      name: libkadm5
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  libldb:
-    - arch: x86_64
-      epoch: null
-      name: libldb
-      release: 2.el7_9
-      source: rpm
-      version: 1.5.4
-  liblockfile:
-    - arch: x86_64
-      epoch: null
-      name: liblockfile
-      release: 17.el7
-      source: rpm
-      version: '1.08'
-  libmng:
-    - arch: x86_64
-      epoch: null
-      name: libmng
-      release: 14.el7
-      source: rpm
-      version: 1.0.10
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmodman:
-    - arch: x86_64
-      epoch: null
-      name: libmodman
-      release: 8.el7
-      source: rpm
-      version: 2.0.1
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl:
-    - arch: x86_64
-      epoch: null
-      name: libnl
-      release: 3.el7
-      source: rpm
-      version: 1.1.4
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpaper:
-    - arch: x86_64
-      epoch: null
-      name: libpaper
-      release: 8.el7
-      source: rpm
-      version: 1.1.24
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 11.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpng12:
-    - arch: x86_64
-      epoch: null
-      name: libpng12
-      release: 10.el7
-      source: rpm
-      version: 1.2.50
-  libproxy:
-    - arch: x86_64
-      epoch: null
-      name: libproxy
-      release: 11.el7
-      source: rpm
-      version: 0.4.11
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  libsmbclient:
-    - arch: x86_64
-      epoch: 0
-      name: libsmbclient
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  libsoup:
-    - arch: x86_64
-      epoch: null
-      name: libsoup
-      release: 2.el7
-      source: rpm
-      version: 2.62.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libsss_autofs:
-    - arch: x86_64
-      epoch: null
-      name: libsss_autofs
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libsss_certmap:
-    - arch: x86_64
-      epoch: null
-      name: libsss_certmap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libsss_idmap:
-    - arch: x86_64
-      epoch: null
-      name: libsss_idmap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libsss_nss_idmap:
-    - arch: x86_64
-      epoch: null
-      name: libsss_nss_idmap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libsss_sudo:
-    - arch: x86_64
-      epoch: null
-      name: libsss_sudo
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++-devel
-      release: 39.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtalloc:
-    - arch: x86_64
-      epoch: null
-      name: libtalloc
-      release: 1.el7
-      source: rpm
-      version: 2.1.16
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libtdb:
-    - arch: x86_64
-      epoch: null
-      name: libtdb
-      release: 1.el7
-      source: rpm
-      version: 1.3.18
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 9.el7
-      source: rpm
-      version: '1.27'
-  libtevent:
-    - arch: x86_64
-      epoch: null
-      name: libtevent
-      release: 1.el7
-      source: rpm
-      version: 0.9.39
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-tevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-tevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwbclient:
-    - arch: x86_64
-      epoch: 0
-      name: libwbclient
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-    - arch: i686
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lm_sensors:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 13.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lsscsi:
-    - arch: x86_64
-      epoch: null
-      name: lsscsi
-      release: 6.el7
-      source: rpm
-      version: '0.27'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 2.el7
-      source: rpm
-      version: 2.02.185
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 2.el7
-      source: rpm
-      version: 2.02.185
-  lz4:
-    - arch: i686
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  m2crypto:
-    - arch: x86_64
-      epoch: null
-      name: m2crypto
-      release: 17.el7
-      source: rpm
-      version: 0.21.1
-  m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  mailx:
-    - arch: x86_64
-      epoch: null
-      name: mailx
-      release: 19.el7
-      source: rpm
-      version: '12.5'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
-  mesa-libGLU:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGLU
-      release: 4.el7
-      source: rpm
-      version: 9.0.0
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 5.el7
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mlocate:
-    - arch: x86_64
-      epoch: null
-      name: mlocate
-      release: 8.el7
-      source: rpm
-      version: '0.26'
-  mokutil:
-    - arch: x86_64
-      epoch: null
-      name: mokutil
-      release: 8.el7_8
-      source: rpm
-      version: '15'
-  motif:
-    - arch: x86_64
-      epoch: null
-      name: motif
-      release: 14.el7_5
-      source: rpm
-      version: 2.3.4
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-utils:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-utils
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  nettle:
-    - arch: x86_64
-      epoch: null
-      name: nettle
-      release: 9.el7_9
-      source: rpm
-      version: 2.7.1
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.65.el7
-      source: rpm
-      version: 1.3.0
-  nscd:
-    - arch: x86_64
-      epoch: null
-      name: nscd
-      release: 322.el7_9
-      source: rpm
-      version: '2.17'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7_8.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7_8.2
-      source: rpm
-      version: 4.2.6p5
-  numactl:
-    - arch: x86_64
-      epoch: null
-      name: numactl
-      release: 3.el7
-      source: rpm
-      version: 2.0.12
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.12
-  numad:
-    - arch: x86_64
-      epoch: null
-      name: numad
-      release: 18.20150602git.el7
-      source: rpm
-      version: '0.5'
-  oddjob:
-    - arch: x86_64
-      epoch: null
-      name: oddjob
-      release: 4.el7
-      source: rpm
-      version: 0.31.5
-  oddjob-mkhomedir:
-    - arch: x86_64
-      epoch: null
-      name: oddjob-mkhomedir
-      release: 4.el7
-      source: rpm
-      version: 0.31.5
-  openjpeg2:
-    - arch: x86_64
-      epoch: null
-      name: openjpeg2
-      release: 3.el7_7
-      source: rpm
-      version: 2.3.1
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 25.el7_9
-      source: rpm
-      version: 2.4.44
-  openldap-clients:
-    - arch: x86_64
-      epoch: null
-      name: openldap-clients
-      release: 25.el7_9
-      source: rpm
-      version: 2.4.44
-  openscap:
-    - arch: x86_64
-      epoch: null
-      name: openscap
-      release: 4.el7
-      source: rpm
-      version: 1.2.17
-  openscap-scanner:
-    - arch: x86_64
-      epoch: null
-      name: openscap-scanner
-      release: 4.el7
-      source: rpm
-      version: 1.2.17
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 25.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 25.el7_9
-      source: rpm
-      version: 1.0.2k
-  oracleasm-support:
-    - arch: x86_64
-      epoch: null
-      name: oracleasm-support
-      release: 3.el7
-      source: rpm
-      version: 2.1.8
-  oracleasmlib:
-    - arch: x86_64
-      epoch: null
-      name: oracleasmlib
-      release: 1.el7
-      source: rpm
-      version: 2.0.12
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-    - arch: i686
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  pam-devel:
-    - arch: x86_64
-      epoch: null
-      name: pam-devel
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 31.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 5.el7
-      source: rpm
-      version: '0.79'
-  patch:
-    - arch: x86_64
-      epoch: null
-      name: patch
-      release: 12.el7_7
-      source: rpm
-      version: 2.7.1
-  pciutils:
-    - arch: x86_64
-      epoch: null
-      name: pciutils
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: i686
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-B-Lint:
-    - arch: noarch
-      epoch: null
-      name: perl-B-Lint
-      release: 3.el7
-      source: rpm
-      version: '1.17'
-  perl-Business-ISBN:
-    - arch: noarch
-      epoch: null
-      name: perl-Business-ISBN
-      release: 2.el7
-      source: rpm
-      version: '2.06'
-  perl-Business-ISBN-Data:
-    - arch: noarch
-      epoch: null
-      name: perl-Business-ISBN-Data
-      release: 2.el7
-      source: rpm
-      version: '20120719.001'
-  perl-CGI:
-    - arch: noarch
-      epoch: null
-      name: perl-CGI
-      release: 4.el7
-      source: rpm
-      version: '3.63'
-  perl-CPAN:
-    - arch: noarch
-      epoch: 0
-      name: perl-CPAN
-      release: 299.el7_9
-      source: rpm
-      version: '1.9800'
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Class-ISA:
-    - arch: noarch
-      epoch: null
-      name: perl-Class-ISA
-      release: 1010.el7
-      source: rpm
-      version: '0.36'
-  perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
-  perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Digest:
-    - arch: noarch
-      epoch: null
-      name: perl-Digest
-      release: 245.el7
-      source: rpm
-      version: '1.17'
-  perl-Digest-MD5:
-    - arch: x86_64
-      epoch: null
-      name: perl-Digest-MD5
-      release: 3.el7
-      source: rpm
-      version: '2.52'
-  perl-Digest-SHA:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Digest-SHA
-      release: 4.el7
-      source: rpm
-      version: '5.85'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Encode-Locale:
-    - arch: noarch
-      epoch: null
-      name: perl-Encode-Locale
-      release: 5.el7
-      source: rpm
-      version: '1.03'
-  perl-Env:
-    - arch: noarch
-      epoch: null
-      name: perl-Env
-      release: 2.el7
-      source: rpm
-      version: '1.04'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-ExtUtils-Install:
-    - arch: noarch
-      epoch: 0
-      name: perl-ExtUtils-Install
-      release: 299.el7_9
-      source: rpm
-      version: '1.58'
-  perl-ExtUtils-MakeMaker:
-    - arch: noarch
-      epoch: null
-      name: perl-ExtUtils-MakeMaker
-      release: 3.el7
-      source: rpm
-      version: '6.68'
-  perl-ExtUtils-Manifest:
-    - arch: noarch
-      epoch: null
-      name: perl-ExtUtils-Manifest
-      release: 244.el7
-      source: rpm
-      version: '1.61'
-  perl-ExtUtils-ParseXS:
-    - arch: noarch
-      epoch: 1
-      name: perl-ExtUtils-ParseXS
-      release: 3.el7
-      source: rpm
-      version: '3.18'
-  perl-FCGI:
-    - arch: x86_64
-      epoch: 1
-      name: perl-FCGI
-      release: 8.el7
-      source: rpm
-      version: '0.74'
-  perl-File-CheckTree:
-    - arch: noarch
-      epoch: null
-      name: perl-File-CheckTree
-      release: 3.el7
-      source: rpm
-      version: '4.42'
-  perl-File-Listing:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Listing
-      release: 7.el7
-      source: rpm
-      version: '6.04'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTML-Parser:
-    - arch: x86_64
-      epoch: null
-      name: perl-HTML-Parser
-      release: 4.el7
-      source: rpm
-      version: '3.71'
-  perl-HTML-Tagset:
-    - arch: noarch
-      epoch: null
-      name: perl-HTML-Tagset
-      release: 15.el7
-      source: rpm
-      version: '3.20'
-  perl-HTTP-Cookies:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Cookies
-      release: 5.el7
-      source: rpm
-      version: '6.01'
-  perl-HTTP-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Daemon
-      release: 8.el7
-      source: rpm
-      version: '6.01'
-  perl-HTTP-Date:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Date
-      release: 8.el7
-      source: rpm
-      version: '6.02'
-  perl-HTTP-Message:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Message
-      release: 6.el7
-      source: rpm
-      version: '6.06'
-  perl-HTTP-Negotiate:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Negotiate
-      release: 5.el7
-      source: rpm
-      version: '6.01'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
-  perl-IO-HTML:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-HTML
-      release: 2.el7
-      source: rpm
-      version: '1.00'
-  perl-IO-Socket-IP:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Socket-IP
-      release: 5.el7
-      source: rpm
-      version: '0.21'
-  perl-IO-Socket-SSL:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Socket-SSL
-      release: 7.el7
-      source: rpm
-      version: '1.94'
-  perl-LWP-MediaTypes:
-    - arch: noarch
-      epoch: null
-      name: perl-LWP-MediaTypes
-      release: 2.el7
-      source: rpm
-      version: '6.02'
-  perl-Locale-Codes:
-    - arch: noarch
-      epoch: null
-      name: perl-Locale-Codes
-      release: 2.el7
-      source: rpm
-      version: '3.26'
-  perl-Locale-Maketext:
-    - arch: noarch
-      epoch: null
-      name: perl-Locale-Maketext
-      release: 3.el7
-      source: rpm
-      version: '1.23'
-  perl-Module-Pluggable:
-    - arch: noarch
-      epoch: 1
-      name: perl-Module-Pluggable
-      release: 3.el7
-      source: rpm
-      version: '4.8'
-  perl-Mozilla-CA:
-    - arch: noarch
-      epoch: null
-      name: perl-Mozilla-CA
-      release: 5.el7
-      source: rpm
-      version: '20130114'
-  perl-Net-HTTP:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-HTTP
-      release: 2.el7
-      source: rpm
-      version: '6.06'
-  perl-Net-LibIDN:
-    - arch: x86_64
-      epoch: null
-      name: perl-Net-LibIDN
-      release: 15.el7
-      source: rpm
-      version: '0.12'
-  perl-Net-SSLeay:
-    - arch: x86_64
-      epoch: null
-      name: perl-Net-SSLeay
-      release: 6.el7
-      source: rpm
-      version: '1.55'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Checker:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Checker
-      release: 2.el7
-      source: rpm
-      version: '1.60'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-LaTeX:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-LaTeX
-      release: 2.el7
-      source: rpm
-      version: '0.61'
-  perl-Pod-Parser:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Parser
-      release: 2.el7
-      source: rpm
-      version: '1.61'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Plainer:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Plainer
-      release: 4.el7
-      source: rpm
-      version: '1.03'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 4.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Sys-Syslog:
-    - arch: x86_64
-      epoch: null
-      name: perl-Sys-Syslog
-      release: 3.el7
-      source: rpm
-      version: '0.33'
-  perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
-  perl-Test-Simple:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Simple
-      release: 243.el7
-      source: rpm
-      version: '0.98'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Text-Soundex:
-    - arch: x86_64
-      epoch: null
-      name: perl-Text-Soundex
-      release: 4.el7
-      source: rpm
-      version: '3.04'
-  perl-Text-Unidecode:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-Unidecode
-      release: 20.el7
-      source: rpm
-      version: '0.04'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-TimeDate:
-    - arch: noarch
-      epoch: 1
-      name: perl-TimeDate
-      release: 2.el7
-      source: rpm
-      version: '2.30'
-  perl-URI:
-    - arch: noarch
-      epoch: null
-      name: perl-URI
-      release: 9.el7
-      source: rpm
-      version: '1.60'
-  perl-WWW-RobotRules:
-    - arch: noarch
-      epoch: null
-      name: perl-WWW-RobotRules
-      release: 5.el7
-      source: rpm
-      version: '6.02'
-  perl-XML-LibXML:
-    - arch: x86_64
-      epoch: 1
-      name: perl-XML-LibXML
-      release: 5.el7
-      source: rpm
-      version: '2.0018'
-  perl-XML-NamespaceSupport:
-    - arch: noarch
-      epoch: null
-      name: perl-XML-NamespaceSupport
-      release: 10.el7
-      source: rpm
-      version: '1.11'
-  perl-XML-SAX:
-    - arch: noarch
-      epoch: null
-      name: perl-XML-SAX
-      release: 9.el7
-      source: rpm
-      version: '0.99'
-  perl-XML-SAX-Base:
-    - arch: noarch
-      epoch: null
-      name: perl-XML-SAX-Base
-      release: 7.el7
-      source: rpm
-      version: '1.08'
-  perl-autodie:
-    - arch: noarch
-      epoch: null
-      name: perl-autodie
-      release: 2.el7
-      source: rpm
-      version: '2.16'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-devel:
-    - arch: x86_64
-      epoch: 4
-      name: perl-devel
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-libwww-perl:
-    - arch: noarch
-      epoch: null
-      name: perl-libwww-perl
-      release: 2.el7
-      source: rpm
-      version: '6.05'
-  perl-local-lib:
-    - arch: noarch
-      epoch: null
-      name: perl-local-lib
-      release: 4.el7
-      source: rpm
-      version: '1.008010'
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  plymouth:
-    - arch: x86_64
-      epoch: null
-      name: plymouth
-      release: 0.32.20140113.el7
-      source: rpm
-      version: 0.8.9
-  plymouth-core-libs:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-core-libs
-      release: 0.32.20140113.el7
-      source: rpm
-      version: 0.8.9
-  plymouth-scripts:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-scripts
-      release: 0.32.20140113.el7
-      source: rpm
-      version: 0.8.9
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 33.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 33.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  poppler-data:
-    - arch: noarch
-      epoch: null
-      name: poppler-data
-      release: 3.el7
-      source: rpm
-      version: 0.4.6
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  powertop:
-    - arch: x86_64
-      epoch: null
-      name: powertop
-      release: 1.el7
-      source: rpm
-      version: '2.9'
-  ppp:
-    - arch: x86_64
-      epoch: null
-      name: ppp
-      release: 34.el7_7
-      source: rpm
-      version: 2.4.5
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 26.el7
-      source: rpm
-      version: 3.3.10
-  psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 16.el7
-      source: rpm
-      version: '22.20'
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pyOpenSSL:
-    - arch: x86_64
-      epoch: null
-      name: pyOpenSSL
-      release: 4.el7
-      source: rpm
-      version: 0.13.1
-  pygobject2:
-    - arch: x86_64
-      epoch: null
-      name: pygobject2
-      release: 11.el7
-      source: rpm
-      version: 2.28.6
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyldb:
-    - arch: x86_64
-      epoch: null
-      name: pyldb
-      release: 2.el7_9
-      source: rpm
-      version: 1.5.4
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyparsing:
-    - arch: noarch
-      epoch: null
-      name: pyparsing
-      release: 9.el7
-      source: rpm
-      version: 1.5.6
-  pytalloc:
-    - arch: x86_64
-      epoch: null
-      name: pytalloc
-      release: 1.el7
-      source: rpm
-      version: 2.1.16
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-dateutil:
-    - arch: noarch
-      epoch: null
-      name: python-dateutil
-      release: 7.el7
-      source: rpm
-      version: '1.5'
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-dmidecode:
-    - arch: x86_64
-      epoch: null
-      name: python-dmidecode
-      release: 3.el7
-      source: rpm
-      version: 3.12.2
-  python-ethtool:
-    - arch: x86_64
-      epoch: null
-      name: python-ethtool
-      release: 8.el7
-      source: rpm
-      version: '0.8'
-  python-firewall:
-    - arch: noarch
-      epoch: null
-      name: python-firewall
-      release: 2.el7_7.1
-      source: rpm
-      version: 0.6.3
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-gudev:
-    - arch: x86_64
-      epoch: null
-      name: python-gudev
-      release: 7.el7
-      source: rpm
-      version: '147.2'
-  python-hwdata:
-    - arch: noarch
-      epoch: null
-      name: python-hwdata
-      release: 4.el7
-      source: rpm
-      version: 1.7.3
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-inotify:
-    - arch: noarch
-      epoch: null
-      name: python-inotify
-      release: 4.el7
-      source: rpm
-      version: 0.9.4
-  python-ipaddr:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddr
-      release: 2.el7
-      source: rpm
-      version: 2.1.11
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-magic:
-    - arch: noarch
-      epoch: null
-      name: python-magic
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.62.1.el7
-      source: rpm
-      version: 3.10.0
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-slip:
-    - arch: noarch
-      epoch: null
-      name: python-slip
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-slip-dbus:
-    - arch: noarch
-      epoch: null
-      name: python-slip-dbus
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-sssdconfig:
-    - arch: noarch
-      epoch: null
-      name: python-sssdconfig
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  python-syspurpose:
-    - arch: x86_64
-      epoch: null
-      name: python-syspurpose
-      release: 3.el7_7
-      source: rpm
-      version: 1.24.13
-  python-tdb:
-    - arch: x86_64
-      epoch: null
-      name: python-tdb
-      release: 1.el7
-      source: rpm
-      version: 1.3.18
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python2-futures:
-    - arch: noarch
-      epoch: null
-      name: python2-futures
-      release: 5.el7
-      source: rpm
-      version: 3.1.1
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_8
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  qt:
-    - arch: x86_64
-      epoch: 1
-      name: qt
-      release: 9.el7_9
-      source: rpm
-      version: 4.8.7
-  qt-settings:
-    - arch: noarch
-      epoch: null
-      name: qt-settings
-      release: 23.10.el7_7
-      source: rpm
-      version: '19'
-  qt-x11:
-    - arch: x86_64
-      epoch: 1
-      name: qt-x11
-      release: 9.el7_9
-      source: rpm
-      version: 4.8.7
-  qt3:
-    - arch: x86_64
-      epoch: null
-      name: qt3
-      release: 51.el7
-      source: rpm
-      version: 3.3.8b
-  qualys-cloud-agent:
-    - arch: x86_64
-      epoch: null
-      name: qualys-cloud-agent
-      release: '49'
-      source: rpm
-      version: 4.8.0
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  rdma-core:
-    - arch: i686
-      epoch: null
-      name: rdma-core
-      release: 3.el7
-      source: rpm
-      version: '22.1'
-    - arch: x86_64
-      epoch: null
-      name: rdma-core
-      release: 3.el7
-      source: rpm
-      version: '22.1'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  realmd:
-    - arch: x86_64
-      epoch: null
-      name: realmd
-      release: 11.el7
-      source: rpm
-      version: 0.16.1
-  redhat-logos:
-    - arch: noarch
-      epoch: null
-      name: redhat-logos
-      release: 1.el7
-      source: rpm
-      version: 70.7.0
-  redhat-lsb:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-core:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-core
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-cxx:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-cxx
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-desktop:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-desktop
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-languages:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-languages
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-printing:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-printing
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-submod-multimedia:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-submod-multimedia
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-lsb-submod-security:
-    - arch: x86_64
-      epoch: null
-      name: redhat-lsb-submod-security
-      release: 27.el7
-      source: rpm
-      version: '4.1'
-  redhat-release-server:
-    - arch: x86_64
-      epoch: null
-      name: redhat-release-server
-      release: 10.el7
-      source: rpm
-      version: '7.7'
-  redhat-support-lib-python:
-    - arch: noarch
-      epoch: null
-      name: redhat-support-lib-python
-      release: 6.el7
-      source: rpm
-      version: 0.9.7
-  redhat-support-tool:
-    - arch: noarch
-      epoch: null
-      name: redhat-support-tool
-      release: 1.el7
-      source: rpm
-      version: 0.9.11
-  rhn-client-tools:
-    - arch: x86_64
-      epoch: null
-      name: rhn-client-tools
-      release: 24.el7
-      source: rpm
-      version: 2.0.2
-  rhnlib:
-    - arch: noarch
-      epoch: null
-      name: rhnlib
-      release: 8.el7
-      source: rpm
-      version: 2.5.65
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 48.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 52.el7
-      source: rpm
-      version: 8.24.0
-  samba-client-libs:
-    - arch: x86_64
-      epoch: 0
-      name: samba-client-libs
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  samba-common:
-    - arch: noarch
-      epoch: 0
-      name: samba-common
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  samba-common-libs:
-    - arch: x86_64
-      epoch: 0
-      name: samba-common-libs
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  samba-common-tools:
-    - arch: x86_64
-      epoch: 0
-      name: samba-common-tools
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  samba-libs:
-    - arch: x86_64
-      epoch: 0
-      name: samba-libs
-      release: 18.el7_9
-      source: rpm
-      version: 4.10.16
-  scap-security-guide:
-    - arch: noarch
-      epoch: null
-      name: scap-security-guide
-      release: 13.el7
-      source: rpm
-      version: 0.1.43
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 252.el7.1
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 252.el7.1
-      source: rpm
-      version: 3.13.1
-  setools-console:
-    - arch: x86_64
-      epoch: null
-      name: setools-console
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 18.el7_7.1
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 18.el7_7.1
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  shim-unsigned:
-    - arch: x86_64
-      epoch: null
-      name: shim-unsigned
-      release: 1.el7
-      source: rpm
-      version: '0.9'
-  shim-x64:
-    - arch: x86_64
-      epoch: null
-      name: shim-x64
-      release: 8.el7_8
-      source: rpm
-      version: '15'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smartmontools:
-    - arch: x86_64
-      epoch: 1
-      name: smartmontools
-      release: 1.el7
-      source: rpm
-      version: '7.0'
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sos:
-    - arch: noarch
-      epoch: null
-      name: sos
-      release: 6.el7_7
-      source: rpm
-      version: '3.7'
-  spax:
-    - arch: x86_64
-      epoch: null
-      name: spax
-      release: 13.el7
-      source: rpm
-      version: 1.5.2
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sssd:
-    - arch: x86_64
-      epoch: null
-      name: sssd
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-ad:
-    - arch: x86_64
-      epoch: null
-      name: sssd-ad
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-client:
-    - arch: x86_64
-      epoch: null
-      name: sssd-client
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-common:
-    - arch: x86_64
-      epoch: null
-      name: sssd-common
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-common-pac:
-    - arch: x86_64
-      epoch: null
-      name: sssd-common-pac
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-ipa:
-    - arch: x86_64
-      epoch: null
-      name: sssd-ipa
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-krb5:
-    - arch: x86_64
-      epoch: null
-      name: sssd-krb5
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-krb5-common:
-    - arch: x86_64
-      epoch: null
-      name: sssd-krb5-common
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-ldap:
-    - arch: x86_64
-      epoch: null
-      name: sssd-ldap
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  sssd-proxy:
-    - arch: x86_64
-      epoch: null
-      name: sssd-proxy
-      release: 10.el7_9.10
-      source: rpm
-      version: 1.16.5
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 9.el7
-      source: rpm
-      version: '4.12'
-  subscription-manager:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager
-      release: 1.el7
-      source: rpm
-      version: 1.24.26
-  subscription-manager-rhsm:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm
-      release: 1.el7
-      source: rpm
-      version: 1.24.26
-  subscription-manager-rhsm-certificates:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm-certificates
-      release: 1.el7
-      source: rpm
-      version: 1.24.26
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.1
-      source: rpm
-      version: 1.8.23
-  sysfsutils:
-    - arch: x86_64
-      epoch: null
-      name: sysfsutils
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 18.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7
-      source: rpm
-      version: '219'
-    - arch: i686
-      epoch: null
-      name: systemd-libs
-      release: 78.el7
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7
-      source: rpm
-      version: '219'
-  systemtap-sdt-devel:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-sdt-devel
-      release: 9.el7
-      source: rpm
-      version: '4.0'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcl:
-    - arch: x86_64
-      epoch: 1
-      name: tcl
-      release: 8.el7
-      source: rpm
-      version: 8.5.13
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 9.el7
-      source: rpm
-      version: '1.27'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 65.el7_8
-      source: rpm
-      version: '0.17'
-  time:
-    - arch: x86_64
-      epoch: null
-      name: time
-      release: 45.el7
-      source: rpm
-      version: '1.7'
-  tk:
-    - arch: x86_64
-      epoch: 1
-      name: tk
-      release: 6.el7
-      source: rpm
-      version: 8.5.13
-  traceroute:
-    - arch: x86_64
-      epoch: 3
-      name: traceroute
-      release: 2.el7
-      source: rpm
-      version: 2.0.22
-  tree:
-    - arch: x86_64
-      epoch: null
-      name: tree
-      release: 10.el7
-      source: rpm
-      version: 1.6.0
-  trousers:
-    - arch: x86_64
-      epoch: null
-      name: trousers
-      release: 2.el7
-      source: rpm
-      version: 0.3.14
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 5.el7_7.1
-      source: rpm
-      version: 2.11.0
-  tuned-utils:
-    - arch: noarch
-      epoch: null
-      name: tuned-utils
-      release: 5.el7_7.1
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019c
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
-  urw-base35-bookman-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-bookman-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-c059-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-c059-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-d050000l-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-d050000l-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-fonts-common
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-gothic-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-gothic-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-nimbus-mono-ps-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-nimbus-mono-ps-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-nimbus-roman-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-nimbus-roman-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-nimbus-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-nimbus-sans-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-p052-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-p052-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-standard-symbols-ps-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-standard-symbols-ps-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  urw-base35-z003-fonts:
-    - arch: noarch
-      epoch: null
-      name: urw-base35-z003-fonts
-      release: 10.el7
-      source: rpm
-      version: '20170801'
-  usermode:
-    - arch: x86_64
-      epoch: null
-      name: usermode
-      release: 6.el7
-      source: rpm
-      version: '1.111'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 61.el7
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xdg-utils:
-    - arch: noarch
-      epoch: null
-      name: xdg-utils
-      release: 0.17.20120809git.el7
-      source: rpm
-      version: 1.1.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 20.el7
-      source: rpm
-      version: 4.5.0
-  xinetd:
-    - arch: x86_64
-      epoch: 2
-      name: xinetd
-      release: 13.el7
-      source: rpm
-      version: 2.3.15
-  xml-common:
-    - arch: noarch
-      epoch: null
-      name: xml-common
-      release: 39.el7
-      source: rpm
-      version: 0.6.3
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-server-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-server-utils
-      release: 20.el7
-      source: rpm
-      version: '7.7'
-  xorg-x11-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-utils
-      release: 23.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-xauth:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-xauth
-      release: 1.el7
-      source: rpm
-      version: 1.0.9
-  xorg-x11-xbitmaps:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-xbitmaps
-      release: 6.el7
-      source: rpm
-      version: 1.1.1
-  xorg-x11-xinit:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-xinit
-      release: 2.el7
-      source: rpm
-      version: 1.3.4
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-    - arch: i686
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 163.el7
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 52.el7
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: i686
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '54'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '63'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '64'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '66'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '67'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '71'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '72'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '73'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '74'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '77'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '78'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '81'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '82'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '83'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '84'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '86'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '88'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '89'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '90'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '91'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '92'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '93'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '94'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '95'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '96'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '97'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '98'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '99'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '105'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '106'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '107'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '108'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '118'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '119'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '121'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '123'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '137'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '176'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '365'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '366'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '367'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '369'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '370'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '371'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '373'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '413'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '414'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '512'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '612'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '613'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '624'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '625'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '638'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '639'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '640'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '641'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '642'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '643'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '644'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '645'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '646'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '647'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '648'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '649'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '732'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '765'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '768'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '810'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '811'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '812'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '813'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '814'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1167'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1168'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1169'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1170'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1171'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1172'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1184'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1185'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1186'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1188'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1195'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1196'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1197'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1198'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1199'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1200'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1201'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1202'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1204'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1205'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1207'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1208'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1210'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1211'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1213'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1214'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1217'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1218'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1219'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1222'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1224'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1225'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1227'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1228'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1237'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1238'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1240'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1241'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1243'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1244'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1246'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1247'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1258'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1259'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1260'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1261'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1262'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1263'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1271'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1273'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1274'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1275'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1277'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1278'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1279'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1280'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1281'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1282'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1283'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1294'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1297'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1298'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1299'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1300'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1301'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1302'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1303'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1304'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1311'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1312'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1313'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1315'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1316'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1318'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1319'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1321'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1322'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1324'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1325'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1326'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1329'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1330'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1331'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1332'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1333'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1334'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1335'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1350'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1351'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1353'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1354'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1355'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1356'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1357'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1358'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1359'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1360'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1361'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1362'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1363'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1364'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1365'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1366'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1367'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1368'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1370'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1371'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1372'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1373'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1374'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1375'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1385'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1386'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1387'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1388'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1389'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1401'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1402'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1403'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1404'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1405'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1406'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1413'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1414'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1415'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1416'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1417'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1418'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1419'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1420'
-    ppid: '2'
-    user: root
-  - cmdline: /opt/CrowdStrike/falcond
-    pid: '1436'
-    ppid: '1'
-    user: root
-  - cmdline: falcon-sensor
-    pid: '1438'
-    ppid: '1436'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '1448'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '1494'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '1499'
-    ppid: '1'
-    user: polkitd
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '1500'
-    ppid: '1'
-    user: dbus
-  - cmdline: '/usr/sbin/ntpd -u ntp:ntp -u ntp:ntp -p /var/run/ntpd.pid -g'
-    pid: '1514'
-    ppid: '1'
-    user: ntp
-  - cmdline: /usr/sbin/NetworkManager --no-daemon
-    pid: '1516'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sssd -i --logger=files
-    pid: '1520'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/rpcbind -w
-    pid: '1564'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/nscd
-    pid: '1597'
-    ppid: '1'
-    user: nscd
-  - cmdline: >-
-      /usr/libexec/sssd/sssd_be --domain ES.WCORP.CARREFOUR.COM --uid 0 --gid 0
-      --logger=files
-    pid: '2392'
-    ppid: '1520'
-    user: root
-  - cmdline: >-
-      /usr/local/avamar/bin/avagent.bin --bindir="/usr/local/avamar/bin"
-      --vardir="/usr/local/avamar/var" --sysdir="/usr/local/avamar/etc"
-      --logfile="/usr/local/avamar/var/avagent.log"
-    pid: '2479'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/vmtoolsd
-    pid: '2490'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/vmware-vgauth/VGAuthService -s
-    pid: '2583'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
-    pid: '2697'
-    ppid: '1520'
-    user: root
-  - cmdline: /usr/libexec/sssd/sssd_pam --uid 0 --gid 0 --logger=files
-    pid: '2698'
-    ppid: '1520'
-    user: root
-  - cmdline: /usr/libexec/sssd/sssd_pac --uid 0 --gid 0 --logger=files
-    pid: '2699'
-    ppid: '1520'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '2722'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/atd -f
-    pid: '2731'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '2735'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '2743'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '2882'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '2884'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '2888'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/share/filebeat/bin/filebeat -c /etc/filebeat/filebeat.yml -path.home
-      /usr/share/filebeat -path.config /etc/filebeat -path.data
-      /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '2891'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh /etc/init.d/init.ohasd run >/dev/null 2>&1 </dev/null
-    pid: '2892'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '2893'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/local/qualys/cloud-agent/bin/qualys-cloud-agent
-    pid: '2907'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/rhsmcertd
-    pid: '2909'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/xinetd -stayalive -pidfile /var/run/xinetd.pid
-    pid: '2919'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm.opt
-    pid: '3268'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '3451'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '3539'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '3568'
-    ppid: '3539'
-    user: postfix
-  - cmdline: bin/rscw
-    pid: '4017'
-    ppid: '1'
-    user: root
-  - cmdline: bin/rscd
-    pid: '4019'
-    ppid: '4017'
-    user: root
-  - cmdline: bin/rscd
-    pid: '4020'
-    ppid: '4017'
-    user: root
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_ARSYS.opt
-      -pass
-    pid: '5787'
-    ppid: '1'
-    user: root
-  - cmdline: ora_o001_BSAREP
-    pid: '7109'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o001_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '7111'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_w005_BSAREP
-    pid: '8166'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w004_BSAAPP
-    pid: '8584'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BNABBDD.opt
-      -pass
-    pid: '9365'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '10723'
-    ppid: '2'
-    user: root
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '11271'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAAPP.opt
-      -pass
-    pid: '11643'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /opt/tivoli/tsm/client/ba/bin/dsmc sched
-      -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAREP.opt
-      -pass
-    pid: '12211'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/perl
+  containers: []
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 3872
+    protocol: tcp
+  discovery_time: '2022-06-15T18:05:12+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0
+  files:
+  - path: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0
+    subtype: generic
+    type: home
+  listening_ports:
+  - 3872
+  packages: []
+  process:
+    cmdline: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/perl
       /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/bin/emwd.pl
-      agent
-      /softOracle/app/oracle/product/12.1.0.4/agentes/gcinst/sysman/log/emagent.nohup
+      agent /softOracle/app/oracle/product/12.1.0.4/agentes/gcinst/sysman/log/emagent.nohup
+    cwd: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/
     pid: '13389'
     ppid: '1'
     user: oracle
-  - cmdline: >-
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
+  type: Oracle Management Agent
+  version:
+  - number: 12.1.0.4.0
+    type: file
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 47632
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 3873
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 3873
+    protocol: udp
+  discovery_time: '2022-06-15T18:05:15+02:00'
+  extra_data:
+    ORACLE_HOME: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0
+  files:
+  - path: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0
+    subtype: generic
+    type: home
+  listening_ports:
+  - 3873
+  - 47632
+  packages: []
+  process:
+    cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
       /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/bin/emwd.pl
-      agent
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_inst/sysman/log/emagent.nohup
+      agent /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_inst/sysman/log/emagent.nohup
+    cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/
     pid: '13482'
     ppid: '1'
     user: oracle
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ohasd.bin
-      reboot
-    pid: '13578'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdk/bin/java
-      -Xmx128M -XX:MaxPermSize=96M -server
-      -Djava.security.egd=file:///dev/./urandom
-      -Dsun.lang.ClassLoader.allowArraySyntax=true
-      -XX:+UseLinuxPosixThreadCPUClocks -XX:+UseConcMarkSweepGC
-      -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -Dwatchdog.pid=13389
-      -cp
-      /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdbc/lib/ojdbc5.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.http_client_11.1.1.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/xmlparserv2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/jsch.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/optic.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.dms_11.1.1/dms.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK.jar
-      oracle.sysman.gcagent.tmmain.TMMain
-    pid: '13590'
-    ppid: '13389'
-    user: oracle
-  - cmdline: >-
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/jdk/bin/java
-      -Xmx128M -XX:MaxMetaspaceSize=224M -server
-      -Djava.security.egd=file:///dev/./urandom
-      -Dsun.lang.ClassLoader.allowArraySyntax=true -XX:-UseLargePages
-      -XX:+UseLinuxPosixThreadCPUClocks -XX:+UseConcMarkSweepGC
-      -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops
-      -DHTTPClient.dontSeekTerminatingChunk=true -Dwatchdog.pid=13482 -cp
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jdbc/lib/ojdbc7.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/jsch-0.1.54.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/com.oracle.http_client.http_client.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.xdk/xmlparserv2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.dms/dms.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/lib/optic.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK.jar
-      oracle.sysman.gcagent.tmmain.TMMain
-    pid: '13648'
-    ppid: '13482'
-    user: oracle
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/oraagent.bin
-    pid: '14470'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmd.bin
-    pid: '14491'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAAPP
-      -no_crs_notify -inherit
-    pid: '14496'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAREP
-      -no_crs_notify -inherit
-    pid: '14500'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BNABBDD
-      -no_crs_notify -inherit
-    pid: '14505'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmlogger.bin
-      -o
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.info
-      -l
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.log
-    pid: '14758'
-    ppid: '14491'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/tnslsnr
-      LISTENER -no_crs_notify -inherit
-    pid: '14763'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_ARSYS
-      -no_crs_notify -inherit
-    pid: '14782'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /usr/local/qualys/cloud-agent/bin/agentid-service -config
-      /etc/qualys/cloud-agent/agentid-service.conf -logdir /var/log/qualys/
-    pid: '14887'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/cssdagent
-    pid: '15030'
-    ppid: '1'
-    user: oragrid
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ocssd.bin
-    pid: '15057'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_pmon_+ASM
-    pid: '15350'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_psp0_+ASM
-    pid: '15354'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_vktm_+ASM
-    pid: '15357'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_gen0_+ASM
-    pid: '15363'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_mman_+ASM
-    pid: '15365'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_diag_+ASM
-    pid: '15369'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_dia0_+ASM
-    pid: '15371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_dbw0_+ASM
-    pid: '15373'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_lgwr_+ASM
-    pid: '15375'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_ckpt_+ASM
-    pid: '15377'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_smon_+ASM
-    pid: '15379'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_lreg_+ASM
-    pid: '15381'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_pxmn_+ASM
-    pid: '15383'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_rbal_+ASM
-    pid: '15385'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_gmon_+ASM
-    pid: '15387'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_mmon_+ASM
-    pid: '15389'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_mmnl_+ASM
-    pid: '15391'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15491'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15494'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15509'
-    ppid: '1'
-    user: oragrid
-  - cmdline: asm_asmb_+ASM
-    pid: '15538'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_+asm (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15545'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '15554'
-    ppid: '2'
-    user: root
-  - cmdline: ora_pmon_ARSYS
-    pid: '15612'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_ARSYS
-    pid: '15614'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_ARSYS
-    pid: '15621'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_ARSYS
-    pid: '15625'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_ARSYS
-    pid: '15627'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_ARSYS
-    pid: '15631'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_ARSYS
-    pid: '15633'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_ARSYS
-    pid: '15635'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_ARSYS
-    pid: '15637'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_ARSYS
-    pid: '15639'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_ARSYS
-    pid: '15641'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_ARSYS
-    pid: '15643'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_ARSYS
-    pid: '15645'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_ARSYS
-    pid: '15647'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_ARSYS
-    pid: '15649'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_ARSYS
-    pid: '15651'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_ARSYS
-    pid: '15653'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_ARSYS
-    pid: '15655'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pxmn_ARSYS
-    pid: '15657'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_ARSYS
-    pid: '15659'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_ARSYS
-    pid: '15661'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_ARSYS
-    pid: '15663'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmnl_ARSYS
-    pid: '15667'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15669'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_d000_ARSYS
-    pid: '15674'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_ARSYS
-    pid: '15676'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_ARSYS
-    pid: '15678'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pmon_BSAAPP
-    pid: '15684'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_BSAAPP
-    pid: '15686'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pmon_BNABBDD
-    pid: '15688'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_BNABBDD
-    pid: '15690'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pmon_BSAREP
-    pid: '15692'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_psp0_BSAREP
-    pid: '15694'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_BSAAPP
-    pid: '15697'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_BSAAPP
-    pid: '15701'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_BSAAPP
-    pid: '15703'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_BNABBDD
-    pid: '15707'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_BSAAPP
-    pid: '15709'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_BSAAPP
-    pid: '15714'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_BNABBDD
-    pid: '15715'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vktm_BSAREP
-    pid: '15717'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_BSAAPP
-    pid: '15719'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_BNABBDD
-    pid: '15723'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_gen0_BSAREP
-    pid: '15725'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_BSAAPP
-    pid: '15727'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mman_BSAREP
-    pid: '15731'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_BNABBDD
-    pid: '15735'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_BSAAPP
-    pid: '15737'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_diag_BSAREP
-    pid: '15739'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_BNABBDD
-    pid: '15741'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_BSAAPP
-    pid: '15744'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbrm_BSAREP
-    pid: '15746'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_BNABBDD
-    pid: '15747'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_vkrm_BSAREP
-    pid: '15749'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_BNABBDD
-    pid: '15751'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_BSAAPP
-    pid: '15753'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dia0_BSAREP
-    pid: '15755'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_BNABBDD
-    pid: '15757'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_BSAAPP
-    pid: '15759'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw0_BSAREP
-    pid: '15761'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_BSAAPP
-    pid: '15763'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_BNABBDD
-    pid: '15765'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_BSAAPP
-    pid: '15767'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_dbw1_BSAREP
-    pid: '15769'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_BNABBDD
-    pid: '15771'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_BSAAPP
-    pid: '15773'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lgwr_BSAREP
-    pid: '15776'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_BNABBDD
-    pid: '15778'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_BSAAPP
-    pid: '15780'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_ckpt_BSAREP
-    pid: '15782'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_BSAAPP
-    pid: '15784'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pxmn_BSAAPP
-    pid: '15786'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_BSAREP
-    pid: '15788'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg00_BNABBDD
-    pid: '15790'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_BSAAPP
-    pid: '15792'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_BSAREP
-    pid: '15794'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smon_BNABBDD
-    pid: '15796'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_BNABBDD
-    pid: '15798'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_BSAAPP
-    pid: '15800'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lg01_BSAREP
-    pid: '15802'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_BNABBDD
-    pid: '15804'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_BSAAPP
-    pid: '15807'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_reco_BSAREP
-    pid: '15808'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_BNABBDD
-    pid: '15810'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_lreg_BSAREP
-    pid: '15813'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmnl_BSAAPP
-    pid: '15814'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15816'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_pxmn_BNABBDD
-    pid: '15818'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_d000_BSAAPP
-    pid: '15821'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_pxmn_BSAREP
-    pid: '15822'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_BSAAPP
-    pid: '15825'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_BSAREP
-    pid: '15826'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_rbal_BNABBDD
-    pid: '15828'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_BSAREP
-    pid: '15830'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_asmb_BNABBDD
-    pid: '15832'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_BSAAPP
-    pid: '15834'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_BSAREP
-    pid: '15836'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmon_BNABBDD
-    pid: '15838'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_asmb_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15840'
-    ppid: '1'
-    user: oracle
-  - cmdline: oracle+ASM_asmb_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '15842'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_mmnl_BSAREP
-    pid: '15844'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mmnl_BNABBDD
-    pid: '15846'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_d000_BSAREP
-    pid: '15848'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_d000_BNABBDD
-    pid: '15852'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_BSAREP
-    pid: '15854'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_mark_BNABBDD
-    pid: '15856'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_BSAREP
-    pid: '15858'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_s000_BNABBDD
-    pid: '15862'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_ARSYS
-    pid: '15964'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_ARSYS
-    pid: '15966'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_ARSYS
-    pid: '15968'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_ARSYS
-    pid: '15970'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_ARSYS
-    pid: '15972'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_ARSYS
-    pid: '15974'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_ARSYS
-    pid: '15976'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_ARSYS
-    pid: '15978'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_ARSYS
-    pid: '15980'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_ARSYS
-    pid: '15982'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_ARSYS
-    pid: '15984'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_ARSYS
-    pid: '15986'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_ARSYS
-    pid: '15988'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_ARSYS
-    pid: '15990'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_ARSYS
-    pid: '15992'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_BNABBDD
-    pid: '15995'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_BNABBDD
-    pid: '15997'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_BSAREP
-    pid: '15999'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p000_BSAAPP
-    pid: '16001'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_BNABBDD
-    pid: '16004'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_BSAREP
-    pid: '16005'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p001_BSAAPP
-    pid: '16007'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_BNABBDD
-    pid: '16010'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_BSAREP
-    pid: '16011'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p002_BSAAPP
-    pid: '16013'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_BNABBDD
-    pid: '16015'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_BSAREP
-    pid: '16017'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_BNABBDD
-    pid: '16019'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p003_BSAAPP
-    pid: '16021'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_BSAREP
-    pid: '16023'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_BNABBDD
-    pid: '16027'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_BSAREP
-    pid: '16028'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p004_BSAAPP
-    pid: '16029'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_BSAREP
-    pid: '16031'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p005_BSAAPP
-    pid: '16033'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_BNABBDD
-    pid: '16035'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_BSAREP
-    pid: '16037'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_BNABBDD
-    pid: '16039'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p006_BSAAPP
-    pid: '16041'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_BSAREP
-    pid: '16044'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p007_BSAAPP
-    pid: '16045'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_BNABBDD
-    pid: '16047'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_BSAREP
-    pid: '16051'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_BNABBDD
-    pid: '16052'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p008_BSAAPP
-    pid: '16053'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_BSAREP
-    pid: '16057'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p009_BSAAPP
-    pid: '16058'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_BNABBDD
-    pid: '16059'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_BSAREP
-    pid: '16063'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00a_BSAAPP
-    pid: '16064'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_BNABBDD
-    pid: '16065'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_BSAREP
-    pid: '16069'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_BNABBDD
-    pid: '16070'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00b_BSAAPP
-    pid: '16071'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_BSAREP
-    pid: '16075'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00c_BSAAPP
-    pid: '16076'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_BNABBDD
-    pid: '16077'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00d_BSAAPP
-    pid: '16079'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_BSAREP
-    pid: '16081'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00e_BSAAPP
-    pid: '16084'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_BNABBDD
-    pid: '16123'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_ARSYS
-    pid: '16131'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_BNABBDD
-    pid: '16133'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_ARSYS
-    pid: '16141'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_BNABBDD
-    pid: '16145'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_BNABBDD
-    pid: '16151'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_ARSYS
-    pid: '16153'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_ARSYS
-    pid: '16156'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_BNABBDD
-    pid: '16157'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_ARSYS
-    pid: '16161'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_BSAAPP
-    pid: '16167'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_BSAAPP
-    pid: '16173'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_ARSYS
-    pid: '16177'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_BSAAPP
-    pid: '16179'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_BNABBDD
-    pid: '16181'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_BSAAPP
-    pid: '16183'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tmon_BSAREP
-    pid: '16185'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_BSAAPP
-    pid: '16187'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc0_BSAREP
-    pid: '16189'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc1_BSAREP
-    pid: '16191'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc2_BSAREP
-    pid: '16194'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_arc3_BSAREP
-    pid: '16196'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_BSAAPP
-    pid: '16198'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_tt00_BSAREP
-    pid: '16200'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_ARSYS
-    pid: '16208'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_BNABBDD
-    pid: '16215'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_BSAAPP
-    pid: '16217'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_smco_BSAREP
-    pid: '16253'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_BNABBDD
-    pid: '16285'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_ARSYS
-    pid: '16287'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_BSAAPP
-    pid: '16292'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '16304'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_aqpc_BSAREP
-    pid: '16309'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_BSAAPP
-    pid: '16318'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_BSAAPP
-    pid: '16320'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_BSAAPP
-    pid: '16322'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_BSAAPP
-    pid: '16324'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_BSAAPP
-    pid: '16328'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_BNABBDD
-    pid: '16330'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_BSAAPP
-    pid: '16332'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_BNABBDD
-    pid: '16334'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_BSAAPP
-    pid: '16336'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_BNABBDD
-    pid: '16338'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_BSAAPP
-    pid: '16340'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_BSAAPP
-    pid: '16343'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_BNABBDD
-    pid: '16344'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_BNABBDD
-    pid: '16346'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_BSAAPP
-    pid: '16348'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_BNABBDD
-    pid: '16351'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_BSAAPP
-    pid: '16352'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_BSAAPP
-    pid: '16354'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_BNABBDD
-    pid: '16356'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_BSAAPP
-    pid: '16361'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_BNABBDD
-    pid: '16363'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_BSAAPP
-    pid: '16365'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_BNABBDD
-    pid: '16367'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_ARSYS
-    pid: '16369'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_BSAAPP
-    pid: '16371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_ARSYS
-    pid: '16373'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_BNABBDD
-    pid: '16375'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_BSAAPP
-    pid: '16377'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_ARSYS
-    pid: '16380'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_BNABBDD
-    pid: '16381'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_BNABBDD
-    pid: '16383'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_BSAAPP
-    pid: '16385'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_ARSYS
-    pid: '16387'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_BSAAPP
-    pid: '16389'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_ARSYS
-    pid: '16391'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_BNABBDD
-    pid: '16393'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_ARSYS
-    pid: '16396'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_BSAAPP
-    pid: '16397'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_BNABBDD
-    pid: '16399'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_BNABBDD
-    pid: '16401'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_ARSYS
-    pid: '16403'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_BSAAPP
-    pid: '16405'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_BSAAPP
-    pid: '16408'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_BNABBDD
-    pid: '16409'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_ARSYS
-    pid: '16411'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_BSAAPP
-    pid: '16413'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_BNABBDD
-    pid: '16415'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_ARSYS
-    pid: '16417'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_BSAAPP
-    pid: '16419'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_ARSYS
-    pid: '16422'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_BNABBDD
-    pid: '16423'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_BSAAPP
-    pid: '16425'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_ARSYS
-    pid: '16428'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_BNABBDD
-    pid: '16429'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_BSAAPP
-    pid: '16431'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_BNABBDD
-    pid: '16434'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_ARSYS
-    pid: '16435'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_BSAAPP
-    pid: '16437'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_ARSYS
-    pid: '16439'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_BNABBDD
-    pid: '16441'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_BSAAPP
-    pid: '16443'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_BNABBDD
-    pid: '16446'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_ARSYS
-    pid: '16447'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_BNABBDD
-    pid: '16449'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_ARSYS
-    pid: '16451'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_BSAAPP
-    pid: '16453'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_ARSYS
-    pid: '16457'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_BNABBDD
-    pid: '16458'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_BSAAPP
-    pid: '16460'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_ARSYS
-    pid: '16462'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_BNABBDD
-    pid: '16464'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_BSAAPP
-    pid: '16466'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_BNABBDD
-    pid: '16468'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_ARSYS
-    pid: '16470'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_BSAAPP
-    pid: '16472'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_BNABBDD
-    pid: '16475'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_ARSYS
-    pid: '16476'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_BSAAPP
-    pid: '16478'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_BNABBDD
-    pid: '16480'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_ARSYS
-    pid: '16482'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_BSAAPP
-    pid: '16484'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_BNABBDD
-    pid: '16486'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_ARSYS
-    pid: '16488'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_BSAAPP
-    pid: '16490'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_ARSYS
-    pid: '16492'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_BNABBDD
-    pid: '16494'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_BSAAPP
-    pid: '16496'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_ARSYS
-    pid: '16498'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_BNABBDD
-    pid: '16500'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_BSAAPP
-    pid: '16502'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_ARSYS
-    pid: '16505'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_BNABBDD
-    pid: '16506'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_BSAAPP
-    pid: '16508'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_ARSYS
-    pid: '16511'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_BNABBDD
-    pid: '16512'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_BSAAPP
-    pid: '16514'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_BNABBDD
-    pid: '16517'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_ARSYS
-    pid: '16518'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_BSAAPP
-    pid: '16520'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_BNABBDD
-    pid: '16523'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_ARSYS
-    pid: '16524'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_BSAAPP
-    pid: '16526'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_BNABBDD
-    pid: '16529'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_ARSYS
-    pid: '16530'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_BSAAPP
-    pid: '16532'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_BNABBDD
-    pid: '16534'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_BSAAPP
-    pid: '16536'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_ARSYS
-    pid: '16538'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_BNABBDD
-    pid: '16540'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_BSAAPP
-    pid: '16542'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_ARSYS
-    pid: '16544'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_BNABBDD
-    pid: '16546'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_BSAAPP
-    pid: '16548'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_ARSYS
-    pid: '16550'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_BNABBDD
-    pid: '16552'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_BSAAPP
-    pid: '16554'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_BNABBDD
-    pid: '16556'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_ARSYS
-    pid: '16558'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_BSAAPP
-    pid: '16560'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_ARSYS
-    pid: '16562'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_BNABBDD
-    pid: '16564'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_BSAAPP
-    pid: '16566'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_ARSYS
-    pid: '16568'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_BNABBDD
-    pid: '16570'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_BSAAPP
-    pid: '16572'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_ARSYS
-    pid: '16574'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_BNABBDD
-    pid: '16576'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_BSAAPP
-    pid: '16579'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_ARSYS
-    pid: '16581'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_BNABBDD
-    pid: '16583'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_BSAAPP
-    pid: '16585'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_ARSYS
-    pid: '16587'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_BNABBDD
-    pid: '16589'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_ARSYS
-    pid: '16591'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_BNABBDD
-    pid: '16593'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_ARSYS
-    pid: '16595'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_BNABBDD
-    pid: '16597'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_ARSYS
-    pid: '16599'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_BNABBDD
-    pid: '16601'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_ARSYS
-    pid: '16603'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_BNABBDD
-    pid: '16605'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_ARSYS
-    pid: '16607'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_ARSYS
-    pid: '16609'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_ARSYS
-    pid: '16611'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_ARSYS
-    pid: '16613'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_ARSYS
-    pid: '16615'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_ARSYS
-    pid: '16617'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_ARSYS
-    pid: '16619'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_ARSYS
-    pid: '16621'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_ARSYS
-    pid: '16623'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '16625'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_BSAAPP
-    pid: '16627'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_BSAAPP
-    pid: '16629'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_BSAAPP
-    pid: '16635'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '16637'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_BNABBDD
-    pid: '16639'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_BNABBDD
-    pid: '16643'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00f_BSAREP
-    pid: '16645'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00g_BSAREP
-    pid: '16649'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00h_BSAREP
-    pid: '16653'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_BNABBDD
-    pid: '16655'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00i_BSAREP
-    pid: '16657'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00j_BSAREP
-    pid: '16659'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_ARSYS
-    pid: '16661'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00k_BSAREP
-    pid: '16663'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_ARSYS
-    pid: '16665'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00l_BSAREP
-    pid: '16667'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q002_ARSYS
-    pid: '16669'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00m_BSAREP
-    pid: '16671'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00n_BSAREP
-    pid: '16673'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00o_BSAREP
-    pid: '16677'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_ARSYS
-    pid: '16679'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00p_BSAREP
-    pid: '16681'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00q_BSAREP
-    pid: '16683'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00r_BSAREP
-    pid: '16685'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00s_BSAREP
-    pid: '16687'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00t_BSAREP
-    pid: '16689'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00u_BSAREP
-    pid: '16691'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_cjq0_BSAREP
-    pid: '16693'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00v_BSAREP
-    pid: '16695'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00w_BSAREP
-    pid: '16698'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00x_BSAREP
-    pid: '16700'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00y_BSAREP
-    pid: '16702'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p00z_BSAREP
-    pid: '16704'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p010_BSAREP
-    pid: '16706'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p011_BSAREP
-    pid: '16708'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p012_BSAREP
-    pid: '16710'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p013_BSAREP
-    pid: '16712'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p014_BSAREP
-    pid: '16714'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p015_BSAREP
-    pid: '16716'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p016_BSAREP
-    pid: '16718'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p017_BSAREP
-    pid: '16720'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p018_BSAREP
-    pid: '16722'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p019_BSAREP
-    pid: '16724'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01a_BSAREP
-    pid: '16726'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01b_BSAREP
-    pid: '16728'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01c_BSAREP
-    pid: '16730'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01d_BSAREP
-    pid: '16732'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01e_BSAREP
-    pid: '16734'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_BSAAPP
-    pid: '16736'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01f_BSAREP
-    pid: '16738'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_BSAAPP
-    pid: '16740'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01g_BSAREP
-    pid: '16742'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_BSAAPP
-    pid: '16744'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01h_BSAREP
-    pid: '16746'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01i_BSAREP
-    pid: '16748'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_BSAAPP
-    pid: '16750'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01j_BSAREP
-    pid: '16752'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_BSAAPP
-    pid: '16754'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01k_BSAREP
-    pid: '16756'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01l_BSAREP
-    pid: '16758'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q00a_BSAAPP
-    pid: '16760'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01m_BSAREP
-    pid: '16762'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01n_BSAREP
-    pid: '16764'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01o_BSAREP
-    pid: '16766'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01p_BSAREP
-    pid: '16768'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01q_BSAREP
-    pid: '16770'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_p01r_BSAREP
-    pid: '16772'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_ARSYS
-    pid: '16774'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_ARSYS
-    pid: '16777'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_ARSYS
-    pid: '16779'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_ARSYS
-    pid: '16781'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_ARSYS
-    pid: '16783'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_BNABBDD
-    pid: '16785'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_BNABBDD
-    pid: '16788'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_BNABBDD
-    pid: '16790'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_BNABBDD
-    pid: '16792'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_BNABBDD
-    pid: '16794'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm02_BSAREP
-    pid: '16797'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_qm00_BSAREP
-    pid: '16799'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q002_BSAREP
-    pid: '16801'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '16805'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q004_BSAREP
-    pid: '16807'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '16837'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q005_BSAREP
-    pid: '16840'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q006_BSAREP
-    pid: '16842'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q007_BSAREP
-    pid: '16844'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q008_BSAREP
-    pid: '16848'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_q009_BSAREP
-    pid: '16854'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '16951'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '17039'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '17069'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '17109'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '17371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '17411'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '17651'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '17657'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '17796'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '18038'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '19700'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '19811'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '19813'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '20577'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '20645'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '20663'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '20675'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '20679'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '21794'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '21914'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '22175'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22208'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22219'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22258'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22262'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22316'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22318'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22320'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22322'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22324'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22326'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22328'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22330'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22332'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22334'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22336'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22338'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22340'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22342'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22344'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22346'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22348'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22350'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22352'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22354'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22356'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22358'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22360'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22363'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22365'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22368'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22371'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22373'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22375'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22379'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22385'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22387'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22393'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22399'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22405'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22411'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22415'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22421'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22425'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22431'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22437'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22443'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22445'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22449'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22451'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22453'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22455'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22458'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22460'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22462'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22464'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22468'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22473'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22477'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22479'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22481'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22483'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22485'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22487'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22489'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22491'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22493'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22495'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22497'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22499'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleARSYS (LOCAL=NO)
-    pid: '22501'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22545'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '22563'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '32378'
-    ppid: '1'
-    user: oragrid
-  - cmdline: 'sshd: cyberark [priv]'
-    pid: '32623'
-    ppid: '2882'
-    user: root
-  - cmdline: 'sshd: cyberark@pts/1'
-    pid: '32631'
-    ppid: '32623'
-    user: cyberark
-  - cmdline: '-bash'
-    pid: '32632'
-    ppid: '32631'
-    user: cyberark
-  - cmdline: su - root
-    pid: '32668'
-    ppid: '32632'
-    user: cyberark
-  - cmdline: '-bash'
-    pid: '32676'
-    ppid: '32668'
-    user: root
-  - cmdline: >-
-      /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/sqlplus                                        
-      as sysasm
-    pid: '33023'
-    ppid: '32676'
-    user: root
-  - cmdline: oracle+ASM (LOCAL=NO)
-    pid: '33025'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '34800'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34963'
-    ppid: '2'
-    user: root
-  - cmdline: ora_w004_BSAREP
-    pid: '35257'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w002_BSAAPP
-    pid: '35341'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w003_ARSYS
-    pid: '35409'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_o001_BNABBDD
-    pid: '35698'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o001_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '35700'
-    ppid: '1'
-    user: oracle
-  - cmdline: ora_o002_ARSYS
-    pid: '35703'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o002_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '35705'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '36134'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37614'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38019'
-    ppid: '2'
-    user: root
-  - cmdline: ora_w001_BNABBDD
-    pid: '38039'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '38380'
-    ppid: '2'
-    user: root
-  - cmdline: ora_w000_BNABBDD
-    pid: '40559'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '41466'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42316'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51639'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53968'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '55115'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57812'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57921'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58479'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58505'
-    ppid: '2'
-    user: root
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '59259'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '62085'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62951'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '67682'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68499'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68515'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68597'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68768'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68938'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68960'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69116'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '69565'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '74694'
-    ppid: '2'
-    user: root
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '76012'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ''
-    pid: '76666'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76667'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76736'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '77158'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79085'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79092'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79256'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79490'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79648'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '79666'
-    ppid: '3539'
-    user: postfix
-  - cmdline: ''
-    pid: '79880'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79915'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79930'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79931'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79933'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80004'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80194'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80196'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80292'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
-      /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/plugins/oracle.sysman.db.agent.plugin_13.4.1.0.0/scripts/failedLogin.pl
-    pid: '80308'
-    ppid: '13648'
-    user: oracle
-  - cmdline: oracleBSAREP (LOCAL=NO)
-    pid: '80326'
-    ppid: '1'
-    user: oragrid
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1655221424
-    pid: '80481'
-    ppid: '2884'
-    user: root
-  - cmdline: 'sshd: cyberark [priv]'
-    pid: '80506'
-    ppid: '2882'
-    user: root
-  - cmdline: 'sshd: cyberark@pts/2'
-    pid: '80508'
-    ppid: '80506'
-    user: cyberark
-  - cmdline: ''
-    pid: '80735'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80741'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80819'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80820'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80821'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80822'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80823'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80824'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80825'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80826'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80827'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80828'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80829'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80830'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80831'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80832'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80833'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80834'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80835'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80836'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80837'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80838'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80839'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80840'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80841'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80842'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80843'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80844'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80845'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80846'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80847'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80848'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80849'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80850'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80851'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80852'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80853'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80854'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80855'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80856'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80857'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80858'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80859'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80860'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80861'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80862'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80863'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80864'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80865'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '80866'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /bin/sh -c su - root -c '/bin/sh -c '"'"'echo
-      BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ; /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'"'"''
-      && sleep 0
-    pid: '80972'
-    ppid: '80508'
-    user: cyberark
-  - cmdline: >-
-      su - root -c /bin/sh -c 'echo
-      BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ; /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'
-    pid: '80990'
-    ppid: '80972'
-    user: cyberark
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ;
-      /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
-    pid: '80991'
-    ppid: '80990'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
-    pid: '81026'
-    ppid: '80991'
-    user: root
-  - cmdline: ''
-    pid: '81076'
-    ppid: '2'
-    user: root
-  - cmdline: ora_q003_BNABBDD
-    pid: '85919'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracleBNABBDD (LOCAL=NO)
-    pid: '98298'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_w000_ARSYS
-    pid: '105757'
-    ppid: '1'
-    user: oragrid
-  - cmdline: ora_o002_BSAAPP
-    pid: '121249'
-    ppid: '1'
-    user: oragrid
-  - cmdline: oracle+ASM_o002_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
-    pid: '121251'
-    ppid: '1'
-    user: oracle
-  - cmdline: oracleBSAAPP (LOCAL=NO)
-    pid: '123382'
-    ppid: '1'
-    user: oragrid
+  type: Oracle Management Agent
+  version:
+  - number: 13.4.0.0.0
+    type: file
+mocked_plugin_tasks:
+  Read env from process:
+    calls:
+    - expected_args:
+        pid: '13389'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0
+    - expected_args:
+        pid: '13482'
+      plugin_result:
+        failed: false
+        parsed:
+          ORACLE_HOME: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0
+packages:
+  AvamarClient:
+  - arch: x86_64
+    epoch: null
+    name: AvamarClient
+    release: '149'
+    source: rpm
+    version: 19.3.100
+  AvamarRMAN:
+  - arch: x86_64
+    epoch: null
+    name: AvamarRMAN
+    release: '149'
+    source: rpm
+    version: 19.3.100
+  BladeLogic_RSCD_Agent:
+  - arch: x86_64
+    epoch: null
+    name: BladeLogic_RSCD_Agent
+    release: '200'
+    source: rpm
+    version: 8.9.04
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
+  NetworkManager:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-config-server:
+  - arch: noarch
+    epoch: 1
+    name: NetworkManager-config-server
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-libnm:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-libnm
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-ppp:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-ppp
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-team:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-team
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  NetworkManager-tui:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-tui
+    release: 1.el7
+    source: rpm
+    version: 1.18.8
+  OpenIPMI:
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
+  OpenIPMI-libs:
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI-libs
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
+  OpenIPMI-modalias:
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI-modalias
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
+  Red_Hat_Enterprise_Linux-Release_Notes-7-en-US:
+  - arch: noarch
+    epoch: null
+    name: Red_Hat_Enterprise_Linux-Release_Notes-7-en-US
+    release: 2.el7
+    source: rpm
+    version: '7'
+  TDP-Oracle:
+  - arch: x86_64
+    epoch: null
+    name: TDP-Oracle
+    release: '0'
+    source: rpm
+    version: 8.1.0
+  TDP-Oracle.Utility:
+  - arch: x86_64
+    epoch: null
+    name: TDP-Oracle.Utility
+    release: '0'
+    source: rpm
+    version: 8.1.0
+  TIVsm-API64:
+  - arch: x86_64
+    epoch: null
+    name: TIVsm-API64
+    release: '0'
+    source: rpm
+    version: 8.1.7
+  TIVsm-BA:
+  - arch: x86_64
+    epoch: null
+    name: TIVsm-BA
+    release: '0'
+    source: rpm
+    version: 8.1.7
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  adcli:
+  - arch: x86_64
+    epoch: null
+    name: adcli
+    release: 9.el7
+    source: rpm
+    version: 0.8.1
+  adobe-mappings-cmap:
+  - arch: noarch
+    epoch: null
+    name: adobe-mappings-cmap
+    release: 3.el7
+    source: rpm
+    version: '20171205'
+  adobe-mappings-cmap-deprecated:
+  - arch: noarch
+    epoch: null
+    name: adobe-mappings-cmap-deprecated
+    release: 3.el7
+    source: rpm
+    version: '20171205'
+  adobe-mappings-pdf:
+  - arch: noarch
+    epoch: null
+    name: adobe-mappings-pdf
+    release: 1.el7
+    source: rpm
+    version: '20180407'
+  aic94xx-firmware:
+  - arch: noarch
+    epoch: null
+    name: aic94xx-firmware
+    release: 6.el7
+    source: rpm
+    version: '30'
+  aide:
+  - arch: x86_64
+    epoch: null
+    name: aide
+    release: 13.el7_9.1
+    source: rpm
+    version: 0.15.1
+  alsa-firmware:
+  - arch: noarch
+    epoch: null
+    name: alsa-firmware
+    release: 2.el7
+    source: rpm
+    version: 1.0.28
+  alsa-lib:
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
+  alsa-tools-firmware:
+  - arch: x86_64
+    epoch: null
+    name: alsa-tools-firmware
+    release: 1.el7
+    source: rpm
+    version: 1.1.0
+  at:
+  - arch: x86_64
+    epoch: null
+    name: at
+    release: 24.el7
+    source: rpm
+    version: 3.1.13
+  atk:
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs:
+  - arch: i686
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autofs:
+  - arch: x86_64
+    epoch: 1
+    name: autofs
+    release: 106.el7
+    source: rpm
+    version: 5.0.7
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  avahi-autoipd:
+  - arch: x86_64
+    epoch: null
+    name: avahi-autoipd
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  avahi-libs:
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
+  bash-completion:
+  - arch: noarch
+    epoch: 1
+    name: bash-completion
+    release: 6.el7
+    source: rpm
+    version: '2.1'
+  bc:
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
+  biosdevname:
+  - arch: x86_64
+    epoch: null
+    name: biosdevname
+    release: 2.el7
+    source: rpm
+    version: 0.7.3
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2:
+  - arch: x86_64
+    epoch: null
+    name: bzip2
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  bzip2-libs:
+  - arch: i686
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  c-ares:
+  - arch: x86_64
+    epoch: null
+    name: c-ares
+    release: 3.el7
+    source: rpm
+    version: 1.10.0
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  cairo:
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
+  cfg2html:
+  - arch: noarch
+    epoch: null
+    name: cfg2html
+    release: '151.1'
+    source: rpm
+    version: '6.30'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  compat-libcap1:
+  - arch: x86_64
+    epoch: null
+    name: compat-libcap1
+    release: 7.el7
+    source: rpm
+    version: '1.10'
+  compat-libstdc++-33:
+  - arch: i686
+    epoch: null
+    name: compat-libstdc++-33
+    release: 72.el7
+    source: rpm
+    version: 3.2.3
+  - arch: x86_64
+    epoch: null
+    name: compat-libstdc++-33
+    release: 72.el7
+    source: rpm
+    version: 3.2.3
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  - arch: i686
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.3
+  cups-client:
+  - arch: x86_64
+    epoch: 1
+    name: cups-client
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
+  cups-libs:
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-gssapi:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-gssapi
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 24.el7_9
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  dejavu-fonts-common:
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  dejavu-sans-fonts:
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  desktop-file-utils:
+  - arch: x86_64
+    epoch: null
+    name: desktop-file-utils
+    release: 2.el7
+    source: rpm
+    version: '0.23'
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
+  device-mapper-event:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
+  device-mapper-event-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 2.el7
+    source: rpm
+    version: 1.02.158
+  device-mapper-multipath:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-multipath
+    release: 127.el7
+    source: rpm
+    version: 0.4.9
+  device-mapper-multipath-libs:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-multipath-libs
+    release: 127.el7
+    source: rpm
+    version: 0.4.9
+  device-mapper-persistent-data:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 1.el7
+    source: rpm
+    version: 0.8.5
+  dhclient:
+  - arch: x86_64
+    epoch: 12
+    name: dhclient
+    release: 83.el7_9.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7_9.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7_9.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 3.el7
+    source: rpm
+    version: '3.2'
+  dnsmasq:
+  - arch: x86_64
+    epoch: null
+    name: dnsmasq
+    release: 16.el7_9.1
+    source: rpm
+    version: '2.76'
+  dosfstools:
+  - arch: x86_64
+    epoch: null
+    name: dosfstools
+    release: 10.el7
+    source: rpm
+    version: 3.0.20
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 564.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 564.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 564.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  ebtables:
+  - arch: x86_64
+    epoch: null
+    name: ebtables
+    release: 16.el7
+    source: rpm
+    version: 2.0.10
+  ed:
+  - arch: x86_64
+    epoch: null
+    name: ed
+    release: 4.el7
+    source: rpm
+    version: '1.9'
+  efibootmgr:
+  - arch: x86_64
+    epoch: null
+    name: efibootmgr
+    release: 2.el7
+    source: rpm
+    version: '17'
+  efivar-libs:
+  - arch: x86_64
+    epoch: null
+    name: efivar-libs
+    release: 12.el7
+    source: rpm
+    version: '36'
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: i686
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  - arch: i686
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.176'
+  emacs-common:
+  - arch: x86_64
+    epoch: 1
+    name: emacs-common
+    release: 23.el7
+    source: rpm
+    version: '24.3'
+  emacs-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: emacs-filesystem
+    release: 23.el7
+    source: rpm
+    version: '24.3'
+  emacs-nox:
+  - arch: x86_64
+    epoch: 1
+    name: emacs-nox
+    release: 23.el7
+    source: rpm
+    version: '24.3'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 14.el7_9
+    source: rpm
+    version: 2.1.0
+  expect:
+  - arch: x86_64
+    epoch: null
+    name: expect
+    release: 14.el7_1
+    source: rpm
+    version: '5.45'
+  falcon-sensor:
+  - arch: x86_64
+    epoch: null
+    name: falcon-sensor
+    release: 10402.el7
+    source: rpm
+    version: 5.38.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 6.8.8
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  finger:
+  - arch: x86_64
+    epoch: null
+    name: finger
+    release: 52.el7
+    source: rpm
+    version: '0.17'
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  firewalld:
+  - arch: noarch
+    epoch: null
+    name: firewalld
+    release: 2.el7_7.1
+    source: rpm
+    version: 0.6.3
+  firewalld-filesystem:
+  - arch: noarch
+    epoch: null
+    name: firewalld-filesystem
+    release: 2.el7_7.1
+    source: rpm
+    version: 0.6.3
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  foomatic-filters:
+  - arch: x86_64
+    epoch: null
+    name: foomatic-filters
+    release: 9.el7
+    source: rpm
+    version: 4.0.9
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  ftp:
+  - arch: x86_64
+    epoch: null
+    name: ftp
+    release: 67.el7
+    source: rpm
+    version: '0.17'
+  fxload:
+  - arch: x86_64
+    epoch: null
+    name: fxload
+    release: 16.el7
+    source: rpm
+    version: '2002_04_11'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdbm-devel:
+  - arch: x86_64
+    epoch: null
+    name: gdbm-devel
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  ghostscript:
+  - arch: x86_64
+    epoch: null
+    name: ghostscript
+    release: 2.el7_7.3
+    source: rpm
+    version: '9.25'
+  ghostscript-fonts:
+  - arch: noarch
+    epoch: null
+    name: ghostscript-fonts
+    release: 32.el7
+    source: rpm
+    version: '5.50'
+  glib-networking:
+  - arch: x86_64
+    epoch: null
+    name: glib-networking
+    release: 1.el7
+    source: rpm
+    version: 2.56.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc-devel
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gnutls:
+  - arch: x86_64
+    epoch: null
+    name: gnutls
+    release: 9.el7_6
+    source: rpm
+    version: 3.3.29
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 45700c69
+    source: rpm
+    version: 2fa658e0
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 4ae0493b
+    source: rpm
+    version: fd431d51
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-efi-x64:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-efi-x64
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-efi-x64-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-efi-x64-modules
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7_9.6
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gsettings-desktop-schemas:
+  - arch: x86_64
+    epoch: null
+    name: gsettings-desktop-schemas
+    release: 3.el7
+    source: rpm
+    version: 3.28.0
+  gskcrypt64:
+  - arch: x86_64
+    epoch: null
+    name: gskcrypt64
+    release: '55.2'
+    source: rpm
+    version: '8.0'
+  gskssl64:
+  - arch: x86_64
+    epoch: null
+    name: gskssl64
+    release: '55.2'
+    source: rpm
+    version: '8.0'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 26.el7
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 5.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hesiod:
+  - arch: x86_64
+    epoch: null
+    name: hesiod
+    release: 3.el7
+    source: rpm
+    version: 3.2.1
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  http-parser:
+  - arch: x86_64
+    epoch: null
+    name: http-parser
+    release: 8.el7_7.2
+    source: rpm
+    version: 2.7.1
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.3.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.47
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iometrics-agent-plugin-oracle-lib-connector:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-lib-connector
+    release: '25'
+    source: rpm
+    version: 18.5.0_1.11.3
+  iometrics-agent-plugin-oracle-libs:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-libs
+    release: '1'
+    source: rpm
+    version: 18.5.0
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  ipmitool:
+  - arch: x86_64
+    epoch: null
+    name: ipmitool
+    release: 9.el7_7
+    source: rpm
+    version: 1.8.18
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 25.el7
+    source: rpm
+    version: 4.11.0
+  iprutils:
+  - arch: x86_64
+    epoch: null
+    name: iprutils
+    release: 2.el7
+    source: rpm
+    version: 2.4.17.1
+  ipset:
+  - arch: x86_64
+    epoch: null
+    name: ipset
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 33.el7
+    source: rpm
+    version: 1.4.21
+  iptables-services:
+  - arch: x86_64
+    epoch: null
+    name: iptables-services
+    release: 33.el7
+    source: rpm
+    version: 1.4.21
+  iptraf-ng:
+  - arch: x86_64
+    epoch: null
+    name: iptraf-ng
+    release: 7.el7
+    source: rpm
+    version: 1.1.4
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  ivtv-firmware:
+  - arch: noarch
+    epoch: 2
+    name: ivtv-firmware
+    release: 26.el7
+    source: rpm
+    version: '20080701'
+  iwl100-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl100-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
+  iwl1000-firmware:
+  - arch: noarch
+    epoch: 1
+    name: iwl1000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
+  iwl105-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl105-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl135-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl135-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl2000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl2000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl2030-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl2030-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl3160-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl3160-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
+  iwl3945-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl3945-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 15.32.2.9
+  iwl4965-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl4965-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 228.61.2.24
+  iwl5000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl5000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.83.5.1_1
+  iwl5150-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl5150-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.24.2.2
+  iwl6000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 9.221.4.1
+  iwl6000g2a-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2a-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl6000g2b-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2b-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl6050-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6050-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 41.28.5.1
+  iwl7260-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7260-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.59.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 33.el7
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 25.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 25.el7
+    source: rpm
+    version: '20'
+  kmod-oracleasm:
+  - arch: x86_64
+    epoch: null
+    name: kmod-oracleasm
+    release: 26.el7
+    source: rpm
+    version: 2.0.8
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 127.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  krb5-workstation:
+  - arch: x86_64
+    epoch: null
+    name: krb5-workstation
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  ksh:
+  - arch: x86_64
+    epoch: null
+    name: ksh
+    release: 142.el7
+    source: rpm
+    version: '20120801'
+  lcms2:
+  - arch: x86_64
+    epoch: null
+    name: lcms2
+    release: 3.el7
+    source: rpm
+    version: '2.6'
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: i686
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  - arch: i686
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: i686
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  - arch: i686
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXmu:
+  - arch: x86_64
+    epoch: null
+    name: libXmu
+    release: 2.el7
+    source: rpm
+    version: 1.1.2
+  libXp:
+  - arch: x86_64
+    epoch: null
+    name: libXp
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.2
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXt:
+  - arch: x86_64
+    epoch: null
+    name: libXt
+    release: 3.el7
+    source: rpm
+    version: 1.1.5
+  libXtst:
+  - arch: i686
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXv:
+  - arch: x86_64
+    epoch: null
+    name: libXv
+    release: 1.el7
+    source: rpm
+    version: 1.0.11
+  libXxf86dga:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86dga
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.4
+  libXxf86misc:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86misc
+    release: 7.1.el7
+    source: rpm
+    version: 1.0.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: i686
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libaio-devel:
+  - arch: i686
+    epoch: null
+    name: libaio-devel
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  - arch: x86_64
+    epoch: null
+    name: libaio-devel
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: i686
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: i686
+    epoch: null
+    name: libcap
+    release: 10.el7
+    source: rpm
+    version: '2.22'
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 10.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  - arch: i686
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcgroup-tools:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup-tools
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  - arch: i686
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-devel:
+  - arch: x86_64
+    epoch: null
+    name: libdb-devel
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdhash:
+  - arch: x86_64
+    epoch: null
+    name: libdhash
+    release: 32.el7
+    source: rpm
+    version: 0.5.0
+  libdmx:
+  - arch: x86_64
+    epoch: null
+    name: libdmx
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  - arch: i686
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  - arch: i686
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libgs:
+  - arch: x86_64
+    epoch: null
+    name: libgs
+    release: 2.el7_7.3
+    source: rpm
+    version: '9.25'
+  libgudev1:
+  - arch: x86_64
+    epoch: null
+    name: libgudev1
+    release: 78.el7
+    source: rpm
+    version: '219'
+  libhugetlbfs:
+  - arch: x86_64
+    epoch: null
+    name: libhugetlbfs
+    release: 13.el7
+    source: rpm
+    version: '2.16'
+  libhugetlbfs-utils:
+  - arch: x86_64
+    epoch: null
+    name: libhugetlbfs-utils
+    release: 13.el7
+    source: rpm
+    version: '2.16'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libipa_hbac:
+  - arch: x86_64
+    epoch: null
+    name: libipa_hbac
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libkadm5:
+  - arch: x86_64
+    epoch: null
+    name: libkadm5
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  libldb:
+  - arch: x86_64
+    epoch: null
+    name: libldb
+    release: 2.el7_9
+    source: rpm
+    version: 1.5.4
+  liblockfile:
+  - arch: x86_64
+    epoch: null
+    name: liblockfile
+    release: 17.el7
+    source: rpm
+    version: '1.08'
+  libmng:
+  - arch: x86_64
+    epoch: null
+    name: libmng
+    release: 14.el7
+    source: rpm
+    version: 1.0.10
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmodman:
+  - arch: x86_64
+    epoch: null
+    name: libmodman
+    release: 8.el7
+    source: rpm
+    version: 2.0.1
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl:
+  - arch: x86_64
+    epoch: null
+    name: libnl
+    release: 3.el7
+    source: rpm
+    version: 1.1.4
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpaper:
+  - arch: x86_64
+    epoch: null
+    name: libpaper
+    release: 8.el7
+    source: rpm
+    version: 1.1.24
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 11.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpng12:
+  - arch: x86_64
+    epoch: null
+    name: libpng12
+    release: 10.el7
+    source: rpm
+    version: 1.2.50
+  libproxy:
+  - arch: x86_64
+    epoch: null
+    name: libproxy
+    release: 11.el7
+    source: rpm
+    version: 0.4.11
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  libsmbclient:
+  - arch: x86_64
+    epoch: 0
+    name: libsmbclient
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  libsoup:
+  - arch: x86_64
+    epoch: null
+    name: libsoup
+    release: 2.el7
+    source: rpm
+    version: 2.62.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libsss_autofs:
+  - arch: x86_64
+    epoch: null
+    name: libsss_autofs
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libsss_certmap:
+  - arch: x86_64
+    epoch: null
+    name: libsss_certmap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libsss_idmap:
+  - arch: x86_64
+    epoch: null
+    name: libsss_idmap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libsss_nss_idmap:
+  - arch: x86_64
+    epoch: null
+    name: libsss_nss_idmap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libsss_sudo:
+  - arch: x86_64
+    epoch: null
+    name: libsss_sudo
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++-devel
+    release: 39.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtalloc:
+  - arch: x86_64
+    epoch: null
+    name: libtalloc
+    release: 1.el7
+    source: rpm
+    version: 2.1.16
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libtdb:
+  - arch: x86_64
+    epoch: null
+    name: libtdb
+    release: 1.el7
+    source: rpm
+    version: 1.3.18
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 9.el7
+    source: rpm
+    version: '1.27'
+  libtevent:
+  - arch: x86_64
+    epoch: null
+    name: libtevent
+    release: 1.el7
+    source: rpm
+    version: 0.9.39
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-tevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-tevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwbclient:
+  - arch: x86_64
+    epoch: 0
+    name: libwbclient
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  - arch: i686
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lm_sensors:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 13.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lsscsi:
+  - arch: x86_64
+    epoch: null
+    name: lsscsi
+    release: 6.el7
+    source: rpm
+    version: '0.27'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 2.el7
+    source: rpm
+    version: 2.02.185
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 2.el7
+    source: rpm
+    version: 2.02.185
+  lz4:
+  - arch: i686
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m2crypto:
+  - arch: x86_64
+    epoch: null
+    name: m2crypto
+    release: 17.el7
+    source: rpm
+    version: 0.21.1
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  mailx:
+  - arch: x86_64
+    epoch: null
+    name: mailx
+    release: 19.el7
+    source: rpm
+    version: '12.5'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
+  mesa-libGLU:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGLU
+    release: 4.el7
+    source: rpm
+    version: 9.0.0
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 5.el7
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mlocate:
+  - arch: x86_64
+    epoch: null
+    name: mlocate
+    release: 8.el7
+    source: rpm
+    version: '0.26'
+  mokutil:
+  - arch: x86_64
+    epoch: null
+    name: mokutil
+    release: 8.el7_8
+    source: rpm
+    version: '15'
+  motif:
+  - arch: x86_64
+    epoch: null
+    name: motif
+    release: 14.el7_5
+    source: rpm
+    version: 2.3.4
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-utils:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-utils
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  nettle:
+  - arch: x86_64
+    epoch: null
+    name: nettle
+    release: 9.el7_9
+    source: rpm
+    version: 2.7.1
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.65.el7
+    source: rpm
+    version: 1.3.0
+  nscd:
+  - arch: x86_64
+    epoch: null
+    name: nscd
+    release: 322.el7_9
+    source: rpm
+    version: '2.17'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7_8.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7_8.2
+    source: rpm
+    version: 4.2.6p5
+  numactl:
+  - arch: x86_64
+    epoch: null
+    name: numactl
+    release: 3.el7
+    source: rpm
+    version: 2.0.12
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.12
+  numad:
+  - arch: x86_64
+    epoch: null
+    name: numad
+    release: 18.20150602git.el7
+    source: rpm
+    version: '0.5'
+  oddjob:
+  - arch: x86_64
+    epoch: null
+    name: oddjob
+    release: 4.el7
+    source: rpm
+    version: 0.31.5
+  oddjob-mkhomedir:
+  - arch: x86_64
+    epoch: null
+    name: oddjob-mkhomedir
+    release: 4.el7
+    source: rpm
+    version: 0.31.5
+  openjpeg2:
+  - arch: x86_64
+    epoch: null
+    name: openjpeg2
+    release: 3.el7_7
+    source: rpm
+    version: 2.3.1
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 25.el7_9
+    source: rpm
+    version: 2.4.44
+  openldap-clients:
+  - arch: x86_64
+    epoch: null
+    name: openldap-clients
+    release: 25.el7_9
+    source: rpm
+    version: 2.4.44
+  openscap:
+  - arch: x86_64
+    epoch: null
+    name: openscap
+    release: 4.el7
+    source: rpm
+    version: 1.2.17
+  openscap-scanner:
+  - arch: x86_64
+    epoch: null
+    name: openscap-scanner
+    release: 4.el7
+    source: rpm
+    version: 1.2.17
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 25.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 25.el7_9
+    source: rpm
+    version: 1.0.2k
+  oracleasm-support:
+  - arch: x86_64
+    epoch: null
+    name: oracleasm-support
+    release: 3.el7
+    source: rpm
+    version: 2.1.8
+  oracleasmlib:
+  - arch: x86_64
+    epoch: null
+    name: oracleasmlib
+    release: 1.el7
+    source: rpm
+    version: 2.0.12
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  - arch: i686
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  pam-devel:
+  - arch: x86_64
+    epoch: null
+    name: pam-devel
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 31.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 5.el7
+    source: rpm
+    version: '0.79'
+  patch:
+  - arch: x86_64
+    epoch: null
+    name: patch
+    release: 12.el7_7
+    source: rpm
+    version: 2.7.1
+  pciutils:
+  - arch: x86_64
+    epoch: null
+    name: pciutils
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: i686
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-B-Lint:
+  - arch: noarch
+    epoch: null
+    name: perl-B-Lint
+    release: 3.el7
+    source: rpm
+    version: '1.17'
+  perl-Business-ISBN:
+  - arch: noarch
+    epoch: null
+    name: perl-Business-ISBN
+    release: 2.el7
+    source: rpm
+    version: '2.06'
+  perl-Business-ISBN-Data:
+  - arch: noarch
+    epoch: null
+    name: perl-Business-ISBN-Data
+    release: 2.el7
+    source: rpm
+    version: '20120719.001'
+  perl-CGI:
+  - arch: noarch
+    epoch: null
+    name: perl-CGI
+    release: 4.el7
+    source: rpm
+    version: '3.63'
+  perl-CPAN:
+  - arch: noarch
+    epoch: 0
+    name: perl-CPAN
+    release: 299.el7_9
+    source: rpm
+    version: '1.9800'
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Class-ISA:
+  - arch: noarch
+    epoch: null
+    name: perl-Class-ISA
+    release: 1010.el7
+    source: rpm
+    version: '0.36'
+  perl-Compress-Raw-Bzip2:
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
+  perl-Compress-Raw-Zlib:
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Digest:
+  - arch: noarch
+    epoch: null
+    name: perl-Digest
+    release: 245.el7
+    source: rpm
+    version: '1.17'
+  perl-Digest-MD5:
+  - arch: x86_64
+    epoch: null
+    name: perl-Digest-MD5
+    release: 3.el7
+    source: rpm
+    version: '2.52'
+  perl-Digest-SHA:
+  - arch: x86_64
+    epoch: 1
+    name: perl-Digest-SHA
+    release: 4.el7
+    source: rpm
+    version: '5.85'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Encode-Locale:
+  - arch: noarch
+    epoch: null
+    name: perl-Encode-Locale
+    release: 5.el7
+    source: rpm
+    version: '1.03'
+  perl-Env:
+  - arch: noarch
+    epoch: null
+    name: perl-Env
+    release: 2.el7
+    source: rpm
+    version: '1.04'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-ExtUtils-Install:
+  - arch: noarch
+    epoch: 0
+    name: perl-ExtUtils-Install
+    release: 299.el7_9
+    source: rpm
+    version: '1.58'
+  perl-ExtUtils-MakeMaker:
+  - arch: noarch
+    epoch: null
+    name: perl-ExtUtils-MakeMaker
+    release: 3.el7
+    source: rpm
+    version: '6.68'
+  perl-ExtUtils-Manifest:
+  - arch: noarch
+    epoch: null
+    name: perl-ExtUtils-Manifest
+    release: 244.el7
+    source: rpm
+    version: '1.61'
+  perl-ExtUtils-ParseXS:
+  - arch: noarch
+    epoch: 1
+    name: perl-ExtUtils-ParseXS
+    release: 3.el7
+    source: rpm
+    version: '3.18'
+  perl-FCGI:
+  - arch: x86_64
+    epoch: 1
+    name: perl-FCGI
+    release: 8.el7
+    source: rpm
+    version: '0.74'
+  perl-File-CheckTree:
+  - arch: noarch
+    epoch: null
+    name: perl-File-CheckTree
+    release: 3.el7
+    source: rpm
+    version: '4.42'
+  perl-File-Listing:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Listing
+    release: 7.el7
+    source: rpm
+    version: '6.04'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTML-Parser:
+  - arch: x86_64
+    epoch: null
+    name: perl-HTML-Parser
+    release: 4.el7
+    source: rpm
+    version: '3.71'
+  perl-HTML-Tagset:
+  - arch: noarch
+    epoch: null
+    name: perl-HTML-Tagset
+    release: 15.el7
+    source: rpm
+    version: '3.20'
+  perl-HTTP-Cookies:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Cookies
+    release: 5.el7
+    source: rpm
+    version: '6.01'
+  perl-HTTP-Daemon:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Daemon
+    release: 8.el7
+    source: rpm
+    version: '6.01'
+  perl-HTTP-Date:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Date
+    release: 8.el7
+    source: rpm
+    version: '6.02'
+  perl-HTTP-Message:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Message
+    release: 6.el7
+    source: rpm
+    version: '6.06'
+  perl-HTTP-Negotiate:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Negotiate
+    release: 5.el7
+    source: rpm
+    version: '6.01'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-IO-Compress:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
+  perl-IO-HTML:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-HTML
+    release: 2.el7
+    source: rpm
+    version: '1.00'
+  perl-IO-Socket-IP:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Socket-IP
+    release: 5.el7
+    source: rpm
+    version: '0.21'
+  perl-IO-Socket-SSL:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Socket-SSL
+    release: 7.el7
+    source: rpm
+    version: '1.94'
+  perl-LWP-MediaTypes:
+  - arch: noarch
+    epoch: null
+    name: perl-LWP-MediaTypes
+    release: 2.el7
+    source: rpm
+    version: '6.02'
+  perl-Locale-Codes:
+  - arch: noarch
+    epoch: null
+    name: perl-Locale-Codes
+    release: 2.el7
+    source: rpm
+    version: '3.26'
+  perl-Locale-Maketext:
+  - arch: noarch
+    epoch: null
+    name: perl-Locale-Maketext
+    release: 3.el7
+    source: rpm
+    version: '1.23'
+  perl-Module-Pluggable:
+  - arch: noarch
+    epoch: 1
+    name: perl-Module-Pluggable
+    release: 3.el7
+    source: rpm
+    version: '4.8'
+  perl-Mozilla-CA:
+  - arch: noarch
+    epoch: null
+    name: perl-Mozilla-CA
+    release: 5.el7
+    source: rpm
+    version: '20130114'
+  perl-Net-HTTP:
+  - arch: noarch
+    epoch: null
+    name: perl-Net-HTTP
+    release: 2.el7
+    source: rpm
+    version: '6.06'
+  perl-Net-LibIDN:
+  - arch: x86_64
+    epoch: null
+    name: perl-Net-LibIDN
+    release: 15.el7
+    source: rpm
+    version: '0.12'
+  perl-Net-SSLeay:
+  - arch: x86_64
+    epoch: null
+    name: perl-Net-SSLeay
+    release: 6.el7
+    source: rpm
+    version: '1.55'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Checker:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Checker
+    release: 2.el7
+    source: rpm
+    version: '1.60'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-LaTeX:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-LaTeX
+    release: 2.el7
+    source: rpm
+    version: '0.61'
+  perl-Pod-Parser:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Parser
+    release: 2.el7
+    source: rpm
+    version: '1.61'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Plainer:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Plainer
+    release: 4.el7
+    source: rpm
+    version: '1.03'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 4.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Sys-Syslog:
+  - arch: x86_64
+    epoch: null
+    name: perl-Sys-Syslog
+    release: 3.el7
+    source: rpm
+    version: '0.33'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Test-Simple:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Simple
+    release: 243.el7
+    source: rpm
+    version: '0.98'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Text-Soundex:
+  - arch: x86_64
+    epoch: null
+    name: perl-Text-Soundex
+    release: 4.el7
+    source: rpm
+    version: '3.04'
+  perl-Text-Unidecode:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-Unidecode
+    release: 20.el7
+    source: rpm
+    version: '0.04'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-TimeDate:
+  - arch: noarch
+    epoch: 1
+    name: perl-TimeDate
+    release: 2.el7
+    source: rpm
+    version: '2.30'
+  perl-URI:
+  - arch: noarch
+    epoch: null
+    name: perl-URI
+    release: 9.el7
+    source: rpm
+    version: '1.60'
+  perl-WWW-RobotRules:
+  - arch: noarch
+    epoch: null
+    name: perl-WWW-RobotRules
+    release: 5.el7
+    source: rpm
+    version: '6.02'
+  perl-XML-LibXML:
+  - arch: x86_64
+    epoch: 1
+    name: perl-XML-LibXML
+    release: 5.el7
+    source: rpm
+    version: '2.0018'
+  perl-XML-NamespaceSupport:
+  - arch: noarch
+    epoch: null
+    name: perl-XML-NamespaceSupport
+    release: 10.el7
+    source: rpm
+    version: '1.11'
+  perl-XML-SAX:
+  - arch: noarch
+    epoch: null
+    name: perl-XML-SAX
+    release: 9.el7
+    source: rpm
+    version: '0.99'
+  perl-XML-SAX-Base:
+  - arch: noarch
+    epoch: null
+    name: perl-XML-SAX-Base
+    release: 7.el7
+    source: rpm
+    version: '1.08'
+  perl-autodie:
+  - arch: noarch
+    epoch: null
+    name: perl-autodie
+    release: 2.el7
+    source: rpm
+    version: '2.16'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-devel:
+  - arch: x86_64
+    epoch: 4
+    name: perl-devel
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-libwww-perl:
+  - arch: noarch
+    epoch: null
+    name: perl-libwww-perl
+    release: 2.el7
+    source: rpm
+    version: '6.05'
+  perl-local-lib:
+  - arch: noarch
+    epoch: null
+    name: perl-local-lib
+    release: 4.el7
+    source: rpm
+    version: '1.008010'
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  plymouth:
+  - arch: x86_64
+    epoch: null
+    name: plymouth
+    release: 0.32.20140113.el7
+    source: rpm
+    version: 0.8.9
+  plymouth-core-libs:
+  - arch: x86_64
+    epoch: null
+    name: plymouth-core-libs
+    release: 0.32.20140113.el7
+    source: rpm
+    version: 0.8.9
+  plymouth-scripts:
+  - arch: x86_64
+    epoch: null
+    name: plymouth-scripts
+    release: 0.32.20140113.el7
+    source: rpm
+    version: 0.8.9
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 33.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 33.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  poppler-data:
+  - arch: noarch
+    epoch: null
+    name: poppler-data
+    release: 3.el7
+    source: rpm
+    version: 0.4.6
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  powertop:
+  - arch: x86_64
+    epoch: null
+    name: powertop
+    release: 1.el7
+    source: rpm
+    version: '2.9'
+  ppp:
+  - arch: x86_64
+    epoch: null
+    name: ppp
+    release: 34.el7_7
+    source: rpm
+    version: 2.4.5
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 26.el7
+    source: rpm
+    version: 3.3.10
+  psmisc:
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 16.el7
+    source: rpm
+    version: '22.20'
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pyOpenSSL:
+  - arch: x86_64
+    epoch: null
+    name: pyOpenSSL
+    release: 4.el7
+    source: rpm
+    version: 0.13.1
+  pygobject2:
+  - arch: x86_64
+    epoch: null
+    name: pygobject2
+    release: 11.el7
+    source: rpm
+    version: 2.28.6
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyldb:
+  - arch: x86_64
+    epoch: null
+    name: pyldb
+    release: 2.el7_9
+    source: rpm
+    version: 1.5.4
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyparsing:
+  - arch: noarch
+    epoch: null
+    name: pyparsing
+    release: 9.el7
+    source: rpm
+    version: 1.5.6
+  pytalloc:
+  - arch: x86_64
+    epoch: null
+    name: pytalloc
+    release: 1.el7
+    source: rpm
+    version: 2.1.16
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-dateutil:
+  - arch: noarch
+    epoch: null
+    name: python-dateutil
+    release: 7.el7
+    source: rpm
+    version: '1.5'
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-dmidecode:
+  - arch: x86_64
+    epoch: null
+    name: python-dmidecode
+    release: 3.el7
+    source: rpm
+    version: 3.12.2
+  python-ethtool:
+  - arch: x86_64
+    epoch: null
+    name: python-ethtool
+    release: 8.el7
+    source: rpm
+    version: '0.8'
+  python-firewall:
+  - arch: noarch
+    epoch: null
+    name: python-firewall
+    release: 2.el7_7.1
+    source: rpm
+    version: 0.6.3
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-gudev:
+  - arch: x86_64
+    epoch: null
+    name: python-gudev
+    release: 7.el7
+    source: rpm
+    version: '147.2'
+  python-hwdata:
+  - arch: noarch
+    epoch: null
+    name: python-hwdata
+    release: 4.el7
+    source: rpm
+    version: 1.7.3
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-inotify:
+  - arch: noarch
+    epoch: null
+    name: python-inotify
+    release: 4.el7
+    source: rpm
+    version: 0.9.4
+  python-ipaddr:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddr
+    release: 2.el7
+    source: rpm
+    version: 2.1.11
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-magic:
+  - arch: noarch
+    epoch: null
+    name: python-magic
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.62.1.el7
+    source: rpm
+    version: 3.10.0
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-slip:
+  - arch: noarch
+    epoch: null
+    name: python-slip
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-slip-dbus:
+  - arch: noarch
+    epoch: null
+    name: python-slip-dbus
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-sssdconfig:
+  - arch: noarch
+    epoch: null
+    name: python-sssdconfig
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  python-syspurpose:
+  - arch: x86_64
+    epoch: null
+    name: python-syspurpose
+    release: 3.el7_7
+    source: rpm
+    version: 1.24.13
+  python-tdb:
+  - arch: x86_64
+    epoch: null
+    name: python-tdb
+    release: 1.el7
+    source: rpm
+    version: 1.3.18
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python2-futures:
+  - arch: noarch
+    epoch: null
+    name: python2-futures
+    release: 5.el7
+    source: rpm
+    version: 3.1.1
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_8
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  qt:
+  - arch: x86_64
+    epoch: 1
+    name: qt
+    release: 9.el7_9
+    source: rpm
+    version: 4.8.7
+  qt-settings:
+  - arch: noarch
+    epoch: null
+    name: qt-settings
+    release: 23.10.el7_7
+    source: rpm
+    version: '19'
+  qt-x11:
+  - arch: x86_64
+    epoch: 1
+    name: qt-x11
+    release: 9.el7_9
+    source: rpm
+    version: 4.8.7
+  qt3:
+  - arch: x86_64
+    epoch: null
+    name: qt3
+    release: 51.el7
+    source: rpm
+    version: 3.3.8b
+  qualys-cloud-agent:
+  - arch: x86_64
+    epoch: null
+    name: qualys-cloud-agent
+    release: '49'
+    source: rpm
+    version: 4.8.0
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  rdma-core:
+  - arch: i686
+    epoch: null
+    name: rdma-core
+    release: 3.el7
+    source: rpm
+    version: '22.1'
+  - arch: x86_64
+    epoch: null
+    name: rdma-core
+    release: 3.el7
+    source: rpm
+    version: '22.1'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  realmd:
+  - arch: x86_64
+    epoch: null
+    name: realmd
+    release: 11.el7
+    source: rpm
+    version: 0.16.1
+  redhat-logos:
+  - arch: noarch
+    epoch: null
+    name: redhat-logos
+    release: 1.el7
+    source: rpm
+    version: 70.7.0
+  redhat-lsb:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-core:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-core
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-cxx:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-cxx
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-desktop:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-desktop
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-languages:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-languages
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-printing:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-printing
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-submod-multimedia:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-submod-multimedia
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-lsb-submod-security:
+  - arch: x86_64
+    epoch: null
+    name: redhat-lsb-submod-security
+    release: 27.el7
+    source: rpm
+    version: '4.1'
+  redhat-release-server:
+  - arch: x86_64
+    epoch: null
+    name: redhat-release-server
+    release: 10.el7
+    source: rpm
+    version: '7.7'
+  redhat-support-lib-python:
+  - arch: noarch
+    epoch: null
+    name: redhat-support-lib-python
+    release: 6.el7
+    source: rpm
+    version: 0.9.7
+  redhat-support-tool:
+  - arch: noarch
+    epoch: null
+    name: redhat-support-tool
+    release: 1.el7
+    source: rpm
+    version: 0.9.11
+  rhn-client-tools:
+  - arch: x86_64
+    epoch: null
+    name: rhn-client-tools
+    release: 24.el7
+    source: rpm
+    version: 2.0.2
+  rhnlib:
+  - arch: noarch
+    epoch: null
+    name: rhnlib
+    release: 8.el7
+    source: rpm
+    version: 2.5.65
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
+    name: rpcbind
+    release: 48.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 52.el7
+    source: rpm
+    version: 8.24.0
+  samba-client-libs:
+  - arch: x86_64
+    epoch: 0
+    name: samba-client-libs
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  samba-common:
+  - arch: noarch
+    epoch: 0
+    name: samba-common
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  samba-common-libs:
+  - arch: x86_64
+    epoch: 0
+    name: samba-common-libs
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  samba-common-tools:
+  - arch: x86_64
+    epoch: 0
+    name: samba-common-tools
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  samba-libs:
+  - arch: x86_64
+    epoch: 0
+    name: samba-libs
+    release: 18.el7_9
+    source: rpm
+    version: 4.10.16
+  scap-security-guide:
+  - arch: noarch
+    epoch: null
+    name: scap-security-guide
+    release: 13.el7
+    source: rpm
+    version: 0.1.43
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 252.el7.1
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 252.el7.1
+    source: rpm
+    version: 3.13.1
+  setools-console:
+  - arch: x86_64
+    epoch: null
+    name: setools-console
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 18.el7_7.1
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 18.el7_7.1
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  shim-unsigned:
+  - arch: x86_64
+    epoch: null
+    name: shim-unsigned
+    release: 1.el7
+    source: rpm
+    version: '0.9'
+  shim-x64:
+  - arch: x86_64
+    epoch: null
+    name: shim-x64
+    release: 8.el7_8
+    source: rpm
+    version: '15'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smartmontools:
+  - arch: x86_64
+    epoch: 1
+    name: smartmontools
+    release: 1.el7
+    source: rpm
+    version: '7.0'
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sos:
+  - arch: noarch
+    epoch: null
+    name: sos
+    release: 6.el7_7
+    source: rpm
+    version: '3.7'
+  spax:
+  - arch: x86_64
+    epoch: null
+    name: spax
+    release: 13.el7
+    source: rpm
+    version: 1.5.2
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sssd:
+  - arch: x86_64
+    epoch: null
+    name: sssd
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-ad:
+  - arch: x86_64
+    epoch: null
+    name: sssd-ad
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-client:
+  - arch: x86_64
+    epoch: null
+    name: sssd-client
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-common:
+  - arch: x86_64
+    epoch: null
+    name: sssd-common
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-common-pac:
+  - arch: x86_64
+    epoch: null
+    name: sssd-common-pac
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-ipa:
+  - arch: x86_64
+    epoch: null
+    name: sssd-ipa
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-krb5:
+  - arch: x86_64
+    epoch: null
+    name: sssd-krb5
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-krb5-common:
+  - arch: x86_64
+    epoch: null
+    name: sssd-krb5-common
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-ldap:
+  - arch: x86_64
+    epoch: null
+    name: sssd-ldap
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  sssd-proxy:
+  - arch: x86_64
+    epoch: null
+    name: sssd-proxy
+    release: 10.el7_9.10
+    source: rpm
+    version: 1.16.5
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 9.el7
+    source: rpm
+    version: '4.12'
+  subscription-manager:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager
+    release: 1.el7
+    source: rpm
+    version: 1.24.26
+  subscription-manager-rhsm:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm
+    release: 1.el7
+    source: rpm
+    version: 1.24.26
+  subscription-manager-rhsm-certificates:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm-certificates
+    release: 1.el7
+    source: rpm
+    version: 1.24.26
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.1
+    source: rpm
+    version: 1.8.23
+  sysfsutils:
+  - arch: x86_64
+    epoch: null
+    name: sysfsutils
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 18.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7
+    source: rpm
+    version: '219'
+  - arch: i686
+    epoch: null
+    name: systemd-libs
+    release: 78.el7
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7
+    source: rpm
+    version: '219'
+  systemtap-sdt-devel:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-sdt-devel
+    release: 9.el7
+    source: rpm
+    version: '4.0'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcl:
+  - arch: x86_64
+    epoch: 1
+    name: tcl
+    release: 8.el7
+    source: rpm
+    version: 8.5.13
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 9.el7
+    source: rpm
+    version: '1.27'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 65.el7_8
+    source: rpm
+    version: '0.17'
+  time:
+  - arch: x86_64
+    epoch: null
+    name: time
+    release: 45.el7
+    source: rpm
+    version: '1.7'
+  tk:
+  - arch: x86_64
+    epoch: 1
+    name: tk
+    release: 6.el7
+    source: rpm
+    version: 8.5.13
+  traceroute:
+  - arch: x86_64
+    epoch: 3
+    name: traceroute
+    release: 2.el7
+    source: rpm
+    version: 2.0.22
+  tree:
+  - arch: x86_64
+    epoch: null
+    name: tree
+    release: 10.el7
+    source: rpm
+    version: 1.6.0
+  trousers:
+  - arch: x86_64
+    epoch: null
+    name: trousers
+    release: 2.el7
+    source: rpm
+    version: 0.3.14
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 5.el7_7.1
+    source: rpm
+    version: 2.11.0
+  tuned-utils:
+  - arch: noarch
+    epoch: null
+    name: tuned-utils
+    release: 5.el7_7.1
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019c
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
+  urw-base35-bookman-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-bookman-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-c059-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-c059-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-d050000l-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-d050000l-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-fonts-common:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-fonts-common
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-gothic-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-gothic-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-nimbus-mono-ps-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-nimbus-mono-ps-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-nimbus-roman-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-nimbus-roman-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-nimbus-sans-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-nimbus-sans-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-p052-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-p052-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-standard-symbols-ps-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-standard-symbols-ps-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  urw-base35-z003-fonts:
+  - arch: noarch
+    epoch: null
+    name: urw-base35-z003-fonts
+    release: 10.el7
+    source: rpm
+    version: '20170801'
+  usermode:
+  - arch: x86_64
+    epoch: null
+    name: usermode
+    release: 6.el7
+    source: rpm
+    version: '1.111'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 61.el7
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xdg-utils:
+  - arch: noarch
+    epoch: null
+    name: xdg-utils
+    release: 0.17.20120809git.el7
+    source: rpm
+    version: 1.1.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 20.el7
+    source: rpm
+    version: 4.5.0
+  xinetd:
+  - arch: x86_64
+    epoch: 2
+    name: xinetd
+    release: 13.el7
+    source: rpm
+    version: 2.3.15
+  xml-common:
+  - arch: noarch
+    epoch: null
+    name: xml-common
+    release: 39.el7
+    source: rpm
+    version: 0.6.3
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-server-utils:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-server-utils
+    release: 20.el7
+    source: rpm
+    version: '7.7'
+  xorg-x11-utils:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-utils
+    release: 23.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-xauth:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-xauth
+    release: 1.el7
+    source: rpm
+    version: 1.0.9
+  xorg-x11-xbitmaps:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-xbitmaps
+    release: 6.el7
+    source: rpm
+    version: 1.1.1
+  xorg-x11-xinit:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-xinit
+    release: 2.el7
+    source: rpm
+    version: 1.3.4
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  - arch: i686
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 163.el7
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 52.el7
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: i686
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '54'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '64'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '66'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '67'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '71'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '72'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '73'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '74'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '77'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '78'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '82'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '84'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '86'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '88'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '89'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '90'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '91'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '92'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '93'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '94'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '95'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '96'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '97'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '98'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '99'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '105'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '106'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '107'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '108'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '118'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '119'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '121'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '123'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '137'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '176'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '365'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '366'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '367'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '369'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '370'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '371'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '373'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '413'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '414'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '512'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '612'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '613'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '624'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '625'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '638'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '639'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '640'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '641'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '642'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '643'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '644'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '645'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '646'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '647'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '648'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '649'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '732'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '765'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '768'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '810'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '811'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '812'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '813'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '814'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1167'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1168'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1169'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1170'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1171'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1172'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1184'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1185'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1186'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1188'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1195'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1196'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1197'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1198'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1199'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1200'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1201'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1202'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1204'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1205'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1207'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1208'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1210'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1211'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1213'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1214'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1217'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1218'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1219'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1222'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1224'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1225'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1227'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1228'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1237'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1238'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1240'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1241'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1243'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1244'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1246'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1247'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1258'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1259'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1260'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1261'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1262'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1263'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1271'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1273'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1275'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1277'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1278'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1279'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1280'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1281'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1282'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1297'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1301'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1302'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1303'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1304'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1311'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1312'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1315'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1321'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1322'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1324'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1325'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1326'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1329'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1330'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1331'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1332'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1333'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1334'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1335'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1350'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1351'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1353'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1354'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1355'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1356'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1357'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1358'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1359'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1360'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1361'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1362'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1363'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1364'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1365'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1366'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1367'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1368'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1370'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1371'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1372'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1373'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1374'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1375'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1385'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1386'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1387'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1388'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1389'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1401'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1402'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1403'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1404'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1405'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1406'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1413'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1414'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1415'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1416'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1417'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1418'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1419'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1420'
+  ppid: '2'
+  user: root
+- cmdline: /opt/CrowdStrike/falcond
+  cwd: /opt/CrowdStrike/
+  pid: '1436'
+  ppid: '1'
+  user: root
+- cmdline: falcon-sensor
+  cwd: /
+  pid: '1438'
+  ppid: '1436'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '1448'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '1494'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '1499'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '1500'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/ntpd -u ntp:ntp -u ntp:ntp -p /var/run/ntpd.pid -g
+  cwd: /usr/sbin/
+  pid: '1514'
+  ppid: '1'
+  user: ntp
+- cmdline: /usr/sbin/NetworkManager --no-daemon
+  cwd: /usr/sbin/
+  pid: '1516'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sssd -i --logger=files
+  cwd: /usr/sbin/
+  pid: '1520'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '1564'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/nscd
+  cwd: /usr/sbin/
+  pid: '1597'
+  ppid: '1'
+  user: nscd
+- cmdline: /usr/libexec/sssd/sssd_be --domain ES.WCORP.CARREFOUR.COM --uid 0 --gid
+    0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2392'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/local/avamar/bin/avagent.bin --bindir="/usr/local/avamar/bin" --vardir="/usr/local/avamar/var"
+    --sysdir="/usr/local/avamar/etc" --logfile="/usr/local/avamar/var/avagent.log"
+  cwd: /usr/local/avamar/bin/
+  pid: '2479'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/vmtoolsd
+  cwd: /usr/sbin/
+  pid: '2490'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/vmware-vgauth/VGAuthService -s
+  cwd: /usr/lib/vmware-vgauth/
+  pid: '2583'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2697'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/libexec/sssd/sssd_pam --uid 0 --gid 0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2698'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/libexec/sssd/sssd_pac --uid 0 --gid 0 --logger=files
+  cwd: /usr/libexec/sssd/
+  pid: '2699'
+  ppid: '1520'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '2722'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/atd -f
+  cwd: /usr/sbin/
+  pid: '2731'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '2735'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '2743'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '2882'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '2884'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '2888'
+  ppid: '1'
+  user: root
+- cmdline: /usr/share/filebeat/bin/filebeat -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '2891'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh /etc/init.d/init.ohasd run >/dev/null 2>&1 </dev/null
+  cwd: /bin/
+  pid: '2892'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '2893'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/qualys/cloud-agent/bin/qualys-cloud-agent
+  cwd: /usr/local/qualys/cloud-agent/bin/
+  pid: '2907'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/rhsmcertd
+  cwd: /usr/bin/
+  pid: '2909'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/xinetd -stayalive -pidfile /var/run/xinetd.pid
+  cwd: /usr/sbin/
+  pid: '2919'
+  ppid: '1'
+  user: root
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm.opt
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '3268'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3451'
+  ppid: '2'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '3539'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '3568'
+  ppid: '3539'
+  user: postfix
+- cmdline: bin/rscw
+  cwd: bin/
+  pid: '4017'
+  ppid: '1'
+  user: root
+- cmdline: bin/rscd
+  cwd: bin/
+  pid: '4019'
+  ppid: '4017'
+  user: root
+- cmdline: bin/rscd
+  cwd: bin/
+  pid: '4020'
+  ppid: '4017'
+  user: root
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_ARSYS.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '5787'
+  ppid: '1'
+  user: root
+- cmdline: ora_o001_BSAREP
+  cwd: /
+  pid: '7109'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o001_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '7111'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_w005_BSAREP
+  cwd: /
+  pid: '8166'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w004_BSAAPP
+  cwd: /
+  pid: '8584'
+  ppid: '1'
+  user: oragrid
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BNABBDD.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '9365'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10723'
+  ppid: '2'
+  user: root
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '11271'
+  ppid: '1'
+  user: oragrid
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAAPP.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '11643'
+  ppid: '1'
+  user: root
+- cmdline: /opt/tivoli/tsm/client/ba/bin/dsmc sched -optfile=/opt/tivoli/tsm/client/ba/bin/dsm_TDP_ORA_LD1BMB02_BSAREP.opt
+    -pass
+  cwd: /opt/tivoli/tsm/client/ba/bin/
+  pid: '12211'
+  ppid: '1'
+  user: root
+- cmdline: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/perl
+    /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/bin/emwd.pl
+    agent /softOracle/app/oracle/product/12.1.0.4/agentes/gcinst/sysman/log/emagent.nohup
+  cwd: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/perl/bin/
+  pid: '13389'
+  ppid: '1'
+  user: oracle
+- cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
+    /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/bin/emwd.pl
+    agent /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_inst/sysman/log/emagent.nohup
+  cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/
+  pid: '13482'
+  ppid: '1'
+  user: oracle
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ohasd.bin
+    reboot
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '13578'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdk/bin/java
+    -Xmx128M -XX:MaxPermSize=96M -server -Djava.security.egd=file:///dev/./urandom
+    -Dsun.lang.ClassLoader.allowArraySyntax=true -XX:+UseLinuxPosixThreadCPUClocks
+    -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -Dwatchdog.pid=13389
+    -cp /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdbc/lib/ojdbc5.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.http_client_11.1.1.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/xmlparserv2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/jsch.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/lib/optic.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.dms_11.1.1/dms.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/modules/oracle.odl_11.1.1/ojdl2.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/sysman/jlib/emagentSDK.jar
+    oracle.sysman.gcagent.tmmain.TMMain
+  cwd: /softOracle/app/oracle/product/12.1.0.4/agentes/agent/core/12.1.0.4.0/jdk/bin/
+  pid: '13590'
+  ppid: '13389'
+  user: oracle
+- cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/jdk/bin/java
+    -Xmx128M -XX:MaxMetaspaceSize=224M -server -Djava.security.egd=file:///dev/./urandom
+    -Dsun.lang.ClassLoader.allowArraySyntax=true -XX:-UseLargePages -XX:+UseLinuxPosixThreadCPUClocks
+    -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+UseCompressedOops -DHTTPClient.dontSeekTerminatingChunk=true
+    -Dwatchdog.pid=13482 -cp /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jdbc/lib/ojdbc7.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/ucp/lib/ucp.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/jsch-0.1.54.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/com.oracle.http_client.http_client.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.xdk/xmlparserv2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.dms/dms.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/modules/oracle.odl/ojdl2.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/lib/optic.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/log4j-core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/jlib/gcagent_core.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK-intg.jar:/softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/sysman/jlib/emagentSDK.jar
+    oracle.sysman.gcagent.tmmain.TMMain
+  cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/oracle_common/jdk/bin/
+  pid: '13648'
+  ppid: '13482'
+  user: oracle
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/oraagent.bin
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14470'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmd.bin
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14491'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAAPP
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14496'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BSAREP
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14500'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_BNABBDD
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14505'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/evmlogger.bin
+    -o /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.info
+    -l /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/log/[HOSTNAME]/evmd/evmlogger.log
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14758'
+  ppid: '14491'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/tnslsnr
+    LISTENER -no_crs_notify -inherit
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '14763'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/tnslsnr LISTENER_ARSYS
+    -no_crs_notify -inherit
+  cwd: /softOracle/app/oracle/product/12.1.0.2/db_1/bin/
+  pid: '14782'
+  ppid: '1'
+  user: oragrid
+- cmdline: /usr/local/qualys/cloud-agent/bin/agentid-service -config /etc/qualys/cloud-agent/agentid-service.conf
+    -logdir /var/log/qualys/
+  cwd: /usr/local/qualys/cloud-agent/bin/
+  pid: '14887'
+  ppid: '1'
+  user: root
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/cssdagent
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '15030'
+  ppid: '1'
+  user: oragrid
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/ocssd.bin
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '15057'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_pmon_+ASM
+  cwd: /
+  pid: '15350'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_psp0_+ASM
+  cwd: /
+  pid: '15354'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_vktm_+ASM
+  cwd: /
+  pid: '15357'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_gen0_+ASM
+  cwd: /
+  pid: '15363'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_mman_+ASM
+  cwd: /
+  pid: '15365'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_diag_+ASM
+  cwd: /
+  pid: '15369'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_dia0_+ASM
+  cwd: /
+  pid: '15371'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_dbw0_+ASM
+  cwd: /
+  pid: '15373'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_lgwr_+ASM
+  cwd: /
+  pid: '15375'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_ckpt_+ASM
+  cwd: /
+  pid: '15377'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_smon_+ASM
+  cwd: /
+  pid: '15379'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_lreg_+ASM
+  cwd: /
+  pid: '15381'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_pxmn_+ASM
+  cwd: /
+  pid: '15383'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_rbal_+ASM
+  cwd: /
+  pid: '15385'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_gmon_+ASM
+  cwd: /
+  pid: '15387'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_mmon_+ASM
+  cwd: /
+  pid: '15389'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_mmnl_+ASM
+  cwd: /
+  pid: '15391'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15491'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15494'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15509'
+  ppid: '1'
+  user: oragrid
+- cmdline: asm_asmb_+ASM
+  cwd: /
+  pid: '15538'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_+asm (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15545'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '15554'
+  ppid: '2'
+  user: root
+- cmdline: ora_pmon_ARSYS
+  cwd: /
+  pid: '15612'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_ARSYS
+  cwd: /
+  pid: '15614'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_ARSYS
+  cwd: /
+  pid: '15621'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_ARSYS
+  cwd: /
+  pid: '15625'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_ARSYS
+  cwd: /
+  pid: '15627'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_ARSYS
+  cwd: /
+  pid: '15631'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_ARSYS
+  cwd: /
+  pid: '15633'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_ARSYS
+  cwd: /
+  pid: '15635'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_ARSYS
+  cwd: /
+  pid: '15637'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_ARSYS
+  cwd: /
+  pid: '15639'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_ARSYS
+  cwd: /
+  pid: '15641'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_ARSYS
+  cwd: /
+  pid: '15643'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_ARSYS
+  cwd: /
+  pid: '15645'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_ARSYS
+  cwd: /
+  pid: '15647'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_ARSYS
+  cwd: /
+  pid: '15649'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_ARSYS
+  cwd: /
+  pid: '15651'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_ARSYS
+  cwd: /
+  pid: '15653'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_ARSYS
+  cwd: /
+  pid: '15655'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pxmn_ARSYS
+  cwd: /
+  pid: '15657'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_ARSYS
+  cwd: /
+  pid: '15659'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_ARSYS
+  cwd: /
+  pid: '15661'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_ARSYS
+  cwd: /
+  pid: '15663'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmnl_ARSYS
+  cwd: /
+  pid: '15667'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15669'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_d000_ARSYS
+  cwd: /
+  pid: '15674'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_ARSYS
+  cwd: /
+  pid: '15676'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_ARSYS
+  cwd: /
+  pid: '15678'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pmon_BSAAPP
+  cwd: /
+  pid: '15684'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_BSAAPP
+  cwd: /
+  pid: '15686'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pmon_BNABBDD
+  cwd: /
+  pid: '15688'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_BNABBDD
+  cwd: /
+  pid: '15690'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pmon_BSAREP
+  cwd: /
+  pid: '15692'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_psp0_BSAREP
+  cwd: /
+  pid: '15694'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_BSAAPP
+  cwd: /
+  pid: '15697'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_BSAAPP
+  cwd: /
+  pid: '15701'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_BSAAPP
+  cwd: /
+  pid: '15703'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_BNABBDD
+  cwd: /
+  pid: '15707'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_BSAAPP
+  cwd: /
+  pid: '15709'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_BSAAPP
+  cwd: /
+  pid: '15714'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_BNABBDD
+  cwd: /
+  pid: '15715'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vktm_BSAREP
+  cwd: /
+  pid: '15717'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_BSAAPP
+  cwd: /
+  pid: '15719'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_BNABBDD
+  cwd: /
+  pid: '15723'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_gen0_BSAREP
+  cwd: /
+  pid: '15725'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_BSAAPP
+  cwd: /
+  pid: '15727'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mman_BSAREP
+  cwd: /
+  pid: '15731'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_BNABBDD
+  cwd: /
+  pid: '15735'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_BSAAPP
+  cwd: /
+  pid: '15737'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_diag_BSAREP
+  cwd: /
+  pid: '15739'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_BNABBDD
+  cwd: /
+  pid: '15741'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_BSAAPP
+  cwd: /
+  pid: '15744'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbrm_BSAREP
+  cwd: /
+  pid: '15746'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_BNABBDD
+  cwd: /
+  pid: '15747'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_vkrm_BSAREP
+  cwd: /
+  pid: '15749'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_BNABBDD
+  cwd: /
+  pid: '15751'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_BSAAPP
+  cwd: /
+  pid: '15753'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dia0_BSAREP
+  cwd: /
+  pid: '15755'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_BNABBDD
+  cwd: /
+  pid: '15757'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_BSAAPP
+  cwd: /
+  pid: '15759'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw0_BSAREP
+  cwd: /
+  pid: '15761'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_BSAAPP
+  cwd: /
+  pid: '15763'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_BNABBDD
+  cwd: /
+  pid: '15765'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_BSAAPP
+  cwd: /
+  pid: '15767'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_dbw1_BSAREP
+  cwd: /
+  pid: '15769'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_BNABBDD
+  cwd: /
+  pid: '15771'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_BSAAPP
+  cwd: /
+  pid: '15773'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lgwr_BSAREP
+  cwd: /
+  pid: '15776'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_BNABBDD
+  cwd: /
+  pid: '15778'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_BSAAPP
+  cwd: /
+  pid: '15780'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_ckpt_BSAREP
+  cwd: /
+  pid: '15782'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_BSAAPP
+  cwd: /
+  pid: '15784'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pxmn_BSAAPP
+  cwd: /
+  pid: '15786'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_BSAREP
+  cwd: /
+  pid: '15788'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg00_BNABBDD
+  cwd: /
+  pid: '15790'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_BSAAPP
+  cwd: /
+  pid: '15792'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_BSAREP
+  cwd: /
+  pid: '15794'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smon_BNABBDD
+  cwd: /
+  pid: '15796'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_BNABBDD
+  cwd: /
+  pid: '15798'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_BSAAPP
+  cwd: /
+  pid: '15800'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lg01_BSAREP
+  cwd: /
+  pid: '15802'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_BNABBDD
+  cwd: /
+  pid: '15804'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_BSAAPP
+  cwd: /
+  pid: '15807'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_reco_BSAREP
+  cwd: /
+  pid: '15808'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_BNABBDD
+  cwd: /
+  pid: '15810'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_lreg_BSAREP
+  cwd: /
+  pid: '15813'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmnl_BSAAPP
+  cwd: /
+  pid: '15814'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15816'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_pxmn_BNABBDD
+  cwd: /
+  pid: '15818'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_d000_BSAAPP
+  cwd: /
+  pid: '15821'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_pxmn_BSAREP
+  cwd: /
+  pid: '15822'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_BSAAPP
+  cwd: /
+  pid: '15825'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_BSAREP
+  cwd: /
+  pid: '15826'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_rbal_BNABBDD
+  cwd: /
+  pid: '15828'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_BSAREP
+  cwd: /
+  pid: '15830'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_asmb_BNABBDD
+  cwd: /
+  pid: '15832'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_BSAAPP
+  cwd: /
+  pid: '15834'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_BSAREP
+  cwd: /
+  pid: '15836'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmon_BNABBDD
+  cwd: /
+  pid: '15838'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_asmb_bsarep (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15840'
+  ppid: '1'
+  user: oracle
+- cmdline: oracle+ASM_asmb_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '15842'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_mmnl_BSAREP
+  cwd: /
+  pid: '15844'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mmnl_BNABBDD
+  cwd: /
+  pid: '15846'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_d000_BSAREP
+  cwd: /
+  pid: '15848'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_d000_BNABBDD
+  cwd: /
+  pid: '15852'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_BSAREP
+  cwd: /
+  pid: '15854'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_mark_BNABBDD
+  cwd: /
+  pid: '15856'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_BSAREP
+  cwd: /
+  pid: '15858'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_s000_BNABBDD
+  cwd: /
+  pid: '15862'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_ARSYS
+  cwd: /
+  pid: '15964'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_ARSYS
+  cwd: /
+  pid: '15966'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_ARSYS
+  cwd: /
+  pid: '15968'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_ARSYS
+  cwd: /
+  pid: '15970'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_ARSYS
+  cwd: /
+  pid: '15972'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_ARSYS
+  cwd: /
+  pid: '15974'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_ARSYS
+  cwd: /
+  pid: '15976'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_ARSYS
+  cwd: /
+  pid: '15978'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_ARSYS
+  cwd: /
+  pid: '15980'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_ARSYS
+  cwd: /
+  pid: '15982'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_ARSYS
+  cwd: /
+  pid: '15984'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_ARSYS
+  cwd: /
+  pid: '15986'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_ARSYS
+  cwd: /
+  pid: '15988'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_ARSYS
+  cwd: /
+  pid: '15990'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_ARSYS
+  cwd: /
+  pid: '15992'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_BNABBDD
+  cwd: /
+  pid: '15995'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_BNABBDD
+  cwd: /
+  pid: '15997'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_BSAREP
+  cwd: /
+  pid: '15999'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p000_BSAAPP
+  cwd: /
+  pid: '16001'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_BNABBDD
+  cwd: /
+  pid: '16004'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_BSAREP
+  cwd: /
+  pid: '16005'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p001_BSAAPP
+  cwd: /
+  pid: '16007'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_BNABBDD
+  cwd: /
+  pid: '16010'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_BSAREP
+  cwd: /
+  pid: '16011'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p002_BSAAPP
+  cwd: /
+  pid: '16013'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_BNABBDD
+  cwd: /
+  pid: '16015'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_BSAREP
+  cwd: /
+  pid: '16017'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_BNABBDD
+  cwd: /
+  pid: '16019'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p003_BSAAPP
+  cwd: /
+  pid: '16021'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_BSAREP
+  cwd: /
+  pid: '16023'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_BNABBDD
+  cwd: /
+  pid: '16027'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_BSAREP
+  cwd: /
+  pid: '16028'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p004_BSAAPP
+  cwd: /
+  pid: '16029'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_BSAREP
+  cwd: /
+  pid: '16031'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p005_BSAAPP
+  cwd: /
+  pid: '16033'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_BNABBDD
+  cwd: /
+  pid: '16035'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_BSAREP
+  cwd: /
+  pid: '16037'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_BNABBDD
+  cwd: /
+  pid: '16039'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p006_BSAAPP
+  cwd: /
+  pid: '16041'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_BSAREP
+  cwd: /
+  pid: '16044'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p007_BSAAPP
+  cwd: /
+  pid: '16045'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_BNABBDD
+  cwd: /
+  pid: '16047'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_BSAREP
+  cwd: /
+  pid: '16051'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_BNABBDD
+  cwd: /
+  pid: '16052'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p008_BSAAPP
+  cwd: /
+  pid: '16053'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_BSAREP
+  cwd: /
+  pid: '16057'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p009_BSAAPP
+  cwd: /
+  pid: '16058'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_BNABBDD
+  cwd: /
+  pid: '16059'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_BSAREP
+  cwd: /
+  pid: '16063'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00a_BSAAPP
+  cwd: /
+  pid: '16064'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_BNABBDD
+  cwd: /
+  pid: '16065'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_BSAREP
+  cwd: /
+  pid: '16069'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_BNABBDD
+  cwd: /
+  pid: '16070'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00b_BSAAPP
+  cwd: /
+  pid: '16071'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_BSAREP
+  cwd: /
+  pid: '16075'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00c_BSAAPP
+  cwd: /
+  pid: '16076'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_BNABBDD
+  cwd: /
+  pid: '16077'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00d_BSAAPP
+  cwd: /
+  pid: '16079'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_BSAREP
+  cwd: /
+  pid: '16081'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00e_BSAAPP
+  cwd: /
+  pid: '16084'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_BNABBDD
+  cwd: /
+  pid: '16123'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_ARSYS
+  cwd: /
+  pid: '16131'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_BNABBDD
+  cwd: /
+  pid: '16133'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_ARSYS
+  cwd: /
+  pid: '16141'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_BNABBDD
+  cwd: /
+  pid: '16145'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_BNABBDD
+  cwd: /
+  pid: '16151'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_ARSYS
+  cwd: /
+  pid: '16153'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_ARSYS
+  cwd: /
+  pid: '16156'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_BNABBDD
+  cwd: /
+  pid: '16157'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_ARSYS
+  cwd: /
+  pid: '16161'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_BSAAPP
+  cwd: /
+  pid: '16167'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_BSAAPP
+  cwd: /
+  pid: '16173'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_ARSYS
+  cwd: /
+  pid: '16177'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_BSAAPP
+  cwd: /
+  pid: '16179'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_BNABBDD
+  cwd: /
+  pid: '16181'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_BSAAPP
+  cwd: /
+  pid: '16183'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tmon_BSAREP
+  cwd: /
+  pid: '16185'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_BSAAPP
+  cwd: /
+  pid: '16187'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc0_BSAREP
+  cwd: /
+  pid: '16189'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc1_BSAREP
+  cwd: /
+  pid: '16191'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc2_BSAREP
+  cwd: /
+  pid: '16194'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_arc3_BSAREP
+  cwd: /
+  pid: '16196'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_BSAAPP
+  cwd: /
+  pid: '16198'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_tt00_BSAREP
+  cwd: /
+  pid: '16200'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_ARSYS
+  cwd: /
+  pid: '16208'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_BNABBDD
+  cwd: /
+  pid: '16215'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_BSAAPP
+  cwd: /
+  pid: '16217'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_smco_BSAREP
+  cwd: /
+  pid: '16253'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_BNABBDD
+  cwd: /
+  pid: '16285'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_ARSYS
+  cwd: /
+  pid: '16287'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_BSAAPP
+  cwd: /
+  pid: '16292'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '16304'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_aqpc_BSAREP
+  cwd: /
+  pid: '16309'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_BSAAPP
+  cwd: /
+  pid: '16318'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_BSAAPP
+  cwd: /
+  pid: '16320'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_BSAAPP
+  cwd: /
+  pid: '16322'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_BSAAPP
+  cwd: /
+  pid: '16324'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_BSAAPP
+  cwd: /
+  pid: '16328'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_BNABBDD
+  cwd: /
+  pid: '16330'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_BSAAPP
+  cwd: /
+  pid: '16332'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_BNABBDD
+  cwd: /
+  pid: '16334'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_BSAAPP
+  cwd: /
+  pid: '16336'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_BNABBDD
+  cwd: /
+  pid: '16338'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_BSAAPP
+  cwd: /
+  pid: '16340'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_BSAAPP
+  cwd: /
+  pid: '16343'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_BNABBDD
+  cwd: /
+  pid: '16344'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_BNABBDD
+  cwd: /
+  pid: '16346'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_BSAAPP
+  cwd: /
+  pid: '16348'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_BNABBDD
+  cwd: /
+  pid: '16351'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_BSAAPP
+  cwd: /
+  pid: '16352'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_BSAAPP
+  cwd: /
+  pid: '16354'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_BNABBDD
+  cwd: /
+  pid: '16356'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_BSAAPP
+  cwd: /
+  pid: '16361'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_BNABBDD
+  cwd: /
+  pid: '16363'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_BSAAPP
+  cwd: /
+  pid: '16365'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_BNABBDD
+  cwd: /
+  pid: '16367'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_ARSYS
+  cwd: /
+  pid: '16369'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_BSAAPP
+  cwd: /
+  pid: '16371'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_ARSYS
+  cwd: /
+  pid: '16373'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_BNABBDD
+  cwd: /
+  pid: '16375'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_BSAAPP
+  cwd: /
+  pid: '16377'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_ARSYS
+  cwd: /
+  pid: '16380'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_BNABBDD
+  cwd: /
+  pid: '16381'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_BNABBDD
+  cwd: /
+  pid: '16383'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_BSAAPP
+  cwd: /
+  pid: '16385'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_ARSYS
+  cwd: /
+  pid: '16387'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_BSAAPP
+  cwd: /
+  pid: '16389'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_ARSYS
+  cwd: /
+  pid: '16391'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_BNABBDD
+  cwd: /
+  pid: '16393'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_ARSYS
+  cwd: /
+  pid: '16396'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_BSAAPP
+  cwd: /
+  pid: '16397'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_BNABBDD
+  cwd: /
+  pid: '16399'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_BNABBDD
+  cwd: /
+  pid: '16401'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_ARSYS
+  cwd: /
+  pid: '16403'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_BSAAPP
+  cwd: /
+  pid: '16405'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_BSAAPP
+  cwd: /
+  pid: '16408'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_BNABBDD
+  cwd: /
+  pid: '16409'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_ARSYS
+  cwd: /
+  pid: '16411'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_BSAAPP
+  cwd: /
+  pid: '16413'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_BNABBDD
+  cwd: /
+  pid: '16415'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_ARSYS
+  cwd: /
+  pid: '16417'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_BSAAPP
+  cwd: /
+  pid: '16419'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_ARSYS
+  cwd: /
+  pid: '16422'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_BNABBDD
+  cwd: /
+  pid: '16423'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_BSAAPP
+  cwd: /
+  pid: '16425'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_ARSYS
+  cwd: /
+  pid: '16428'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_BNABBDD
+  cwd: /
+  pid: '16429'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_BSAAPP
+  cwd: /
+  pid: '16431'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_BNABBDD
+  cwd: /
+  pid: '16434'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_ARSYS
+  cwd: /
+  pid: '16435'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_BSAAPP
+  cwd: /
+  pid: '16437'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_ARSYS
+  cwd: /
+  pid: '16439'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_BNABBDD
+  cwd: /
+  pid: '16441'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_BSAAPP
+  cwd: /
+  pid: '16443'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_BNABBDD
+  cwd: /
+  pid: '16446'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_ARSYS
+  cwd: /
+  pid: '16447'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_BNABBDD
+  cwd: /
+  pid: '16449'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_ARSYS
+  cwd: /
+  pid: '16451'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_BSAAPP
+  cwd: /
+  pid: '16453'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_ARSYS
+  cwd: /
+  pid: '16457'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_BNABBDD
+  cwd: /
+  pid: '16458'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_BSAAPP
+  cwd: /
+  pid: '16460'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_ARSYS
+  cwd: /
+  pid: '16462'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_BNABBDD
+  cwd: /
+  pid: '16464'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_BSAAPP
+  cwd: /
+  pid: '16466'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_BNABBDD
+  cwd: /
+  pid: '16468'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_ARSYS
+  cwd: /
+  pid: '16470'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_BSAAPP
+  cwd: /
+  pid: '16472'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_BNABBDD
+  cwd: /
+  pid: '16475'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_ARSYS
+  cwd: /
+  pid: '16476'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_BSAAPP
+  cwd: /
+  pid: '16478'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_BNABBDD
+  cwd: /
+  pid: '16480'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_ARSYS
+  cwd: /
+  pid: '16482'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_BSAAPP
+  cwd: /
+  pid: '16484'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_BNABBDD
+  cwd: /
+  pid: '16486'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_ARSYS
+  cwd: /
+  pid: '16488'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_BSAAPP
+  cwd: /
+  pid: '16490'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_ARSYS
+  cwd: /
+  pid: '16492'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_BNABBDD
+  cwd: /
+  pid: '16494'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_BSAAPP
+  cwd: /
+  pid: '16496'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_ARSYS
+  cwd: /
+  pid: '16498'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_BNABBDD
+  cwd: /
+  pid: '16500'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_BSAAPP
+  cwd: /
+  pid: '16502'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_ARSYS
+  cwd: /
+  pid: '16505'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_BNABBDD
+  cwd: /
+  pid: '16506'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_BSAAPP
+  cwd: /
+  pid: '16508'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_ARSYS
+  cwd: /
+  pid: '16511'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_BNABBDD
+  cwd: /
+  pid: '16512'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_BSAAPP
+  cwd: /
+  pid: '16514'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_BNABBDD
+  cwd: /
+  pid: '16517'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_ARSYS
+  cwd: /
+  pid: '16518'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_BSAAPP
+  cwd: /
+  pid: '16520'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_BNABBDD
+  cwd: /
+  pid: '16523'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_ARSYS
+  cwd: /
+  pid: '16524'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_BSAAPP
+  cwd: /
+  pid: '16526'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_BNABBDD
+  cwd: /
+  pid: '16529'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_ARSYS
+  cwd: /
+  pid: '16530'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_BSAAPP
+  cwd: /
+  pid: '16532'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_BNABBDD
+  cwd: /
+  pid: '16534'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_BSAAPP
+  cwd: /
+  pid: '16536'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_ARSYS
+  cwd: /
+  pid: '16538'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_BNABBDD
+  cwd: /
+  pid: '16540'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_BSAAPP
+  cwd: /
+  pid: '16542'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_ARSYS
+  cwd: /
+  pid: '16544'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_BNABBDD
+  cwd: /
+  pid: '16546'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_BSAAPP
+  cwd: /
+  pid: '16548'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_ARSYS
+  cwd: /
+  pid: '16550'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_BNABBDD
+  cwd: /
+  pid: '16552'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_BSAAPP
+  cwd: /
+  pid: '16554'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_BNABBDD
+  cwd: /
+  pid: '16556'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_ARSYS
+  cwd: /
+  pid: '16558'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_BSAAPP
+  cwd: /
+  pid: '16560'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_ARSYS
+  cwd: /
+  pid: '16562'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_BNABBDD
+  cwd: /
+  pid: '16564'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_BSAAPP
+  cwd: /
+  pid: '16566'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_ARSYS
+  cwd: /
+  pid: '16568'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_BNABBDD
+  cwd: /
+  pid: '16570'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_BSAAPP
+  cwd: /
+  pid: '16572'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_ARSYS
+  cwd: /
+  pid: '16574'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_BNABBDD
+  cwd: /
+  pid: '16576'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_BSAAPP
+  cwd: /
+  pid: '16579'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_ARSYS
+  cwd: /
+  pid: '16581'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_BNABBDD
+  cwd: /
+  pid: '16583'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_BSAAPP
+  cwd: /
+  pid: '16585'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_ARSYS
+  cwd: /
+  pid: '16587'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_BNABBDD
+  cwd: /
+  pid: '16589'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_ARSYS
+  cwd: /
+  pid: '16591'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_BNABBDD
+  cwd: /
+  pid: '16593'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_ARSYS
+  cwd: /
+  pid: '16595'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_BNABBDD
+  cwd: /
+  pid: '16597'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_ARSYS
+  cwd: /
+  pid: '16599'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_BNABBDD
+  cwd: /
+  pid: '16601'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_ARSYS
+  cwd: /
+  pid: '16603'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_BNABBDD
+  cwd: /
+  pid: '16605'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_ARSYS
+  cwd: /
+  pid: '16607'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_ARSYS
+  cwd: /
+  pid: '16609'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_ARSYS
+  cwd: /
+  pid: '16611'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_ARSYS
+  cwd: /
+  pid: '16613'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_ARSYS
+  cwd: /
+  pid: '16615'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_ARSYS
+  cwd: /
+  pid: '16617'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_ARSYS
+  cwd: /
+  pid: '16619'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_ARSYS
+  cwd: /
+  pid: '16621'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_ARSYS
+  cwd: /
+  pid: '16623'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '16625'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_BSAAPP
+  cwd: /
+  pid: '16627'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_BSAAPP
+  cwd: /
+  pid: '16629'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_BSAAPP
+  cwd: /
+  pid: '16635'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '16637'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_BNABBDD
+  cwd: /
+  pid: '16639'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_BNABBDD
+  cwd: /
+  pid: '16643'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00f_BSAREP
+  cwd: /
+  pid: '16645'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00g_BSAREP
+  cwd: /
+  pid: '16649'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00h_BSAREP
+  cwd: /
+  pid: '16653'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_BNABBDD
+  cwd: /
+  pid: '16655'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00i_BSAREP
+  cwd: /
+  pid: '16657'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00j_BSAREP
+  cwd: /
+  pid: '16659'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_ARSYS
+  cwd: /
+  pid: '16661'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00k_BSAREP
+  cwd: /
+  pid: '16663'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_ARSYS
+  cwd: /
+  pid: '16665'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00l_BSAREP
+  cwd: /
+  pid: '16667'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q002_ARSYS
+  cwd: /
+  pid: '16669'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00m_BSAREP
+  cwd: /
+  pid: '16671'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00n_BSAREP
+  cwd: /
+  pid: '16673'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00o_BSAREP
+  cwd: /
+  pid: '16677'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_ARSYS
+  cwd: /
+  pid: '16679'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00p_BSAREP
+  cwd: /
+  pid: '16681'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00q_BSAREP
+  cwd: /
+  pid: '16683'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00r_BSAREP
+  cwd: /
+  pid: '16685'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00s_BSAREP
+  cwd: /
+  pid: '16687'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00t_BSAREP
+  cwd: /
+  pid: '16689'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00u_BSAREP
+  cwd: /
+  pid: '16691'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_cjq0_BSAREP
+  cwd: /
+  pid: '16693'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00v_BSAREP
+  cwd: /
+  pid: '16695'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00w_BSAREP
+  cwd: /
+  pid: '16698'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00x_BSAREP
+  cwd: /
+  pid: '16700'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00y_BSAREP
+  cwd: /
+  pid: '16702'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p00z_BSAREP
+  cwd: /
+  pid: '16704'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p010_BSAREP
+  cwd: /
+  pid: '16706'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p011_BSAREP
+  cwd: /
+  pid: '16708'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p012_BSAREP
+  cwd: /
+  pid: '16710'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p013_BSAREP
+  cwd: /
+  pid: '16712'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p014_BSAREP
+  cwd: /
+  pid: '16714'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p015_BSAREP
+  cwd: /
+  pid: '16716'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p016_BSAREP
+  cwd: /
+  pid: '16718'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p017_BSAREP
+  cwd: /
+  pid: '16720'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p018_BSAREP
+  cwd: /
+  pid: '16722'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p019_BSAREP
+  cwd: /
+  pid: '16724'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01a_BSAREP
+  cwd: /
+  pid: '16726'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01b_BSAREP
+  cwd: /
+  pid: '16728'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01c_BSAREP
+  cwd: /
+  pid: '16730'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01d_BSAREP
+  cwd: /
+  pid: '16732'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01e_BSAREP
+  cwd: /
+  pid: '16734'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_BSAAPP
+  cwd: /
+  pid: '16736'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01f_BSAREP
+  cwd: /
+  pid: '16738'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_BSAAPP
+  cwd: /
+  pid: '16740'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01g_BSAREP
+  cwd: /
+  pid: '16742'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_BSAAPP
+  cwd: /
+  pid: '16744'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01h_BSAREP
+  cwd: /
+  pid: '16746'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01i_BSAREP
+  cwd: /
+  pid: '16748'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_BSAAPP
+  cwd: /
+  pid: '16750'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01j_BSAREP
+  cwd: /
+  pid: '16752'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_BSAAPP
+  cwd: /
+  pid: '16754'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01k_BSAREP
+  cwd: /
+  pid: '16756'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01l_BSAREP
+  cwd: /
+  pid: '16758'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q00a_BSAAPP
+  cwd: /
+  pid: '16760'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01m_BSAREP
+  cwd: /
+  pid: '16762'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01n_BSAREP
+  cwd: /
+  pid: '16764'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01o_BSAREP
+  cwd: /
+  pid: '16766'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01p_BSAREP
+  cwd: /
+  pid: '16768'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01q_BSAREP
+  cwd: /
+  pid: '16770'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_p01r_BSAREP
+  cwd: /
+  pid: '16772'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_ARSYS
+  cwd: /
+  pid: '16774'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_ARSYS
+  cwd: /
+  pid: '16777'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_ARSYS
+  cwd: /
+  pid: '16779'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_ARSYS
+  cwd: /
+  pid: '16781'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_ARSYS
+  cwd: /
+  pid: '16783'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_BNABBDD
+  cwd: /
+  pid: '16785'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_BNABBDD
+  cwd: /
+  pid: '16788'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_BNABBDD
+  cwd: /
+  pid: '16790'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_BNABBDD
+  cwd: /
+  pid: '16792'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_BNABBDD
+  cwd: /
+  pid: '16794'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm02_BSAREP
+  cwd: /
+  pid: '16797'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_qm00_BSAREP
+  cwd: /
+  pid: '16799'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q002_BSAREP
+  cwd: /
+  pid: '16801'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '16805'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q004_BSAREP
+  cwd: /
+  pid: '16807'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '16837'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q005_BSAREP
+  cwd: /
+  pid: '16840'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q006_BSAREP
+  cwd: /
+  pid: '16842'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q007_BSAREP
+  cwd: /
+  pid: '16844'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q008_BSAREP
+  cwd: /
+  pid: '16848'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_q009_BSAREP
+  cwd: /
+  pid: '16854'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '16951'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '17039'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '17069'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '17109'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '17371'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '17411'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '17651'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '17657'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '17796'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '18038'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '19700'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '19811'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '19813'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '20577'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '20645'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '20663'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '20675'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '20679'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '21794'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '21914'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '22175'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22208'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22219'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22258'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22262'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22316'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22318'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22320'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22322'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22324'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22326'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22328'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22330'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22332'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22334'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22336'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22338'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22340'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22342'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22344'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22346'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22348'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22350'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22352'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22354'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22356'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22358'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22360'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22363'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22365'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22368'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22371'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22373'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22375'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22379'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22385'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22387'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22393'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22399'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22405'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22411'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22415'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22421'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22425'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22431'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22437'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22443'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22445'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22449'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22451'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22453'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22455'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22458'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22460'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22462'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22464'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22468'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22473'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22477'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22479'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22481'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22483'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22485'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22487'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22489'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22491'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22493'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22495'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22497'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22499'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleARSYS (LOCAL=NO)
+  cwd: /
+  pid: '22501'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22545'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '22563'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '32378'
+  ppid: '1'
+  user: oragrid
+- cmdline: 'sshd: cyberark [priv]'
+  cwd: /
+  pid: '32623'
+  ppid: '2882'
+  user: root
+- cmdline: 'sshd: cyberark@pts/1'
+  cwd: /
+  pid: '32631'
+  ppid: '32623'
+  user: cyberark
+- cmdline: -bash
+  cwd: /
+  pid: '32632'
+  ppid: '32631'
+  user: cyberark
+- cmdline: su - root
+  cwd: /
+  pid: '32668'
+  ppid: '32632'
+  user: cyberark
+- cmdline: -bash
+  cwd: /
+  pid: '32676'
+  ppid: '32668'
+  user: root
+- cmdline: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/sqlplus                                         as
+    sysasm
+  cwd: /softOracle_local/app/oragrid/product/12.1.0.2/grid_infraestructure/bin/
+  pid: '33023'
+  ppid: '32676'
+  user: root
+- cmdline: oracle+ASM (LOCAL=NO)
+  cwd: /
+  pid: '33025'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '34800'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34963'
+  ppid: '2'
+  user: root
+- cmdline: ora_w004_BSAREP
+  cwd: /
+  pid: '35257'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w002_BSAAPP
+  cwd: /
+  pid: '35341'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w003_ARSYS
+  cwd: /
+  pid: '35409'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_o001_BNABBDD
+  cwd: /
+  pid: '35698'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o001_bnabbdd (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '35700'
+  ppid: '1'
+  user: oracle
+- cmdline: ora_o002_ARSYS
+  cwd: /
+  pid: '35703'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o002_arsys (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '35705'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '36134'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37614'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38019'
+  ppid: '2'
+  user: root
+- cmdline: ora_w001_BNABBDD
+  cwd: /
+  pid: '38039'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '38380'
+  ppid: '2'
+  user: root
+- cmdline: ora_w000_BNABBDD
+  cwd: /
+  pid: '40559'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '41466'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51639'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53968'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '55115'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57812'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57921'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58479'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58505'
+  ppid: '2'
+  user: root
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '59259'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '62085'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62951'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '67682'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68499'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68515'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68597'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68768'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68938'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68960'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '69565'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '74694'
+  ppid: '2'
+  user: root
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '76012'
+  ppid: '1'
+  user: oragrid
+- cmdline: ''
+  cwd: /
+  pid: '76666'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76667'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76736'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '77158'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79085'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79092'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79256'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79490'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79648'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '79666'
+  ppid: '3539'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '79880'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79915'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79930'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79931'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79933'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80004'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80194'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80196'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80292'
+  ppid: '2'
+  user: root
+- cmdline: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/perl
+    /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/plugins/oracle.sysman.db.agent.plugin_13.4.1.0.0/scripts/failedLogin.pl
+  cwd: /softOracle/app/oracle/product/13.4.0.0/agentes/agent/agent_13.4.0.0.0/perl/bin/
+  pid: '80308'
+  ppid: '13648'
+  user: oracle
+- cmdline: oracleBSAREP (LOCAL=NO)
+  cwd: /
+  pid: '80326'
+  ppid: '1'
+  user: oragrid
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1655221424
+  cwd: /usr/lib64/sa/
+  pid: '80481'
+  ppid: '2884'
+  user: root
+- cmdline: 'sshd: cyberark [priv]'
+  cwd: /
+  pid: '80506'
+  ppid: '2882'
+  user: root
+- cmdline: 'sshd: cyberark@pts/2'
+  cwd: /
+  pid: '80508'
+  ppid: '80506'
+  user: cyberark
+- cmdline: ''
+  cwd: /
+  pid: '80735'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80741'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80819'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80820'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80821'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80822'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80823'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80824'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80825'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80826'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80827'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80828'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80829'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80830'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80831'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80832'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80833'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80834'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80835'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80836'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80837'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80838'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80839'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80840'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80841'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80842'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80843'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80844'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80845'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80846'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80847'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80848'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80849'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80850'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80851'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80852'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80853'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80854'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80855'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80856'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80857'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80858'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80859'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80860'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80861'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80862'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80863'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80864'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80865'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80866'
+  ppid: '2'
+  user: root
+- cmdline: /bin/sh -c su - root -c '/bin/sh -c '"'"'echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve
+    ; /usr/bin/python /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'"'"''
+    && sleep 0
+  cwd: /bin/
+  pid: '80972'
+  ppid: '80508'
+  user: cyberark
+- cmdline: su - root -c /bin/sh -c 'echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve
+    ; /usr/bin/python /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py'
+  cwd: /
+  pid: '80990'
+  ppid: '80972'
+  user: cyberark
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-fhvdvivkrdupojdrahaywomkpinesqve ; /usr/bin/python
+    /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '80991'
+  ppid: '80990'
+  user: root
+- cmdline: /usr/bin/python /home/cyberark/.ansible/tmp/ansible-tmp-1655221435.4981172-14482-199826771838919/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '81026'
+  ppid: '80991'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81076'
+  ppid: '2'
+  user: root
+- cmdline: ora_q003_BNABBDD
+  cwd: /
+  pid: '85919'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracleBNABBDD (LOCAL=NO)
+  cwd: /
+  pid: '98298'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_w000_ARSYS
+  cwd: /
+  pid: '105757'
+  ppid: '1'
+  user: oragrid
+- cmdline: ora_o002_BSAAPP
+  cwd: /
+  pid: '121249'
+  ppid: '1'
+  user: oragrid
+- cmdline: oracle+ASM_o002_bsaapp (DESCRIPTION=(LOCAL=YES)(ADDRESS=(PROTOCOL=beq)))
+  cwd: /
+  pid: '121251'
+  ppid: '1'
+  user: oracle
+- cmdline: oracleBSAAPP (LOCAL=NO)
+  cwd: /
+  pid: '123382'
+  ppid: '1'
+  user: oragrid
+software_list:
+- cmd_regexp: emwd.pl agent
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/oracle_management_agent.yaml'
+    name: Include Oracle Management Agent specific plugins
+  name: Oracle Management Agent
+  process_type: parent
+  return_children: false
+  return_packages: true
+  vars: {}
 tcp_listen:
-  - address: 0.0.0.0
-    name: java
-    pid: 13648
-    port: 47632
-    protocol: tcp
-    stime: 'Thu May 12 19:11:16 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_BSAR
-    pid: 15848
-    port: 24016
-    protocol: tcp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 192.168.25.186
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 192.168.22.25
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 192.168.28.229
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: agentid-servi
-    pid: 14887
-    port: 10001
-    protocol: tcp
-    stime: 'Thu May 12 19:11:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14763
-    port: 1521
-    protocol: tcp
-    stime: 'Thu May 12 19:11:29 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14782
-    port: 1522
-    protocol: tcp
-    stime: 'Thu May 12 19:11:29 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14505
-    port: 1523
-    protocol: tcp
-    stime: 'Thu May 12 19:11:28 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14496
-    port: 1524
-    protocol: tcp
-    stime: 'Thu May 12 19:11:27 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: sshd
-    pid: 2882
-    port: 22
-    protocol: tcp
-    stime: 'Thu May 12 19:10:27 2022'
-    user: root
-  - address: 0.0.0.0
-    name: tnslsnr
-    pid: 14500
-    port: 1527
-    protocol: tcp
-    stime: 'Thu May 12 19:11:27 2022'
-    user: oragrid
-  - address: 127.0.0.1
-    name: master
-    pid: 3539
-    port: 25
-    protocol: tcp
-    stime: 'Thu May 12 19:10:28 2022'
-    user: root
-  - address: 0.0.0.0
-    name: dsmc
-    pid: 3268
-    port: 1501
-    protocol: tcp
-    stime: 'Thu May 12 19:10:28 2022'
-    user: root
-  - address: 127.0.0.1
-    name: oraagent.bin
-    pid: 14470
-    port: 2016
-    protocol: tcp
-    stime: 'Thu May 12 19:11:27 2022'
-    user: oragrid
-  - address: 0.0.0.0
-    name: java
-    pid: 13590
-    port: 3872
-    protocol: tcp
-    stime: 'Thu May 12 19:11:14 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: java
-    pid: 13648
-    port: 3873
-    protocol: tcp
-    stime: 'Thu May 12 19:11:16 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_ARSY
-    pid: 15674
-    port: 20266
-    protocol: tcp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_BSAA
-    pid: 15821
-    port: 20267
-    protocol: tcp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: ora_d000_BNAB
-    pid: 15852
-    port: 13966
-    protocol: tcp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Thu May 12 19:10:02 2022'
-    user: root
-  - address: '::'
-    name: avagent.bin
-    pid: 2479
-    port: 30002
-    protocol: tcp
-    stime: 'Thu May 12 19:10:25 2022'
-    user: root
-  - address: '::'
-    name: avagent.bin
-    pid: 2479
-    port: 28002
-    protocol: tcp
-    stime: 'Thu May 12 19:10:25 2022'
-    user: root
-  - address: 127.0.0.1
-    name: avagent.bin
-    pid: 2479
-    port: 30984
-    protocol: tcp
-    stime: 'Thu May 12 19:10:25 2022'
-    user: root
-  - address: '::'
-    name: bin/rscd
-    pid: 4020
-    port: 4750
-    protocol: tcp
-    stime: 'Thu May 12 19:10:29 2022'
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 1564
-    port: 111
-    protocol: tcp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: java
+  pid: 13648
+  port: 47632
+  protocol: tcp
+  stime: Thu May 12 19:11:16 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_BSAR
+  pid: 15848
+  port: 24016
+  protocol: tcp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 192.168.25.186
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 192.168.22.25
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 192.168.28.229
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 127.0.0.1
+  name: agentid-servi
+  pid: 14887
+  port: 10001
+  protocol: tcp
+  stime: Thu May 12 19:11:30 2022
+  user: root
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14763
+  port: 1521
+  protocol: tcp
+  stime: Thu May 12 19:11:29 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14782
+  port: 1522
+  protocol: tcp
+  stime: Thu May 12 19:11:29 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14505
+  port: 1523
+  protocol: tcp
+  stime: Thu May 12 19:11:28 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14496
+  port: 1524
+  protocol: tcp
+  stime: Thu May 12 19:11:27 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: sshd
+  pid: 2882
+  port: 22
+  protocol: tcp
+  stime: Thu May 12 19:10:27 2022
+  user: root
+- address: 0.0.0.0
+  name: tnslsnr
+  pid: 14500
+  port: 1527
+  protocol: tcp
+  stime: Thu May 12 19:11:27 2022
+  user: oragrid
+- address: 127.0.0.1
+  name: master
+  pid: 3539
+  port: 25
+  protocol: tcp
+  stime: Thu May 12 19:10:28 2022
+  user: root
+- address: 0.0.0.0
+  name: dsmc
+  pid: 3268
+  port: 1501
+  protocol: tcp
+  stime: Thu May 12 19:10:28 2022
+  user: root
+- address: 127.0.0.1
+  name: oraagent.bin
+  pid: 14470
+  port: 2016
+  protocol: tcp
+  stime: Thu May 12 19:11:27 2022
+  user: oragrid
+- address: 0.0.0.0
+  name: java
+  pid: 13590
+  port: 3872
+  protocol: tcp
+  stime: Thu May 12 19:11:14 2022
+  user: oracle
+- address: 0.0.0.0
+  name: java
+  pid: 13648
+  port: 3873
+  protocol: tcp
+  stime: Thu May 12 19:11:16 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_ARSY
+  pid: 15674
+  port: 20266
+  protocol: tcp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_BSAA
+  pid: 15821
+  port: 20267
+  protocol: tcp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: ora_d000_BNAB
+  pid: 15852
+  port: 13966
+  protocol: tcp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Thu May 12 19:10:02 2022
+  user: root
+- address: '::'
+  name: avagent.bin
+  pid: 2479
+  port: 30002
+  protocol: tcp
+  stime: Thu May 12 19:10:25 2022
+  user: root
+- address: '::'
+  name: avagent.bin
+  pid: 2479
+  port: 28002
+  protocol: tcp
+  stime: Thu May 12 19:10:25 2022
+  user: root
+- address: 127.0.0.1
+  name: avagent.bin
+  pid: 2479
+  port: 30984
+  protocol: tcp
+  stime: Thu May 12 19:10:25 2022
+  user: root
+- address: '::'
+  name: bin/rscd
+  pid: 4020
+  port: 4750
+  protocol: tcp
+  stime: Thu May 12 19:10:29 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 1564
+  port: 111
+  protocol: tcp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc
 udp_listen:
-  - address: 127.0.0.1
-    name: ora_s000_BNAB
-    pid: 15862
-    port: 9756
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: rsyslogd
-    pid: 2888
-    port: 10583
-    protocol: udp
-    stime: 'Thu May 12 19:10:27 2022'
-    user: root
-  - address: 127.0.0.1
-    name: ora_d000_BNAB
-    pid: 15852
-    port: 43469
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_lreg_BNAB
-    pid: 15810
-    port: 43845
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_s000_ARSY
-    pid: 15676
-    port: 46109
-    protocol: udp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_s000_BSAA
-    pid: 15825
-    port: 15051
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_d000_BSAR
-    pid: 15848
-    port: 18969
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_s000_BSAR
-    pid: 15858
-    port: 52283
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ohasd.bin
-    pid: 13578
-    port: 53703
-    protocol: udp
-    stime: 'Thu May 12 19:11:11 2022'
-    user: oragrid
-  - address: 127.0.0.1
-    name: asm_lreg_+ASM
-    pid: 15381
-    port: 23389
-    protocol: udp
-    stime: 'Thu May 12 19:12:03 2022'
-    user: oragrid
-  - address: 127.0.0.1
-    name: ora_lreg_ARSY
-    pid: 15655
-    port: 57074
-    protocol: udp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_d000_BSAA
-    pid: 15821
-    port: 26201
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_lreg_BSAR
-    pid: 15813
-    port: 60678
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: ora_d000_ARSY
-    pid: 15674
-    port: 62388
-    protocol: udp
-    stime: 'Thu May 12 19:12:27 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Thu May 12 19:10:02 2022'
-    user: root
-  - address: 192.168.25.186
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 192.168.22.25
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 192.168.28.229
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 127.0.0.1
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 0.0.0.0
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 1564
-    port: 850
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
-  - address: 127.0.0.1
-    name: ora_lreg_BSAA
-    pid: 15784
-    port: 34911
-    protocol: udp
-    stime: 'Thu May 12 19:12:29 2022'
-    user: oracle
-  - address: 0.0.0.0
-    name: java
-    pid: 13648
-    port: 3873
-    protocol: udp
-    stime: 'Thu May 12 19:11:16 2022'
-    user: oracle
-  - address: '::'
-    name: rpcbind
-    pid: 1564
-    port: 111
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
-  - address: '::'
-    name: ntpd
-    pid: 1514
-    port: 123
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: ntp
-  - address: '::'
-    name: rpcbind
-    pid: 1564
-    port: 850
-    protocol: udp
-    stime: 'Thu May 12 19:10:23 2022'
-    user: rpc
+- address: 127.0.0.1
+  name: ora_s000_BNAB
+  pid: 15862
+  port: 9756
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: rsyslogd
+  pid: 2888
+  port: 10583
+  protocol: udp
+  stime: Thu May 12 19:10:27 2022
+  user: root
+- address: 127.0.0.1
+  name: ora_d000_BNAB
+  pid: 15852
+  port: 43469
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_lreg_BNAB
+  pid: 15810
+  port: 43845
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_s000_ARSY
+  pid: 15676
+  port: 46109
+  protocol: udp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_s000_BSAA
+  pid: 15825
+  port: 15051
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_d000_BSAR
+  pid: 15848
+  port: 18969
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_s000_BSAR
+  pid: 15858
+  port: 52283
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ohasd.bin
+  pid: 13578
+  port: 53703
+  protocol: udp
+  stime: Thu May 12 19:11:11 2022
+  user: oragrid
+- address: 127.0.0.1
+  name: asm_lreg_+ASM
+  pid: 15381
+  port: 23389
+  protocol: udp
+  stime: Thu May 12 19:12:03 2022
+  user: oragrid
+- address: 127.0.0.1
+  name: ora_lreg_ARSY
+  pid: 15655
+  port: 57074
+  protocol: udp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_d000_BSAA
+  pid: 15821
+  port: 26201
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_lreg_BSAR
+  pid: 15813
+  port: 60678
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 127.0.0.1
+  name: ora_d000_ARSY
+  pid: 15674
+  port: 62388
+  protocol: udp
+  stime: Thu May 12 19:12:27 2022
+  user: oracle
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Thu May 12 19:10:02 2022
+  user: root
+- address: 192.168.25.186
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 192.168.22.25
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 192.168.28.229
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 127.0.0.1
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 0.0.0.0
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 1564
+  port: 850
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc
+- address: 127.0.0.1
+  name: ora_lreg_BSAA
+  pid: 15784
+  port: 34911
+  protocol: udp
+  stime: Thu May 12 19:12:29 2022
+  user: oracle
+- address: 0.0.0.0
+  name: java
+  pid: 13648
+  port: 3873
+  protocol: udp
+  stime: Thu May 12 19:11:16 2022
+  user: oracle
+- address: '::'
+  name: rpcbind
+  pid: 1564
+  port: 111
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc
+- address: '::'
+  name: ntpd
+  pid: 1514
+  port: 123
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: ntp
+- address: '::'
+  name: rpcbind
+  pid: 1564
+  port: 850
+  protocol: udp
+  stime: Thu May 12 19:10:23 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/panda/windows_server_2012_r2_panda_sp_4.yaml
+++ b/tests/unit/plugins/action/auto/resources/panda/windows_server_2012_r2_panda_sp_4.yaml
@@ -1,2275 +1,2355 @@
-expected_result:
-  - bindings: []
-    discovery_time: '2022-09-06T13:49:37+02:00'
-    listening_ports: []
-    type: Panda Security Protection
-    process:
-      cmdline: '"C:\Program Files (x86)\Panda Security\Panda Security Protection\PSUAService.exe"'
-      pid: 1245
-      ppid: 432
-      user: NT AUTHORITY\SYSTEM
-    version:
-      - 'number': '4.0.0.346'
-        'type': 'package'
-
-software_list:
-  - name: Panda Security Protection
-    cmd_regexp: ".*PSUAService.exe"
-    pkg_regexp: "Panda"
-    process_type: parent
-    return_children: false
-    return_packages: false
-
 dockers:
-  containers: [ ]
-packages:
-  Azure Data Studio:
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 543259
-      help_link: https://github.com/Microsoft/azuredatastudio
-      help_telephone: null
-      install_date: '20220530'
-      install_location: C:\Program Files\Azure Data Studio\
-      install_source: null
-      language: null
-      modify_path: null
-      name: Azure Data Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\Azure Data Studio\unins000.exe"'
-      url_info_about: https://github.com/Microsoft/azuredatastudio
-      url_update_info: https://github.com/Microsoft/azuredatastudio
-      vendor: null
-      version: 1.35.0
-      version_major: 1
-      version_minor: 35
-      windows_installer: null
-  Browser for SQL Server 2017:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11312
-      help_link: https://go.microsoft.com/fwlink/?LinkId=90959
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
-      name: Browser for SQL Server 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Cloudbase-Init 0.9.11:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 121670
-      help_link: ''
-      help_telephone: ''
-      install_date: '20170320'
-      install_location: ''
-      install_source: C:\UnattendResources\
-      language: 1033
-      modify_path: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
-      name: Cloudbase-Init 0.9.11
-      no_repair: null
-      publisher: Cloudbase Solutions Srl
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 0.9.11.0
-      version_major: 0
-      version_minor: 9
-      windows_installer: 1
-  Integration Services:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 91264
-      help_link: https://support.microsoft.com
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{4938A647-7EA4-4496-A843-5E338B91C07E}v15.0.2000.168\x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
-      name: Integration Services
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.168
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Analysis Services OLE DB Provider:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 243952
-      help_link: https://go.microsoft.com/fwlink/?LinkId=52159
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}v15.0.2000.832\x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
-      name: Microsoft Analysis Services OLE DB Provider
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.832
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 499504
-      help_link: https://go.microsoft.com/fwlink/?LinkId=52159
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}v15.0.2000.832\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
-      name: Microsoft Analysis Services OLE DB Provider
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.832
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Help Viewer 2.3:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 12438
-      help_link: https://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: null
-      install_date: null
-      install_location: C:\Program Files (x86)\Microsoft Help Viewer\v2.3\
-      install_source: null
-      language: null
-      modify_path: msiexec.exe /I{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      name: Microsoft Help Viewer 2.3
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: msiexec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      url_info_about: null
-      url_update_info: https://go.microsoft.com/fwlink/?LinkId=133408
-      vendor: null
-      version: 2.3.28307
-      version_major: '2'
-      version_minor: '0'
-      windows_installer: null
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 13260
-      help_link: https://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}v2.3.28307\redist\
-      language: 1033
-      modify_path: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      name: Microsoft Help Viewer 2.3
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 2.3.28307
-      version_major: 2
-      version_minor: 3
-      windows_installer: 1
-  Microsoft ODBC Driver 13 for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 5124
-      help_link: https://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
-      name: Microsoft ODBC Driver 13 for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft ODBC Driver 17 for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 7184
-      help_link: https://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{853997DA-6FCB-4FB9-918E-E0FF881FAF65}v17.7.2.1\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
-      name: Microsoft ODBC Driver 17 for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 17.7.2.1
-      version_major: 17
-      version_minor: 7
-      windows_installer: 1
-  Microsoft OLE DB Driver for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8480
-      help_link: https://go.microsoft.com/fwlink/?linkid=870127
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{9D6F8754-28E9-4940-B319-3FC8588CF18F}v18.5.0.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
-      name: Microsoft OLE DB Driver for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 18.5.0.0
-      version_major: 18
-      version_minor: 5
-      windows_installer: 1
-  'Microsoft SQL Server 2012 Native Client ':
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8160
-      help_link: http://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{9D93D367-A2CC-4378-BD63-79EF3FE76C78}v11.4.7462.6\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
-      name: 'Microsoft SQL Server 2012 Native Client '
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 11.4.7462.6
-      version_major: 11
-      version_minor: 4
-      windows_installer: 1
-  Microsoft SQL Server 2017 (64-bit):
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: null
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server 2017 (64-bit)
-      no_repair: null
-      publisher: null
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: 1
-      uninstall_string: null
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: null
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: null
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server 2017 (64-bit)
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\Microsoft SQL Server\140\Setup Bootstrap\SQL2017\x64\SetupARP.exe"'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: null
-  Microsoft SQL Server 2017 RsFx Driver:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 344
-      help_link: https://go.microsoft.com/fwlink/?LinkId=101173
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
-      name: Microsoft SQL Server 2017 RsFx Driver
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft SQL Server 2017 Setup (English):
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 39588
-      help_link: https://go.microsoft.com/fwlink/?LinkId=101173
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
-      name: Microsoft SQL Server 2017 Setup (English)
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  'Microsoft SQL Server 2017 T-SQL Language Service ':
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8116
-      help_link: https://go.microsoft.com/fwlink/?LinkID=150605
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
-      name: 'Microsoft SQL Server 2017 T-SQL Language Service '
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft SQL Server Management Studio - 18.11.1:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 2881605
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server Management Studio - 18.11.1
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{88f77b67-7f88-4b59-b93b-c9f2546b649c}\SSMS-Setup-ENU.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 15.0.18410.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft VSS Writer for SQL Server 2017:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 3256
-      help_link: https://go.microsoft.com/fwlink/?LinkId=90958
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
-      name: Microsoft VSS Writer for SQL Server 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 21062
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe" /modify'
-      name: Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 12.0.40664.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 17602
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe" /modify'
-      name: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 12.0.40664.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 11784
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{010792BA-551A-3AC0-A7EF-0FAB4156C382}v12.0.40664\packages\vcRuntimeAdditional_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
-      name: Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 2524
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{53CF6934-A98D-3D84-9146-FC4EDF3D5641}v12.0.40664\packages\vcRuntimeMinimum_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
-      name: Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 9456
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{D401961D-3A20-3AC7-943B-6139D5BD490A}v12.0.40664\packages\vcRuntimeAdditional_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
-      name: Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 2076
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{8122DAB1-ED4D-3676-BB0A-CA368196543E}v12.0.40664\packages\vcRuntimeMinimum_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
-      name: Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 22598
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe" /modify'
-      name: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.30.30704.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 19969
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe" /modify'
-      name: Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.30.30704.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11724
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}v14.30.30704\packages\vcRuntimeAdditional_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
-      name: Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 2168
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{662A0088-6FCD-45DD-9EA7-68674058AED5}v14.30.30704\packages\vcRuntimeMinimum_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
-      name: Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 10164
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{BF08E976-B92E-4336-B56F-2171179476C4}v14.30.30704\packages\vcRuntimeAdditional_x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
-      name: Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 1744
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}v14.30.30704\packages\vcRuntimeMinimum_x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
-      name: Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual Studio Tools for Applications 2017:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 19606
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe" /modify'
-      name: Microsoft Visual Studio Tools for Applications 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 15.0.26717
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 2844
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{10AB056B-1B8C-3E9E-95CC-43C33EB88513}v15.0.26717\packages\vsta_hostingcore_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
-      name: Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.26717
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 3828
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}v15.0.26717\packages\vsta_hostingcore_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
-      name: Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.26717
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Panda Security Protection:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: ''
-      contact: ''
-      estimated_size: 27913
-      help_link: ''
-      help_telephone: null
-      install_date: '20220218'
-      install_location: 'C:\Program Files (x86)\Panda Security\Panda Security Protection\PSUAService.exe'
-      install_source: null
-      language: null
-      modify_path: null
-      name: Panda Security Protection
-      no_repair: '1'
-      publisher: Panda Security
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files (x86)\Panda Security\Panda Security Protection\PSUAService.exe"'
-      url_info_about: ''
-      url_update_info: null
-      vendor: null
-      version: 4.0.0.346
-      version_major: 4
-      version_minor: 0
-      windows_installer: null
-  PgBouncer 1.16.1:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: 'PgBouncer: Connection pooler for PostgreSQL, packaged by EnterpriseDB'
-      contact: ''
-      estimated_size: 25101
-      help_link: ''
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files (x86)\PgBouncer
-      install_source: null
-      language: null
-      modify_path: null
-      name: PgBouncer 1.16.1
-      no_repair: '1'
-      publisher: EnterpriseDB
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files (x86)\PgBouncer\uninstall-pgbouncer.exe"'
-      url_info_about: ''
-      url_update_info: null
-      vendor: null
-      version: 1.16.1-1
-      version_major: 1
-      version_minor: 16
-      windows_installer: null
-  'PostgreSQL 14 ':
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: The PostgreSQL RDBMS, version 14, packaged by EnterpriseDB
-      contact: ''
-      estimated_size: 829400
-      help_link: http://www.postgresql.org/docs
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files\PostgreSQL\14
-      install_source: null
-      language: null
-      modify_path: null
-      name: 'PostgreSQL 14 '
-      no_repair: '1'
-      publisher: PostgreSQL Global Development Group
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\PostgreSQL\14\uninstall-postgresql.exe"'
-      url_info_about: http://www.postgresql.org/
-      url_update_info: null
-      vendor: null
-      version: '14'
-      version_major: 14
-      version_minor: 0
-      windows_installer: null
-  SQL Server 2017 Batch Parser:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 744
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
-      name: SQL Server 2017 Batch Parser
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Common Files:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 21464
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
-      name: SQL Server 2017 Common Files
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 760
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
-      name: SQL Server 2017 Common Files
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Connection Info:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 264
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
-      name: SQL Server 2017 Connection Info
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 884
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
-      name: SQL Server 2017 Connection Info
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 DMF:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 1376
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
-      name: SQL Server 2017 DMF
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 408
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
-      name: SQL Server 2017 DMF
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Database Engine Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 72372
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
-      name: SQL Server 2017 Database Engine Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 285556
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
-      name: SQL Server 2017 Database Engine Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Database Engine Shared:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 87436
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
-      name: SQL Server 2017 Database Engine Shared
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11884
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
-      name: SQL Server 2017 Database Engine Shared
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 SQL Diagnostics:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 516
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
-      name: SQL Server 2017 SQL Diagnostics
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Shared Management Objects:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 5908
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
-      name: SQL Server 2017 Shared Management Objects
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 12528
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
-      name: SQL Server 2017 Shared Management Objects
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Shared Management Objects Extensions:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 4952
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
-      name: SQL Server 2017 Shared Management Objects Extensions
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 532
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
-      name: SQL Server 2017 Shared Management Objects Extensions
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 XEvent:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 84
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
-      name: SQL Server 2017 XEvent
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 732
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
-      name: SQL Server 2017 XEvent
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server Management Studio:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 4796
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{3A6E604C-766B-46F2-8E2D-4371B4CDF858}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
-      name: SQL Server Management Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 215640
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
-      name: SQL Server Management Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  SQL Server Management Studio for Analysis Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 358312
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
-      name: SQL Server Management Studio for Analysis Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  SQL Server Management Studio for Reporting Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 26840
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{D91AA5D8-1080-487B-83B6-622061902012}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
-      name: SQL Server Management Studio for Reporting Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  SSMS Post Install Tasks:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 296
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{7AEA9B43-10CD-4D33-B116-621B81A45490}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
-      name: SSMS Post Install Tasks
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Visual Studio 2017 Isolated Shell for SSMS:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 412588
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{AAA9F15B-AF45-4562-9991-93A848D3A902}v15.0.28307.421\redist\
-      language: 1033
-      modify_path: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
-      name: Visual Studio 2017 Isolated Shell for SSMS
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.28307.421
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  psqlODBC 13.00.0000:
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: ODBC drivers for PostgreSQL, packaged by EnterpriseDB
-      contact: ''
-      estimated_size: 13676
-      help_link: ''
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files\PostgreSQL\psqlODBC
-      install_source: null
-      language: null
-      modify_path: null
-      name: psqlODBC 13.00.0000
-      no_repair: '1'
-      publisher: EnterpriseDB
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\PostgreSQL\psqlODBC\uninstall-psqlodbc.exe"'
-      url_info_about: ''
-      url_update_info: null
-      vendor: null
-      version: 13.00.0000-2
-      version_major: 13
-      version_minor: 0
-      windows_installer: null
-processes:
-  - cmdline: null
-    pid: 0
-    ppid: 0
-    user: null
-  - cmdline: null
-    pid: 4
-    ppid: 0
-    user: null
-  - cmdline: null
-    pid: 192
-    ppid: 4
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: 284
-    ppid: 276
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: 336
-    ppid: 328
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: wininit.exe
-    pid: 344
-    ppid: 276
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: winlogon.exe
-    pid: 372
-    ppid: 328
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: 432
-    ppid: 344
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\lsass.exe
-    pid: 440
-    ppid: 344
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\svchost.exe -k DcomLaunch
-    pid: 496
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\svchost.exe -k RPCSS
-    pid: 524
-    ppid: 432
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"LogonUI.exe" /flags:0x0'
-    pid: 624
-    ppid: 372
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"dwm.exe"'
-    pid: 632
-    ppid: 372
-    user: Window Manager\DWM-1
-  - cmdline: C:\windows\System32\svchost.exe -k LocalServiceNetworkRestricted
-    pid: 652
-    ppid: 432
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: C:\windows\system32\svchost.exe -k netsvcs
-    pid: 708
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\svchost.exe -k LocalService
-    pid: 800
-    ppid: 432
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: C:\windows\system32\svchost.exe -k NetworkService
-    pid: 888
-    ppid: 432
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: C:\windows\system32\svchost.exe -k LocalServiceNoNetwork
-    pid: 292
-    ppid: 432
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: C:\windows\System32\spoolsv.exe
-    pid: 444
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\System32\svchost.exe -k utcsvc
-    pid: 1040
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"C:\Program Files (x86)\PgBouncer\bin\pgbouncer.exe" --service "C:\Program Files (x86)\PgBouncer\share\pgbouncer.ini"'
-    pid: 1076
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"C:\Program Files\PostgreSQL\14\bin\pg_ctl.exe" runservice -N "postgresql-x64-14" -D "C:\Program Files\PostgreSQL\14\data" -w'
-    pid: 1176
-    ppid: 432
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlceip.exe" -Service SQLEXPRESS'
-    pid: 1240
-    ppid: 432
-    user: NT SERVICE\SQLTELEMETRY$SQLEXPRESS
-  - cmdline: '"C:\Program Files (x86)\Panda Security\Panda Security Protection\PSUAService.exe"'
+  containers: []
+expected_result:
+- bindings: []
+  discovery_time: '2022-09-06T13:49:37+02:00'
+  listening_ports: []
+  process:
+    cmdline: '"C:\Program Files (x86)\Panda Security\Panda Security Protection\PSUAService.exe"'
+    cwd: /
     pid: 1245
     ppid: 432
     user: NT AUTHORITY\SYSTEM
-  - cmdline: '"C:\Program Files\PostgreSQL\14\bin\postgres.exe" -D "C:\Program Files\PostgreSQL\14\data" '
-    pid: 1248
-    ppid: 1176
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: \??\C:\windows\system32\conhost.exe 0x4
-    pid: 1256
-    ppid: 1248
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forklog" "5308" "5312" "0"'
-    pid: 1304
-    ppid: 1248
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5212" "-x5"'
-    pid: 1336
-    ppid: 1248
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5224" "-x3"'
-    pid: 1344
-    ppid: 1248
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5204" "-x6"'
-    pid: 1352
-    ppid: 1248
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkavlauncher" "5196"'
-    pid: 1360
-    ppid: 1248
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkcol" "5188"'
-    pid: 1368
-    ppid: 1248
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkbgworker=0" "5180"'
-    pid: 1376
-    ppid: 1248
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe"'
-    pid: 1420
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\System32\svchost.exe -k LocalSystemNetworkRestricted
-    pid: 1444
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"C:\winlogbeat\winlogbeat.exe" -c "C:\winlogbeat\winlogbeat.yml" -path.home "C:\winlogbeat" -path.data "C:\ProgramData\winlogbeat" -path.logs "C:\ProgramData\winlogbeat\logs"'
-    pid: 1484
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\System32\svchost.exe -k termsvcs
-    pid: 2028
-    ppid: 432
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: C:\windows\system32\svchost.exe -k NetworkServiceNetworkRestricted
-    pid: 1052
-    ppid: 432
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: null
-    pid: 2772
-    ppid: 2764
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: winlogon.exe
-    pid: 2800
-    ppid: 2764
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"dwm.exe"'
-    pid: 2856
-    ppid: 2800
-    user: Window Manager\DWM-2
-  - cmdline: 'taskhostex.exe '
-    pid: 3008
-    ppid: 708
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: rdpclip
-    pid: 880
-    ppid: 2028
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\Explorer.EXE
-    pid: 2144
-    ppid: 2176
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\system32\wbem\wmiprvse.exe
-    pid: 2084
-    ppid: 496
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: C:\windows\System32\msdtc.exe
-    pid: 1836
-    ppid: 432
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: C:/telegraf/telegraf.exe -config C:/telegraf/telegraf.conf -config-directory C:/telegraf/telegraf.d/
-    pid: 3272
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe" -sSQLEXPRESS'
-    pid: 1904
-    ppid: 432
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - cmdline: '"C:\Program Files (x86)\Microsoft SQL Server Management Studio 18\Common7\IDE\Ssms.exe" '
-    pid: 3236
-    ppid: 2144
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
-    pid: 3316
-    ppid: 2144
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: \??\C:\windows\system32\conhost.exe 0x4
-    pid: 1908
-    ppid: 3316
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
-    pid: 2384
-    ppid: 2144
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: \??\C:\windows\system32\conhost.exe 0x4
-    pid: 3208
-    ppid: 2384
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\system32\msiexec.exe /V
-    pid: 1600
-    ppid: 432
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\WinrsHost.exe -Embedding
-    pid: 4552
-    ppid: 496
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: \??\C:\windows\system32\conhost.exe 0x4
-    pid: 5352
-    ppid: 4552
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\system32\cmd.exe /C PowerShell -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
-    pid: 6104
-    ppid: 4552
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: PowerShell  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
-    pid: 6056
-    ppid: 6104
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe"  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand JgBjAGgAYwBwAC4AYwBvAG0AIAA2ADUAMAAwADEAIAA+ACAAJABuAHUAbABsAAoAaQBmACAAKAAkAFAAUwBWAGUAcgBzAGkAbwBuAFQAYQBiAGwAZQAuAFAAUwBWAGUAcgBzAGkAbwBuACAALQBsAHQAIABbAFYAZQByAHMAaQBvAG4AXQAiADMALgAwACIAKQAgAHsACgAnAHsAIgBmAGEAaQBsAGUAZAAiADoAdAByAHUAZQAsACIAbQBzAGcAIgA6ACIAQQBuAHMAaQBiAGwAZQAgAHIAZQBxAHUAaQByAGUAcwAgAFAAbwB3AGUAcgBTAGgAZQBsAGwAIAB2ADMALgAwACAAbwByACAAbgBlAHcAZQByACIAfQAnAAoAZQB4AGkAdAAgADEACgB9AAoAJABlAHgAZQBjAF8AdwByAGEAcABwAGUAcgBfAHMAdAByACAAPQAgACQAaQBuAHAAdQB0ACAAfAAgAE8AdQB0AC0AUwB0AHIAaQBuAGcACgAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAgAD0AIAAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAF8AcwB0AHIALgBTAHAAbABpAHQAKABAACgAIgBgADAAYAAwAGAAMABgADAAIgApACwAIAAyACwAIABbAFMAdAByAGkAbgBnAFMAcABsAGkAdABPAHAAdABpAG8AbgBzAF0AOgA6AFIAZQBtAG8AdgBlAEUAbQBwAHQAeQBFAG4AdAByAGkAZQBzACkACgBJAGYAIAAoAC0AbgBvAHQAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAuAEwAZQBuAGcAdABoACAALQBlAHEAIAAyACkAIAB7ACAAdABoAHIAbwB3ACAAIgBpAG4AdgBhAGwAaQBkACAAcABhAHkAbABvAGEAZAAiACAAfQAKAFMAZQB0AC0AVgBhAHIAaQBhAGIAbABlACAALQBOAGEAbQBlACAAagBzAG8AbgBfAHIAYQB3ACAALQBWAGEAbAB1AGUAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADEAXQAKACQAZQB4AGUAYwBfAHcAcgBhAHAAcABlAHIAIAA9ACAAWwBTAGMAcgBpAHAAdABCAGwAbwBjAGsAXQA6ADoAQwByAGUAYQB0AGUAKAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADAAXQApAAoAJgAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAA=='
-    pid: 4416
-    ppid: 6056
-    user: TEST-NORM-WIN01\Administrator
+  type: Panda Security Protection
+  version:
+  - number: 4.0.0.346
+    type: package
+packages:
+  Azure Data Studio:
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 543259
+    help_link: https://github.com/Microsoft/azuredatastudio
+    help_telephone: null
+    install_date: '20220530'
+    install_location: C:\Program Files\Azure Data Studio\
+    install_source: null
+    language: null
+    modify_path: null
+    name: Azure Data Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\Azure Data Studio\unins000.exe"'
+    url_info_about: https://github.com/Microsoft/azuredatastudio
+    url_update_info: https://github.com/Microsoft/azuredatastudio
+    vendor: null
+    version: 1.35.0
+    version_major: 1
+    version_minor: 35
+    windows_installer: null
+  Browser for SQL Server 2017:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11312
+    help_link: https://go.microsoft.com/fwlink/?LinkId=90959
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
+    name: Browser for SQL Server 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Cloudbase-Init 0.9.11:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 121670
+    help_link: ''
+    help_telephone: ''
+    install_date: '20170320'
+    install_location: ''
+    install_source: C:\UnattendResources\
+    language: 1033
+    modify_path: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
+    name: Cloudbase-Init 0.9.11
+    no_repair: null
+    publisher: Cloudbase Solutions Srl
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 0.9.11.0
+    version_major: 0
+    version_minor: 9
+    windows_installer: 1
+  Integration Services:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 91264
+    help_link: https://support.microsoft.com
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{4938A647-7EA4-4496-A843-5E338B91C07E}v15.0.2000.168\x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
+    name: Integration Services
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.168
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Analysis Services OLE DB Provider:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 243952
+    help_link: https://go.microsoft.com/fwlink/?LinkId=52159
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}v15.0.2000.832\x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
+    name: Microsoft Analysis Services OLE DB Provider
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.832
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 499504
+    help_link: https://go.microsoft.com/fwlink/?LinkId=52159
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}v15.0.2000.832\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
+    name: Microsoft Analysis Services OLE DB Provider
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.832
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Help Viewer 2.3:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 12438
+    help_link: https://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: null
+    install_date: null
+    install_location: C:\Program Files (x86)\Microsoft Help Viewer\v2.3\
+    install_source: null
+    language: null
+    modify_path: msiexec.exe /I{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    name: Microsoft Help Viewer 2.3
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: msiexec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    url_info_about: null
+    url_update_info: https://go.microsoft.com/fwlink/?LinkId=133408
+    vendor: null
+    version: 2.3.28307
+    version_major: '2'
+    version_minor: '0'
+    windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 13260
+    help_link: https://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}v2.3.28307\redist\
+    language: 1033
+    modify_path: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    name: Microsoft Help Viewer 2.3
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 2.3.28307
+    version_major: 2
+    version_minor: 3
+    windows_installer: 1
+  Microsoft ODBC Driver 13 for SQL Server:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 5124
+    help_link: https://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
+    name: Microsoft ODBC Driver 13 for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft ODBC Driver 17 for SQL Server:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 7184
+    help_link: https://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{853997DA-6FCB-4FB9-918E-E0FF881FAF65}v17.7.2.1\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
+    name: Microsoft ODBC Driver 17 for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 17.7.2.1
+    version_major: 17
+    version_minor: 7
+    windows_installer: 1
+  Microsoft OLE DB Driver for SQL Server:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8480
+    help_link: https://go.microsoft.com/fwlink/?linkid=870127
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{9D6F8754-28E9-4940-B319-3FC8588CF18F}v18.5.0.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
+    name: Microsoft OLE DB Driver for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 18.5.0.0
+    version_major: 18
+    version_minor: 5
+    windows_installer: 1
+  'Microsoft SQL Server 2012 Native Client ':
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8160
+    help_link: http://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{9D93D367-A2CC-4378-BD63-79EF3FE76C78}v11.4.7462.6\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
+    name: 'Microsoft SQL Server 2012 Native Client '
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 11.4.7462.6
+    version_major: 11
+    version_minor: 4
+    windows_installer: 1
+  Microsoft SQL Server 2017 (64-bit):
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: null
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server 2017 (64-bit)
+    no_repair: null
+    publisher: null
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: 1
+    uninstall_string: null
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: null
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: null
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server 2017 (64-bit)
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\Microsoft SQL Server\140\Setup Bootstrap\SQL2017\x64\SetupARP.exe"'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: null
+  Microsoft SQL Server 2017 RsFx Driver:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 344
+    help_link: https://go.microsoft.com/fwlink/?LinkId=101173
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
+    name: Microsoft SQL Server 2017 RsFx Driver
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft SQL Server 2017 Setup (English):
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 39588
+    help_link: https://go.microsoft.com/fwlink/?LinkId=101173
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
+    name: Microsoft SQL Server 2017 Setup (English)
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  'Microsoft SQL Server 2017 T-SQL Language Service ':
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8116
+    help_link: https://go.microsoft.com/fwlink/?LinkID=150605
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
+    name: 'Microsoft SQL Server 2017 T-SQL Language Service '
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft SQL Server Management Studio - 18.11.1:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 2881605
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server Management Studio - 18.11.1
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{88f77b67-7f88-4b59-b93b-c9f2546b649c}\SSMS-Setup-ENU.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 15.0.18410.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft VSS Writer for SQL Server 2017:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 3256
+    help_link: https://go.microsoft.com/fwlink/?LinkId=90958
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
+    name: Microsoft VSS Writer for SQL Server 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 21062
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"
+      /modify'
+    name: Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 12.0.40664.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 17602
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"
+      /modify'
+    name: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 12.0.40664.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 11784
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{010792BA-551A-3AC0-A7EF-0FAB4156C382}v12.0.40664\packages\vcRuntimeAdditional_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
+    name: Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 2524
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{53CF6934-A98D-3D84-9146-FC4EDF3D5641}v12.0.40664\packages\vcRuntimeMinimum_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
+    name: Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 9456
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{D401961D-3A20-3AC7-943B-6139D5BD490A}v12.0.40664\packages\vcRuntimeAdditional_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
+    name: Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 2076
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{8122DAB1-ED4D-3676-BB0A-CA368196543E}v12.0.40664\packages\vcRuntimeMinimum_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
+    name: Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 22598
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"
+      /modify'
+    name: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.30.30704.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 19969
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"
+      /modify'
+    name: Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.30.30704.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11724
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}v14.30.30704\packages\vcRuntimeAdditional_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
+    name: Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 2168
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{662A0088-6FCD-45DD-9EA7-68674058AED5}v14.30.30704\packages\vcRuntimeMinimum_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
+    name: Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 10164
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{BF08E976-B92E-4336-B56F-2171179476C4}v14.30.30704\packages\vcRuntimeAdditional_x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
+    name: Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 1744
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}v14.30.30704\packages\vcRuntimeMinimum_x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
+    name: Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual Studio Tools for Applications 2017:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 19606
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"
+      /modify'
+    name: Microsoft Visual Studio Tools for Applications 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 15.0.26717
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 2844
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{10AB056B-1B8C-3E9E-95CC-43C33EB88513}v15.0.26717\packages\vsta_hostingcore_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
+    name: Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.26717
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 3828
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}v15.0.26717\packages\vsta_hostingcore_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
+    name: Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.26717
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Panda Security Protection:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: ''
+    contact: ''
+    estimated_size: 27913
+    help_link: ''
+    help_telephone: null
+    install_date: '20220218'
+    install_location: C:\Program Files (x86)\Panda Security\Panda Security Protection\PSUAService.exe
+    install_source: null
+    language: null
+    modify_path: null
+    name: Panda Security Protection
+    no_repair: '1'
+    publisher: Panda Security
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files (x86)\Panda Security\Panda Security Protection\PSUAService.exe"'
+    url_info_about: ''
+    url_update_info: null
+    vendor: null
+    version: 4.0.0.346
+    version_major: 4
+    version_minor: 0
+    windows_installer: null
+  PgBouncer 1.16.1:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: 'PgBouncer: Connection pooler for PostgreSQL, packaged by EnterpriseDB'
+    contact: ''
+    estimated_size: 25101
+    help_link: ''
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files (x86)\PgBouncer
+    install_source: null
+    language: null
+    modify_path: null
+    name: PgBouncer 1.16.1
+    no_repair: '1'
+    publisher: EnterpriseDB
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files (x86)\PgBouncer\uninstall-pgbouncer.exe"'
+    url_info_about: ''
+    url_update_info: null
+    vendor: null
+    version: 1.16.1-1
+    version_major: 1
+    version_minor: 16
+    windows_installer: null
+  'PostgreSQL 14 ':
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: The PostgreSQL RDBMS, version 14, packaged by EnterpriseDB
+    contact: ''
+    estimated_size: 829400
+    help_link: http://www.postgresql.org/docs
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files\PostgreSQL\14
+    install_source: null
+    language: null
+    modify_path: null
+    name: 'PostgreSQL 14 '
+    no_repair: '1'
+    publisher: PostgreSQL Global Development Group
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\PostgreSQL\14\uninstall-postgresql.exe"'
+    url_info_about: http://www.postgresql.org/
+    url_update_info: null
+    vendor: null
+    version: '14'
+    version_major: 14
+    version_minor: 0
+    windows_installer: null
+  SQL Server 2017 Batch Parser:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 744
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
+    name: SQL Server 2017 Batch Parser
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Common Files:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 21464
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
+    name: SQL Server 2017 Common Files
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 760
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
+    name: SQL Server 2017 Common Files
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Connection Info:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 264
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
+    name: SQL Server 2017 Connection Info
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 884
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
+    name: SQL Server 2017 Connection Info
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 DMF:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 1376
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
+    name: SQL Server 2017 DMF
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 408
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
+    name: SQL Server 2017 DMF
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Database Engine Services:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 72372
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
+    name: SQL Server 2017 Database Engine Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 285556
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
+    name: SQL Server 2017 Database Engine Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Database Engine Shared:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 87436
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
+    name: SQL Server 2017 Database Engine Shared
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11884
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
+    name: SQL Server 2017 Database Engine Shared
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 SQL Diagnostics:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 516
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
+    name: SQL Server 2017 SQL Diagnostics
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Shared Management Objects:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 5908
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
+    name: SQL Server 2017 Shared Management Objects
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 12528
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
+    name: SQL Server 2017 Shared Management Objects
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Shared Management Objects Extensions:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 4952
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
+    name: SQL Server 2017 Shared Management Objects Extensions
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 532
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
+    name: SQL Server 2017 Shared Management Objects Extensions
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 XEvent:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 84
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
+    name: SQL Server 2017 XEvent
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 732
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
+    name: SQL Server 2017 XEvent
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server Management Studio:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 4796
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{3A6E604C-766B-46F2-8E2D-4371B4CDF858}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
+    name: SQL Server Management Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 215640
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
+    name: SQL Server Management Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  SQL Server Management Studio for Analysis Services:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 358312
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
+    name: SQL Server Management Studio for Analysis Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  SQL Server Management Studio for Reporting Services:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 26840
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{D91AA5D8-1080-487B-83B6-622061902012}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
+    name: SQL Server Management Studio for Reporting Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  SSMS Post Install Tasks:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 296
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{7AEA9B43-10CD-4D33-B116-621B81A45490}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
+    name: SSMS Post Install Tasks
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Visual Studio 2017 Isolated Shell for SSMS:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 412588
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{AAA9F15B-AF45-4562-9991-93A848D3A902}v15.0.28307.421\redist\
+    language: 1033
+    modify_path: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
+    name: Visual Studio 2017 Isolated Shell for SSMS
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.28307.421
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  psqlODBC 13.00.0000:
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: ODBC drivers for PostgreSQL, packaged by EnterpriseDB
+    contact: ''
+    estimated_size: 13676
+    help_link: ''
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files\PostgreSQL\psqlODBC
+    install_source: null
+    language: null
+    modify_path: null
+    name: psqlODBC 13.00.0000
+    no_repair: '1'
+    publisher: EnterpriseDB
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\PostgreSQL\psqlODBC\uninstall-psqlodbc.exe"'
+    url_info_about: ''
+    url_update_info: null
+    vendor: null
+    version: 13.00.0000-2
+    version_major: 13
+    version_minor: 0
+    windows_installer: null
+processes:
+- cmdline: null
+  cwd: /
+  pid: 0
+  ppid: 0
+  user: null
+- cmdline: null
+  cwd: /
+  pid: 4
+  ppid: 0
+  user: null
+- cmdline: null
+  cwd: /
+  pid: 192
+  ppid: 4
+  user: NT AUTHORITY\SYSTEM
+- cmdline: null
+  cwd: /
+  pid: 284
+  ppid: 276
+  user: NT AUTHORITY\SYSTEM
+- cmdline: null
+  cwd: /
+  pid: 336
+  ppid: 328
+  user: NT AUTHORITY\SYSTEM
+- cmdline: wininit.exe
+  cwd: /
+  pid: 344
+  ppid: 276
+  user: NT AUTHORITY\SYSTEM
+- cmdline: winlogon.exe
+  cwd: /
+  pid: 372
+  ppid: 328
+  user: NT AUTHORITY\SYSTEM
+- cmdline: null
+  cwd: /
+  pid: 432
+  ppid: 344
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\lsass.exe
+  cwd: /
+  pid: 440
+  ppid: 344
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k DcomLaunch
+  cwd: /
+  pid: 496
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k RPCSS
+  cwd: /
+  pid: 524
+  ppid: 432
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"LogonUI.exe" /flags:0x0'
+  cwd: /
+  pid: 624
+  ppid: 372
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"dwm.exe"'
+  cwd: /
+  pid: 632
+  ppid: 372
+  user: Window Manager\DWM-1
+- cmdline: C:\windows\System32\svchost.exe -k LocalServiceNetworkRestricted
+  cwd: /
+  pid: 652
+  ppid: 432
+  user: NT AUTHORITY\LOCAL SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k netsvcs
+  cwd: /
+  pid: 708
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k LocalService
+  cwd: /
+  pid: 800
+  ppid: 432
+  user: NT AUTHORITY\LOCAL SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k NetworkService
+  cwd: /
+  pid: 888
+  ppid: 432
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k LocalServiceNoNetwork
+  cwd: /
+  pid: 292
+  ppid: 432
+  user: NT AUTHORITY\LOCAL SERVICE
+- cmdline: C:\windows\System32\spoolsv.exe
+  cwd: /
+  pid: 444
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\System32\svchost.exe -k utcsvc
+  cwd: /
+  pid: 1040
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\Program Files (x86)\PgBouncer\bin\pgbouncer.exe" --service "C:\Program
+    Files (x86)\PgBouncer\share\pgbouncer.ini"'
+  cwd: /
+  pid: 1076
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\Program Files\PostgreSQL\14\bin\pg_ctl.exe" runservice -N "postgresql-x64-14"
+    -D "C:\Program Files\PostgreSQL\14\data" -w'
+  cwd: /
+  pid: 1176
+  ppid: 432
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlceip.exe"
+    -Service SQLEXPRESS'
+  cwd: /
+  pid: 1240
+  ppid: 432
+  user: NT SERVICE\SQLTELEMETRY$SQLEXPRESS
+- cmdline: '"C:\Program Files (x86)\Panda Security\Panda Security Protection\PSUAService.exe"'
+  cwd: /
+  pid: 1245
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\Program Files\PostgreSQL\14\bin\postgres.exe" -D "C:\Program Files\PostgreSQL\14\data" '
+  cwd: /
+  pid: 1248
+  ppid: 1176
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: 1256
+  ppid: 1248
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forklog" "5308" "5312"
+    "0"'
+  cwd: '"C:/'
+  pid: 1304
+  ppid: 1248
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5212"
+    "-x5"'
+  cwd: '"C:/'
+  pid: 1336
+  ppid: 1248
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5224"
+    "-x3"'
+  cwd: '"C:/'
+  pid: 1344
+  ppid: 1248
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5204"
+    "-x6"'
+  cwd: '"C:/'
+  pid: 1352
+  ppid: 1248
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkavlauncher" "5196"'
+  cwd: '"C:/'
+  pid: 1360
+  ppid: 1248
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkcol" "5188"'
+  cwd: '"C:/'
+  pid: 1368
+  ppid: 1248
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkbgworker=0" "5180"'
+  cwd: '"C:/'
+  pid: 1376
+  ppid: 1248
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe"'
+  cwd: /
+  pid: 1420
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+  cwd: /
+  pid: 1444
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\winlogbeat\winlogbeat.exe" -c "C:\winlogbeat\winlogbeat.yml" -path.home
+    "C:\winlogbeat" -path.data "C:\ProgramData\winlogbeat" -path.logs "C:\ProgramData\winlogbeat\logs"'
+  cwd: /
+  pid: 1484
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\System32\svchost.exe -k termsvcs
+  cwd: /
+  pid: 2028
+  ppid: 432
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k NetworkServiceNetworkRestricted
+  cwd: /
+  pid: 1052
+  ppid: 432
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: null
+  cwd: /
+  pid: 2772
+  ppid: 2764
+  user: NT AUTHORITY\SYSTEM
+- cmdline: winlogon.exe
+  cwd: /
+  pid: 2800
+  ppid: 2764
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"dwm.exe"'
+  cwd: /
+  pid: 2856
+  ppid: 2800
+  user: Window Manager\DWM-2
+- cmdline: 'taskhostex.exe '
+  cwd: /
+  pid: 3008
+  ppid: 708
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: rdpclip
+  cwd: /
+  pid: 880
+  ppid: 2028
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\Explorer.EXE
+  cwd: /
+  pid: 2144
+  ppid: 2176
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\system32\wbem\wmiprvse.exe
+  cwd: /
+  pid: 2084
+  ppid: 496
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:\windows\System32\msdtc.exe
+  cwd: /
+  pid: 1836
+  ppid: 432
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:/telegraf/telegraf.exe -config C:/telegraf/telegraf.conf -config-directory
+    C:/telegraf/telegraf.d/
+  cwd: C:/telegraf/
+  pid: 3272
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe"
+    -sSQLEXPRESS'
+  cwd: /
+  pid: 1904
+  ppid: 432
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- cmdline: '"C:\Program Files (x86)\Microsoft SQL Server Management Studio 18\Common7\IDE\Ssms.exe" '
+  cwd: /
+  pid: 3236
+  ppid: 2144
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
+  cwd: /
+  pid: 3316
+  ppid: 2144
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: 1908
+  ppid: 3316
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
+  cwd: /
+  pid: 2384
+  ppid: 2144
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: 3208
+  ppid: 2384
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\system32\msiexec.exe /V
+  cwd: /
+  pid: 1600
+  ppid: 432
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\WinrsHost.exe -Embedding
+  cwd: /
+  pid: 4552
+  ppid: 496
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: 5352
+  ppid: 4552
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\system32\cmd.exe /C PowerShell -NoProfile -NonInteractive -ExecutionPolicy
+    Unrestricted -EncodedCommand UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
+  cwd: /
+  pid: 6104
+  ppid: 4552
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: PowerShell  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand
+    UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
+  cwd: /
+  pid: 6056
+  ppid: 6104
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: '"C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe"  -NoProfile
+    -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand JgBjAGgAYwBwAC4AYwBvAG0AIAA2ADUAMAAwADEAIAA+ACAAJABuAHUAbABsAAoAaQBmACAAKAAkAFAAUwBWAGUAcgBzAGkAbwBuAFQAYQBiAGwAZQAuAFAAUwBWAGUAcgBzAGkAbwBuACAALQBsAHQAIABbAFYAZQByAHMAaQBvAG4AXQAiADMALgAwACIAKQAgAHsACgAnAHsAIgBmAGEAaQBsAGUAZAAiADoAdAByAHUAZQAsACIAbQBzAGcAIgA6ACIAQQBuAHMAaQBiAGwAZQAgAHIAZQBxAHUAaQByAGUAcwAgAFAAbwB3AGUAcgBTAGgAZQBsAGwAIAB2ADMALgAwACAAbwByACAAbgBlAHcAZQByACIAfQAnAAoAZQB4AGkAdAAgADEACgB9AAoAJABlAHgAZQBjAF8AdwByAGEAcABwAGUAcgBfAHMAdAByACAAPQAgACQAaQBuAHAAdQB0ACAAfAAgAE8AdQB0AC0AUwB0AHIAaQBuAGcACgAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAgAD0AIAAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAF8AcwB0AHIALgBTAHAAbABpAHQAKABAACgAIgBgADAAYAAwAGAAMABgADAAIgApACwAIAAyACwAIABbAFMAdAByAGkAbgBnAFMAcABsAGkAdABPAHAAdABpAG8AbgBzAF0AOgA6AFIAZQBtAG8AdgBlAEUAbQBwAHQAeQBFAG4AdAByAGkAZQBzACkACgBJAGYAIAAoAC0AbgBvAHQAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAuAEwAZQBuAGcAdABoACAALQBlAHEAIAAyACkAIAB7ACAAdABoAHIAbwB3ACAAIgBpAG4AdgBhAGwAaQBkACAAcABhAHkAbABvAGEAZAAiACAAfQAKAFMAZQB0AC0AVgBhAHIAaQBhAGIAbABlACAALQBOAGEAbQBlACAAagBzAG8AbgBfAHIAYQB3ACAALQBWAGEAbAB1AGUAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADEAXQAKACQAZQB4AGUAYwBfAHcAcgBhAHAAcABlAHIAIAA9ACAAWwBTAGMAcgBpAHAAdABCAGwAbwBjAGsAXQA6ADoAQwByAGUAYQB0AGUAKAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADAAXQApAAoAJgAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAA=='
+  cwd: /
+  pid: 4416
+  ppid: 6056
+  user: TEST-NORM-WIN01\Administrator
+software_list:
+- cmd_regexp: .*PSUAService.exe
+  name: Panda Security Protection
+  pkg_regexp: Panda
+  process_type: parent
+  return_children: false
+  return_packages: false
 tcp_listen:
-  - address: '::'
-    name: sqlservr.exe
-    pid: 1904
-    port: 49350
-    protocol: tcp
-    stime: Mon May 30 17:47:16 2022
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - address: '::'
-    name: services.exe
-    pid: 432
-    port: 49169
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: lsass.exe
-    pid: 440
-    port: 49167
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: spoolsv.exe
-    pid: 444
-    port: 49155
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: svchost.exe
-    pid: 708
-    port: 49154
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: svchost.exe
-    pid: 652
-    port: 49153
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: '::'
-    name: wininit.exe
-    pid: 344
-    port: 49152
-    protocol: tcp
-    stime: Mon May 30 17:21:40 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: System
-    pid: 4
-    port: 47001
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: ::1
-    name: pgbouncer.exe
-    pid: 1076
-    port: 6432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: System
-    pid: 4
-    port: 5986
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System
-    pid: 4
-    port: 5985
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: postgres.exe
-    pid: 1248
-    port: 5432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: svchost.exe
-    pid: 2028
-    port: 3389
-    protocol: tcp
-    stime: Mon May 30 17:21:53 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: System
-    pid: 4
-    port: 445
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: svchost.exe
-    pid: 524
-    port: 135
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: sqlservr.exe
-    pid: 1904
-    port: 49350
-    protocol: tcp
-    stime: Mon May 30 17:47:16 2022
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - address: 0.0.0.0
-    name: services.exe
-    pid: 432
-    port: 49169
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: lsass.exe
-    pid: 440
-    port: 49167
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: spoolsv.exe
-    pid: 444
-    port: 49155
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 708
-    port: 49154
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 652
-    port: 49153
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: 0.0.0.0
-    name: wininit.exe
-    pid: 344
-    port: 49152
-    protocol: tcp
-    stime: Mon May 30 17:21:40 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 127.0.0.1
-    name: pgbouncer.exe
-    pid: 1076
-    port: 6432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: postgres.exe
-    pid: 1248
-    port: 5432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 2028
-    port: 3389
-    protocol: tcp
-    stime: Mon May 30 17:21:53 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 192.168.0.94
-    name: System
-    pid: 4
-    port: 139
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 524
-    port: 135
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: sqlservr.exe
+  pid: 1904
+  port: 49350
+  protocol: tcp
+  stime: Mon May 30 17:47:16 2022
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- address: '::'
+  name: services.exe
+  pid: 432
+  port: 49169
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: lsass.exe
+  pid: 440
+  port: 49167
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: spoolsv.exe
+  pid: 444
+  port: 49155
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: svchost.exe
+  pid: 708
+  port: 49154
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: svchost.exe
+  pid: 652
+  port: 49153
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: '::'
+  name: wininit.exe
+  pid: 344
+  port: 49152
+  protocol: tcp
+  stime: Mon May 30 17:21:40 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: System
+  pid: 4
+  port: 47001
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: ::1
+  name: pgbouncer.exe
+  pid: 1076
+  port: 6432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: System
+  pid: 4
+  port: 5986
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System
+  pid: 4
+  port: 5985
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: postgres.exe
+  pid: 1248
+  port: 5432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: svchost.exe
+  pid: 2028
+  port: 3389
+  protocol: tcp
+  stime: Mon May 30 17:21:53 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: System
+  pid: 4
+  port: 445
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: svchost.exe
+  pid: 524
+  port: 135
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: sqlservr.exe
+  pid: 1904
+  port: 49350
+  protocol: tcp
+  stime: Mon May 30 17:47:16 2022
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- address: 0.0.0.0
+  name: services.exe
+  pid: 432
+  port: 49169
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: lsass.exe
+  pid: 440
+  port: 49167
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: spoolsv.exe
+  pid: 444
+  port: 49155
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 708
+  port: 49154
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 652
+  port: 49153
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: 0.0.0.0
+  name: wininit.exe
+  pid: 344
+  port: 49152
+  protocol: tcp
+  stime: Mon May 30 17:21:40 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 127.0.0.1
+  name: pgbouncer.exe
+  pid: 1076
+  port: 6432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: postgres.exe
+  pid: 1248
+  port: 5432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 2028
+  port: 3389
+  protocol: tcp
+  stime: Mon May 30 17:21:53 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 192.168.0.94
+  name: System
+  pid: 4
+  port: 139
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 524
+  port: 135
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\NETWORK SERVICE
 udp_listen:
-  - address: fe80::1002:b306:e05b:c850%12
-    name: System Idle Process
-    pid: null
-    port: 546
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: ::1
-    name: System Idle Process
-    pid: null
-    port: 59132
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 5355
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 4500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 3389
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 123
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 5355
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 4500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 3389
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 192.168.0.94
-    name: System Idle Process
-    pid: null
-    port: 138
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 192.168.0.94
-    name: System Idle Process
-    pid: null
-    port: 137
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 123
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
+- address: fe80::1002:b306:e05b:c850%12
+  name: System Idle Process
+  pid: null
+  port: 546
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: ::1
+  name: System Idle Process
+  pid: null
+  port: 59132
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 5355
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 4500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 3389
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 123
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 5355
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 4500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 3389
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 192.168.0.94
+  name: System Idle Process
+  pid: null
+  port: 138
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 192.168.0.94
+  name: System Idle Process
+  pid: null
+  port: 137
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 123
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null

--- a/tests/unit/plugins/action/auto/resources/patrol_agent/patrolagent_test.yaml
+++ b/tests/unit/plugins/action/auto/resources/patrol_agent/patrolagent_test.yaml
@@ -1,1251 +1,1208 @@
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 53314
-        protocol: 'tcp'
-    discovery_time: '2022-07-05T18:06:22+02:00'
-    listening_ports:
-      - 53314
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: patrol service package
-        release: 18.el7
-        source: rpm
-        version: 1.2.7
-    process:
-      cmdline: /usr/bin/PatrolAgent -b config.yaml
-      listening_ports:
-        - 53314
-      pid: '121'
-      ppid: '0'
-      user: root
-    type: Patrol Agent
-    version:
-      - number: 1.2.7
-        type: package
-software_list:
-  - cmd_regexp: PatrolAgent
-    name: Patrol Agent
-    pkg_regexp: patrol
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: {}
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: 'sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25'
-      LogPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: []
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /var/lib/grafana: {}
-          /var/log/grafana: {}
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: {}
-          /var/lib/postgresql/data: {}
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: {}
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ''
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 724bbb9271771d99d7ff6dcdeb5fd0e5ec6b4050365f4a76333591eda828117c
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 1
-        FinishedAt: '2022-07-05T16:06:20.007358679Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 0
-        Restarting: false
-        Running: false
-        StartedAt: '2022-07-05T16:06:18.811996225Z'
-        Status: exited
-packages:
-  patrol-package:
-    - arch: x86_64
-      epoch: null
-      name: patrol service package
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/bin/PatrolAgent -b config.yaml
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ''
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 724bbb9271771d99d7ff6dcdeb5fd0e5ec6b4050365f4a76333591eda828117c
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 1
+      FinishedAt: '2022-07-05T16:06:20.007358679Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 0
+      Restarting: false
+      Running: false
+      StartedAt: '2022-07-05T16:06:18.811996225Z'
+      Status: exited
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 53314
+    protocol: tcp
+  discovery_time: '2022-07-05T18:06:22+02:00'
+  listening_ports:
+  - 53314
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: patrol service package
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+  process:
+    cmdline: /usr/bin/PatrolAgent -b config.yaml
+    cwd: /usr/bin/
+    listening_ports:
+    - 53314
     pid: '121'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
+  type: Patrol Agent
+  version:
+  - number: 1.2.7
+    type: package
+packages:
+  patrol-package:
+  - arch: x86_64
+    epoch: null
+    name: patrol service package
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/bin/PatrolAgent -b config.yaml
+  cwd: /usr/bin/
+  pid: '121'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: PatrolAgent
+  name: Patrol Agent
+  pkg_regexp: patrol
+  process_type: parent
+  return_children: false
+  return_packages: true
 tcp_listen:
-  - address: 0.0.0.0
-    name: port1
-    pid: 121
-    port: 53314
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: port2
-    pid: 122
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: port3
-    pid: 123
-    port: 52914
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port4
-    pid: 124
-    port: 53213
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port5
-    pid: 125
-    port: 52614
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
+- address: 0.0.0.0
+  name: port1
+  pid: 121
+  port: 53314
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: port2
+  pid: 122
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: port3
+  pid: 123
+  port: 52914
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port4
+  pid: 124
+  port: 53213
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port5
+  pid: 125
+  port: 52614
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
 udp_listen:
-  - address: 0.0.0.0
-    name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/postgres/centos7.9_postgres10.17.yaml
+++ b/tests/unit/plugins/action/auto/resources/postgres/centos7.9_postgres10.17.yaml
@@ -1,63 +1,1647 @@
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - /usr/local/bin/docker-entrypoint.sh
+    - catalina.sh
+    - run
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - catalina.sh
+      - run
+      Domainname: ''
+      Entrypoint:
+      - /bin/sh
+      - -c
+      - /usr/local/bin/docker-entrypoint.sh
+      Env:
+      - LANG=C.UTF-8
+      - CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
+      - POSTGRES_PORT=5432
+      - CMDBUILD_DUMP=empty.dump.xz
+      - POSTGRES_HOST=192.168.64.34
+      - POSTGRES_PASS=the_password
+      - JAVA_OPTS=-Xmx7876m -Xms3846m
+      - POSTGRES_DB=cmdbuild_r2u2
+      - PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - TZ=Europe/Madrid
+      - POSTGRES_APP_USER=datadope
+      - POSTGRES_APP_PASSWORD=the_password
+      - POSTGRES_USER=datadope
+      - JAVA_HOME=/usr/local/openjdk-17
+      - JAVA_VERSION=17.0.2
+      - CATALINA_HOME=/usr/local/tomcat
+      - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
+      - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
+      - GPG_KEYS=48F8E69F6390C9F25CFEDCD268248959359E722B A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
+        DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
+      - TOMCAT_MAJOR=9
+      - TOMCAT_VERSION=9.0.60
+      - TOMCAT_SHA512=a4d43ac45f76e29d3dea23a2712c7570a11419aad7a1af2d1533454709c020b59666c7f9e063a77120224e0cbd4020cac06ca596dda7057cacb9a8a7e6d73eea
+      - APM_JAR_URL=https://nexus.opensolutions.cloud/repository/datadope-public/elastic-apm/elastic-apm-agent-1.28.1.jar
+      ExposedPorts:
+        8080/tcp: {}
+        8443/tcp: {}
+      Hostname: localhost
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.5.3
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: tomcat
+      Volumes: null
+      WorkingDir: /usr/local/tomcat
+    Created: '2022-03-25T12:04:52.930305974Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794-init/diff:/var/lib/docker/overlay2/0ca2f0e4b67ae95aef370146269b3fb10e55a6859d278f2997e8b84ff9122875/diff:/var/lib/docker/overlay2/308c2efd326216c0efe94e857b82520af6ab116a978811106d99e49ddf15fc1b/diff:/var/lib/docker/overlay2/c0610b1db247b6b1804c3b992e3f89f1ff75375a3b9c395de68e7dd6f0c5af41/diff:/var/lib/docker/overlay2/b49fa08f0f5246651d4fc001af50b8fc4f316d3add326329766d389a5b8597e1/diff:/var/lib/docker/overlay2/30067671d40d8ef3df665781083700fdb08887c64131c247ff8210714dd2d7a8/diff:/var/lib/docker/overlay2/acec1c4357e89e939adefb7160deb62f2e3dd2fb8e2b89c50a84d7e807b27220/diff:/var/lib/docker/overlay2/348d6cd50875127305d1c94e3d700856d51fc4a33a7c735163a54451c6fc3791/diff:/var/lib/docker/overlay2/b2dbb49865766b5568101566c79fdb955744097af5e48de46fc508b6de374d4a/diff:/var/lib/docker/overlay2/679f2167259fbc9d27c7bc3b9c872e59655afc90478754d2774935f005c62a2d/diff:/var/lib/docker/overlay2/1e770257e07955a14878870e1146a4954ff84e3a9a13f439b617d5a93316369b/diff:/var/lib/docker/overlay2/f4ddf2e6b8e7240af6c8026059475c51e762150436d2e78369347e31154144af/diff:/var/lib/docker/overlay2/10a54c98f41b6862c3ffb03a07cc1b23d517b5fce34238706646aa8949467afb/diff:/var/lib/docker/overlay2/f8c4e742a18bbeeaff6a7f3e99d59e12186868fbd68718b9adf44213e51fe1fc/diff:/var/lib/docker/overlay2/eaeac3feaa55318680b5311656bb14d685c03b356403ea6109fa7b1f16e63189/diff:/var/lib/docker/overlay2/5179e1277d7830285af10f6cd4bd09708b36dfe341288a6dcd68c7896718bb75/diff:/var/lib/docker/overlay2/8562f678e444a225812e39cdf950838f4ee626f1264ce3eac883dcc27bb165d2/diff:/var/lib/docker/overlay2/0f25f2ae977f5674027aac8cdd9cf2e07456a422fb88425fde7d3026f1f8ecdc/diff:/var/lib/docker/overlay2/997ff03392129602e78b3f0e6b5879ec656d11d8c3fa536f5577b0e540b40173/diff:/var/lib/docker/overlay2/994f47ca80b9c00cfabf4d1dcff4992f6b0c1647d89589dd5f31fdaa1bf6340f/diff:/var/lib/docker/overlay2/359f2d072fad20815db5e37ab4284e6c3376233db3163033fe04ba8b1153b443/diff:/var/lib/docker/overlay2/8a3f7b2f222926cdf88d12cd34fed89094bd049498fc78b1ddf625ce837f3760/diff:/var/lib/docker/overlay2/6daf829f7b4e94d9cba1f56aeab10d06a317241ee7aa01217ef88d2676fefce8/diff
+        MergedDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/merged
+        UpperDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/diff
+        WorkDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:ro
+      - /etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw
+      - /var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: []
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: []
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: bridge
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/hostname
+    HostsPath: /etc/hosts
+    Id: 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
+    Image: sha256:eb3e461a2b2785cb353346a408a9e43b7f0fb86bb8a9a592ada57ca4c52e3bfd
+    LogPath: /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /usr/local/tomcat/certs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics-cmdbuild/certs
+      Type: bind
+    - Destination: /usr/local/tomcat/logs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/iometrics-cmdbuild
+      Type: bind
+    Name: /iometrics-cmdbuild
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 41c2ca0665e3ff46604f87a86347667647caede3bf1e50854538526bf62154b4
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 41c2ca0665e3ff46604f87a86347667647caede3bf1e50854538526bf62154b4
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: e245cfe31a9637868b704e96aa6cbd268c001dc02bc3d706b7a2abb2276532ff
+      Ports:
+        8080/tcp: null
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      SandboxID: 5ceb4ee7e267ae9df7e902a05d972cabdfec1c00db6a751675b2872c08931dfe
+      SandboxKey: /var/run/docker/netns/5ceb4ee7e267
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-05-05T10:22:35.906672463Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 88679
+      Restarting: false
+      Running: true
+      StartedAt: '2022-05-05T14:06:36.663836267Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - ./start_cmdb_gateway.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - ./start_cmdb_gateway.sh
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.5
+      - CMDB_GATEWAY_CONFIG_FILE=config/cmdb_gateway.yaml
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - PYTHON_PIP_VERSION=20.2.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
+      - PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      Hostname: oss-devel-cmdb
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-gateway:0.18.0
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: /app
+    Created: '2021-12-16T13:40:54.11945545Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9-init/diff:/var/lib/docker/overlay2/f28f032f19b8e36176d7f5c3c3280960a1f0b2d030b1461fde6f85608b268fb7/diff:/var/lib/docker/overlay2/c812399fd0157a9db6cd588828f224d26a076ebaa05397d46399616d7491559b/diff:/var/lib/docker/overlay2/04dc77fa805a06bb44c58399ae78a7ab110bc9d714c346b0df5a7e5b349ae16c/diff:/var/lib/docker/overlay2/4c9d61501d1130eeaea40e3c6e8c58e3790995f474c04c2bb10c904a71431edb/diff:/var/lib/docker/overlay2/4993b8fafd5a9d9a6023eaf5d25fe51a2fabcb3dbee5ea7549ec9420497d57e5/diff:/var/lib/docker/overlay2/d6460864d519c5967a63083553d16607e9e209a7eab0d4c098a649aaa0cdf0f2/diff:/var/lib/docker/overlay2/70210d890e6f91fbea58cad88a3fce3e126382bc7b33645fc961fdb8faa8542f/diff:/var/lib/docker/overlay2/ca78aa40f8918ea045999b7270f6fd9704cb0cdb7540c93b5b2608c336057ab5/diff:/var/lib/docker/overlay2/a6183d5cdfd1c5842b63dc840de2a5ef55eb86dcd92872076825f6ae35fa240a/diff:/var/lib/docker/overlay2/b46ed7aa9054a838c1438c581e9d770be0a97cf687a962a532c5096af8f4714b/diff:/var/lib/docker/overlay2/46919684c7f455b8be1662fbc502637c471f5ea2fe53e4ea3edceadc8a28b14f/diff:/var/lib/docker/overlay2/764a651bc4126949119711643715095b4394c88d62b64f6c83a1720378145f0b/diff:/var/lib/docker/overlay2/9f37cd3fc4a2444f9ab442262e3f41cc348cee444f14100f61a487031cfe07f5/diff:/var/lib/docker/overlay2/47b0f955a1643f1d46055c3aeaa3a2ffdd59ccb1f5f14e89dcf603db8463b81b/diff:/var/lib/docker/overlay2/f3aa2fa503c8e7277a423cd85d1d8bdfd147fc867f5fab859a097188e0e6d004/diff
+        MergedDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/merged
+        UpperDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/diff
+        WorkDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/cmdb/config:/app/config:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: []
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: []
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: 'no'
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hostname
+    HostsPath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hosts
+    Id: da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
+    Image: sha256:af61c42a1772b373dbc30a6d3650af40d4e738a5d22959eccea5974946ada9fa
+    LogPath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/config
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/cmdb/config
+      Type: bind
+    Name: /iometrics-cmdb-gateway
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: eae8f75be12d4ee5414e78442f3d68fab431b5ac569a73345570f3a7029f9a68
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: 959cd311c6ccbbaf8b55b63b3b07166a6ad63782235f0f5a1ce50d2e1bdf6ee7
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-05-05T13:28:48.020900022Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 86277
+      Restarting: false
+      Running: true
+      StartedAt: '2022-05-05T13:28:48.31349014Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - python ./listener.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - python ./listener.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.5
+      - PYTHON_PIP_VERSION=20.2.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
+      - PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
+      Hostname: oss-devel-cmdb
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.0.1
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /config: {}
+      WorkingDir: ''
+    Created: '2021-05-25T10:08:10.097442624Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41-init/diff:/var/lib/docker/overlay2/ba78f066d9e46b0f7b41380a42ef0a747aa591e78992e40447ca78b8528de8ed/diff:/var/lib/docker/overlay2/3b784c7b5c126900be4badb31068a06fbfdfe15a2f15049ed151fb2a5a370659/diff:/var/lib/docker/overlay2/c6b744055dfca315c6446e3723460947b34efd1d75325b2caae502367afa3c2e/diff:/var/lib/docker/overlay2/a1a2492e64ab4e7a012e36e61ceabaf1d80bed24e72c2ae69d7172e35a3831de/diff:/var/lib/docker/overlay2/39a5edc9ab57849080990571d9a3f410b66a3bb04f12ca966d3f4a64e0cbbd8a/diff:/var/lib/docker/overlay2/0780a973dbea66c8f367c507554356a5d27303cd0a1d8b5396e7b0aa392b6149/diff:/var/lib/docker/overlay2/e1f23af492edda46763c05b32bcfe283f83fdd27460a55cf1a5dcf437a0e0ae7/diff:/var/lib/docker/overlay2/9f8debce0febecd5e1c4e50351a37d422b1b60f3826ddfd9dadc1961fe3e007f/diff
+        MergedDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/merged
+        UpperDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/diff
+        WorkDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/redis-cleaner:/config:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hostname
+    HostsPath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hosts
+    Id: 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
+    Image: sha256:70c1ea6bb3f2e939311b21e6b49cd3cce10ffb2e21e8b5b431bd293421ca8472
+    LogPath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /config
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis-cleaner
+      Type: bind
+    Name: /iometrics-cmdb-redis-cleaner
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ed464b6f49997d37e646e04846527f61c970de6c91c3deb620c2c3c80fca0b96
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: 72ed345048dcc6240fabf7e33835c2a4fd99d59e7fa0972a4685872da6303113
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 34206
+      Restarting: false
+      Running: true
+      StartedAt: '2021-05-25T10:08:10.240751099Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --tls-port
+    - '6378'
+    - --appendonly
+    - 'no'
+    - --maxmemory
+    - '0'
+    - --maxclients
+    - '10000'
+    - --bind
+    - 0.0.0.0
+    - --requirepass
+    - the_password
+    - --tls-auth-clients
+    - 'no'
+    - --tls-cert-file
+    - /data/ssl/redis.crt
+    - --tls-key-file
+    - /data/ssl/redis.pem
+    - --tls-ca-cert-file
+    - /data/ssl/redis_ca.crt
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - --tls-port
+      - '6378'
+      - --appendonly
+      - 'no'
+      - --maxmemory
+      - '0'
+      - --maxclients
+      - '10000'
+      - --bind
+      - 0.0.0.0
+      - --requirepass
+      - the_password
+      - --tls-auth-clients
+      - 'no'
+      - --tls-cert-file
+      - /data/ssl/redis.crt
+      - --tls-key-file
+      - /data/ssl/redis.pem
+      - --tls-ca-cert-file
+      - /data/ssl/redis_ca.crt
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.0.1
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
+      - REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: oss-devel-cmdb
+      Image: redis:6.0.1
+      Labels:
+        os_contianer_type: redis
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+        /data/ssl/: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+      WorkingDir: /data
+    Created: '2021-05-25T09:00:32.257009145Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce-init/diff:/var/lib/docker/overlay2/895c1f99a736e2df91bfc2a00c7551e51fd433dde75de2279435ff47ea0e6b38/diff:/var/lib/docker/overlay2/a9841cfec194609a7ec73913c03ba7d4155bc5334e801da50362b4a928a3fe93/diff:/var/lib/docker/overlay2/d9cb4756a3d19486043c08cf2b9492aca7b6664e4914a64c4ae7d649510fb8fb/diff:/var/lib/docker/overlay2/348fb45e5b21b874e1972d7abf6267aedb49052fe240ff1ca65c31d01f0cd49e/diff:/var/lib/docker/overlay2/1f6d3088e9933dfa837efd70762bf9724143691931203267ec5ff24aa5dfe170/diff:/var/lib/docker/overlay2/c96ac52a498ef5b1c8f81d0d7ee4cb762e570fee584f3b41148aceca3a8664b5/diff
+        MergedDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/merged
+        UpperDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/diff
+        WorkDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/redis:/data:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/redis/ssl/:/data/ssl/:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/hostname
+    HostsPath: /etc/hosts
+    Id: b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
+    Image: sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c
+    LogPath: /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis/ssl
+      Type: bind
+    - Destination: /data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/redis
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    Name: /redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: beb2a749121a2b11fd9bc6093b92eb8fd64c1abf38a38f39261bc633429fc566
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: 6b4a27d90042eb73469fe2c90437f604c16aade938163e14d93d88892703a15f
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 20064
+      Restarting: false
+      Running: true
+      StartedAt: '2021-05-25T09:00:32.529069205Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: oss-devel-cmdb
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2021-05-24T14:27:58.280498639Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098-init/diff:/var/lib/docker/overlay2/572d19da46f80f29256ff94ed86f500ede7764af796338b02e10f781d4387407/diff:/var/lib/docker/overlay2/16e7f7bacf68db89a426b0b90b68188ce3387cd01bad762550e49c926b5879d8/diff:/var/lib/docker/overlay2/26ea1b9023be5dfd133dd9e015e47da4265ab65445bb17899fcc275604d3754d/diff
+        MergedDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/merged
+        UpperDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/diff
+        WorkDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/hostname
+    HostsPath: /etc/hosts
+    Id: df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 29d2d1ebe738bc2b3d44373cd6019b50940e82931b720cfd949e7c08c8a110ea
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: c2fdaac80977cad0b65bf2e24939c5a22c6ad249d8db4aab83f390a0bb1305d6
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2021-05-24T14:56:41.686346314Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 23339
+      Restarting: false
+      Running: true
+      StartedAt: '2021-06-01T15:04:41.797753434Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 5432
+    protocol: tcp
+  configuration:
+    archive_command: ''
+    archive_mode: 'off'
+    archive_timeout: '0'
+    array_nulls: 'on'
+    authentication_timeout: 60s
+    autovacuum: 'on'
+    autovacuum_analyze_scale_factor: '0.1'
+    autovacuum_analyze_threshold: '50'
+    autovacuum_freeze_max_age: '200000000'
+    autovacuum_max_workers: '3'
+    autovacuum_multixact_freeze_max_age: '400000000'
+    autovacuum_naptime: 1min
+    autovacuum_vacuum_cost_delay: 20ms
+    autovacuum_vacuum_cost_limit: '-1'
+    autovacuum_vacuum_scale_factor: '0.2'
+    autovacuum_vacuum_threshold: '50'
+    autovacuum_work_mem: '-1'
+    backend_flush_after: '0'
+    backslash_quote: safe_encoding
+    bgwriter_delay: 200ms
+    bgwriter_flush_after: '0'
+    bgwriter_lru_maxpages: '100'
+    bgwriter_lru_multiplier: '2.0'
+    bonjour: 'off'
+    bonjour_name: ''
+    bytea_output: hex
+    check_function_bodies: 'on'
+    checkpoint_completion_target: '0.9'
+    checkpoint_flush_after: '0'
+    checkpoint_timeout: 5min
+    checkpoint_warning: 30s
+    client_min_messages: notice
+    cluster_name: data
+    commit_delay: '0'
+    commit_siblings: '5'
+    constraint_exclusion: partition
+    cpu_index_tuple_cost: '0.005'
+    cpu_operator_cost: '0.0025'
+    cpu_tuple_cost: '0.01'
+    cursor_tuple_fraction: '0.1'
+    data_directory: /var/lib/pgsql/10/data
+    datestyle: iso,mdy
+    db_user_namespace: 'off'
+    deadlock_timeout: 1s
+    debug_pretty_print: 'on'
+    debug_print_parse: 'off'
+    debug_print_plan: 'off'
+    debug_print_rewritten: 'off'
+    default_statistics_target: '500'
+    default_tablespace: ''
+    default_text_search_config: pg_catalog.english
+    default_transaction_deferrable: 'off'
+    default_transaction_isolation: read committed
+    default_transaction_read_only: 'off'
+    default_with_oids: 'off'
+    dynamic_library_path: $libdir
+    dynamic_shared_memory_type: posix
+    effective_cache_size: 9GB
+    effective_io_concurrency: '200'
+    enable_bitmapscan: 'on'
+    enable_hashagg: 'on'
+    enable_hashjoin: 'on'
+    enable_indexonlyscan: 'on'
+    enable_indexscan: 'on'
+    enable_material: 'on'
+    enable_mergejoin: 'on'
+    enable_nestloop: 'on'
+    enable_seqscan: 'on'
+    enable_sort: 'on'
+    enable_tidscan: 'on'
+    escape_string_warning: 'on'
+    event_source: PostgreSQL
+    exit_on_error: 'off'
+    external_pid_file: /var/run/postgresql/10-data.pid
+    extra_float_digits: '0'
+    force_parallel_mode: 'off'
+    from_collapse_limit: '8'
+    fsync: 'on'
+    full_page_writes: 'on'
+    geqo: 'on'
+    geqo_effort: '5'
+    geqo_generations: '0'
+    geqo_pool_size: '0'
+    geqo_seed: '0.0'
+    geqo_selection_bias: '2.0'
+    geqo_threshold: '12'
+    gin_fuzzy_search_limit: '0'
+    gin_pending_list_limit: 4MB
+    hba_file: /etc/postgresql/10/data/pg_hba.conf
+    hot_standby: 'off'
+    hot_standby_feedback: 'off'
+    huge_pages: try
+    ident_file: /etc/postgresql/10/data/pg_ident.conf
+    idle_in_transaction_session_timeout: '0'
+    include_dir: conf.d
+    intervalstyle: postgres
+    join_collapse_limit: '8'
+    krb_caseins_users: 'off'
+    krb_server_keyfile: ''
+    lc_messages: en_US.UTF-8
+    lc_monetary: en_US.UTF-8
+    lc_numeric: en_US.UTF-8
+    lc_time: en_US.UTF-8
+    listen_addresses: 0.0.0.0
+    lo_compat_privileges: 'off'
+    local_preload_libraries: ''
+    lock_timeout: '0'
+    log_autovacuum_min_duration: '-1'
+    log_checkpoints: 'off'
+    log_connections: 'off'
+    log_destination: stderr
+    log_directory: pg_log
+    log_disconnections: 'off'
+    log_duration: 'off'
+    log_error_verbosity: default
+    log_executor_stats: 'off'
+    log_file_mode: '0600'
+    log_filename: postgresql-%Y-%m-%d_%H%M%S.log
+    log_hostname: 'off'
+    log_line_prefix: '%t '
+    log_lock_waits: 'off'
+    log_min_duration_statement: '-1'
+    log_min_error_statement: error
+    log_min_messages: warning
+    log_parser_stats: 'off'
+    log_planner_stats: 'off'
+    log_replication_commands: 'off'
+    log_rotation_age: 1d
+    log_rotation_size: 10MB
+    log_statement: none
+    log_statement_stats: 'off'
+    log_temp_files: '-1'
+    log_timezone: UTC
+    log_truncate_on_rotation: 'off'
+    logging_collector: 'off'
+    maintenance_work_mem: 1536MB
+    max_connections: '150'
+    max_files_per_process: '1000'
+    max_locks_per_transaction: '1024'
+    max_logical_replication_workers: '4'
+    max_parallel_workers: '6'
+    max_parallel_workers_per_gather: '3'
+    max_pred_locks_per_page: '2'
+    max_pred_locks_per_relation: '-2'
+    max_pred_locks_per_transaction: '64'
+    max_prepared_transactions: '0'
+    max_replication_slots: '0'
+    max_stack_depth: 2MB
+    max_standby_archive_delay: 30s
+    max_standby_streaming_delay: 30s
+    max_sync_workers_per_subscription: '2'
+    max_wal_senders: '0'
+    max_wal_size: 16GB
+    max_worker_processes: '6'
+    min_parallel_index_scan_size: 512kB
+    min_parallel_table_scan_size: 8MB
+    min_wal_size: 4GB
+    old_snapshot_threshold: '-1'
+    operator_precedence_warning: 'off'
+    parallel_setup_cost: '1000.0'
+    parallel_tuple_cost: '0.1'
+    password_encryption: 'on'
+    port: '5432'
+    quote_all_identifiers: 'off'
+    random_page_cost: '1.1'
+    replacement_sort_tuples: '150000'
+    restart_after_crash: 'on'
+    row_security: 'off'
+    search_path: '"$user",public'
+    seq_page_cost: '1.0'
+    session_preload_libraries: ''
+    session_replication_role: origin
+    shared_buffers: 3GB
+    shared_preload_libraries: ''
+    ssl: 'off'
+    ssl_ca_file: ''
+    ssl_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
+    ssl_ciphers: DEFAULT:!LOW:!EXP:!MD5:@STRENGTH
+    ssl_crl_file: ''
+    ssl_dh_params_file: ''
+    ssl_ecdh_curve: prime256v1
+    ssl_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
+    ssl_prefer_server_ciphers: 'on'
+    standard_conforming_strings: 'on'
+    statement_timeout: '0'
+    stats_temp_directory: pg_stat_tmp
+    superuser_reserved_connections: '3'
+    synchronize_seqscans: 'on'
+    synchronous_commit: 'on'
+    synchronous_standby_names: ''
+    syslog_facility: LOCAL0
+    syslog_ident: postgres
+    syslog_sequence_numbers: 'on'
+    syslog_split_messages: 'on'
+    tcp_keepalives_count: '0'
+    tcp_keepalives_idle: '0'
+    tcp_keepalives_interval: '0'
+    temp_buffers: 8MB
+    temp_file_limit: '-1'
+    temp_tablespaces: ''
+    timezone: UTC
+    timezone_abbreviations: Default
+    track_activities: 'on'
+    track_activity_query_size: '1024'
+    track_commit_timestamp: 'off'
+    track_counts: 'on'
+    track_functions: none
+    track_io_timing: 'off'
+    transform_null_equals: 'off'
+    unix_socket_directories: /var/run/postgresql,/tmp
+    unix_socket_group: ''
+    unix_socket_permissions: '0777'
+    update_process_title: 'on'
+    vacuum_cost_delay: '0'
+    vacuum_cost_limit: '200'
+    vacuum_cost_page_dirty: '20'
+    vacuum_cost_page_hit: '1'
+    vacuum_cost_page_miss: '10'
+    vacuum_defer_cleanup_age: '0'
+    vacuum_freeze_min_age: '50000000'
+    vacuum_freeze_table_age: '150000000'
+    vacuum_multixact_freeze_min_age: '5000000'
+    vacuum_multixact_freeze_table_age: '150000000'
+    wal_buffers: 16MB
+    wal_compression: 'off'
+    wal_keep_segments: '0'
+    wal_level: minimal
+    wal_log_hints: 'off'
+    wal_receiver_status_interval: 10s
+    wal_receiver_timeout: 60s
+    wal_retrieve_retry_interval: 5s
+    wal_sender_timeout: 60s
+    wal_sync_method: fsync
+    wal_writer_delay: 200ms
+    wal_writer_flush_after: 1MB
+    work_mem: 5242kB
+    xmlbinary: base64
+    xmloption: content
+  discovery_time: '2022-05-26T18:00:00+02:00'
+  extra_data:
+    active_databases:
+    - cmdbuild_r2u2
+    databases:
+    - cmdbuild_r2u2
+  files:
+  - path: /usr/pgsql-10/bin/postmaster
+    subtype: generic
+    type: binary
+  - name: postgresql.conf
+    path: /etc/postgresql/10/data
+    subtype: generic
+    type: conf
+  - path: /var/lib/pgsql/10/data
+    subtype: generic
+    type: data
+  listening_ports:
+  - 5432
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
+  process:
+    children:
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56180) idle'
+      cwd: /
+      pid: '3042'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56186) idle'
+      cwd: /
+      pid: '3046'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56192) idle'
+      cwd: /
+      pid: '3050'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56198) idle'
+      cwd: /
+      pid: '3067'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56200) idle'
+      cwd: /
+      pid: '3069'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56874) idle'
+      cwd: /
+      pid: '4768'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56876) idle'
+      cwd: /
+      pid: '4772'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56880) idle'
+      cwd: /
+      pid: '4845'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56882) idle'
+      cwd: /
+      pid: '4859'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42334) idle'
+      cwd: /
+      pid: '44206'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42336) idle'
+      cwd: /
+      pid: '44207'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42342) idle'
+      cwd: /
+      pid: '44210'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43028) idle'
+      cwd: /
+      pid: '45527'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43040) idle'
+      cwd: /
+      pid: '45533'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43042) idle'
+      cwd: /
+      pid: '45534'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42934) idle'
+      cwd: /
+      pid: '45877'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42938) idle'
+      cwd: /
+      pid: '45879'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43470) idle'
+      cwd: /
+      pid: '47004'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: checkpointer process'
+      cwd: /
+      pid: '86332'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: writer process'
+      cwd: /
+      pid: '86333'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: wal writer process'
+      cwd: /
+      pid: '86334'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: autovacuum launcher process'
+      cwd: /
+      pid: '86335'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: stats collector process'
+      cwd: /
+      pid: '86336'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: bgworker: logical replication launcher'
+      cwd: /
+      pid: '86337'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(45768) idle'
+      cwd: /
+      pid: '88921'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56796) idle'
+      cwd: /
+      pid: '90009'
+      ppid: '86330'
+      user: postgres
+    - children: []
+      cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56802) idle'
+      cwd: /
+      pid: '90012'
+      ppid: '86330'
+      user: postgres
+    cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
+    cwd: /usr/pgsql-10/bin/
+    listening_ports:
+    - 5432
+    pid: '86330'
+    ppid: '1'
+    user: postgres
+  type: PostgreSQL Database
+  version:
+  - number: '10'
+    type: file
+  - number: '10.17'
+    type: active
+  - number: '10.17'
+    type: package
+expected_tasks_calls:
+  Get active databases: 27
+  Get from child processes cmdline: 27
+  Store active database if needed: 1
+  Store databases: 1
+expected_tasks_calls_mode_strict: false
 mocked_plugin_tasks:
-  Read process environment:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      parsed: {}
-  Extract port:
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-  Get from child processes cmdline:
-    calls:
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - run
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - run
-      - run
-      - run
-  "Attempt to extract conf path":
-    number_of_calls: 1
+  Attempt to extract conf path:
     check_instance_vars:
       _conf_path: /etc/postgresql/10/data
-  "Read configuration file as dict":
-    # Force only 1 call using number_of_calls
     number_of_calls: 1
+  Extract port:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Get active databases:
+    number_of_calls: 27
+  Get from child processes cmdline:
+    calls:
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - run
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - run
+    - run
+    - run
+  Get user if available:
+    expected_exception:
+      message: any
+      type: any
+    number_of_calls: 1
+  Read VERSION file from path:
+    calls:
+    - expected_args:
+        delegate_reading: false
+        file_path: /var/lib/pgsql/10/data/PG_VERSION
+        in_docker: true
+        parser: null
+        parser_params: null
+      expected_attributes:
+        register: result
+      plugin_result:
+        content: '10'
+        failed: false
+  Read configuration file as dict:
     expected_args:
       delegate_reading: false
       file_path: /etc/postgresql/10/data/postgresql.conf
       in_docker: true
       parser: key_value
       parser_params:
-        separators: ["=", " "]
+        separators:
+        - '='
+        - ' '
     expected_attributes:
       register: result
+    number_of_calls: 1
     plugin_result:
       failed: false
       parsed:
@@ -102,7 +1686,7 @@ mocked_plugin_tasks:
         cpu_tuple_cost: '0.01'
         cursor_tuple_fraction: '0.1'
         data_directory: /var/lib/pgsql/10/data
-        datestyle: 'iso,mdy'
+        datestyle: iso,mdy
         db_user_namespace: 'off'
         deadlock_timeout: 1s
         debug_pretty_print: 'on'
@@ -238,7 +1822,7 @@ mocked_plugin_tasks:
         ssl: 'off'
         ssl_ca_file: ''
         ssl_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
-        ssl_ciphers: 'DEFAULT:!LOW:!EXP:!MD5:@STRENGTH'
+        ssl_ciphers: DEFAULT:!LOW:!EXP:!MD5:@STRENGTH
         ssl_crl_file: ''
         ssl_dh_params_file: ''
         ssl_ecdh_curve: prime256v1
@@ -270,7 +1854,7 @@ mocked_plugin_tasks:
         track_functions: none
         track_io_timing: 'off'
         transform_null_equals: 'off'
-        unix_socket_directories: '/var/run/postgresql,/tmp'
+        unix_socket_directories: /var/run/postgresql,/tmp
         unix_socket_group: ''
         unix_socket_permissions: '0777'
         update_process_title: 'on'
@@ -299,7035 +1883,5716 @@ mocked_plugin_tasks:
         work_mem: 5242kB
         xmlbinary: base64
         xmloption: content
-  "Read VERSION file from path":
-    # Force only 1 call using calls list
-    calls:
-      - expected_args:
-          delegate_reading: false
-          file_path: /var/lib/pgsql/10/data/PG_VERSION
-          in_docker: true
-          parser: null
-          parser_params: null
-        expected_attributes:
-          register: result
-        plugin_result:
-          failed: false
-          content: "10"
-  "Run command version":
-    plugin_result:
-      failed: false
-      stdout: postgres (PostgreSQL) 10.17
-  "Get active databases":
-    # Blocks can only check number of calls
-    number_of_calls: 27
-  "Read pg_hba file from path":
-    number_of_calls: 1
+  Read pg_hba file from path:
     expected_args:
       delegate_reading: false
       file_path: /etc/postgresql/10/data/pg_hba.conf
       in_docker: true
       parser: null
       parser_params: null
+    number_of_calls: 1
+    plugin_result:
+      content: '# Ansible managed
+
+        # PostgreSQL Client Authentication Configuration File
+
+        # ===================================================
+
+        #
+
+        # Refer to the "Client Authentication" section in the PostgreSQL
+
+        # documentation for a complete description of this file.  A short
+
+        # synopsis follows.
+
+        #
+
+        # This file controls: which hosts are allowed to connect, how clients
+
+        # are authenticated, which PostgreSQL user names they can use, which
+
+        # databases they can access.  Records take one of these forms:
+
+        #
+
+        # local      DATABASE  USER  METHOD  [OPTIONS]
+
+        # host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+
+        # hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+
+        # hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+
+        #
+
+        # TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+
+        # Default:
+
+        # "local" is for Unix domain socket connections only
+
+        local  all  all    peer
+
+        # IPv4 local connections:
+
+        host  all  all  127.0.0.1/32  md5
+
+        # IPv6 local connections:
+
+        host  all  all  ::1/128  md5
+
+        # Local root Unix user, passwordless access
+
+        local  all  postgres    peer map=root_as_postgres
+
+
+        # MD5 hashed password hosts
+
+        host  all  all  0.0.0.0/0  md5
+
+
+        # Password hosts
+
+        host  all  all  0.0.0.0/0  password
+
+
+        # Trusted hosts
+
+
+        # User custom'
+      failed: false
+  Read process environment:
+    number_of_calls: 1
     plugin_result:
       failed: false
-      content: |-
-        # Ansible managed
-        # PostgreSQL Client Authentication Configuration File
-        # ===================================================
-        #
-        # Refer to the "Client Authentication" section in the PostgreSQL
-        # documentation for a complete description of this file.  A short
-        # synopsis follows.
-        #
-        # This file controls: which hosts are allowed to connect, how clients
-        # are authenticated, which PostgreSQL user names they can use, which
-        # databases they can access.  Records take one of these forms:
-        #
-        # local      DATABASE  USER  METHOD  [OPTIONS]
-        # host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
-        # hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
-        # hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
-        #
-        # TYPE  DATABASE        USER            ADDRESS                 METHOD
-        
-        # Default:
-        # "local" is for Unix domain socket connections only
-        local  all  all    peer
-        # IPv4 local connections:
-        host  all  all  127.0.0.1/32  md5
-        # IPv6 local connections:
-        host  all  all  ::1/128  md5
-        # Local root Unix user, passwordless access
-        local  all  postgres    peer map=root_as_postgres
-        
-        # MD5 hashed password hosts
-        host  all  all  0.0.0.0/0  md5
-        
-        # Password hosts
-        host  all  all  0.0.0.0/0  password
-        
-        # Trusted hosts
-        
-        # User custom
-
-  "Get user if available":
-    number_of_calls: 1
-    expected_exception:
-      type: any
-      message: any
-
-  "Run command to get databases":
+      parsed: {}
+  Run command to get databases:
     calls:
-      - plugin_result:
-          failed: true
-      - plugin_result:
-          failed: false
-          stdout_lines:
-            - postgres
-            - template1
-            - template0
-            - cmdbuild_r2u2
-
-expected_tasks_calls_mode_strict: false  # if true all called tasks must be present. If false only present tasks will be checked
-expected_tasks_calls:
-  Get active databases: 27
-  Get from child processes cmdline: 27
-  Store active database if needed: 1
-  Store databases: 1
-
-task_vars:
-  postgresql_monitor_user: the_postgres_user
-  postgresql_monitor_pass: the_password
-
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 5432
-        protocol: 'tcp'
-    extra_data:
-      active_databases: [cmdbuild_r2u2]
-      databases: [cmdbuild_r2u2]
-    files:
-      - path: /usr/pgsql-10/bin/postmaster
-        subtype: generic
-        type: binary
-      - path: /etc/postgresql/10/data
-        name: postgresql.conf
-        subtype: generic
-        type: conf
-      - path: /var/lib/pgsql/10/data
-        subtype: generic
-        type: data
-    configuration:
-      archive_command: ''
-      archive_mode: 'off'
-      archive_timeout: '0'
-      array_nulls: 'on'
-      authentication_timeout: 60s
-      autovacuum: 'on'
-      autovacuum_analyze_scale_factor: '0.1'
-      autovacuum_analyze_threshold: '50'
-      autovacuum_freeze_max_age: '200000000'
-      autovacuum_max_workers: '3'
-      autovacuum_multixact_freeze_max_age: '400000000'
-      autovacuum_naptime: 1min
-      autovacuum_vacuum_cost_delay: 20ms
-      autovacuum_vacuum_cost_limit: '-1'
-      autovacuum_vacuum_scale_factor: '0.2'
-      autovacuum_vacuum_threshold: '50'
-      autovacuum_work_mem: '-1'
-      backend_flush_after: '0'
-      backslash_quote: safe_encoding
-      bgwriter_delay: 200ms
-      bgwriter_flush_after: '0'
-      bgwriter_lru_maxpages: '100'
-      bgwriter_lru_multiplier: '2.0'
-      bonjour: 'off'
-      bonjour_name: ''
-      bytea_output: hex
-      check_function_bodies: 'on'
-      checkpoint_completion_target: '0.9'
-      checkpoint_flush_after: '0'
-      checkpoint_timeout: 5min
-      checkpoint_warning: 30s
-      client_min_messages: notice
-      cluster_name: data
-      commit_delay: '0'
-      commit_siblings: '5'
-      constraint_exclusion: partition
-      cpu_index_tuple_cost: '0.005'
-      cpu_operator_cost: '0.0025'
-      cpu_tuple_cost: '0.01'
-      cursor_tuple_fraction: '0.1'
-      data_directory: /var/lib/pgsql/10/data
-      datestyle: 'iso,mdy'
-      db_user_namespace: 'off'
-      deadlock_timeout: 1s
-      debug_pretty_print: 'on'
-      debug_print_parse: 'off'
-      debug_print_plan: 'off'
-      debug_print_rewritten: 'off'
-      default_statistics_target: '500'
-      default_tablespace: ''
-      default_text_search_config: pg_catalog.english
-      default_transaction_deferrable: 'off'
-      default_transaction_isolation: read committed
-      default_transaction_read_only: 'off'
-      default_with_oids: 'off'
-      dynamic_library_path: $libdir
-      dynamic_shared_memory_type: posix
-      effective_cache_size: 9GB
-      effective_io_concurrency: '200'
-      enable_bitmapscan: 'on'
-      enable_hashagg: 'on'
-      enable_hashjoin: 'on'
-      enable_indexonlyscan: 'on'
-      enable_indexscan: 'on'
-      enable_material: 'on'
-      enable_mergejoin: 'on'
-      enable_nestloop: 'on'
-      enable_seqscan: 'on'
-      enable_sort: 'on'
-      enable_tidscan: 'on'
-      escape_string_warning: 'on'
-      event_source: PostgreSQL
-      exit_on_error: 'off'
-      external_pid_file: /var/run/postgresql/10-data.pid
-      extra_float_digits: '0'
-      force_parallel_mode: 'off'
-      from_collapse_limit: '8'
-      fsync: 'on'
-      full_page_writes: 'on'
-      geqo: 'on'
-      geqo_effort: '5'
-      geqo_generations: '0'
-      geqo_pool_size: '0'
-      geqo_seed: '0.0'
-      geqo_selection_bias: '2.0'
-      geqo_threshold: '12'
-      gin_fuzzy_search_limit: '0'
-      gin_pending_list_limit: 4MB
-      hba_file: /etc/postgresql/10/data/pg_hba.conf
-      hot_standby: 'off'
-      hot_standby_feedback: 'off'
-      huge_pages: try
-      ident_file: /etc/postgresql/10/data/pg_ident.conf
-      idle_in_transaction_session_timeout: '0'
-      include_dir: conf.d
-      intervalstyle: postgres
-      join_collapse_limit: '8'
-      krb_caseins_users: 'off'
-      krb_server_keyfile: ''
-      lc_messages: en_US.UTF-8
-      lc_monetary: en_US.UTF-8
-      lc_numeric: en_US.UTF-8
-      lc_time: en_US.UTF-8
-      listen_addresses: 0.0.0.0
-      lo_compat_privileges: 'off'
-      local_preload_libraries: ''
-      lock_timeout: '0'
-      log_autovacuum_min_duration: '-1'
-      log_checkpoints: 'off'
-      log_connections: 'off'
-      log_destination: stderr
-      log_directory: pg_log
-      log_disconnections: 'off'
-      log_duration: 'off'
-      log_error_verbosity: default
-      log_executor_stats: 'off'
-      log_file_mode: '0600'
-      log_filename: postgresql-%Y-%m-%d_%H%M%S.log
-      log_hostname: 'off'
-      log_line_prefix: '%t '
-      log_lock_waits: 'off'
-      log_min_duration_statement: '-1'
-      log_min_error_statement: error
-      log_min_messages: warning
-      log_parser_stats: 'off'
-      log_planner_stats: 'off'
-      log_replication_commands: 'off'
-      log_rotation_age: 1d
-      log_rotation_size: 10MB
-      log_statement: none
-      log_statement_stats: 'off'
-      log_temp_files: '-1'
-      log_timezone: UTC
-      log_truncate_on_rotation: 'off'
-      logging_collector: 'off'
-      maintenance_work_mem: 1536MB
-      max_connections: '150'
-      max_files_per_process: '1000'
-      max_locks_per_transaction: '1024'
-      max_logical_replication_workers: '4'
-      max_parallel_workers: '6'
-      max_parallel_workers_per_gather: '3'
-      max_pred_locks_per_page: '2'
-      max_pred_locks_per_relation: '-2'
-      max_pred_locks_per_transaction: '64'
-      max_prepared_transactions: '0'
-      max_replication_slots: '0'
-      max_stack_depth: 2MB
-      max_standby_archive_delay: 30s
-      max_standby_streaming_delay: 30s
-      max_sync_workers_per_subscription: '2'
-      max_wal_senders: '0'
-      max_wal_size: 16GB
-      max_worker_processes: '6'
-      min_parallel_index_scan_size: 512kB
-      min_parallel_table_scan_size: 8MB
-      min_wal_size: 4GB
-      old_snapshot_threshold: '-1'
-      operator_precedence_warning: 'off'
-      parallel_setup_cost: '1000.0'
-      parallel_tuple_cost: '0.1'
-      password_encryption: 'on'
-      port: '5432'
-      quote_all_identifiers: 'off'
-      random_page_cost: '1.1'
-      replacement_sort_tuples: '150000'
-      restart_after_crash: 'on'
-      row_security: 'off'
-      search_path: '"$user",public'
-      seq_page_cost: '1.0'
-      session_preload_libraries: ''
-      session_replication_role: origin
-      shared_buffers: 3GB
-      shared_preload_libraries: ''
-      ssl: 'off'
-      ssl_ca_file: ''
-      ssl_cert_file: /etc/ssl/certs/ssl-cert-snakeoil.pem
-      ssl_ciphers: 'DEFAULT:!LOW:!EXP:!MD5:@STRENGTH'
-      ssl_crl_file: ''
-      ssl_dh_params_file: ''
-      ssl_ecdh_curve: prime256v1
-      ssl_key_file: /etc/ssl/private/ssl-cert-snakeoil.key
-      ssl_prefer_server_ciphers: 'on'
-      standard_conforming_strings: 'on'
-      statement_timeout: '0'
-      stats_temp_directory: pg_stat_tmp
-      superuser_reserved_connections: '3'
-      synchronize_seqscans: 'on'
-      synchronous_commit: 'on'
-      synchronous_standby_names: ''
-      syslog_facility: LOCAL0
-      syslog_ident: postgres
-      syslog_sequence_numbers: 'on'
-      syslog_split_messages: 'on'
-      tcp_keepalives_count: '0'
-      tcp_keepalives_idle: '0'
-      tcp_keepalives_interval: '0'
-      temp_buffers: 8MB
-      temp_file_limit: '-1'
-      temp_tablespaces: ''
-      timezone: UTC
-      timezone_abbreviations: Default
-      track_activities: 'on'
-      track_activity_query_size: '1024'
-      track_commit_timestamp: 'off'
-      track_counts: 'on'
-      track_functions: none
-      track_io_timing: 'off'
-      transform_null_equals: 'off'
-      unix_socket_directories: '/var/run/postgresql,/tmp'
-      unix_socket_group: ''
-      unix_socket_permissions: '0777'
-      update_process_title: 'on'
-      vacuum_cost_delay: '0'
-      vacuum_cost_limit: '200'
-      vacuum_cost_page_dirty: '20'
-      vacuum_cost_page_hit: '1'
-      vacuum_cost_page_miss: '10'
-      vacuum_defer_cleanup_age: '0'
-      vacuum_freeze_min_age: '50000000'
-      vacuum_freeze_table_age: '150000000'
-      vacuum_multixact_freeze_min_age: '5000000'
-      vacuum_multixact_freeze_table_age: '150000000'
-      wal_buffers: 16MB
-      wal_compression: 'off'
-      wal_keep_segments: '0'
-      wal_level: minimal
-      wal_log_hints: 'off'
-      wal_receiver_status_interval: 10s
-      wal_receiver_timeout: 60s
-      wal_retrieve_retry_interval: 5s
-      wal_sender_timeout: 60s
-      wal_sync_method: fsync
-      wal_writer_delay: 200ms
-      wal_writer_flush_after: 1MB
-      work_mem: 5242kB
-      xmlbinary: base64
-      xmloption: content
-    discovery_time: '2022-05-26T18:00:00+02:00'
-    listening_ports:
-      - 5432
-    type: PostgreSQL Database
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: postgresql10-server
-        release: 1PGDG.rhel7
-        source: rpm
-        version: '10.17'
-    process:
-      children:
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56180) idle'
-          pid: '3042'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56186) idle'
-          pid: '3046'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56192) idle'
-          pid: '3050'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56198) idle'
-          pid: '3067'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56200) idle'
-          pid: '3069'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56874) idle'
-          pid: '4768'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56876) idle'
-          pid: '4772'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56880) idle'
-          pid: '4845'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56882) idle'
-          pid: '4859'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42334) idle'
-          pid: '44206'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42336) idle'
-          pid: '44207'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42342) idle'
-          pid: '44210'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43028) idle'
-          pid: '45527'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43040) idle'
-          pid: '45533'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43042) idle'
-          pid: '45534'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42934) idle'
-          pid: '45877'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42938) idle'
-          pid: '45879'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43470) idle'
-          pid: '47004'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: checkpointer process'
-          pid: '86332'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: writer process'
-          pid: '86333'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: wal writer process'
-          pid: '86334'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: autovacuum launcher process'
-          pid: '86335'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: stats collector process'
-          pid: '86336'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: bgworker: logical replication launcher'
-          pid: '86337'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(45768) idle'
-          pid: '88921'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56796) idle'
-          pid: '90009'
-          ppid: '86330'
-          user: postgres
-        - children: []
-          cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56802) idle'
-          pid: '90012'
-          ppid: '86330'
-          user: postgres
-      cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
-      listening_ports:
-        - 5432
-      pid: '86330'
-      ppid: '1'
-      user: postgres
-    version:
-      - number: '10'
-        type: file
-      - number: '10.17'
-        type: active
-      - number: '10.17'
-        type: package
-
-software_list:
-  - cmd_regexp: 'postgres:'
-    name: PostgreSQL Database
-    pkg_regexp: postgresql.*-server|postgresql-\d
-    process_type: child
-    return_children: true
-    return_packages: true
-    vars:
-      ignore_databases:
+    - plugin_result:
+        failed: true
+    - plugin_result:
+        failed: false
+        stdout_lines:
         - postgres
-        - template0
         - template1
-      connect_with_users: "{{ postgresql_monitor_users_info 
-        | default([{'username': postgresql_monitor_user | default('postgres'), 
-        'password': postgresql_monitor_pass | default('postgres')}]) }}"
-      sql_connection_extra_params: '-h 127.0.0.1'
-    custom_tasks:
-      - name: Include postgres specific plugins
-        include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/postgresql.yaml"
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - /usr/local/bin/docker-entrypoint.sh
-        - catalina.sh
-        - run
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - catalina.sh
-          - run
-        Domainname: ''
-        Entrypoint:
-          - /bin/sh
-          - '-c'
-          - /usr/local/bin/docker-entrypoint.sh
-        Env:
-          - LANG=C.UTF-8
-          - >-
-            CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
-          - POSTGRES_PORT=5432
-          - CMDBUILD_DUMP=empty.dump.xz
-          - POSTGRES_HOST=192.168.64.34
-          - POSTGRES_PASS=the_password
-          - JAVA_OPTS=-Xmx7876m -Xms3846m
-          - POSTGRES_DB=cmdbuild_r2u2
-          - >-
-            PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - TZ=Europe/Madrid
-          - POSTGRES_APP_USER=datadope
-          - POSTGRES_APP_PASSWORD=the_password
-          - POSTGRES_USER=datadope
-          - JAVA_HOME=/usr/local/openjdk-17
-          - JAVA_VERSION=17.0.2
-          - CATALINA_HOME=/usr/local/tomcat
-          - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
-          - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
-          - >-
-            GPG_KEYS=48F8E69F6390C9F25CFEDCD268248959359E722B
-            A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
-            DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
-          - TOMCAT_MAJOR=9
-          - TOMCAT_VERSION=9.0.60
-          - >-
-            TOMCAT_SHA512=a4d43ac45f76e29d3dea23a2712c7570a11419aad7a1af2d1533454709c020b59666c7f9e063a77120224e0cbd4020cac06ca596dda7057cacb9a8a7e6d73eea
-          - >-
-            APM_JAR_URL=https://nexus.opensolutions.cloud/repository/datadope-public/elastic-apm/elastic-apm-agent-1.28.1.jar
-        ExposedPorts:
-          8080/tcp: {}
-          8443/tcp: {}
-        Hostname: localhost
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.5.3'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: tomcat
-        Volumes: null
-        WorkingDir: /usr/local/tomcat
-      Created: '2022-03-25T12:04:52.930305974Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794-init/diff:/var/lib/docker/overlay2/0ca2f0e4b67ae95aef370146269b3fb10e55a6859d278f2997e8b84ff9122875/diff:/var/lib/docker/overlay2/308c2efd326216c0efe94e857b82520af6ab116a978811106d99e49ddf15fc1b/diff:/var/lib/docker/overlay2/c0610b1db247b6b1804c3b992e3f89f1ff75375a3b9c395de68e7dd6f0c5af41/diff:/var/lib/docker/overlay2/b49fa08f0f5246651d4fc001af50b8fc4f316d3add326329766d389a5b8597e1/diff:/var/lib/docker/overlay2/30067671d40d8ef3df665781083700fdb08887c64131c247ff8210714dd2d7a8/diff:/var/lib/docker/overlay2/acec1c4357e89e939adefb7160deb62f2e3dd2fb8e2b89c50a84d7e807b27220/diff:/var/lib/docker/overlay2/348d6cd50875127305d1c94e3d700856d51fc4a33a7c735163a54451c6fc3791/diff:/var/lib/docker/overlay2/b2dbb49865766b5568101566c79fdb955744097af5e48de46fc508b6de374d4a/diff:/var/lib/docker/overlay2/679f2167259fbc9d27c7bc3b9c872e59655afc90478754d2774935f005c62a2d/diff:/var/lib/docker/overlay2/1e770257e07955a14878870e1146a4954ff84e3a9a13f439b617d5a93316369b/diff:/var/lib/docker/overlay2/f4ddf2e6b8e7240af6c8026059475c51e762150436d2e78369347e31154144af/diff:/var/lib/docker/overlay2/10a54c98f41b6862c3ffb03a07cc1b23d517b5fce34238706646aa8949467afb/diff:/var/lib/docker/overlay2/f8c4e742a18bbeeaff6a7f3e99d59e12186868fbd68718b9adf44213e51fe1fc/diff:/var/lib/docker/overlay2/eaeac3feaa55318680b5311656bb14d685c03b356403ea6109fa7b1f16e63189/diff:/var/lib/docker/overlay2/5179e1277d7830285af10f6cd4bd09708b36dfe341288a6dcd68c7896718bb75/diff:/var/lib/docker/overlay2/8562f678e444a225812e39cdf950838f4ee626f1264ce3eac883dcc27bb165d2/diff:/var/lib/docker/overlay2/0f25f2ae977f5674027aac8cdd9cf2e07456a422fb88425fde7d3026f1f8ecdc/diff:/var/lib/docker/overlay2/997ff03392129602e78b3f0e6b5879ec656d11d8c3fa536f5577b0e540b40173/diff:/var/lib/docker/overlay2/994f47ca80b9c00cfabf4d1dcff4992f6b0c1647d89589dd5f31fdaa1bf6340f/diff:/var/lib/docker/overlay2/359f2d072fad20815db5e37ab4284e6c3376233db3163033fe04ba8b1153b443/diff:/var/lib/docker/overlay2/8a3f7b2f222926cdf88d12cd34fed89094bd049498fc78b1ddf625ce837f3760/diff:/var/lib/docker/overlay2/6daf829f7b4e94d9cba1f56aeab10d06a317241ee7aa01217ef88d2676fefce8/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw'
-          - '/var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: []
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: []
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: bridge
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/hostname
-      HostsPath: /etc/hosts
-      Id: 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
-      Image: 'sha256:eb3e461a2b2785cb353346a408a9e43b7f0fb86bb8a9a592ada57ca4c52e3bfd'
-      LogPath: >-
-        /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /usr/local/tomcat/certs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics-cmdbuild/certs
-          Type: bind
-        - Destination: /usr/local/tomcat/logs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/iometrics-cmdbuild
-          Type: bind
-      Name: /iometrics-cmdbuild
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 41c2ca0665e3ff46604f87a86347667647caede3bf1e50854538526bf62154b4
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: '02:42:ac:11:00:02'
-        Networks:
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 41c2ca0665e3ff46604f87a86347667647caede3bf1e50854538526bf62154b4
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:11:00:02'
-            NetworkID: e245cfe31a9637868b704e96aa6cbd268c001dc02bc3d706b7a2abb2276532ff
-        Ports:
-          8080/tcp: null
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        SandboxID: 5ceb4ee7e267ae9df7e902a05d972cabdfec1c00db6a751675b2872c08931dfe
-        SandboxKey: /var/run/docker/netns/5ceb4ee7e267
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-05-05T10:22:35.906672463Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 88679
-        Restarting: false
-        Running: true
-        StartedAt: '2022-05-05T14:06:36.663836267Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - ./start_cmdb_gateway.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - ./start_cmdb_gateway.sh
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.5
-          - CMDB_GATEWAY_CONFIG_FILE=config/cmdb_gateway.yaml
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - PYTHON_PIP_VERSION=20.2.2
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-        Hostname: oss-devel-cmdb
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdb-gateway:0.18.0'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: /app
-      Created: '2021-12-16T13:40:54.11945545Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9-init/diff:/var/lib/docker/overlay2/f28f032f19b8e36176d7f5c3c3280960a1f0b2d030b1461fde6f85608b268fb7/diff:/var/lib/docker/overlay2/c812399fd0157a9db6cd588828f224d26a076ebaa05397d46399616d7491559b/diff:/var/lib/docker/overlay2/04dc77fa805a06bb44c58399ae78a7ab110bc9d714c346b0df5a7e5b349ae16c/diff:/var/lib/docker/overlay2/4c9d61501d1130eeaea40e3c6e8c58e3790995f474c04c2bb10c904a71431edb/diff:/var/lib/docker/overlay2/4993b8fafd5a9d9a6023eaf5d25fe51a2fabcb3dbee5ea7549ec9420497d57e5/diff:/var/lib/docker/overlay2/d6460864d519c5967a63083553d16607e9e209a7eab0d4c098a649aaa0cdf0f2/diff:/var/lib/docker/overlay2/70210d890e6f91fbea58cad88a3fce3e126382bc7b33645fc961fdb8faa8542f/diff:/var/lib/docker/overlay2/ca78aa40f8918ea045999b7270f6fd9704cb0cdb7540c93b5b2608c336057ab5/diff:/var/lib/docker/overlay2/a6183d5cdfd1c5842b63dc840de2a5ef55eb86dcd92872076825f6ae35fa240a/diff:/var/lib/docker/overlay2/b46ed7aa9054a838c1438c581e9d770be0a97cf687a962a532c5096af8f4714b/diff:/var/lib/docker/overlay2/46919684c7f455b8be1662fbc502637c471f5ea2fe53e4ea3edceadc8a28b14f/diff:/var/lib/docker/overlay2/764a651bc4126949119711643715095b4394c88d62b64f6c83a1720378145f0b/diff:/var/lib/docker/overlay2/9f37cd3fc4a2444f9ab442262e3f41cc348cee444f14100f61a487031cfe07f5/diff:/var/lib/docker/overlay2/47b0f955a1643f1d46055c3aeaa3a2ffdd59ccb1f5f14e89dcf603db8463b81b/diff:/var/lib/docker/overlay2/f3aa2fa503c8e7277a423cd85d1d8bdfd147fc867f5fab859a097188e0e6d004/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/cmdb/config:/app/config:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: []
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: []
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: {}
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: {}
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: 'no'
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hosts
-      Id: da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
-      Image: 'sha256:af61c42a1772b373dbc30a6d3650af40d4e738a5d22959eccea5974946ada9fa'
-      LogPath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/config
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/cmdb/config
-          Type: bind
-      Name: /iometrics-cmdb-gateway
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: eae8f75be12d4ee5414e78442f3d68fab431b5ac569a73345570f3a7029f9a68
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: {}
-        SandboxID: 959cd311c6ccbbaf8b55b63b3b07166a6ad63782235f0f5a1ce50d2e1bdf6ee7
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-05-05T13:28:48.020900022Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 86277
-        Restarting: false
-        Running: true
-        StartedAt: '2022-05-05T13:28:48.31349014Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - python ./listener.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - python ./listener.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.5
-          - PYTHON_PIP_VERSION=20.2.2
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
-        Hostname: oss-devel-cmdb
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.0.1'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /config: {}
-        WorkingDir: ''
-      Created: '2021-05-25T10:08:10.097442624Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41-init/diff:/var/lib/docker/overlay2/ba78f066d9e46b0f7b41380a42ef0a747aa591e78992e40447ca78b8528de8ed/diff:/var/lib/docker/overlay2/3b784c7b5c126900be4badb31068a06fbfdfe15a2f15049ed151fb2a5a370659/diff:/var/lib/docker/overlay2/c6b744055dfca315c6446e3723460947b34efd1d75325b2caae502367afa3c2e/diff:/var/lib/docker/overlay2/a1a2492e64ab4e7a012e36e61ceabaf1d80bed24e72c2ae69d7172e35a3831de/diff:/var/lib/docker/overlay2/39a5edc9ab57849080990571d9a3f410b66a3bb04f12ca966d3f4a64e0cbbd8a/diff:/var/lib/docker/overlay2/0780a973dbea66c8f367c507554356a5d27303cd0a1d8b5396e7b0aa392b6149/diff:/var/lib/docker/overlay2/e1f23af492edda46763c05b32bcfe283f83fdd27460a55cf1a5dcf437a0e0ae7/diff:/var/lib/docker/overlay2/9f8debce0febecd5e1c4e50351a37d422b1b60f3826ddfd9dadc1961fe3e007f/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/redis-cleaner:/config:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hosts
-      Id: 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
-      Image: 'sha256:70c1ea6bb3f2e939311b21e6b49cd3cce10ffb2e21e8b5b431bd293421ca8472'
-      LogPath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /config
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis-cleaner
-          Type: bind
-      Name: /iometrics-cmdb-redis-cleaner
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ed464b6f49997d37e646e04846527f61c970de6c91c3deb620c2c3c80fca0b96
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: {}
-        SandboxID: 72ed345048dcc6240fabf7e33835c2a4fd99d59e7fa0972a4685872da6303113
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 34206
-        Restarting: false
-        Running: true
-        StartedAt: '2021-05-25T10:08:10.240751099Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '--tls-port'
-        - '6378'
-        - '--appendonly'
-        - 'no'
-        - '--maxmemory'
-        - '0'
-        - '--maxclients'
-        - '10000'
-        - '--bind'
-        - 0.0.0.0
-        - '--requirepass'
-        - the_password
-        - '--tls-auth-clients'
-        - 'no'
-        - '--tls-cert-file'
-        - /data/ssl/redis.crt
-        - '--tls-key-file'
-        - /data/ssl/redis.pem
-        - '--tls-ca-cert-file'
-        - /data/ssl/redis_ca.crt
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '--tls-port'
-          - '6378'
-          - '--appendonly'
-          - 'no'
-          - '--maxmemory'
-          - '0'
-          - '--maxclients'
-          - '10000'
-          - '--bind'
-          - 0.0.0.0
-          - '--requirepass'
-          - the_password
-          - '--tls-auth-clients'
-          - 'no'
-          - '--tls-cert-file'
-          - /data/ssl/redis.crt
-          - '--tls-key-file'
-          - /data/ssl/redis.pem
-          - '--tls-ca-cert-file'
-          - /data/ssl/redis_ca.crt
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.0.1
-          - >-
-            REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
-          - >-
-            REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
-        ExposedPorts:
-          6379/tcp: {}
-        Hostname: oss-devel-cmdb
-        Image: 'redis:6.0.1'
-        Labels:
-          os_contianer_type: redis
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: {}
-          /data/ssl/: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-        WorkingDir: /data
-      Created: '2021-05-25T09:00:32.257009145Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce-init/diff:/var/lib/docker/overlay2/895c1f99a736e2df91bfc2a00c7551e51fd433dde75de2279435ff47ea0e6b38/diff:/var/lib/docker/overlay2/a9841cfec194609a7ec73913c03ba7d4155bc5334e801da50362b4a928a3fe93/diff:/var/lib/docker/overlay2/d9cb4756a3d19486043c08cf2b9492aca7b6664e4914a64c4ae7d649510fb8fb/diff:/var/lib/docker/overlay2/348fb45e5b21b874e1972d7abf6267aedb49052fe240ff1ca65c31d01f0cd49e/diff:/var/lib/docker/overlay2/1f6d3088e9933dfa837efd70762bf9724143691931203267ec5ff24aa5dfe170/diff:/var/lib/docker/overlay2/c96ac52a498ef5b1c8f81d0d7ee4cb762e570fee584f3b41148aceca3a8664b5/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/redis:/data:rw'
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/redis/ssl/:/data/ssl/:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/hostname
-      HostsPath: /etc/hosts
-      Id: b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
-      Image: 'sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c'
-      LogPath: >-
-        /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis/ssl
-          Type: bind
-        - Destination: /data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/redis
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-      Name: /redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: beb2a749121a2b11fd9bc6093b92eb8fd64c1abf38a38f39261bc633429fc566
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: {}
-        SandboxID: 6b4a27d90042eb73469fe2c90437f604c16aade938163e14d93d88892703a15f
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 20064
-        Restarting: false
-        Running: true
-        StartedAt: '2021-05-25T09:00:32.529069205Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: oss-devel-cmdb
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2021-05-24T14:27:58.280498639Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098-init/diff:/var/lib/docker/overlay2/572d19da46f80f29256ff94ed86f500ede7764af796338b02e10f781d4387407/diff:/var/lib/docker/overlay2/16e7f7bacf68db89a426b0b90b68188ce3387cd01bad762550e49c926b5879d8/diff:/var/lib/docker/overlay2/26ea1b9023be5dfd133dd9e015e47da4265ab65445bb17899fcc275604d3754d/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/hostname
-      HostsPath: /etc/hosts
-      Id: df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 29d2d1ebe738bc2b3d44373cd6019b50940e82931b720cfd949e7c08c8a110ea
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: {}
-        SandboxID: c2fdaac80977cad0b65bf2e24939c5a22c6ad249d8db4aab83f390a0bb1305d6
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2021-05-24T14:56:41.686346314Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 23339
-        Restarting: false
-        Running: true
-        StartedAt: '2021-06-01T15:04:41.797753434Z'
-        Status: running
+        - template0
+        - cmdbuild_r2u2
+  Run command version:
+    plugin_result:
+      failed: false
+      stdout: postgres (PostgreSQL) 10.17
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   MariaDB-client:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-client
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-client
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
   MariaDB-common:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-common
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-common
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
   MariaDB-compat:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-compat
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-compat
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
   MariaDB-server:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-server
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-server
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
   NetworkManager:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
   NetworkManager-libnm:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-libnm
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-libnm
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
   NetworkManager-team:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-team
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-team
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
   NetworkManager-tui:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-tui
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-tui
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   aic94xx-firmware:
-    - arch: noarch
-      epoch: null
-      name: aic94xx-firmware
-      release: 6.el7
-      source: rpm
-      version: '30'
+  - arch: noarch
+    epoch: null
+    name: aic94xx-firmware
+    release: 6.el7
+    source: rpm
+    version: '30'
   alsa-firmware:
-    - arch: noarch
-      epoch: null
-      name: alsa-firmware
-      release: 2.el7
-      source: rpm
-      version: 1.0.28
+  - arch: noarch
+    epoch: null
+    name: alsa-firmware
+    release: 2.el7
+    source: rpm
+    version: 1.0.28
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   alsa-tools-firmware:
-    - arch: x86_64
-      epoch: null
-      name: alsa-tools-firmware
-      release: 1.el7
-      source: rpm
-      version: 1.1.0
+  - arch: x86_64
+    epoch: null
+    name: alsa-tools-firmware
+    release: 1.el7
+    source: rpm
+    version: 1.1.0
   apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
   apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autoconf:
-    - arch: noarch
-      epoch: null
-      name: autoconf
-      release: 11.el7
-      source: rpm
-      version: '2.69'
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
   automake:
-    - arch: noarch
-      epoch: null
-      name: automake
-      release: 3.el7
-      source: rpm
-      version: 1.13.4
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.5
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.5
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7
+    source: rpm
+    version: '2.27'
   biosdevname:
-    - arch: x86_64
-      epoch: null
-      name: biosdevname
-      release: 2.el7
-      source: rpm
-      version: 0.7.3
+  - arch: x86_64
+    epoch: null
+    name: biosdevname
+    release: 2.el7
+    source: rpm
+    version: 0.7.3
   bison:
-    - arch: x86_64
-      epoch: null
-      name: bison
-      release: 2.el7
-      source: rpm
-      version: 3.0.4
+  - arch: x86_64
+    epoch: null
+    name: bison
+    release: 2.el7
+    source: rpm
+    version: 3.0.4
   boost-date-time:
-    - arch: x86_64
-      epoch: null
-      name: boost-date-time
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
+  - arch: x86_64
+    epoch: null
+    name: boost-date-time
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
   boost-program-options:
-    - arch: x86_64
-      epoch: null
-      name: boost-program-options
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
+  - arch: x86_64
+    epoch: null
+    name: boost-program-options
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
   boost-system:
-    - arch: x86_64
-      epoch: null
-      name: boost-system
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
+  - arch: x86_64
+    epoch: null
+    name: boost-system
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
   boost-thread:
-    - arch: x86_64
-      epoch: null
-      name: boost-thread
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
+  - arch: x86_64
+    epoch: null
+    name: boost-thread
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   byacc:
-    - arch: x86_64
-      epoch: null
-      name: byacc
-      release: 3.el7
-      source: rpm
-      version: 1.9.20130304
+  - arch: x86_64
+    epoch: null
+    name: byacc
+    release: 3.el7
+    source: rpm
+    version: 1.9.20130304
   bzip2:
-    - arch: x86_64
-      epoch: null
-      name: bzip2
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   c-ares:
-    - arch: x86_64
-      epoch: null
-      name: c-ares
-      release: 3.el7
-      source: rpm
-      version: 1.10.0
+  - arch: x86_64
+    epoch: null
+    name: c-ares
+    release: 3.el7
+    source: rpm
+    version: 1.10.0
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_8
-      source: rpm
-      version: 2020.2.41
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_8
+    source: rpm
+    version: 2020.2.41
   centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.4.4
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.4.4
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cscope:
-    - arch: x86_64
-      epoch: null
-      name: cscope
-      release: 10.el7
-      source: rpm
-      version: '15.8'
+  - arch: x86_64
+    epoch: null
+    name: cscope
+    release: 10.el7
+    source: rpm
+    version: '15.8'
   ctags:
-    - arch: x86_64
-      epoch: null
-      name: ctags
-      release: 13.el7
-      source: rpm
-      version: '5.8'
+  - arch: x86_64
+    epoch: null
+    name: ctags
+    release: 13.el7
+    source: rpm
+    version: '5.8'
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 3.el7_9.2
-      source: rpm
-      version: 0.8.5
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 3.el7_9.2
+    source: rpm
+    version: 0.8.5
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
+  - arch: x86_64
+    epoch: 12
+    name: dhclient
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
   dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
   dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
   diffstat:
-    - arch: x86_64
-      epoch: null
-      name: diffstat
-      release: 4.el7
-      source: rpm
-      version: '1.57'
+  - arch: x86_64
+    epoch: null
+    name: diffstat
+    release: 4.el7
+    source: rpm
+    version: '1.57'
   diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
   dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
   docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
   docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
   docker-ce-rootless-extras:
-    - arch: x86_64
-      epoch: 0
-      name: docker-ce-rootless-extras
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
+  - arch: x86_64
+    epoch: 0
+    name: docker-ce-rootless-extras
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
   docker-scan-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-scan-plugin
-      release: 3.el7
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: 0
+    name: docker-scan-plugin
+    release: 3.el7
+    source: rpm
+    version: 0.7.0
   doxygen:
-    - arch: x86_64
-      epoch: 1
-      name: doxygen
-      release: 4.el7
-      source: rpm
-      version: 1.8.5
+  - arch: x86_64
+    epoch: 1
+    name: doxygen
+    release: 4.el7
+    source: rpm
+    version: 1.8.5
   dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
   dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
   dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
   dwz:
-    - arch: x86_64
-      epoch: null
-      name: dwz
-      release: 3.el7
-      source: rpm
-      version: '0.11'
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
   dyninst:
-    - arch: x86_64
-      epoch: null
-      name: dyninst
-      release: 3.el7
-      source: rpm
-      version: 9.3.1
+  - arch: x86_64
+    epoch: null
+    name: dyninst
+    release: 3.el7
+    source: rpm
+    version: 9.3.1
   e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   ebtables:
-    - arch: x86_64
-      epoch: null
-      name: ebtables
-      release: 16.el7
-      source: rpm
-      version: 2.0.10
+  - arch: x86_64
+    epoch: null
+    name: ebtables
+    release: 16.el7
+    source: rpm
+    version: 2.0.10
   efivar-libs:
-    - arch: x86_64
-      epoch: null
-      name: efivar-libs
-      release: 12.el7
-      source: rpm
-      version: '36'
+  - arch: x86_64
+    epoch: null
+    name: efivar-libs
+    release: 12.el7
+    source: rpm
+    version: '36'
   elfutils:
-    - arch: x86_64
-      epoch: null
-      name: elfutils
-      release: 5.el7
-      source: rpm
-      version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils
+    release: 5.el7
+    source: rpm
+    version: '0.176'
   elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
   elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
   elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
   emacs-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: emacs-filesystem
-      release: 23.el7
-      source: rpm
-      version: '24.3'
+  - arch: noarch
+    epoch: 1
+    name: emacs-filesystem
+    release: 23.el7
+    source: rpm
+    version: '24.3'
   epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '13'
-      source: rpm
-      version: '7'
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '13'
+    source: rpm
+    version: '7'
   ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
   expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
   file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
   file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
   filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
   findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
   fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
   fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
   firewalld:
-    - arch: noarch
-      epoch: null
-      name: firewalld
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
+  - arch: noarch
+    epoch: null
+    name: firewalld
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
   firewalld-filesystem:
-    - arch: noarch
-      epoch: null
-      name: firewalld-filesystem
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
+  - arch: noarch
+    epoch: null
+    name: firewalld-filesystem
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
   flex:
-    - arch: x86_64
-      epoch: null
-      name: flex
-      release: 6.el7
-      source: rpm
-      version: 2.5.37
+  - arch: x86_64
+    epoch: null
+    name: flex
+    release: 6.el7
+    source: rpm
+    version: 2.5.37
   freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
   fuse:
-    - arch: x86_64
-      epoch: null
-      name: fuse
-      release: 11.el7
-      source: rpm
-      version: 2.9.2
+  - arch: x86_64
+    epoch: null
+    name: fuse
+    release: 11.el7
+    source: rpm
+    version: 2.9.2
   fuse-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-libs
-      release: 11.el7
-      source: rpm
-      version: 2.9.2
+  - arch: x86_64
+    epoch: null
+    name: fuse-libs
+    release: 11.el7
+    source: rpm
+    version: 2.9.2
   fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
   fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
   fxload:
-    - arch: x86_64
-      epoch: null
-      name: fxload
-      release: 16.el7
-      source: rpm
-      version: '2002_04_11'
+  - arch: x86_64
+    epoch: null
+    name: fxload
+    release: 16.el7
+    source: rpm
+    version: '2002_04_11'
   galera-4:
-    - arch: x86_64
-      epoch: null
-      name: galera-4
-      release: 1.el7.centos
-      source: rpm
-      version: 26.4.8
+  - arch: x86_64
+    epoch: null
+    name: galera-4
+    release: 1.el7.centos
+    source: rpm
+    version: 26.4.8
   gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
   gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   gcc-gfortran:
-    - arch: x86_64
-      epoch: null
-      name: gcc-gfortran
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: gcc-gfortran
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   gdb:
-    - arch: x86_64
-      epoch: null
-      name: gdb
-      release: 120.el7
-      source: rpm
-      version: 7.6.1
+  - arch: x86_64
+    epoch: null
+    name: gdb
+    release: 120.el7
+    source: rpm
+    version: 7.6.1
   gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
   geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
   gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-common-devel:
-    - arch: noarch
-      epoch: null
-      name: gettext-common-devel
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: noarch
+    epoch: null
+    name: gettext-common-devel
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-devel:
-    - arch: x86_64
-      epoch: null
-      name: gettext-devel
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext-devel
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
   git:
-    - arch: x86_64
-      epoch: null
-      name: git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
+  - arch: x86_64
+    epoch: null
+    name: git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
   glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 8.el7
-      source: rpm
-      version: 2.56.1
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 8.el7
+    source: rpm
+    version: 2.56.1
   glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
   glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
   glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
   glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
   gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
   gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
   gnutls:
-    - arch: x86_64
-      epoch: null
-      name: gnutls
-      release: 9.el7_6
-      source: rpm
-      version: 3.3.29
+  - arch: x86_64
+    epoch: null
+    name: gnutls
+    release: 9.el7_6
+    source: rpm
+    version: 3.3.29
   gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
   gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 511147a9
-      source: rpm
-      version: 1bb943db
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 608c8351
-      source: rpm
-      version: 442df0f8
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 511147a9
+    source: rpm
+    version: 1bb943db
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
   gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
   gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
   grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
   groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
   grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
   grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
   gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
   gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
   hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
   hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
   htop:
-    - arch: x86_64
-      epoch: null
-      name: htop
-      release: 3.el7
-      source: rpm
-      version: 2.2.0
+  - arch: x86_64
+    epoch: null
+    name: htop
+    release: 3.el7
+    source: rpm
+    version: 2.2.0
   hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
   indent:
-    - arch: x86_64
-      epoch: null
-      name: indent
-      release: 13.el7
-      source: rpm
-      version: 2.2.11
+  - arch: x86_64
+    epoch: null
+    name: indent
+    release: 13.el7
+    source: rpm
+    version: 2.2.11
   info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
   initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
   intltool:
-    - arch: noarch
-      epoch: null
-      name: intltool
-      release: 7.el7
-      source: rpm
-      version: 0.50.2
+  - arch: noarch
+    epoch: null
+    name: intltool
+    release: 7.el7
+    source: rpm
+    version: 0.50.2
   iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
   iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
   iprutils:
-    - arch: x86_64
-      epoch: null
-      name: iprutils
-      release: 3.el7_7
-      source: rpm
-      version: 2.4.17.1
+  - arch: x86_64
+    epoch: null
+    name: iprutils
+    release: 3.el7_7
+    source: rpm
+    version: 2.4.17.1
   ipset:
-    - arch: x86_64
-      epoch: null
-      name: ipset
-      release: 1.el7
-      source: rpm
-      version: '7.1'
+  - arch: x86_64
+    epoch: null
+    name: ipset
+    release: 1.el7
+    source: rpm
+    version: '7.1'
   ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
   iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
   iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
   irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
   ivtv-firmware:
-    - arch: noarch
-      epoch: 2
-      name: ivtv-firmware
-      release: 26.el7
-      source: rpm
-      version: '20080701'
+  - arch: noarch
+    epoch: 2
+    name: ivtv-firmware
+    release: 26.el7
+    source: rpm
+    version: '20080701'
   iwl100-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl100-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
+  - arch: noarch
+    epoch: null
+    name: iwl100-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
   iwl1000-firmware:
-    - arch: noarch
-      epoch: 1
-      name: iwl1000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
+  - arch: noarch
+    epoch: 1
+    name: iwl1000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
   iwl105-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl105-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl105-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl135-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl135-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl135-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl2000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl2000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl2030-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2030-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl2030-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl3160-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3160-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
+  - arch: noarch
+    epoch: null
+    name: iwl3160-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
   iwl3945-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3945-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 15.32.2.9
+  - arch: noarch
+    epoch: null
+    name: iwl3945-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 15.32.2.9
   iwl4965-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl4965-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 228.61.2.24
+  - arch: noarch
+    epoch: null
+    name: iwl4965-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 228.61.2.24
   iwl5000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.83.5.1_1
+  - arch: noarch
+    epoch: null
+    name: iwl5000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.83.5.1_1
   iwl5150-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5150-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.24.2.2
+  - arch: noarch
+    epoch: null
+    name: iwl5150-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.24.2.2
   iwl6000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 9.221.4.1
+  - arch: noarch
+    epoch: null
+    name: iwl6000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 9.221.4.1
   iwl6000g2a-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2a-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2a-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl6000g2b-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2b-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2b-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
   iwl6050-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6050-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 41.28.5.1
+  - arch: noarch
+    epoch: null
+    name: iwl6050-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 41.28.5.1
   iwl7260-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7260-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
+  - arch: noarch
+    epoch: null
+    name: iwl7260-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
   jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
   jnettop:
-    - arch: x86_64
-      epoch: null
-      name: jnettop
-      release: 16.el7
-      source: rpm
-      version: 0.13.0
+  - arch: x86_64
+    epoch: null
+    name: jnettop
+    release: 16.el7
+    source: rpm
+    version: 0.13.0
   json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
   kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
   kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
   kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
   kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.21.3.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 862.9.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.10.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.15.2.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.21.3.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 862.9.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.10.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.15.2.el7
+    source: rpm
+    version: 3.10.0
   kernel-debug-devel:
-    - arch: x86_64
-      epoch: null
-      name: kernel-debug-devel
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-debug-devel
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
   kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
   kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
   kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
   kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.2
-      source: rpm
-      version: 2.0.15
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.2
+    source: rpm
+    version: 2.0.15
   keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
   keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
   kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
   kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
   kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 134.el7_9
-      source: rpm
-      version: 0.4.9
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 134.el7_9
+    source: rpm
+    version: 0.4.9
   krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 50.el7
-      source: rpm
-      version: 1.15.1
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 50.el7
+    source: rpm
+    version: 1.15.1
   less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
   libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
   libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
   libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
   libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
   libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
   libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
   libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
   libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
   libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
   libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
   libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
   libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
   libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
   libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
   libdnet:
-    - arch: x86_64
-      epoch: null
-      name: libdnet
-      release: 13.1.el7
-      source: rpm
-      version: '1.12'
+  - arch: x86_64
+    epoch: null
+    name: libdnet
+    release: 13.1.el7
+    source: rpm
+    version: '1.12'
   libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
   libdwarf:
-    - arch: x86_64
-      epoch: null
-      name: libdwarf
-      release: 4.el7
-      source: rpm
-      version: '20130207'
+  - arch: x86_64
+    epoch: null
+    name: libdwarf
+    release: 4.el7
+    source: rpm
+    version: '20130207'
   libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
   libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
   libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
   libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
   libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
   libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
   libgfortran:
-    - arch: x86_64
-      epoch: null
-      name: libgfortran
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgfortran
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
   libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
   libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
   libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
   libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
   libmodman:
-    - arch: x86_64
-      epoch: null
-      name: libmodman
-      release: 8.el7
-      source: rpm
-      version: 2.0.1
+  - arch: x86_64
+    epoch: null
+    name: libmodman
+    release: 8.el7
+    source: rpm
+    version: 2.0.1
   libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
   libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
   libmspack:
-    - arch: x86_64
-      epoch: null
-      name: libmspack
-      release: 0.8.alpha.el7
-      source: rpm
-      version: '0.5'
+  - arch: x86_64
+    epoch: null
+    name: libmspack
+    release: 0.8.alpha.el7
+    source: rpm
+    version: '0.5'
   libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
   libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
   libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
   libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
   libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
   libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
   libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
   libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
   libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
   libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
   libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
   libproxy:
-    - arch: x86_64
-      epoch: null
-      name: libproxy
-      release: 11.el7
-      source: rpm
-      version: 0.4.11
+  - arch: x86_64
+    epoch: null
+    name: libproxy
+    release: 11.el7
+    source: rpm
+    version: 0.4.11
   libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
   libquadmath:
-    - arch: x86_64
-      epoch: null
-      name: libquadmath
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libquadmath
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libquadmath-devel:
-    - arch: x86_64
-      epoch: null
-      name: libquadmath-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libquadmath-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
   libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.4.1
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.4.1
   libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
   libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
   libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
   libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
   libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
   libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
   libsmi:
-    - arch: x86_64
-      epoch: null
-      name: libsmi
-      release: 13.el7
-      source: rpm
-      version: 0.4.8
+  - arch: x86_64
+    epoch: null
+    name: libsmi
+    release: 13.el7
+    source: rpm
+    version: 0.4.8
   libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
   libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
   libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
   libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
   libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
   libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
   libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
   libtool:
-    - arch: x86_64
-      epoch: null
-      name: libtool
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
   libtool-ltdl:
-    - arch: x86_64
-      epoch: null
-      name: libtool-ltdl
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
+  - arch: x86_64
+    epoch: null
+    name: libtool-ltdl
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
   libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
   libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
   libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
   libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
   libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
   libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
   libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7.5
-      source: rpm
-      version: 2.9.1
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.5
+    source: rpm
+    version: 2.9.1
   libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7.5
-      source: rpm
-      version: 2.9.1
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.5
+    source: rpm
+    version: 2.9.1
   libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
   linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
   lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
   logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
   lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
   lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
   lsscsi:
-    - arch: x86_64
-      epoch: null
-      name: lsscsi
-      release: 6.el7
-      source: rpm
-      version: '0.27'
+  - arch: x86_64
+    epoch: null
+    name: lsscsi
+    release: 6.el7
+    source: rpm
+    version: '0.27'
   lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
   lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
   lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
   lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
   lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
   m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
   make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
   man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
   microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.8.el7_9
-      source: rpm
-      version: '2.1'
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.8.el7_9
+    source: rpm
+    version: '2.1'
   mokutil:
-    - arch: x86_64
-      epoch: null
-      name: mokutil
-      release: 8.el7
-      source: rpm
-      version: '15'
+  - arch: x86_64
+    epoch: null
+    name: mokutil
+    release: 8.el7
+    source: rpm
+    version: '15'
   mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
   mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
   nagios-common:
-    - arch: x86_64
-      epoch: null
-      name: nagios-common
-      release: 4.el7
-      source: rpm
-      version: 4.4.6
+  - arch: x86_64
+    epoch: null
+    name: nagios-common
+    release: 4.el7
+    source: rpm
+    version: 4.4.6
   nagios-plugins:
-    - arch: x86_64
-      epoch: null
-      name: nagios-plugins
-      release: 2.el7
-      source: rpm
-      version: 2.3.3
+  - arch: x86_64
+    epoch: null
+    name: nagios-plugins
+    release: 2.el7
+    source: rpm
+    version: 2.3.3
   nagios-plugins-perl:
-    - arch: x86_64
-      epoch: null
-      name: nagios-plugins-perl
-      release: 2.el7
-      source: rpm
-      version: 2.3.3
+  - arch: x86_64
+    epoch: null
+    name: nagios-plugins-perl
+    release: 2.el7
+    source: rpm
+    version: 2.3.3
   nano:
-    - arch: x86_64
-      epoch: null
-      name: nano
-      release: 10.el7
-      source: rpm
-      version: 2.3.1
+  - arch: x86_64
+    epoch: null
+    name: nano
+    release: 10.el7
+    source: rpm
+    version: 2.3.1
   ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
   ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
   ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
   neon:
-    - arch: x86_64
-      epoch: null
-      name: neon
-      release: 4.el7
-      source: rpm
-      version: 0.30.0
+  - arch: x86_64
+    epoch: null
+    name: neon
+    release: 4.el7
+    source: rpm
+    version: 0.30.0
   net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
   netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 2.el7
-      source: rpm
-      version: '1.218'
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 2.el7
+    source: rpm
+    version: '1.218'
   nettle:
-    - arch: x86_64
-      epoch: null
-      name: nettle
-      release: 9.el7_9
-      source: rpm
-      version: 2.7.1
+  - arch: x86_64
+    epoch: null
+    name: nettle
+    release: 9.el7_9
+    source: rpm
+    version: 2.7.1
   newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
   newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
   nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7
-      source: rpm
-      version: 1.3.0
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7
+    source: rpm
+    version: 1.3.0
   nrpe:
-    - arch: x86_64
-      epoch: null
-      name: nrpe
-      release: 6.el7
-      source: rpm
-      version: 4.0.3
+  - arch: x86_64
+    epoch: null
+    name: nrpe
+    release: 6.el7
+    source: rpm
+    version: 4.0.3
   nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 2.el7_9
-      source: rpm
-      version: 4.25.0
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 2.el7_9
+    source: rpm
+    version: 4.25.0
   nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
   nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
   nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 6.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 6.el7_9
+    source: rpm
+    version: 3.53.1
   nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 6.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 6.el7_9
+    source: rpm
+    version: 3.53.1
   nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
   nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
   nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.53.1
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.53.1
   numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
   open-vm-tools:
-    - arch: x86_64
-      epoch: null
-      name: open-vm-tools
-      release: 3.el7_9.3
-      source: rpm
-      version: 11.0.5
+  - arch: x86_64
+    epoch: null
+    name: open-vm-tools
+    release: 3.el7_9.3
+    source: rpm
+    version: 11.0.5
   openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 23.el7_9
-      source: rpm
-      version: 2.4.44
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 23.el7_9
+    source: rpm
+    version: 2.4.44
   openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
   openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
   openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
   openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 21.el7_9
-      source: rpm
-      version: 1.0.2k
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 21.el7_9
+    source: rpm
+    version: 1.0.2k
   openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 21.el7_9
-      source: rpm
-      version: 1.0.2k
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 21.el7_9
+    source: rpm
+    version: 1.0.2k
   openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
   os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
   p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
   p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
   pakchois:
-    - arch: x86_64
-      epoch: null
-      name: pakchois
-      release: 10.el7
-      source: rpm
-      version: '0.4'
+  - arch: x86_64
+    epoch: null
+    name: pakchois
+    release: 10.el7
+    source: rpm
+    version: '0.4'
   pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
   parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
   passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
   patch:
-    - arch: x86_64
-      epoch: null
-      name: patch
-      release: 12.el7_7
-      source: rpm
-      version: 2.7.1
+  - arch: x86_64
+    epoch: null
+    name: patch
+    release: 12.el7_7
+    source: rpm
+    version: 2.7.1
   patchutils:
-    - arch: x86_64
-      epoch: null
-      name: patchutils
-      release: 5.el7_9
-      source: rpm
-      version: 0.3.3
+  - arch: x86_64
+    epoch: null
+    name: patchutils
+    release: 5.el7_9
+    source: rpm
+    version: 0.3.3
   pciutils:
-    - arch: x86_64
-      epoch: null
-      name: pciutils
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
+  - arch: x86_64
+    epoch: null
+    name: pciutils
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
   pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
   pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
   pcre2:
-    - arch: x86_64
-      epoch: null
-      name: pcre2
-      release: 2.el7
-      source: rpm
-      version: '10.23'
+  - arch: x86_64
+    epoch: null
+    name: pcre2
+    release: 2.el7
+    source: rpm
+    version: '10.23'
   perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
   perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
   perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
   perl-DBD-MySQL:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBD-MySQL
-      release: 6.el7
-      source: rpm
-      version: '4.023'
+  - arch: x86_64
+    epoch: null
+    name: perl-DBD-MySQL
+    release: 6.el7
+    source: rpm
+    version: '4.023'
   perl-DBI:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBI
-      release: 4.el7
-      source: rpm
-      version: '1.627'
+  - arch: x86_64
+    epoch: null
+    name: perl-DBI
+    release: 4.el7
+    source: rpm
+    version: '1.627'
   perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
   perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
   perl-Error:
-    - arch: noarch
-      epoch: 1
-      name: perl-Error
-      release: 2.el7
-      source: rpm
-      version: '0.17020'
+  - arch: noarch
+    epoch: 1
+    name: perl-Error
+    release: 2.el7
+    source: rpm
+    version: '0.17020'
   perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
   perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
   perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
   perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
   perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
   perl-Git:
-    - arch: noarch
-      epoch: null
-      name: perl-Git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
+  - arch: noarch
+    epoch: null
+    name: perl-Git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
   perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
   perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
   perl-Net-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-Daemon
-      release: 5.el7
-      source: rpm
-      version: '0.48'
+  - arch: noarch
+    epoch: null
+    name: perl-Net-Daemon
+    release: 5.el7
+    source: rpm
+    version: '0.48'
   perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
   perl-PlRPC:
-    - arch: noarch
-      epoch: null
-      name: perl-PlRPC
-      release: 14.el7
-      source: rpm
-      version: '0.2020'
+  - arch: noarch
+    epoch: null
+    name: perl-PlRPC
+    release: 14.el7
+    source: rpm
+    version: '0.2020'
   perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
   perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
   perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
   perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
   perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
   perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
   perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
   perl-Sys-Statistics-Linux:
-    - arch: noarch
-      epoch: null
-      name: perl-Sys-Statistics-Linux
-      release: 14.el7
-      source: rpm
-      version: '0.66'
+  - arch: noarch
+    epoch: null
+    name: perl-Sys-Statistics-Linux
+    release: 14.el7
+    source: rpm
+    version: '0.66'
   perl-TermReadKey:
-    - arch: x86_64
-      epoch: null
-      name: perl-TermReadKey
-      release: 20.el7
-      source: rpm
-      version: '2.30'
+  - arch: x86_64
+    epoch: null
+    name: perl-TermReadKey
+    release: 20.el7
+    source: rpm
+    version: '2.30'
   perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
   perl-Test-Simple:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Simple
-      release: 243.el7
-      source: rpm
-      version: '0.98'
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Simple
+    release: 243.el7
+    source: rpm
+    version: '0.98'
   perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
   perl-Thread-Queue:
-    - arch: noarch
-      epoch: null
-      name: perl-Thread-Queue
-      release: 2.el7
-      source: rpm
-      version: '3.02'
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
   perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
   perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
   perl-XML-Parser:
-    - arch: x86_64
-      epoch: null
-      name: perl-XML-Parser
-      release: 10.el7
-      source: rpm
-      version: '2.41'
+  - arch: x86_64
+    epoch: null
+    name: perl-XML-Parser
+    release: 10.el7
+    source: rpm
+    version: '2.41'
   perl-YAML-Syck:
-    - arch: x86_64
-      epoch: null
-      name: perl-YAML-Syck
-      release: 3.el7
-      source: rpm
-      version: '1.27'
+  - arch: x86_64
+    epoch: null
+    name: perl-YAML-Syck
+    release: 3.el7
+    source: rpm
+    version: '1.27'
   perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
   perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
   perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
   perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
   perl-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: perl-srpm-macros
-      release: 8.el7
-      source: rpm
-      version: '1'
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
   perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
   perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
   pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
   pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
   plymouth:
-    - arch: x86_64
-      epoch: null
-      name: plymouth
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
+  - arch: x86_64
+    epoch: null
+    name: plymouth
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
   plymouth-core-libs:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-core-libs
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
+  - arch: x86_64
+    epoch: null
+    name: plymouth-core-libs
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
   plymouth-scripts:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-scripts
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
+  - arch: x86_64
+    epoch: null
+    name: plymouth-scripts
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
   policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
   policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
   polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
   polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
   popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
   postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
   postgresql:
-    - arch: x86_64
-      epoch: null
-      name: postgresql
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
+  - arch: x86_64
+    epoch: null
+    name: postgresql
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
   postgresql-devel:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-devel
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
+  - arch: x86_64
+    epoch: null
+    name: postgresql-devel
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
   postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
   postgresql10:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
+  - arch: x86_64
+    epoch: null
+    name: postgresql10
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
   postgresql10-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-contrib
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
   postgresql10-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-libs
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
   postgresql10-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-server
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
   postgresql12:
-    - arch: x86_64
-      epoch: null
-      name: postgresql12
-      release: 2PGDG.rhel7
-      source: rpm
-      version: '12.2'
+  - arch: x86_64
+    epoch: null
+    name: postgresql12
+    release: 2PGDG.rhel7
+    source: rpm
+    version: '12.2'
   postgresql12-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql12-libs
-      release: 2PGDG.rhel7
-      source: rpm
-      version: '12.2'
+  - arch: x86_64
+    epoch: null
+    name: postgresql12-libs
+    release: 2PGDG.rhel7
+    source: rpm
+    version: '12.2'
   procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
   psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 17.el7
-      source: rpm
-      version: '22.20'
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 17.el7
+    source: rpm
+    version: '22.20'
   pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
   pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
   pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
   python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-firewall:
-    - arch: noarch
-      epoch: null
-      name: python-firewall
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  python-psycopg2:
-    - arch: x86_64
-      epoch: null
-      name: python-psycopg2
-      release: 1.rhel7
-      source: rpm
-      version: 2.7.5
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-slip:
-    - arch: noarch
-      epoch: null
-      name: python-slip
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-slip-dbus:
-    - arch: noarch
-      epoch: null
-      name: python-slip-dbus
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-devel:
-    - arch: x86_64
-      epoch: null
-      name: python3-devel
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-rpm-generators:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-generators
-      release: 2.el7
-      source: rpm
-      version: '6'
-  python3-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  rcs:
-    - arch: x86_64
-      epoch: null
-      name: rcs
-      release: 7.el7
-      source: rpm
-      version: 5.9.0
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redhat-rpm-config:
-    - arch: noarch
-      epoch: null
-      name: redhat-rpm-config
-      release: 88.el7.centos
-      source: rpm
-      version: 9.1.0
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-sign:
-    - arch: x86_64
-      epoch: null
-      name: rpm-sign
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  socat:
-    - arch: x86_64
-      epoch: null
-      name: socat
-      release: 2.el7
-      source: rpm
-      version: 1.7.3.2
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 6.el7
-      source: rpm
-      version: '4.24'
-  subversion:
-    - arch: x86_64
-      epoch: null
-      name: subversion
-      release: 16.el7
-      source: rpm
-      version: 1.7.14
-  subversion-libs:
-    - arch: x86_64
-      epoch: null
-      name: subversion-libs
-      release: 16.el7
-      source: rpm
-      version: 1.7.14
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.1
-      source: rpm
-      version: 1.8.23
-  swig:
-    - arch: x86_64
-      epoch: null
-      name: swig
-      release: 5.el7
-      source: rpm
-      version: 2.0.10
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemtap:
-    - arch: x86_64
-      epoch: null
-      name: systemtap
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-client:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-client
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-devel:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-devel
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-runtime:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-runtime
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 66.el7
-      source: rpm
-      version: '0.17'
-  traceroute:
-    - arch: x86_64
-      epoch: 3
-      name: traceroute
-      release: 2.el7
-      source: rpm
-      version: 2.0.22
-  trousers:
-    - arch: x86_64
-      epoch: null
-      name: trousers
-      release: 2.el7
-      source: rpm
-      version: 0.3.14
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021a
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  webtatic-release:
-    - arch: noarch
-      epoch: null
-      name: webtatic-release
-      release: '3'
-      source: rpm
-      version: '7'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wireshark:
-    - arch: x86_64
-      epoch: null
-      name: wireshark
-      release: 25.el7
-      source: rpm
-      version: 1.10.14
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xagt:
-    - arch: x86_64
-      epoch: null
-      name: xagt
-      release: 1.el7
-      source: rpm
-      version: 33.46.6
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xmlsec1:
-    - arch: x86_64
-      epoch: null
-      name: xmlsec1
-      release: 7.el7_4
-      source: rpm
-      version: 1.2.20
-  xmlsec1-openssl:
-    - arch: x86_64
-      epoch: null
-      name: xmlsec1-openssl
-      release: 7.el7_4
-      source: rpm
-      version: 1.2.20
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zip:
-    - arch: x86_64
-      epoch: null
-      name: zip
-      release: 11.el7
-      source: rpm
-      version: '3.0'
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '50'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '54'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '55'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '65'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '66'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '68'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '76'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '78'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '79'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '81'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '83'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '98'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '136'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '283'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '298'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '299'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '302'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '305'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '306'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '308'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '309'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '310'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '311'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '312'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '313'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '315'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '316'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '318'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '319'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '321'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '322'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '324'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '325'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '326'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '327'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '328'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '329'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '330'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '331'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '332'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '333'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '334'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '335'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '347'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '348'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '349'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '350'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '351'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '352'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '353'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '354'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '355'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '356'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '357'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '358'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '359'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '360'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '361'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '362'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '363'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '364'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '405'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '406'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '420'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '427'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '428'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '429'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '430'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '431'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '432'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '433'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '434'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '435'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '436'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '437'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '438'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '518'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '552'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '607'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '608'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '611'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '612'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '613'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '614'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '615'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '623'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '682'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/VGAuthService -s
-    pid: '705'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/vmtoolsd
-    pid: '706'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '708'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '710'
-    ppid: '1'
-    user: polkitd
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '713'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/sbin/chronyd
-    pid: '719'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/NetworkManager --no-daemon
-    pid: '732'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '734'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '738'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '813'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f
-    pid: '999'
-    ppid: '1'
-    user: nrpe
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1002'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1004'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1005'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1186'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1207'
-    ppid: '1186'
-    user: postfix
-  - cmdline: ''
-    pid: '1467'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1489'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1498'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '1521'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '2185'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '3002'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56180) idle'
-    pid: '3042'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56186) idle'
-    pid: '3046'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56192) idle'
-    pid: '3050'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56198) idle'
-    pid: '3067'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56200) idle'
-    pid: '3069'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56874) idle'
-    pid: '4768'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56876) idle'
-    pid: '4772'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56880) idle'
-    pid: '4845'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56882) idle'
-    pid: '4859'
-    ppid: '86330'
-    user: postgres
-  - cmdline: ''
-    pid: '9986'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12880'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17528'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17569'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17625'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d -address
-      /run/containerd/containerd.sock
-    pid: '20044'
-    ppid: '1'
-    user: root
-  - cmdline: 'redis-server 0.0.0.0:6379'
-    pid: '20064'
-    ppid: '20044'
-    user: polkitd
-  - cmdline: /usr/bin/docker start -a redis
-    pid: '20366'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb -address
-      /run/containerd/containerd.sock
-    pid: '23319'
-    ppid: '1'
-    user: root
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '23339'
-    ppid: '23319'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '23356'
-    ppid: '23339'
-    user: '101'
-  - cmdline: /usr/bin/docker start -a nginx
-    pid: '23581'
-    ppid: '1'
-    user: root
-  - cmdline: SCREEN
-    pid: '24403'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/bash
-    pid: '24404'
-    ppid: '24403'
-    user: root
-  - cmdline: sudo -u postgres psql
-    pid: '28523'
-    ppid: '24404'
-    user: root
-  - cmdline: psql
-    pid: '28524'
-    ppid: '28523'
-    user: postgres
-  - cmdline: ''
-    pid: '29958'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00 -address
-      /run/containerd/containerd.sock
-    pid: '34186'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh -c python ./listener.py
-    pid: '34206'
-    ppid: '34186'
-    user: root
-  - cmdline: python ./listener.py
-    pid: '34220'
-    ppid: '34206'
-    user: root
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42334) idle'
-    pid: '44206'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42336) idle'
-    pid: '44207'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42342) idle'
-    pid: '44210'
-    ppid: '86330'
-    user: postgres
-  - cmdline: ''
-    pid: '45150'
-    ppid: '2'
-    user: root
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43028) idle'
-    pid: '45527'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43040) idle'
-    pid: '45533'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43042) idle'
-    pid: '45534'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42934) idle'
-    pid: '45877'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42938) idle'
-    pid: '45879'
-    ppid: '86330'
-    user: postgres
-  - cmdline: ''
-    pid: '46732'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46733'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '46865'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43470) idle'
-    pid: '47004'
-    ppid: '86330'
-    user: postgres
-  - cmdline: /sbin/rpcbind -w
-    pid: '47374'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '47383'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '47397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47398'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/rpc.statd
-    pid: '47406'
-    ppid: '1'
-    user: rpcuser
-  - cmdline: /usr/sbin/rpc.idmapd
-    pid: '47408'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rpc.mountd
-    pid: '47410'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '47415'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47416'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47421'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47422'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47423'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47424'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47425'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47426'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47427'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47428'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47623'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49068'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52259'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '54568'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '59036'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '60435'
-    ppid: '1186'
-    user: postfix
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '60677'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '61265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61266'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61267'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61271'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '61272'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '63199'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '63443'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '64680'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '65191'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: root@notty'
-    pid: '66030'
-    ppid: '1005'
-    user: root
-  - cmdline: ''
-    pid: '66110'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: root@pts/2'
-    pid: '67080'
-    ppid: '1005'
-    user: root
-  - cmdline: >-
-      /bin/sh -c /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1653469034.289239-97044-98249588652670/AnsiballZ_process_facts.py
-      && sleep 0
-    pid: '67237'
-    ppid: '67080'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1653469034.289239-97044-98249588652670/AnsiballZ_process_facts.py
-    pid: '67248'
-    ppid: '67237'
-    user: root
-  - cmdline: /opt/fireeye/bin/xagt -M DAEMON
-    pid: '69963'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT
-      --logfd 4
-    pid: '69987'
-    ppid: '69963'
-    user: root
-  - cmdline: 'sshd: root@pts/0'
-    pid: '71236'
-    ppid: '1005'
-    user: root
-  - cmdline: '-bash'
-    pid: '71238'
-    ppid: '71236'
-    user: root
-  - cmdline: /usr/sbin/mariadbd
-    pid: '73979'
-    ppid: '1'
-    user: mysql
-  - cmdline: ''
-    pid: '82946'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-cmdb-gateway
-    pid: '86226'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42 -address
-      /run/containerd/containerd.sock
-    pid: '86257'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh -c ./start_cmdb_gateway.sh
-    pid: '86277'
-    ppid: '86257'
-    user: root
-  - cmdline: /bin/sh ./start_cmdb_gateway.sh
-    pid: '86293'
-    ppid: '86277'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '86295'
-    ppid: '86293'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '86297'
-    ppid: '86295'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '86298'
-    ppid: '86295'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '86299'
-    ppid: '86295'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '86300'
-    ppid: '86295'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '86301'
-    ppid: '86295'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '86302'
-    ppid: '86295'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '86303'
-    ppid: '86295'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '86304'
-    ppid: '86295'
-    user: root
-  - cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
-    pid: '86330'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: data: checkpointer process'
-    pid: '86332'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: writer process'
-    pid: '86333'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: wal writer process'
-    pid: '86334'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: autovacuum launcher process'
-    pid: '86335'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: stats collector process'
-    pid: '86336'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: bgworker: logical replication launcher'
-    pid: '86337'
-    ppid: '86330'
-    user: postgres
-  - cmdline: /usr/bin/docker start -a iometrics-cmdbuild
-    pid: '88617'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443
-      -container-ip 192.168.1.2 -container-port 8443
-    pid: '88642'
-    ppid: '60677'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187 -address
-      /run/containerd/containerd.sock
-    pid: '88659'
-    ppid: '1'
-    user: root
-  - cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
-    pid: '88679'
-    ppid: '88659'
-    user: tomcat
-  - cmdline: >-
-      /usr/local/openjdk-17/bin/java
-      -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      -Xmx7876m -Xms3846m -Djdk.tls.ephemeralDHKeySize=2048
-      -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
-      -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
-      -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
-      -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar
-      -Delastic.apm.service_name=cmdb
-      -Delastic.apm.server_url=http://192.168.8.53:8200
-      -Delastic.apm.environment=dev -Delastic.apm.enabled=true
-      -Delastic.apm.profiling_inferred_spans_enabled=true
-      -Delastic.apm.profiling_inferred_spans_min_duration=250ms
-      -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
-      -Dignore.endorsed.dirs= -classpath
-      /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
-      -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat
-      -Djava.io.tmpdir=/usr/local/tomcat/temp
-      org.apache.catalina.startup.Bootstrap start
-    pid: '88716'
-    ppid: '88679'
-    user: tomcat
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(45768) idle'
-    pid: '88921'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56796) idle'
-    pid: '90009'
-    ppid: '86330'
-    user: postgres
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56802) idle'
-    pid: '90012'
-    ppid: '86330'
-    user: postgres
-  - cmdline: ''
-    pid: '100311'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '106553'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '112599'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '112882'
-    ppid: '2'
-    user: root
-tcp_listen:
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1005
-    port: 22
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: 0.0.0.0
-    name: postmaster
-    pid: 86330
-    port: 5432
-    protocol: tcp
-    stime: 'Thu May  5 15:28:58 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1186
-    port: 25
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: 0.0.0.0
-    name: docker-proxy
-    pid: 88642
-    port: 8443
-    protocol: tcp
-    stime: 'Thu May  5 16:06:35 2022'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 46171
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 23339
-    port: 443
-    protocol: tcp
-    stime: 'Tue Jun  1 17:04:40 2021'
-    user: root
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: null
     name: python
-    pid: 86295
-    port: 8444
-    protocol: tcp
-    stime: 'Thu May  5 15:28:47 2022'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: nrpe
-    pid: 999
-    port: 5666
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: nrpe
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 20064
-    port: 6378
-    protocol: tcp
-    stime: 'Tue May 25 11:00:31 2021'
-    user: polkitd
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 20064
-    port: 6379
-    protocol: tcp
-    stime: 'Tue May 25 11:00:31 2021'
-    user: polkitd
-  - address: 0.0.0.0
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-firewall:
+  - arch: noarch
+    epoch: null
+    name: python-firewall
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  python-psycopg2:
+  - arch: x86_64
+    epoch: null
+    name: python-psycopg2
+    release: 1.rhel7
+    source: rpm
+    version: 2.7.5
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-slip:
+  - arch: noarch
+    epoch: null
+    name: python-slip
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-slip-dbus:
+  - arch: noarch
+    epoch: null
+    name: python-slip-dbus
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  rcs:
+  - arch: x86_64
+    epoch: null
+    name: rcs
+    release: 7.el7
+    source: rpm
+    version: 5.9.0
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 0.0.0.0
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: 0.0.0.0
-    name: rpc.statd
-    pid: 47406
-    port: 53648
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 23339
-    port: 80
-    protocol: tcp
-    stime: 'Tue Jun  1 17:04:40 2021'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1005
-    port: 22
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1186
-    port: 25
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 40957
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: nrpe
-    pid: 999
-    port: 5666
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: nrpe
-  - address: '::'
-    name: mariadbd
-    pid: 73979
-    port: 3306
-    protocol: tcp
-    stime: 'Tue May 25 15:30:13 2021'
-    user: mysql
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: '::'
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: '::'
-    name: rpc.statd
-    pid: 47406
-    port: 47601
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-sign:
+  - arch: x86_64
+    epoch: null
+    name: rpm-sign
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  socat:
+  - arch: x86_64
+    epoch: null
+    name: socat
+    release: 2.el7
+    source: rpm
+    version: 1.7.3.2
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 6.el7
+    source: rpm
+    version: '4.24'
+  subversion:
+  - arch: x86_64
+    epoch: null
+    name: subversion
+    release: 16.el7
+    source: rpm
+    version: 1.7.14
+  subversion-libs:
+  - arch: x86_64
+    epoch: null
+    name: subversion-libs
+    release: 16.el7
+    source: rpm
+    version: 1.7.14
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.1
+    source: rpm
+    version: 1.8.23
+  swig:
+  - arch: x86_64
+    epoch: null
+    name: swig
+    release: 5.el7
+    source: rpm
+    version: 2.0.10
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemtap:
+  - arch: x86_64
+    epoch: null
+    name: systemtap
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-client:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-client
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-devel:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-devel
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-runtime:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-runtime
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 66.el7
+    source: rpm
+    version: '0.17'
+  traceroute:
+  - arch: x86_64
+    epoch: 3
+    name: traceroute
+    release: 2.el7
+    source: rpm
+    version: 2.0.22
+  trousers:
+  - arch: x86_64
+    epoch: null
+    name: trousers
+    release: 2.el7
+    source: rpm
+    version: 0.3.14
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  webtatic-release:
+  - arch: noarch
+    epoch: null
+    name: webtatic-release
+    release: '3'
+    source: rpm
+    version: '7'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wireshark:
+  - arch: x86_64
+    epoch: null
+    name: wireshark
+    release: 25.el7
+    source: rpm
+    version: 1.10.14
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xagt:
+  - arch: x86_64
+    epoch: null
+    name: xagt
+    release: 1.el7
+    source: rpm
+    version: 33.46.6
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xmlsec1:
+  - arch: x86_64
+    epoch: null
+    name: xmlsec1
+    release: 7.el7_4
+    source: rpm
+    version: 1.2.20
+  xmlsec1-openssl:
+  - arch: x86_64
+    epoch: null
+    name: xmlsec1-openssl
+    release: 7.el7_4
+    source: rpm
+    version: 1.2.20
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '54'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '55'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '66'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '78'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '98'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '136'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '302'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '305'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '306'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '308'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '309'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '310'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '311'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '312'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '315'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '321'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '322'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '324'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '325'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '326'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '327'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '328'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '329'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '330'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '331'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '332'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '333'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '334'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '335'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '347'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '348'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '349'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '350'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '351'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '352'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '353'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '354'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '355'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '356'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '357'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '358'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '359'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '360'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '361'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '362'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '363'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '364'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '405'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '406'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '420'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '427'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '428'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '429'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '430'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '431'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '432'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '433'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '434'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '435'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '436'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '437'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '438'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '518'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '552'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '607'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '608'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '611'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '612'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '613'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '614'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '615'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '623'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '682'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/VGAuthService -s
+  cwd: /usr/bin/
+  pid: '705'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/vmtoolsd
+  cwd: /usr/bin/
+  pid: '706'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '708'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '710'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '713'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '719'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/NetworkManager --no-daemon
+  cwd: /usr/sbin/
+  pid: '732'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '734'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '738'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '813'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f
+  cwd: /usr/sbin/
+  pid: '999'
+  ppid: '1'
+  user: nrpe
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1002'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1004'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1005'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1186'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1207'
+  ppid: '1186'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '1467'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1489'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1498'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1521'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2185'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '3002'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56180) idle'
+  cwd: /
+  pid: '3042'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56186) idle'
+  cwd: /
+  pid: '3046'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56192) idle'
+  cwd: /
+  pid: '3050'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56198) idle'
+  cwd: /
+  pid: '3067'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56200) idle'
+  cwd: /
+  pid: '3069'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56874) idle'
+  cwd: /
+  pid: '4768'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56876) idle'
+  cwd: /
+  pid: '4772'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56880) idle'
+  cwd: /
+  pid: '4845'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56882) idle'
+  cwd: /
+  pid: '4859'
+  ppid: '86330'
+  user: postgres
+- cmdline: ''
+  cwd: /
+  pid: '9986'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12880'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17528'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17569'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17625'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '20044'
+  ppid: '1'
+  user: root
+- cmdline: redis-server 0.0.0.0:6379
+  cwd: /
+  pid: '20064'
+  ppid: '20044'
+  user: polkitd
+- cmdline: /usr/bin/docker start -a redis
+  cwd: /usr/bin/
+  pid: '20366'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '23319'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '23339'
+  ppid: '23319'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '23356'
+  ppid: '23339'
+  user: '101'
+- cmdline: /usr/bin/docker start -a nginx
+  cwd: /usr/bin/
+  pid: '23581'
+  ppid: '1'
+  user: root
+- cmdline: SCREEN
+  cwd: /
+  pid: '24403'
+  ppid: '1'
+  user: root
+- cmdline: /bin/bash
+  cwd: /bin/
+  pid: '24404'
+  ppid: '24403'
+  user: root
+- cmdline: sudo -u postgres psql
+  cwd: /
+  pid: '28523'
+  ppid: '24404'
+  user: root
+- cmdline: psql
+  cwd: /
+  pid: '28524'
+  ppid: '28523'
+  user: postgres
+- cmdline: ''
+  cwd: /
+  pid: '29958'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '34186'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c python ./listener.py
+  cwd: /bin/
+  pid: '34206'
+  ppid: '34186'
+  user: root
+- cmdline: python ./listener.py
+  cwd: /
+  pid: '34220'
+  ppid: '34206'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42334) idle'
+  cwd: /
+  pid: '44206'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42336) idle'
+  cwd: /
+  pid: '44207'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42342) idle'
+  cwd: /
+  pid: '44210'
+  ppid: '86330'
+  user: postgres
+- cmdline: ''
+  cwd: /
+  pid: '45150'
+  ppid: '2'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43028) idle'
+  cwd: /
+  pid: '45527'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43040) idle'
+  cwd: /
+  pid: '45533'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43042) idle'
+  cwd: /
+  pid: '45534'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42934) idle'
+  cwd: /
+  pid: '45877'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42938) idle'
+  cwd: /
+  pid: '45879'
+  ppid: '86330'
+  user: postgres
+- cmdline: ''
+  cwd: /
+  pid: '46732'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46733'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '46865'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(43470) idle'
+  cwd: /
+  pid: '47004'
+  ppid: '86330'
+  user: postgres
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '47374'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '47383'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47398'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/rpc.statd
+  cwd: /usr/sbin/
+  pid: '47406'
+  ppid: '1'
+  user: rpcuser
+- cmdline: /usr/sbin/rpc.idmapd
+  cwd: /usr/sbin/
+  pid: '47408'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rpc.mountd
+  cwd: /usr/sbin/
+  pid: '47410'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47415'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47416'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47421'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47422'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47423'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47424'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47425'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47426'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47427'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47428'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47623'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49068'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52259'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '54568'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59036'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '60435'
+  ppid: '1186'
+  user: postfix
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '60677'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61266'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61271'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61272'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63199'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63443'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '64680'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65191'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: root@notty'
+  cwd: /
+  pid: '66030'
+  ppid: '1005'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '66110'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: root@pts/2'
+  cwd: /
+  pid: '67080'
+  ppid: '1005'
+  user: root
+- cmdline: /bin/sh -c /usr/bin/python /root/.ansible/tmp/ansible-tmp-1653469034.289239-97044-98249588652670/AnsiballZ_process_facts.py
+    && sleep 0
+  cwd: /bin/
+  pid: '67237'
+  ppid: '67080'
+  user: root
+- cmdline: /usr/bin/python /root/.ansible/tmp/ansible-tmp-1653469034.289239-97044-98249588652670/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '67248'
+  ppid: '67237'
+  user: root
+- cmdline: /opt/fireeye/bin/xagt -M DAEMON
+  cwd: /opt/fireeye/bin/
+  pid: '69963'
+  ppid: '1'
+  user: root
+- cmdline: /opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT --logfd
+    4
+  cwd: /opt/fireeye/bin/
+  pid: '69987'
+  ppid: '69963'
+  user: root
+- cmdline: 'sshd: root@pts/0'
+  cwd: /
+  pid: '71236'
+  ppid: '1005'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '71238'
+  ppid: '71236'
+  user: root
+- cmdline: /usr/sbin/mariadbd
+  cwd: /usr/sbin/
+  pid: '73979'
+  ppid: '1'
+  user: mysql
+- cmdline: ''
+  cwd: /
+  pid: '82946'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-cmdb-gateway
+  cwd: /usr/bin/
+  pid: '86226'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '86257'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c ./start_cmdb_gateway.sh
+  cwd: /bin/
+  pid: '86277'
+  ppid: '86257'
+  user: root
+- cmdline: /bin/sh ./start_cmdb_gateway.sh
+  cwd: /bin/
+  pid: '86293'
+  ppid: '86277'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '86295'
+  ppid: '86293'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '86297'
+  ppid: '86295'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '86298'
+  ppid: '86295'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '86299'
+  ppid: '86295'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '86300'
+  ppid: '86295'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '86301'
+  ppid: '86295'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '86302'
+  ppid: '86295'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '86303'
+  ppid: '86295'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '86304'
+  ppid: '86295'
+  user: root
+- cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
+  cwd: /usr/pgsql-10/bin/
+  pid: '86330'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: data: checkpointer process'
+  cwd: /
+  pid: '86332'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: writer process'
+  cwd: /
+  pid: '86333'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: wal writer process'
+  cwd: /
+  pid: '86334'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: autovacuum launcher process'
+  cwd: /
+  pid: '86335'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: stats collector process'
+  cwd: /
+  pid: '86336'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: bgworker: logical replication launcher'
+  cwd: /
+  pid: '86337'
+  ppid: '86330'
+  user: postgres
+- cmdline: /usr/bin/docker start -a iometrics-cmdbuild
+  cwd: /usr/bin/
+  pid: '88617'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 -container-ip
+    192.168.1.2 -container-port 8443
+  cwd: /usr/bin/
+  pid: '88642'
+  ppid: '60677'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '88659'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
+  cwd: /bin/
+  pid: '88679'
+  ppid: '88659'
+  user: tomcat
+- cmdline: /usr/local/openjdk-17/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx7876m -Xms3846m
+    -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+    -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
+    -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar -Delastic.apm.service_name=cmdb
+    -Delastic.apm.server_url=http://192.168.8.53:8200 -Delastic.apm.environment=dev
+    -Delastic.apm.enabled=true -Delastic.apm.profiling_inferred_spans_enabled=true
+    -Delastic.apm.profiling_inferred_spans_min_duration=250ms -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
+    -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
+    -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp
+    org.apache.catalina.startup.Bootstrap start
+  cwd: /usr/local/openjdk-17/bin/
+  pid: '88716'
+  ppid: '88679'
+  user: tomcat
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(45768) idle'
+  cwd: /
+  pid: '88921'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56796) idle'
+  cwd: /
+  pid: '90009'
+  ppid: '86330'
+  user: postgres
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(56802) idle'
+  cwd: /
+  pid: '90012'
+  ppid: '86330'
+  user: postgres
+- cmdline: ''
+  cwd: /
+  pid: '100311'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '106553'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '112599'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '112882'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: 'postgres:'
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/postgresql.yaml
+    name: Include postgres specific plugins
+  name: PostgreSQL Database
+  pkg_regexp: postgresql.*-server|postgresql-\d
+  process_type: child
+  return_children: true
+  return_packages: true
+  vars:
+    connect_with_users: '{{ postgresql_monitor_users_info | default([{''username'':
+      postgresql_monitor_user | default(''postgres''), ''password'': postgresql_monitor_pass
+      | default(''postgres'')}]) }}'
+    ignore_databases:
+    - postgres
+    - template0
+    - template1
+    sql_connection_extra_params: -h 127.0.0.1
+task_vars:
+  postgresql_monitor_pass: the_password
+  postgresql_monitor_user: the_postgres_user
+tcp_listen:
+- address: 0.0.0.0
+  name: sshd
+  pid: 1005
+  port: 22
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: 0.0.0.0
+  name: postmaster
+  pid: 86330
+  port: 5432
+  protocol: tcp
+  stime: Thu May  5 15:28:58 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1186
+  port: 25
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: 0.0.0.0
+  name: docker-proxy
+  pid: 88642
+  port: 8443
+  protocol: tcp
+  stime: Thu May  5 16:06:35 2022
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 46171
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 23339
+  port: 443
+  protocol: tcp
+  stime: Tue Jun  1 17:04:40 2021
+  user: root
+- address: 0.0.0.0
+  name: python
+  pid: 86295
+  port: 8444
+  protocol: tcp
+  stime: Thu May  5 15:28:47 2022
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: nrpe
+  pid: 999
+  port: 5666
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: nrpe
+- address: 0.0.0.0
+  name: redis-server
+  pid: 20064
+  port: 6378
+  protocol: tcp
+  stime: Tue May 25 11:00:31 2021
+  user: polkitd
+- address: 0.0.0.0
+  name: redis-server
+  pid: 20064
+  port: 6379
+  protocol: tcp
+  stime: Tue May 25 11:00:31 2021
+  user: polkitd
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: tcp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 0.0.0.0
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: 0.0.0.0
+  name: rpc.statd
+  pid: 47406
+  port: 53648
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 23339
+  port: 80
+  protocol: tcp
+  stime: Tue Jun  1 17:04:40 2021
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1005
+  port: 22
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: ::1
+  name: master
+  pid: 1186
+  port: 25
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: '::'
+  name: ''
+  pid: 0
+  port: 40957
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: '::'
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: '::'
+  name: nrpe
+  pid: 999
+  port: 5666
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: nrpe
+- address: '::'
+  name: mariadbd
+  pid: 73979
+  port: 3306
+  protocol: tcp
+  stime: Tue May 25 15:30:13 2021
+  user: mysql
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: tcp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: '::'
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: '::'
+  name: rpc.statd
+  pid: 47406
+  port: 47601
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
 udp_listen:
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 59970
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: rpc.statd
-    pid: 47406
-    port: 60822
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 719
-    port: 323
-    protocol: udp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 909
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 127.0.0.1
-    name: rpc.statd
-    pid: 47406
-    port: 942
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: '::'
-    name: rpc.statd
-    pid: 47406
-    port: 42219
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 42799
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 719
-    port: 323
-    protocol: udp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 909
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: udp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 59970
+  protocol: udp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: rpc.statd
+  pid: 47406
+  port: 60822
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 719
+  port: 323
+  protocol: udp
+  stime: Fri May 21 08:55:20 2021
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 909
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 127.0.0.1
+  name: rpc.statd
+  pid: 47406
+  port: 942
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: '::'
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: udp
+  stime: ''
+  user: ''
+- address: '::'
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: '::'
+  name: rpc.statd
+  pid: 47406
+  port: 42219
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: '::'
+  name: ''
+  pid: 0
+  port: 42799
+  protocol: udp
+  stime: ''
+  user: ''
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 719
+  port: 323
+  protocol: udp
+  stime: Fri May 21 08:55:20 2021
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 909
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/postgres/centos7_children.json
+++ b/tests/unit/plugins/action/auto/resources/postgres/centos7_children.json
@@ -13,55 +13,64 @@
       "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
       "pid": "1",
       "ppid": "0",
-      "user": "root"
+      "user": "root",
+      "cwd": "/usr/lib/systemd/"
     },
     {
       "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
       "pid": "24895",
       "ppid": "1",
-      "user": "root"
+      "user": "root",
+      "cwd": "/usr/pgsql-11/bin/"
     },
     {
       "cmdline": "postgres: logger",
       "pid": "24898",
       "ppid": "24895",
-      "user": "root"
+      "user": "root",
+      "cwd": "/"
     },
     {
       "cmdline": "postgres: checkpointer",
       "pid": "24900",
       "ppid": "24895",
-      "user": "root"
+      "user": "root",
+      "cwd": "/"
     },
     {
       "cmdline": "postgres: background writer",
       "pid": "24901",
       "ppid": "24895",
-      "user": "root"
+      "user": "root",
+      "cwd": "/"
     },
     {
       "cmdline": "postgres: walwriter",
       "pid": "24902",
       "ppid": "24895",
-      "user": "root"
+      "user": "root",
+      "cwd": "/"
     },
     {
       "cmdline": "postgres: autovacuum launcher",
       "pid": "24903",
       "ppid": "24895",
-      "user": "root"
+      "user": "root",
+      "cwd": "/"
     },
     {
       "cmdline": "postgres: stats collector",
       "pid": "24904",
       "ppid": "24895",
-      "user": "root"
+      "user": "root",
+      "cwd": "/"
     },
     {
       "cmdline": "postgres: logical replication launcher",
       "pid": "24905",
       "ppid": "24895",
-      "user": "root"
+      "user": "root",
+      "cwd": "/"
     }
   ],
   "tcp_listen": [
@@ -78,10 +87,14 @@
   "udp_listen": [],
   "expected_result": [
     {
-      "bindings": [{"address": "127.0.0.1",
-                "class": "service",
-                "port": 5432,
-                "protocol": "tcp"}],
+      "bindings": [
+        {
+          "address": "127.0.0.1",
+          "class": "service",
+          "port": 5432,
+          "protocol": "tcp"
+        }
+      ],
       "type": "PostgreSQL Database",
       "discovery_time": "2022-05-26T18:00:00+02:00",
       "process": {
@@ -91,49 +104,56 @@
             "cmdline": "postgres: logger",
             "pid": "24898",
             "ppid": "24895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
           },
           {
             "children": [],
             "cmdline": "postgres: checkpointer",
             "pid": "24900",
             "ppid": "24895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
           },
           {
             "children": [],
             "cmdline": "postgres: background writer",
             "pid": "24901",
             "ppid": "24895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
           },
           {
             "children": [],
             "cmdline": "postgres: walwriter",
             "pid": "24902",
             "ppid": "24895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
           },
           {
             "children": [],
             "cmdline": "postgres: autovacuum launcher",
             "pid": "24903",
             "ppid": "24895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
           },
           {
             "children": [],
             "cmdline": "postgres: stats collector",
             "pid": "24904",
             "ppid": "24895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
           },
           {
             "children": [],
             "cmdline": "postgres: logical replication launcher",
             "pid": "24905",
             "ppid": "24895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
           }
         ],
         "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
@@ -142,7 +162,8 @@
         ],
         "pid": "24895",
         "ppid": "1",
-        "user": "root"
+        "user": "root",
+        "cwd": "/usr/pgsql-11/bin/"
       },
       "listening_ports": [
         5432

--- a/tests/unit/plugins/action/auto/resources/postgres/centos7_no_children.yaml
+++ b/tests/unit/plugins/action/auto/resources/postgres/centos7_no_children.yaml
@@ -1,92 +1,100 @@
-task_vars:
-  inventory_hostname: the_host
+expected_result:
+- bindings:
+  - address: 127.0.0.1
+    class: service
+    port: 5432
+    protocol: tcp
+  discovery_time: '2022-05-26T18:00:00+02:00'
+  listening_ports:
+  - 5432
+  process:
+    cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
+    cwd: /usr/pgsql-11/bin/
+    listening_ports:
+    - 5432
+    pid: '24895'
+    ppid: '1'
+    user: root
+  the_fact: '5432'
+  type: PostgreSQL Database
 mocked_plugin_tasks:
-  "Task to mock 1":
+  Task to mock 1:
     plugin_result:
       key1: val1
       key2: val2
-
-expected_result:
-  - bindings:
-      - address: '127.0.0.1'
-        class: 'service'
-        port: 5432
-        protocol: 'tcp'
-    type: PostgreSQL Database
-    discovery_time: '2022-05-26T18:00:00+02:00'
-    process:
-      cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
-      listening_ports:
-        - 5432
-      pid: '24895'
-      ppid: '1'
-      user: 'root'
-    listening_ports:
-      - 5432
-    the_fact: '5432'
-
-software_list:
-  - name: PostgreSQL Database
-    cmd_regexp: 'postgres:'
-    pkg_regexp: postgresql.*-server|postgresql-\d
-    process_type: child
-    return_children: false
-    custom_tasks:
-      - name: Task to execute 1
-        testing_plugin:
-          host: "{{ inventory_hostname }}"
-        register: testing_plugin_result
-      - name: Task to execute 2
-        set_instance_fact:
-          the_fact: << __instance__.listening_ports  | last  >>
-        register: the_plugin_value
-      - name: Task to mock 1
-        read_remote_file:
-          file_path: "path_to_file"
-        register: the_plugin_value
 processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: 'root'
-  - cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
-    pid: '24895'
-    ppid: '1'
-    user: 'root'
-  - cmdline: 'postgres: logger'
-    pid: '24898'
-    ppid: '24895'
-    user: 'root'
-  - cmdline: 'postgres: checkpointer'
-    pid: '24900'
-    ppid: '24895'
-    user: 'root'
-  - cmdline: 'postgres: background writer'
-    pid: '24901'
-    ppid: '24895'
-    user: 'root'
-  - cmdline: 'postgres: walwriter'
-    pid: '24902'
-    ppid: '24895'
-    user: 'root'
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '24903'
-    ppid: '24895'
-    user: 'root'
-  - cmdline: 'postgres: stats collector'
-    pid: '24904'
-    ppid: '24895'
-    user: 'root'
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '24905'
-    ppid: '24895'
-    user: 'root'
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
+  cwd: /usr/pgsql-11/bin/
+  pid: '24895'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: logger'
+  cwd: /
+  pid: '24898'
+  ppid: '24895'
+  user: root
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '24900'
+  ppid: '24895'
+  user: root
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '24901'
+  ppid: '24895'
+  user: root
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '24902'
+  ppid: '24895'
+  user: root
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '24903'
+  ppid: '24895'
+  user: root
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '24904'
+  ppid: '24895'
+  user: root
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '24905'
+  ppid: '24895'
+  user: root
+software_list:
+- cmd_regexp: 'postgres:'
+  custom_tasks:
+  - name: Task to execute 1
+    register: testing_plugin_result
+    testing_plugin:
+      host: '{{ inventory_hostname }}'
+  - name: Task to execute 2
+    register: the_plugin_value
+    set_instance_fact:
+      the_fact: << __instance__.listening_ports  | last  >>
+  - name: Task to mock 1
+    read_remote_file:
+      file_path: path_to_file
+    register: the_plugin_value
+  name: PostgreSQL Database
+  pkg_regexp: postgresql.*-server|postgresql-\d
+  process_type: child
+  return_children: false
+task_vars:
+  inventory_hostname: the_host
 tcp_listen:
-  - address: 127.0.0.1
-    name: postmaster
-    pid: 24895
-    port: 5432
-    protocol: tcp
-    stime: 'Fri Apr  8 01:14:02 2022'
-    user: postgres
+- address: 127.0.0.1
+  name: postmaster
+  pid: 24895
+  port: 5432
+  protocol: tcp
+  stime: Fri Apr  8 01:14:02 2022
+  user: postgres
 udp_listen: []

--- a/tests/unit/plugins/action/auto/resources/postgres/postgres12-alpine_ubuntu18_2dockers.yaml
+++ b/tests/unit/plugins/action/auto/resources/postgres/postgres12-alpine_ubuntu18_2dockers.yaml
@@ -1,8867 +1,8815 @@
----
-task_vars:
-  postgresql_monitor_users_info:
-    - username: user_a
-      password: password_a
-    - username: user_b
-      password: password_b
-#  postgresql_monitor_user: the_postgres_user
-#  postgresql_monitor_pass: the_password
-
+dockers:
+  containers:
+  - AppArmorProfile: docker-default
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - ./agent
+      Env:
+      - AGENT_CLUSTER_ADDR=tasks.agent
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      Hostname: 51b871604742
+      Image: portainer/agent:1.5.1
+      Labels:
+        com.docker.stack.namespace: iometrics-infrabase
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: zv63ez6d7np17nhba28sfzcta
+        com.docker.swarm.service.name: iometrics-infrabase_agent
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: htwtsb7ml6p5ynviol7o0toc6
+        com.docker.swarm.task.name: iometrics-infrabase_agent.wh12ct3jzpllqaj4mv233ey4f.htwtsb7ml6p5ynviol7o0toc6
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: /app
+    Created: '2022-04-26T14:58:49.594174611Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/e641ecda862d1dca612f30d132d2f4a7f3b428ad608b9db7261122be6ab671dd-init/diff:/var/lib/docker/overlay2/80a892dff2eb793bc1c241b2f11645c9f168b020142621ca85c7794012c1c9e5/diff:/var/lib/docker/overlay2/e20f364832b775bae223881abc805b1ab493959e18d606ca68960cc5ce1ba911/diff:/var/lib/docker/overlay2/27c537348347b2b75a1ed0826a682fd208a72841c7b151793b2f8600c8c49bfe/diff:/var/lib/docker/overlay2/4d90fe38400d770794d3ac1ac5be31209408bcc8d66e8d944201815fc0f670f3/diff
+        MergedDir: /var/lib/docker/overlay2/e641ecda862d1dca612f30d132d2f4a7f3b428ad608b9db7261122be6ab671dd/merged
+        UpperDir: /var/lib/docker/overlay2/e641ecda862d1dca612f30d132d2f4a7f3b428ad608b9db7261122be6ab671dd/diff
+        WorkDir: /var/lib/docker/overlay2/e641ecda862d1dca612f30d132d2f4a7f3b428ad608b9db7261122be6ab671dd/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: /var/run/docker.sock
+        Target: /var/run/docker.sock
+        Type: bind
+      - Source: /var/lib/docker/volumes
+        Target: /var/lib/docker/volumes
+        Type: bind
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23/hostname
+    HostsPath: /var/lib/docker/containers/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23/hosts
+    Id: 51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23
+    Image: sha256:5b96aa0902cb3584c223e512b3488e4db66f4e43f642a66ba78ac58047d9df10
+    LogPath: /var/lib/docker/containers/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/run/docker.sock
+      Mode: ''
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/docker.sock
+      Type: bind
+    - Destination: /var/lib/docker/volumes
+      Mode: ''
+      Propagation: rslave
+      RW: true
+      Source: /var/lib/docker/volumes
+      Type: bind
+    Name: /iometrics-infrabase_agent.wh12ct3jzpllqaj4mv233ey4f.htwtsb7ml6p5ynviol7o0toc6
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - 51b871604742
+          DriverOpts: null
+          EndpointID: d2bd4a26839ef39a2d801fae724d8d5d1bcd9e193b698c395755126a73093cb0
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.49
+          IPAddress: 192.168.4.49
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:31
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports: {}
+      SandboxID: c2e1ebf2941fa4fb42261fef92040ad5f6be771658a2ce727a9e3f6bd6e8e238
+      SandboxKey: /var/run/docker/netns/c2e1ebf2941f
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: ./agent
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 5508
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:54.130089375Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - GF_ANALITICS_REPORTING_ENABLED=false
+      - GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource,alexanderzobnin-zabbix-app
+        3.10.0,flant-statusmap-panel,snuids-trafficlights-panel,natel-discrete-panel
+      - GF_LOG_CONSOLE_FORMAT=json
+      - GF_LOG_FILTERS=alerting.notifier:debug,alerting.notifier.slack:debug,auth:debug
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SERVER_DOMAIN=grafanac4.robotito.lab.iometrics.io
+      - GF_SERVER_ROOT_URL=https://grafanac4.robotito.lab.iometrics.io
+      - GF_SERVER_ROUTER_LOGGING=true
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PLUGINS=/var/lib/grafana/plugins
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: 857aa9d4f13e
+      Image: grafana/grafana:5.4.2
+      Labels:
+        com.docker.stack.namespace: iometrics-zabbix-gw
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: o6d6z5zd36c3gfcgp0ck4w311
+        com.docker.swarm.service.name: iometrics-zabbix-gw_grafana
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: rgov6pf309hemkdkx3qg9rci0
+        com.docker.swarm.task.name: iometrics-zabbix-gw_grafana.1.rgov6pf309hemkdkx3qg9rci0
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes: null
+      WorkingDir: /usr/share/grafana
+    Created: '2022-04-26T14:58:34.408632045Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/5180c79bb3a87b177f6d9cbce73efb685d78eaf91c4e3ed1c64fdb225a07bb85-init/diff:/var/lib/docker/overlay2/8a91025aab8b9ff9fdcaff873c6552834950816ce4d344c3461303490eb6d965/diff:/var/lib/docker/overlay2/cc996ab9fabf0542fdc09c792d8f907a944180924fa3eec6f94db2757f5f246a/diff:/var/lib/docker/overlay2/54e93bedf43af593f00e45025bffed735f26b9f0f749fb80ed505fdf47b8453c/diff:/var/lib/docker/overlay2/770916c068ba6f58bd4a7a9be20d406d0f5d4988e2160fccdfd5242acb28b792/diff:/var/lib/docker/overlay2/18c9784de782dea92d578e00440c8d3b3f5b47aea10691ec8738809fce4f3e02/diff:/var/lib/docker/overlay2/dfbe518aad7b4fa7a09494a73507d53f307eecabe6c44e0bd5c5c5b4bf8a878a/diff
+        MergedDir: /var/lib/docker/overlay2/5180c79bb3a87b177f6d9cbce73efb685d78eaf91c4e3ed1c64fdb225a07bb85/merged
+        UpperDir: /var/lib/docker/overlay2/5180c79bb3a87b177f6d9cbce73efb685d78eaf91c4e3ed1c64fdb225a07bb85/diff
+        WorkDir: /var/lib/docker/overlay2/5180c79bb3a87b177f6d9cbce73efb685d78eaf91c4e3ed1c64fdb225a07bb85/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: iometrics-zabbix-gw_grafanac4-data
+        Target: /var/lib/grafana
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-zabbix-gw
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8/hostname
+    HostsPath: /var/lib/docker/containers/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8/hosts
+    Id: 857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8
+    Image: sha256:6f18ddf9e552921525b5279cddd90bf5fe778c5f20ac3a27fd1a0e32f1763fe6
+    LogPath: /var/lib/docker/containers/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/grafana
+      Driver: local
+      Mode: z
+      Name: iometrics-zabbix-gw_grafanac4-data
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-zabbix-gw_grafanac4-data/_data
+      Type: volume
+    Name: /iometrics-zabbix-gw_grafana.1.rgov6pf309hemkdkx3qg9rci0
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - 857aa9d4f13e
+          DriverOpts: null
+          EndpointID: fedba26314f48fb417358fc4f68d7e9e59bc45664d83bac801528a0c4284861e
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.15
+          IPAddress: 192.168.4.15
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:0f
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        3000/tcp: null
+      SandboxID: 25d21a12dbd35600ce36dd506235ccc7bb9b5f495decd27256bca5bd7e60deaf
+      SandboxKey: /var/run/docker/netns/25d21a12dbd3
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3849
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:40.1468933Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_DB=gitea
+      - POSTGRES_PASSWORD=admin
+      - POSTGRES_USER=admin
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.8
+      - PG_SHA256=e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: 2f572d9641d8
+      Image: postgres:12-alpine@sha256:de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
+      Labels:
+        com.docker.stack.namespace: iometrics-cicd
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: sl6p3tfi11qy2a4ilydeh2906
+        com.docker.swarm.service.name: iometrics-cicd_git-db
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: y6zi23c5jilcof2zl954u1u5z
+        com.docker.swarm.task.name: iometrics-cicd_git-db.1.y6zi23c5jilcof2zl954u1u5z
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2022-04-26T14:58:34.177932791Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/0015303b3f5ae8b5b276abd206b8aa784fd60a4e56b543d8e80458acd5d5f067-init/diff:/var/lib/docker/overlay2/7430b814543c8e92e23d3bad2878bc918c3f0ee7d76cf6672a42e7541c8ff098/diff:/var/lib/docker/overlay2/b9e33979729ec5acf69c47e206c4a3b8855f968fee959105bd36b9e00e02a068/diff:/var/lib/docker/overlay2/8a732ae77f1797777ebaef206c5307963336f211df988f57942f52b3ffc4cf45/diff:/var/lib/docker/overlay2/a5a3474e844bd3bc888b72a4ef47d42334549eb7ad65412003f4a00849ba6cc2/diff:/var/lib/docker/overlay2/8451823ccf17f8d05e52bea00201534e3aea451155c7d140635e2efd541c0757/diff:/var/lib/docker/overlay2/fc4197e07029dc453276b12b55d7ed31c4249e2145c2121e124fbd77f89c1868/diff:/var/lib/docker/overlay2/fbfd0fdd04a9b9622cdd56b32aa4bcb6ad2b8353fdf78a81743010cb2d59aecd/diff:/var/lib/docker/overlay2/1755d933ee03247981a8cbd22753cb4d98060b0cc15aef77f6060f2222ea76b2/diff
+        MergedDir: /var/lib/docker/overlay2/0015303b3f5ae8b5b276abd206b8aa784fd60a4e56b543d8e80458acd5d5f067/merged
+        UpperDir: /var/lib/docker/overlay2/0015303b3f5ae8b5b276abd206b8aa784fd60a4e56b543d8e80458acd5d5f067/diff
+        WorkDir: /var/lib/docker/overlay2/0015303b3f5ae8b5b276abd206b8aa784fd60a4e56b543d8e80458acd5d5f067/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: iometrics-cicd_gitea-db
+        Target: /var/lib/postgresql/data
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-cicd
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac/hostname
+    HostsPath: /var/lib/docker/containers/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac/hosts
+    Id: 2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac
+    Image: sha256:d029edc386822ae1bb9c649cd81770e43ff615472c83a262b08cacfdd9c20d3c
+    LogPath: /var/lib/docker/containers/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/postgresql/data
+      Driver: local
+      Mode: z
+      Name: iometrics-cicd_gitea-db
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-cicd_gitea-db/_data
+      Type: volume
+    Name: /iometrics-cicd_git-db.1.y6zi23c5jilcof2zl954u1u5z
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - 2f572d9641d8
+          DriverOpts: null
+          EndpointID: 01706899cd0c2d2fed9ca28a30f41961455f9cc37c64cef0f7148233f7857871
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.18
+          IPAddress: 192.168.4.18
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:12
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        5432/tcp: null
+      SandboxID: 2aef9381f2a2518a1af90080cee4368db33a22f920fc398a7ddb53edf4054050
+      SandboxKey: /var/run/docker/netns/2aef9381f2a2
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3818
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:41.008493294Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /usr/bin/zippersrv
+      Env:
+      - ENDPOINT=minio.robotito.lab.iometrics.io
+      - KEY=admin
+      - SECRET=the_secret
+      - SECURE=true
+      - SSL_SKIP_VERIFY=true
+      - TRACE=true
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      Hostname: 78bc3826302f
+      Image: nexusregistry.opensolutions.cloud/iometrics-synthetix-miniozipper:0.1@sha256:ad29666dea6d814b2974a1f7c5b786f983fd81eaf3112af57b8d479cac72ca71
+      Labels:
+        com.docker.stack.namespace: iometrics-cicd
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: wcz8kqfmpnj67lgo2yqiy0701
+        com.docker.swarm.service.name: iometrics-cicd_miniozipper
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: zkhlqnwpqxrvl907dxfz5i9iu
+        com.docker.swarm.task.name: iometrics-cicd_miniozipper.1.zkhlqnwpqxrvl907dxfz5i9iu
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: ''
+    Created: '2022-04-26T14:58:34.117137559Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/6eeb8dc63440dbe98d1dca26334540c283b1cafe8e33ecaf883218d092c48671-init/diff:/var/lib/docker/overlay2/a770f644bc6e8af73f4b92973855d61f470e34f2406de46e1338489abedb96be/diff:/var/lib/docker/overlay2/f10065e6f4eabeb7ed781ac10116d5f9c59fd591d75f426b3df199a1f27d0a0e/diff:/var/lib/docker/overlay2/176912bdc0e6dc7d5c1d6e81ce623215c36d702d56ba32fe223efeb1a12f7ffb/diff
+        MergedDir: /var/lib/docker/overlay2/6eeb8dc63440dbe98d1dca26334540c283b1cafe8e33ecaf883218d092c48671/merged
+        UpperDir: /var/lib/docker/overlay2/6eeb8dc63440dbe98d1dca26334540c283b1cafe8e33ecaf883218d092c48671/diff
+        WorkDir: /var/lib/docker/overlay2/6eeb8dc63440dbe98d1dca26334540c283b1cafe8e33ecaf883218d092c48671/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19/hostname
+    HostsPath: /var/lib/docker/containers/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19/hosts
+    Id: 78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19
+    Image: sha256:61fe57b566f7b2bb12a5d4903fd5641fc30893485ab42e48882f4d457a96d6b0
+    LogPath: /var/lib/docker/containers/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19-json.log
+    MountLabel: ''
+    Mounts: []
+    Name: /iometrics-cicd_miniozipper.1.zkhlqnwpqxrvl907dxfz5i9iu
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - 78bc3826302f
+          DriverOpts: null
+          EndpointID: 041be94001cfe78b1b1a66414c285ba89788aef650471de5cb7f0d2b0ab1a2cf
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.19
+          IPAddress: 192.168.4.19
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:13
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports: {}
+      SandboxID: 2fbef10c83428b7d81c7a5bcd8274fd7641794e564752ba85bc72ebdb6198745
+      SandboxKey: /var/run/docker/netns/2fbef10c8342
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/bin/zippersrv
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3835
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:42.059212004Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_DB=reports
+      - POSTGRES_PASSWORD=admin
+      - POSTGRES_USER=admin
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.8
+      - PG_SHA256=e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: 2b5cc9c1f3f3
+      Image: postgres:12-alpine@sha256:de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
+      Labels:
+        com.docker.stack.namespace: iometrics-reporter
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: zptaxb22an2qd5kgl2g90p9ha
+        com.docker.swarm.service.name: iometrics-reporter_api-reporter-db
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: siynlece6pmr42vs3wkslfwej
+        com.docker.swarm.task.name: iometrics-reporter_api-reporter-db.1.siynlece6pmr42vs3wkslfwej
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2022-04-26T14:58:33.309205335Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/f870f1df5dc2f52c9ab442606653e7ffed63196736959f434d5ddcdc5a94365f-init/diff:/var/lib/docker/overlay2/7430b814543c8e92e23d3bad2878bc918c3f0ee7d76cf6672a42e7541c8ff098/diff:/var/lib/docker/overlay2/b9e33979729ec5acf69c47e206c4a3b8855f968fee959105bd36b9e00e02a068/diff:/var/lib/docker/overlay2/8a732ae77f1797777ebaef206c5307963336f211df988f57942f52b3ffc4cf45/diff:/var/lib/docker/overlay2/a5a3474e844bd3bc888b72a4ef47d42334549eb7ad65412003f4a00849ba6cc2/diff:/var/lib/docker/overlay2/8451823ccf17f8d05e52bea00201534e3aea451155c7d140635e2efd541c0757/diff:/var/lib/docker/overlay2/fc4197e07029dc453276b12b55d7ed31c4249e2145c2121e124fbd77f89c1868/diff:/var/lib/docker/overlay2/fbfd0fdd04a9b9622cdd56b32aa4bcb6ad2b8353fdf78a81743010cb2d59aecd/diff:/var/lib/docker/overlay2/1755d933ee03247981a8cbd22753cb4d98060b0cc15aef77f6060f2222ea76b2/diff
+        MergedDir: /var/lib/docker/overlay2/f870f1df5dc2f52c9ab442606653e7ffed63196736959f434d5ddcdc5a94365f/merged
+        UpperDir: /var/lib/docker/overlay2/f870f1df5dc2f52c9ab442606653e7ffed63196736959f434d5ddcdc5a94365f/diff
+        WorkDir: /var/lib/docker/overlay2/f870f1df5dc2f52c9ab442606653e7ffed63196736959f434d5ddcdc5a94365f/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: iometrics-reporter_pgdata
+        Target: /var/lib/postgresql/data/
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-reporter
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839/hostname
+    HostsPath: /var/lib/docker/containers/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839/hosts
+    Id: 2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839
+    Image: sha256:d029edc386822ae1bb9c649cd81770e43ff615472c83a262b08cacfdd9c20d3c
+    LogPath: /var/lib/docker/containers/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/postgresql/data
+      Driver: local
+      Mode: z
+      Name: iometrics-reporter_pgdata
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-reporter_pgdata/_data
+      Type: volume
+    Name: /iometrics-reporter_api-reporter-db.1.siynlece6pmr42vs3wkslfwej
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - 2b5cc9c1f3f3
+          DriverOpts: null
+          EndpointID: 4c518ed87d2f51f9a36be297b168bd07c79a555782ae84518f2bdd038f4389f0
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.16
+          IPAddress: 192.168.4.16
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:10
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        5432/tcp: null
+      SandboxID: df5dadbd8a2e46a704df14e79fe54ef805fcb86280b466575382731a473be123
+      SandboxKey: /var/run/docker/netns/df5dadbd8a2e
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3572
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:38.481019162Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /entrypoint.sh
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - SYUI_GENERAL_LOGLEVEL=debug
+      - SYUI_GENERAL_LOGMODE=console
+      - SYUI_HTTP_ADMIN_PASSWORD=admin
+      - SYUI_HTTP_ADMIN_USER=admin
+      - SYUI_HTTP_WS_PUBLIC_URL=syui.robotito.lab.iometrics.io
+      - SYUI_INFLUX_DB=sondas
+      - SYUI_INFLUX_HOST=influxdb
+      - SYUI_INFLUX_ID=syui
+      - SYUI_INFLUX_PASS=sondas
+      - SYUI_INFLUX_PORT=8086
+      - SYUI_INFLUX_USER=sondas
+      - SYUI_TUNNEL_DEFAULTS_SSH_PASSWORD=syUI
+      - SYUI_TUNNEL_DEFAULTS_SSH_USERNAME=synthetix
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LC_ALL=C.UTF-8
+      - LD_LIBRARY_PATH=/usr/local/guacamole/lib
+      - GUACD_LOG_LEVEL=info
+      - PATHS_HOME=/opt/iometrics-synthetix-ui/
+      - SYUI_GENERAL_DATADIR=/opt/iometrics-synthetix-ui//data/
+      - SYUI_GENERAL_LOGDIR=/opt/iometrics-synthetix-ui//log/
+      ExposedPorts:
+        4822/tcp: {}
+        5090/tcp: {}
+      Hostname: d769662f72d3
+      Image: nexusregistry.opensolutions.cloud/iometrics-synthetix-ui:0.1@sha256:936bb335dcfdd9cf77194a55cc00b0af9465f4010001b767656b2c769867a497
+      Labels:
+        com.docker.stack.namespace: iometrics-ui
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: bldqs9xmx2r0fhciytjv3j3vt
+        com.docker.swarm.service.name: iometrics-ui_syui
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: p8a37fsybhj3vc2rzxkr7tv0e
+        com.docker.swarm.task.name: iometrics-ui_syui.1.p8a37fsybhj3vc2rzxkr7tv0e
+        maintainer: Datadope team <hello@datadope.io>
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: synui
+      Volumes: null
+      WorkingDir: /opt/iometrics-synthetix-ui
+    Created: '2022-04-26T14:58:33.272242021Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/26f59a6eccd92f11b8c27ab0694f5bfd5a3186180775a2201e5053c7b0ebf643-init/diff:/var/lib/docker/overlay2/354d6e470c7ee87edff88f5bf4f6481d6907e00d5d2f4e8bb0dfb22e1da33be9/diff:/var/lib/docker/overlay2/ac798d815bb57299db6ae2e0ef634695eaacd3fab0c3311b1f9273aa12f8d2e2/diff:/var/lib/docker/overlay2/511d48a012d48d8b97352e36afe6d76b6edaf0c682cb57ea9ce95c6df7f8d779/diff:/var/lib/docker/overlay2/a9b29fd17c08b625fa1496a66e1a395dd4587bee0bbf8d50bce5e6ef1859ad04/diff:/var/lib/docker/overlay2/6dd88ce122ec147dbbdb452acfa76535662824d4d1860461fef5531f7e5e636a/diff:/var/lib/docker/overlay2/b7bf1215e99d3d5b4b470c4ccd91cfa2501f27ca6986a8e8baa117a13491e635/diff:/var/lib/docker/overlay2/c89e11572d1651660eea863e0b56619196eaba8d9ba9c6e907b1a114b4a1525f/diff:/var/lib/docker/overlay2/06aff82af5e3fc061f32433afef5b00dfcadfb35f9076f1a05417ba7df1bfcc0/diff:/var/lib/docker/overlay2/d78b4d05356aa0578ecc73b5c1a8aca281d4d6d727edb5391b64eefb07809ae2/diff:/var/lib/docker/overlay2/37f13e635e553fc33718307f7f5f4a5809de4f875bca532a81ad922ac4ac6ce4/diff:/var/lib/docker/overlay2/1f13da162409aa6daec69282a3ab39273a4747d204894ee06e878940ebaf9dfb/diff:/var/lib/docker/overlay2/2f3d6af2a0094499eddf10a8d6d5b9c8e1353eca31e47338cc97981108d43b31/diff:/var/lib/docker/overlay2/0220f3d43627d5f9e8eac4f30580707a9e791a8eaa87907900a21a3ac238ee1b/diff
+        MergedDir: /var/lib/docker/overlay2/26f59a6eccd92f11b8c27ab0694f5bfd5a3186180775a2201e5053c7b0ebf643/merged
+        UpperDir: /var/lib/docker/overlay2/26f59a6eccd92f11b8c27ab0694f5bfd5a3186180775a2201e5053c7b0ebf643/diff
+        WorkDir: /var/lib/docker/overlay2/26f59a6eccd92f11b8c27ab0694f5bfd5a3186180775a2201e5053c7b0ebf643/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: iometrics-ui_synthetix-ui-data
+        Target: /opt/iometrics-synthetix-ui/data
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-ui
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a/hostname
+    HostsPath: /var/lib/docker/containers/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a/hosts
+    Id: d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a
+    Image: sha256:8cfda68421ccc9937ed90ab44b64e72b0ce4acfcc85bc803656c00ef0a5fb807
+    LogPath: /var/lib/docker/containers/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /opt/iometrics-synthetix-ui/data
+      Driver: local
+      Mode: z
+      Name: iometrics-ui_synthetix-ui-data
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-ui_synthetix-ui-data/_data
+      Type: volume
+    Name: /iometrics-ui_syui.1.p8a37fsybhj3vc2rzxkr7tv0e
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - d769662f72d3
+          DriverOpts: null
+          EndpointID: 38869dbd22a59b74e1ba98e2fb803cf1a0030e7baa15ed74e954bebf866b3b05
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.23
+          IPAddress: 192.168.4.23
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:17
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        4822/tcp: null
+        5090/tcp: null
+      SandboxID: f61355e89ac445126a47aae000e450dcda53c71de6470c188ddf4791fa2d42fc
+      SandboxKey: /var/run/docker/netns/f61355e89ac4
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3480
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:40.492687878Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - GF_ANALITICS_REPORTING_ENABLED=false
+      - GF_LOG_CONSOLE_FORMAT=json
+      - GF_LOG_FILTERS=alerting.notifier:debug,alerting.notifier.slack:debug,auth:debug
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SERVER_DOMAIN=iometrics-ui.robotito.lab.iometrics.io
+      - GF_SERVER_ROOT_URL=https://iometrics-ui.robotito.lab.iometrics.io
+      - GF_SERVER_ROUTER_LOGGING=true
+      - TZ="Europe/Madrid"
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      - GF_RENDERER_PLUGIN_CHROME_BIN=/usr/bin/chromium-browser
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: 879dd93dd234
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2.3_0.16@sha256:13be599d28d1be08722e0c28fdaf30adf81a636af0768cb1234066c840b0f19b
+      Labels:
+        com.docker.stack.namespace: iometrics-influxdb-grafana
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: x7j3dee8x9xwtm2kek1o6dtaw
+        com.docker.swarm.service.name: iometrics-influxdb-grafana_grafana
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: s5zrbl40wdkqzmjcohve8xmmg
+        com.docker.swarm.task.name: iometrics-influxdb-grafana_grafana.1.s5zrbl40wdkqzmjcohve8xmmg
+        maintainer: Grafana team <hello@grafana.com>
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes: null
+      WorkingDir: /usr/share/grafana
+    Created: '2022-04-26T14:58:33.238325683Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/192248d38a38825d7f6145a20dbf6f08fa7f2bab09221e2c6ed0043762c80df5-init/diff:/var/lib/docker/overlay2/06067347ce85197709e15ced1440324e840442d735f71b39dc085bf8235304d0/diff:/var/lib/docker/overlay2/6b76e23dd25a0e741318cc0fc144a84d56489d054e5216bfbfc9184cffda97e3/diff:/var/lib/docker/overlay2/dc516c2970c8fef2c9eaeddaeb7d1989e876274251c48165ec4937a415509d78/diff:/var/lib/docker/overlay2/009a10252e10cdbcf082de884d2854adf81c1c031aac81e127b1c020a851632d/diff:/var/lib/docker/overlay2/0ac04c1610f9dee024851a3c1ba58ea16cd7cd6df396838acc51379eb4842e5e/diff:/var/lib/docker/overlay2/296155f1b193499b6ddb98fea687d3c0ae4fb17b814eceb91e4b16c6064c3cbf/diff:/var/lib/docker/overlay2/da219d320c57b9e2d73e30fc0d138c96ca6bc6b689a6e250fd6e9a9cff36dbb1/diff:/var/lib/docker/overlay2/96e904899a7a251682b87ad6f5926d46793da5da873e26caa908f895109aac23/diff:/var/lib/docker/overlay2/9ec33c55d0db535901f8a7781a4a73e3f6269d2fa84d47478a0fca9d8631a703/diff:/var/lib/docker/overlay2/bb84ca10caa02a052fbc954a97be6248bcd599e52a5ac26b61f1796d146dd453/diff:/var/lib/docker/overlay2/a3c15e84b817a672e5a1273b2640aa4cabd2cf63c30f83fbaa91c2ed676c8032/diff:/var/lib/docker/overlay2/e8f912b3144df4b93b971d88091fb2c5d76e66c61ee92df4af5030726617a21d/diff:/var/lib/docker/overlay2/2c2e5ae28a8424053718d87fb1d3e1dfc57bfecfc4ed2a927fa3a2635b61fdaa/diff:/var/lib/docker/overlay2/de45a85d9813ee0d784e0436c3654cd56f980c80da111f0bb45e8d667f6970e2/diff:/var/lib/docker/overlay2/3e99629fb7ac7eae632355e7708c20f0747a423d81352b9c418d877883fdac43/diff:/var/lib/docker/overlay2/054e6b34f419919cd17764132bc0f3347ca7d8ebe83afb8a7b2823902760b455/diff:/var/lib/docker/overlay2/ec99b1f554cb5c83a3a4855a2b4d6f5faa6203d00014030b2d3addd843ee2307/diff:/var/lib/docker/overlay2/322029f4255d6c5b3882de711401da2345fbaaa39016aa40688673ea4b0e979b/diff:/var/lib/docker/overlay2/16ffdc9ffd366b5d296609f90f91c5ed14bee3bbc231c1dd72c7ac4d30d6fc57/diff
+        MergedDir: /var/lib/docker/overlay2/192248d38a38825d7f6145a20dbf6f08fa7f2bab09221e2c6ed0043762c80df5/merged
+        UpperDir: /var/lib/docker/overlay2/192248d38a38825d7f6145a20dbf6f08fa7f2bab09221e2c6ed0043762c80df5/diff
+        WorkDir: /var/lib/docker/overlay2/192248d38a38825d7f6145a20dbf6f08fa7f2bab09221e2c6ed0043762c80df5/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: iometrics-influxdb-grafana_grafana-data
+        Target: /var/lib/grafana
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-influxdb-grafana
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72/hostname
+    HostsPath: /var/lib/docker/containers/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72/hosts
+    Id: 879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72
+    Image: sha256:d36044c3cbb465635be7c762365fb265c68ae316568a0a609cf8f46b4c31ce2c
+    LogPath: /var/lib/docker/containers/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/lib/grafana
+      Driver: local
+      Mode: z
+      Name: iometrics-influxdb-grafana_grafana-data
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-influxdb-grafana_grafana-data/_data
+      Type: volume
+    Name: /iometrics-influxdb-grafana_grafana.1.s5zrbl40wdkqzmjcohve8xmmg
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - 879dd93dd234
+          DriverOpts: null
+          EndpointID: 8a5fd555ccce13ac8635ee2c8b0ec939fdde19cb472128bd71617837e4df2297
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.26
+          IPAddress: 192.168.4.26
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:1a
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        3000/tcp: null
+      SandboxID: c9dcd06bc72075e6b7c7a59311354b3b8d46f84de8b8c7f328a47cf3a47a1188
+      SandboxKey: /var/run/docker/netns/c9dcd06bc720
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 2841
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:37.813771612Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /entrypoint.sh
+      Env:
+      - LOGLEVEL=DEBUG
+      - NOBITA_IMAGE=nexusregistry.opensolutions.cloud/tokiov1/nobita:0.1.14
+      - ZABBIX_GROUP_ID=15
+      - ZABBIX_PASS=zabbix
+      - ZABBIX_SERVER=zabbix
+      - ZABBIX_TEMPLATE_ID=10264
+      - ZABBIX_URL=http://zabbix/api_jsonrpc.php
+      - ZABBIX_USER=Admin
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - APP_DIR=/app
+      - NOBITA_DELETE_CONTAINER=true
+      - ROBOTFRAMEWORK_TEST_PATH=/opt/robotframework/tests
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: 01dacf67f658
+      Image: nexusregistry.opensolutions.cloud/tokiov1/doraemon:0.1.12@sha256:30a93b0f309fe7e86dc468099d0571fbb5e54a386b1551eac36ee2911f5395e3
+      Labels:
+        com.docker.stack.namespace: iometrics-tokiov1
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: 21rxw3957oetw2rhcrwl85zxy
+        com.docker.swarm.service.name: iometrics-tokiov1_doraemon
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: y5qfta29vj3dysshtzlh27os6
+        com.docker.swarm.task.name: iometrics-tokiov1_doraemon.1.y5qfta29vj3dysshtzlh27os6
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        '[/app]': {}
+      WorkingDir: /app
+    Created: '2022-04-26T14:58:32.420641996Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/3f9c4264296036526fdf3122cb35b5496a5e82b48667592ad548205197bdd928-init/diff:/var/lib/docker/overlay2/e0fa9b6c33a5233d56b98b0ef967436cd243c23fbbf90dffec127435049fa94c/diff:/var/lib/docker/overlay2/f2f695f510d597b62698eda69b20466341231a6650a8ac39f2382701033185a5/diff:/var/lib/docker/overlay2/9470c69741b8b1efec5beaac235e3e71b319555ee07f8dd6a83f1505d9207d2a/diff:/var/lib/docker/overlay2/f573056a516fe87ed9e8e24feb55c07531bd743318e8a918398795670de320bf/diff:/var/lib/docker/overlay2/11e25e640ae0118f09e9059fca35bb34fe18ddd28abac4aa7c4cfe26b8026f72/diff:/var/lib/docker/overlay2/e0c0c4615c41516033dc99b72a99e790a4b9bfcd7b0872fbe8aea0d8ed4de0fe/diff:/var/lib/docker/overlay2/ce00982fa2585615b36a285318149926a84ce1f1919858bc03af462cbdb3826a/diff
+        MergedDir: /var/lib/docker/overlay2/3f9c4264296036526fdf3122cb35b5496a5e82b48667592ad548205197bdd928/merged
+        UpperDir: /var/lib/docker/overlay2/3f9c4264296036526fdf3122cb35b5496a5e82b48667592ad548205197bdd928/diff
+        WorkDir: /var/lib/docker/overlay2/3f9c4264296036526fdf3122cb35b5496a5e82b48667592ad548205197bdd928/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: /var/run/docker.sock
+        Target: /var/run/docker.sock
+        Type: bind
+      - Source: /opt/robotframework/tests
+        Target: /opt/robotframework/tests
+        Type: bind
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce/hostname
+    HostsPath: /var/lib/docker/containers/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce/hosts
+    Id: 01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce
+    Image: sha256:4a76f535ab746d6787d84889a59a65dec896c888bec9b20797c08e6d67b0dab4
+    LogPath: /var/lib/docker/containers/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/run/docker.sock
+      Mode: ''
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/docker.sock
+      Type: bind
+    - Destination: /opt/robotframework/tests
+      Mode: ''
+      Propagation: rprivate
+      RW: true
+      Source: /opt/robotframework/tests
+      Type: bind
+    - Destination: '[/app]'
+      Driver: local
+      Mode: ''
+      Name: f3f659a45f46ac548a9590cbc4796a902ecb2b992aece00ff75a1df7585f2b12
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/f3f659a45f46ac548a9590cbc4796a902ecb2b992aece00ff75a1df7585f2b12/_data
+      Type: volume
+    Name: /iometrics-tokiov1_doraemon.1.y5qfta29vj3dysshtzlh27os6
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - 01dacf67f658
+          DriverOpts: null
+          EndpointID: 02d7cc1a5d3a03f8e5ed9fdd28b6107acb8606beb4e3d4c0c54d05752c70ae24
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.17
+          IPAddress: 192.168.4.17
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:11
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        80/tcp: null
+      SandboxID: d89f428f7b5da99d2a91bdeae474d5b9b02d7e2552b6face97a800acad735e83
+      SandboxKey: /var/run/docker/netns/d89f428f7b5d
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3380
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:39.427858261Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args:
+    - /opt/bitnami/scripts/tomcat/run.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /opt/bitnami/scripts/tomcat/run.sh
+      Domainname: ''
+      Entrypoint:
+      - /opt/bitnami/scripts/jasperreports/entrypoint.sh
+      Env:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - JASPERREPORTS_DATABASE_NAME=jasperreport
+      - JASPERREPORTS_DATABASE_USER=admin
+      - JASPERREPORTS_PASSWORD=admin
+      - JASPERREPORTS_USERNAME=admin
+      - MARIADB_HOST=mariadb
+      - MARIADB_PORT_NUMBER=3306
+      - TZ="Europe/Madrid"
+      - PATH=/opt/bitnami/java/bin:/opt/bitnami/tomcat/bin:/opt/bitnami/mysql/bin:/opt/bitnami/git/bin:/opt/bitnami/common/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - HOME=/
+      - OS_ARCH=amd64
+      - OS_FLAVOUR=debian-10
+      - OS_NAME=linux
+      - BITNAMI_APP_NAME=jasperreports
+      - BITNAMI_IMAGE_VERSION=7.8.0-debian-10-r322
+      - MARIADB_ROOT_PASSWORD=
+      - MARIADB_ROOT_USER=root
+      - MYSQL_CLIENT_CREATE_DATABASE_NAME=
+      - MYSQL_CLIENT_CREATE_DATABASE_PASSWORD=
+      - MYSQL_CLIENT_CREATE_DATABASE_PRIVILEGES=ALL
+      - MYSQL_CLIENT_CREATE_DATABASE_USER=
+      - MYSQL_CLIENT_ENABLE_SSL=no
+      - MYSQL_CLIENT_SSL_CA_FILE=
+      ExposedPorts:
+        8009/tcp: {}
+        8080/tcp: {}
+        8443/tcp: {}
+      Hostname: cdb768fd554e
+      Image: bitnami/jasperreports:7-debian-10@sha256:79688cbe1217ab27ddec20a33a34ff449fbe3a3ee4bfc342cce0e1bc49a4c24c
+      Labels:
+        com.docker.stack.namespace: iometrics-reporter
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: c4j05xv0edxsvo0xz152on1xf
+        com.docker.swarm.service.name: iometrics-reporter_jasperreports
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: 5q63h0wg3e0vykeww8r6vytpz
+        com.docker.swarm.task.name: iometrics-reporter_jasperreports.1.5q63h0wg3e0vykeww8r6vytpz
+        maintainer: Bitnami <containers@bitnami.com>
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: '1001'
+      Volumes: null
+      WorkingDir: ''
+    Created: '2022-04-26T14:58:32.417192319Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/15532e05b91dfd64cff90b986ef94e67ec6b8cd827b7718c68081b0730bc0055-init/diff:/var/lib/docker/overlay2/381189b72bd5fb3646fe8313ec0382563fa1c82cbc14297ab66a3c2e174c0024/diff:/var/lib/docker/overlay2/ec81616ad58a19087927ee1539869ec80b496addcbd484a78556c91e0c8c1f4d/diff:/var/lib/docker/overlay2/bfea1030abaf8711e35e73207f761e495bf6c405b163c231caee970d781155db/diff:/var/lib/docker/overlay2/0575075cb2d6e153151759f4d537b665870e7a617b60625308f78f5d2add95aa/diff:/var/lib/docker/overlay2/a7a4c8647c4f3256540edac046bba045c9e89e26fe4692f8729c2d2d927b9a5b/diff:/var/lib/docker/overlay2/3236c64a445b65ae11fc54c7dfdd8e12a6ad120613a63db3ff382e074484dedc/diff:/var/lib/docker/overlay2/5469ddf4621e7fee374511e4b5bf5df8d7add91e6ed14813f49c35d7cf058bcd/diff:/var/lib/docker/overlay2/95a0109c88499fb73e231fea68fd8a50644ab5ec78c22927b5f6ad8f6dffb255/diff:/var/lib/docker/overlay2/1017c2e98c414e568e8dfb0ec581e8bb4bbaef8cc26a9f34345a026907650153/diff:/var/lib/docker/overlay2/f8e4f4f57bc111e0b42602559ee5a563e88f803d6477faf7ddc3938be4ae0d8d/diff:/var/lib/docker/overlay2/c03248c6b0f4506110c4331e61a754062f460ff49173f71cd490f20e43c975df/diff:/var/lib/docker/overlay2/9e73143bde40de50785dbec9f55b17bdc4c71135361b696e3b27bf889d66b7cb/diff:/var/lib/docker/overlay2/a8e8bf4f3018978b500affeb1c977ae1fc9e2ed68a1987ee16988bcc04519922/diff:/var/lib/docker/overlay2/26a334fee69317bf7aaa0d2ea738778c1cd604b78e8505ddf9612a117109aa50/diff:/var/lib/docker/overlay2/d6022d7f3341bc30a594cebed98e0f7563c19316ca7bc8a2828fb263a5925984/diff
+        MergedDir: /var/lib/docker/overlay2/15532e05b91dfd64cff90b986ef94e67ec6b8cd827b7718c68081b0730bc0055/merged
+        UpperDir: /var/lib/docker/overlay2/15532e05b91dfd64cff90b986ef94e67ec6b8cd827b7718c68081b0730bc0055/diff
+        WorkDir: /var/lib/docker/overlay2/15532e05b91dfd64cff90b986ef94e67ec6b8cd827b7718c68081b0730bc0055/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: iometrics-reporter_jasperreports_data
+        Target: /bitnami
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-reporter
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4/hostname
+    HostsPath: /var/lib/docker/containers/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4/hosts
+    Id: cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4
+    Image: sha256:271280ba9644a0a71b1c650fcd117d77afaa5f8baac17a0f31a91968fdd6a8ef
+    LogPath: /var/lib/docker/containers/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /bitnami
+      Driver: local
+      Mode: z
+      Name: iometrics-reporter_jasperreports_data
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-reporter_jasperreports_data/_data
+      Type: volume
+    Name: /iometrics-reporter_jasperreports.1.5q63h0wg3e0vykeww8r6vytpz
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - cdb768fd554e
+          DriverOpts: null
+          EndpointID: 5fc6b71f8201a2f86b627168135a8f2f8666ca245265d3b4ea0ef7268a94802d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.21
+          IPAddress: 192.168.4.21
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:15
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        8009/tcp: null
+        8080/tcp: null
+        8443/tcp: null
+      SandboxID: 58e7593dddba78cf1314b5bf286027701a2c277002a18baa878148aab1621f94
+      SandboxKey: /var/run/docker/netns/58e7593dddba
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /opt/bitnami/scripts/jasperreports/entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3242
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:44.066964241Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args:
+    - /bin/s6-svscan
+    - /etc/s6
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/s6-svscan
+      - /etc/s6
+      Domainname: ''
+      Entrypoint:
+      - /usr/bin/entrypoint
+      Env:
+      - DB_HOST=git-db:5432
+      - DB_NAME=gitea
+      - DB_PASSWD=admin
+      - DB_TYPE=postgres
+      - DB_USER=admin
+      - SKIP_TLS_VERIFY=true
+      - SSH_DOMAIN=git.robotito.lab.iometrics.io
+      - USER_GID=1000
+      - USER_UID=1000
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - USER=git
+      - GITEA_CUSTOM=/data/gitea
+      ExposedPorts:
+        22/tcp: {}
+        3000/tcp: {}
+      Hostname: 8c55132b38ba
+      Image: gitea/gitea:1.11.4@sha256:5f4470925ea02b0a6c518e1d6658f2b39c0c4fb60600915c388331b19b5f97dd
+      Labels:
+        com.docker.stack.namespace: iometrics-cicd
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: x5t22c0qj2puvia30103if0l2
+        com.docker.swarm.service.name: iometrics-cicd_git
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: c01gjdokgyg4g92sb657mg2d3
+        com.docker.swarm.task.name: iometrics-cicd_git.1.c01gjdokgyg4g92sb657mg2d3
+        maintainer: maintainers@gitea.io
+        org.label-schema.build-date: '2020-04-01T17:13:06Z'
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.vcs-ref: 3afbbfe921c5fb5b71555ffdf60bcdbb8b227d8a
+        org.label-schema.vcs-url: https://github.com/go-gitea/gitea.git
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+      WorkingDir: ''
+    Created: '2022-04-26T14:58:32.32067015Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/5a61df80c21a3a5bd09cf536dceb5ad2d6c9a4fb2f28401c15fa174e574432c2-init/diff:/var/lib/docker/overlay2/05bdb218c8021e608f313ad7c58fdcf433fda3ad24bb101bcb5a9788ee15f913/diff:/var/lib/docker/overlay2/9baf0e2eac3bf90813d0373b3545ce535cc093c97be98aa155130a283661469b/diff:/var/lib/docker/overlay2/823e10125c5b65c55ea3b916f1d4be281facabcee516de6bb6305c9c7da6d3e1/diff:/var/lib/docker/overlay2/0963476208f641b2861f54c53f2210c8b3b5835d8acc09b69261b6503b1224c2/diff:/var/lib/docker/overlay2/4f16b1b02abacb254a016b9758908bc97c198fb8cf91362f2b42e2b14b6c0e59/diff:/var/lib/docker/overlay2/c2c6ee6e6f1813b910ae7c4bc8e4c7092265792e2fbc51cdbc5e0379eaf948e1/diff
+        MergedDir: /var/lib/docker/overlay2/5a61df80c21a3a5bd09cf536dceb5ad2d6c9a4fb2f28401c15fa174e574432c2/merged
+        UpperDir: /var/lib/docker/overlay2/5a61df80c21a3a5bd09cf536dceb5ad2d6c9a4fb2f28401c15fa174e574432c2/diff
+        WorkDir: /var/lib/docker/overlay2/5a61df80c21a3a5bd09cf536dceb5ad2d6c9a4fb2f28401c15fa174e574432c2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: iometrics-cicd_gitea-data
+        Target: /data
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-cicd
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec/hostname
+    HostsPath: /var/lib/docker/containers/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec/hosts
+    Id: 8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec
+    Image: sha256:194c2480b6fbff60d3f9bf4b18beea94d82c787497b1a60ce569ddb48643dcce
+    LogPath: /var/lib/docker/containers/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data
+      Driver: local
+      Mode: z
+      Name: iometrics-cicd_gitea-data
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-cicd_gitea-data/_data
+      Type: volume
+    Name: /iometrics-cicd_git.1.c01gjdokgyg4g92sb657mg2d3
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        ingress:
+          Aliases:
+          - 8c55132b38ba
+          DriverOpts: null
+          EndpointID: 1ae5c1684cd9e526d3ad44461114d9868f37301b328f2df9d77868c36fdbbd1b
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.10.10
+          IPAddress: 192.168.10.10
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:ff:00:0a
+          NetworkID: 8mvsot5titaaepgeuh3z5d6el
+        iometrics-public:
+          Aliases:
+          - 8c55132b38ba
+          DriverOpts: null
+          EndpointID: e6c58716836f77eaa4dc6d23021e214d3f7ec26bd53c7e055182b74f048146ee
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.28
+          IPAddress: 192.168.4.28
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:1c
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        22/tcp: null
+        3000/tcp: null
+      SandboxID: d98e7a6c2aaf7b146db63923c336b11583f91d0ad4915b21c02312bdc8e372a8
+      SandboxKey: /var/run/docker/netns/d98e7a6c2aaf
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/bin/entrypoint
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3784
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:44.941616583Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args:
+    - telegraf
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - telegraf
+      Domainname: ''
+      Entrypoint:
+      - /entrypoint.sh
+      Env:
+      - AGENT_MONITOR_DATABASE=telegraf
+      - AGENT_MONITOR_HOST=http://influxdb:8086
+      - AGENT_MONITOR_PASSWORD=telegraf
+      - AGENT_MONITOR_USERNAME=telegraf
+      - CLIENT_NAME=iometrics
+      - CLIENT_TYPE=infraestructure
+      - CLUSTER=robotito.lab.iometrics.io
+      - HOSTNAME=synthetix-worker01
+      - HOST_MOUNT_PREFIX=/hostfs
+      - HOST_PROC=/hostfs/proc
+      - INFRA_MONITOR_DATABASE=swarm
+      - INFRA_MONITOR_HOST=http://influxdb:8086
+      - INFRA_MONITOR_PASSWORD=swarm
+      - INFRA_MONITOR_USERNAME=swarm
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - TELEGRAF_VERSION=1.18.2
+      ExposedPorts:
+        8092/udp: {}
+        8094/tcp: {}
+        8125/udp: {}
+      Hostname: wh12ct3jzpllqaj4mv233ey4f
+      Image: telegraf:latest@sha256:bbe1dcfda1a7c5ab9c03abd3014874ea78edd64dbbf8e09880b1d78bec4ae6ff
+      Labels:
+        com.docker.stack.namespace: iometrics-influxdb-grafana
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: n7snet96arr2vwb2988cji3ej
+        com.docker.swarm.service.name: iometrics-influxdb-grafana_telegraf
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: fwkcidtl0wrghgri2podb7wbm
+        com.docker.swarm.task.name: iometrics-influxdb-grafana_telegraf.wh12ct3jzpllqaj4mv233ey4f.fwkcidtl0wrghgri2podb7wbm
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: ''
+    Created: '2022-04-26T14:58:32.284749778Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/dd2e83b1258964407377e36296e3891cd8e7763928576dce6496b9b4b80f2496-init/diff:/var/lib/docker/overlay2/71ffb2821d15bbe09f3970691db55e745537d7011178c561356eff7c94c1b65d/diff:/var/lib/docker/overlay2/e707e1ce5f6d7c852af13510744ab1f22b867895ebc2401954bf18ec9beaa2a8/diff:/var/lib/docker/overlay2/69bb4d9d1e3ccdb5c87394c0fe19802ea613e068d8cbee3a8f34733a2048662f/diff:/var/lib/docker/overlay2/40c6a882ac823e75c33e28db30b10bf17b2f7f746e6315d4e594a4c5813e3272/diff:/var/lib/docker/overlay2/6030db9539e5eba21394fc5f6c84913911d47b9d6f8a627cb1b0b452190520f7/diff:/var/lib/docker/overlay2/bcd13b47b64c2b2d938ac00a950727beefcc423178625d366f4e4837a3ab5888/diff:/var/lib/docker/overlay2/7f07db2d4d9e64706002df00bb03b55e4959b62b0d0e38b41a0038db1f71297f/diff
+        MergedDir: /var/lib/docker/overlay2/dd2e83b1258964407377e36296e3891cd8e7763928576dce6496b9b4b80f2496/merged
+        UpperDir: /var/lib/docker/overlay2/dd2e83b1258964407377e36296e3891cd8e7763928576dce6496b9b4b80f2496/diff
+        WorkDir: /var/lib/docker/overlay2/dd2e83b1258964407377e36296e3891cd8e7763928576dce6496b9b4b80f2496/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - ReadOnly: true
+        Source: /
+        Target: /hostfs
+        Type: bind
+      - Source: /var/run/docker.sock
+        Target: /var/run/docker.sock
+        Type: bind
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272/hostname
+    HostsPath: /var/lib/docker/containers/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272/hosts
+    Id: f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272
+    Image: sha256:c09835a46c6a12928f91f8450f7aaba668b0210ca4b4efc2e9404ad9307d036c
+    LogPath: /var/lib/docker/containers/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /hostfs
+      Mode: ''
+      Propagation: rslave
+      RW: false
+      Source: /
+      Type: bind
+    - Destination: /var/run/docker.sock
+      Mode: ''
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/docker.sock
+      Type: bind
+    Name: /iometrics-influxdb-grafana_telegraf.wh12ct3jzpllqaj4mv233ey4f.fwkcidtl0wrghgri2podb7wbm
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - f8d0dafa40a0
+          DriverOpts: null
+          EndpointID: 8efad8a405d4bb9835a4dfcb4f0e6fadc72fffdf7337438be6e0bae7c79c0b2a
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.46
+          IPAddress: 192.168.4.46
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:2e
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        8092/udp: null
+        8094/tcp: null
+        8125/udp: null
+      SandboxID: d81bb311b7bdebe5d5f26684df3ffb31bc8ef1bb258371aebab436145f2445f7
+      SandboxKey: /var/run/docker/netns/d81bb311b7bd
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3112
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:38.760432309Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args:
+    - /opt/bitnami/scripts/mariadb/run.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /opt/bitnami/scripts/mariadb/run.sh
+      Domainname: ''
+      Entrypoint:
+      - /opt/bitnami/scripts/mariadb/entrypoint.sh
+      Env:
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MARIADB_DATABASE=jasperreport
+      - MARIADB_USER=admin
+      - PATH=/opt/bitnami/common/bin:/opt/bitnami/mariadb/bin:/opt/bitnami/mariadb/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - HOME=/
+      - OS_ARCH=amd64
+      - OS_FLAVOUR=debian-10
+      - OS_NAME=linux
+      - BITNAMI_APP_NAME=mariadb
+      - BITNAMI_IMAGE_VERSION=10.3.31-debian-10-r33
+      ExposedPorts:
+        3306/tcp: {}
+      Hostname: 8071bb422bac
+      Image: bitnami/mariadb:10.3-debian-10@sha256:ce8a9c2db3e868f440dc4e15f6bb80871388d3798939c6ad0a14269727fb935d
+      Labels:
+        com.docker.stack.namespace: iometrics-reporter
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: xvywi6ktad7s9jot8ha6y2qxj
+        com.docker.swarm.service.name: iometrics-reporter_mariadb
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: jococetrpj2hs7ius7c6mkxf5
+        com.docker.swarm.task.name: iometrics-reporter_mariadb.1.jococetrpj2hs7ius7c6mkxf5
+        maintainer: Bitnami <containers@bitnami.com>
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: '1001'
+      Volumes: null
+      WorkingDir: ''
+    Created: '2022-04-26T14:58:32.255743503Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/19ac661ee97a08f8a1d44687008b6b0076b35923cb2b19148e27cd4b7662cb22-init/diff:/var/lib/docker/overlay2/5db53748954d97cd1ef4005914eed0322f2078a55dfaa61af8d086618b488aae/diff:/var/lib/docker/overlay2/8e7ed2e7ffe4a6bc328004ab4a7fe5673d6469b72a5f9ffc2bc7cba36abbb363/diff:/var/lib/docker/overlay2/62b25b57f464f3cb683127ebc29148ac52997c20bf79869d61d9616280da3e3c/diff:/var/lib/docker/overlay2/a7b3e558376c755b47d6064040dcedd05cab7fd146f23b6b6b40633cfdcd3a37/diff:/var/lib/docker/overlay2/8a1c5bd77f1d7f2c1b24c8bc54c39ce204a01b531d4e6d20eaa1bfb43d2793d2/diff:/var/lib/docker/overlay2/bf55c9843ef497be08ec5e0160797da5aa9d42c5057068cb2f065552a024dc41/diff:/var/lib/docker/overlay2/7a815ccceb764fe4e989f5a7c817ae8aff03292eae66cf94c7f161166498e59d/diff:/var/lib/docker/overlay2/06e6a6ac463782ae9b4b554de2defe652a2cf646ebbadd24627864bf6d18e4a2/diff:/var/lib/docker/overlay2/fc7740507940da47ea924acc3caee0907ed8a1c30c8a7def799c50eec2c4b621/diff:/var/lib/docker/overlay2/d6022d7f3341bc30a594cebed98e0f7563c19316ca7bc8a2828fb263a5925984/diff
+        MergedDir: /var/lib/docker/overlay2/19ac661ee97a08f8a1d44687008b6b0076b35923cb2b19148e27cd4b7662cb22/merged
+        UpperDir: /var/lib/docker/overlay2/19ac661ee97a08f8a1d44687008b6b0076b35923cb2b19148e27cd4b7662cb22/diff
+        WorkDir: /var/lib/docker/overlay2/19ac661ee97a08f8a1d44687008b6b0076b35923cb2b19148e27cd4b7662cb22/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: iometrics-reporter_mariadb_data
+        Target: /bitnami
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-reporter
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e/hostname
+    HostsPath: /var/lib/docker/containers/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e/hosts
+    Id: 8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e
+    Image: sha256:7318d6f52b002fffaa05d851ec647cc981ababd9319f8da4487babd992a53ea2
+    LogPath: /var/lib/docker/containers/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /bitnami
+      Driver: local
+      Mode: z
+      Name: iometrics-reporter_mariadb_data
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-reporter_mariadb_data/_data
+      Type: volume
+    Name: /iometrics-reporter_mariadb.1.jococetrpj2hs7ius7c6mkxf5
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - 8071bb422bac
+          DriverOpts: null
+          EndpointID: af07f30c6e05169605d3ba106ca9a6b9df43d5d606c43c18e212581a03cfeaab
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.20
+          IPAddress: 192.168.4.20
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:14
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        3306/tcp: null
+      SandboxID: 18b3cb3f5649461f1c8e4a73ac453409200f72a1eaf8a8c0fd6994c69f5e9fd3
+      SandboxKey: /var/run/docker/netns/18b3cb3f5649
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /opt/bitnami/scripts/mariadb/entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3184
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:38.170800352Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - ./bin/synthetix-agent
+      Env:
+      - SYA_AGENT_CLONE_IMAGE=alpine/git
+      - SYA_AGENT_EXTRA_ENV=GIT_SSL_NO_VERIFY:"true",TEST_VAR:"mytest"
+      - SYA_AGENT_EXTRA_NETWORKS=iometrics-public
+      - SYA_AGENT_LOG_EXTRA_ON_FILES=false
+      - SYA_AGENT_LOG_LEVEL=debug
+      - SYA_AGENT_MAX_PARALLEL_EXEC=20
+      - SYA_MANAGER_ENDPOINT=https://sym:7070
+      - SYA_MANAGER_PASSWORD=admin
+      - SYA_MANAGER_SKIP_TLS_VERIFY=true
+      - SYA_NODEID=synthetix-worker01
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - PATHS_HOME=/opt/iometrics-synthetix-agent/
+      Hostname: synthetix-worker01
+      Image: nexusregistry.opensolutions.cloud/iometrics-synthetix-agent:0.6.0@sha256:20e652769dccc49bb65527b0d67f949264d1daee8f338ae4a69b68093792acb5
+      Labels:
+        com.docker.stack.namespace: iometrics-cicd
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: 1l57fyo6z9nl94r5xepjbqz57
+        com.docker.swarm.service.name: iometrics-cicd_sya
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: isx6lr7eq7lhfd8ydzvktbzs3
+        com.docker.swarm.task.name: iometrics-cicd_sya.wh12ct3jzpllqaj4mv233ey4f.isx6lr7eq7lhfd8ydzvktbzs3
+        maintainer: Datadope team <hello@datadope.io>
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: /opt/iometrics-synthetix-agent
+    Created: '2022-04-26T14:58:32.205472884Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/821d27d31217988044bc4bf681c17b4f7d2a633d92c9255f12e01fa1ec8586f5-init/diff:/var/lib/docker/overlay2/7c0f66c943350b58106a7e28331439e175588e8eb4d267acb5bd81a94bf4769b/diff:/var/lib/docker/overlay2/a7cbd4f757675c74d9f1c3522db76c99c5d12fb86d5b5418230485e30c7710a4/diff:/var/lib/docker/overlay2/37ad486043fbbc2ae00636fd3547ea2a56bd4d9e972e1654ae99137ac3f84634/diff:/var/lib/docker/overlay2/a997600d0ae26706e04b08d3a7391f76405aec12da65cdcecc0fcdd0e6ed318e/diff
+        MergedDir: /var/lib/docker/overlay2/821d27d31217988044bc4bf681c17b4f7d2a633d92c9255f12e01fa1ec8586f5/merged
+        UpperDir: /var/lib/docker/overlay2/821d27d31217988044bc4bf681c17b4f7d2a633d92c9255f12e01fa1ec8586f5/diff
+        WorkDir: /var/lib/docker/overlay2/821d27d31217988044bc4bf681c17b4f7d2a633d92c9255f12e01fa1ec8586f5/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: /var/run/docker.sock
+        Target: /var/run/docker.sock
+        Type: bind
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733/hostname
+    HostsPath: /var/lib/docker/containers/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733/hosts
+    Id: dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733
+    Image: sha256:9f76922121ae515bca5f2a65836ba0075102ad819fafe49aaef5e88ea3fdeac6
+    LogPath: /var/lib/docker/containers/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/run/docker.sock
+      Mode: ''
+      Propagation: rprivate
+      RW: true
+      Source: /var/run/docker.sock
+      Type: bind
+    Name: /iometrics-cicd_sya.wh12ct3jzpllqaj4mv233ey4f.isx6lr7eq7lhfd8ydzvktbzs3
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - dbce739954ef
+          DriverOpts: null
+          EndpointID: 0e3376430c2c41cda7e392bf6e734f6fa5f37cf047f1e5f469a7fcc4029adade
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.43
+          IPAddress: 192.168.4.43
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:2b
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports: {}
+      SandboxID: 2b496e9f6bdc8d81990c775d2c6c840791a63e6cb093054586903ea1ec617411
+      SandboxKey: /var/run/docker/netns/2b496e9f6bdc
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: ./bin/synthetix-agent
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3217
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:37.290708838Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args:
+    - telegraf
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - telegraf
+      Domainname: ''
+      Entrypoint:
+      - /entrypoint.sh
+      Env:
+      - AGENT_MONITOR_DATABASE=telegraf
+      - AGENT_MONITOR_HOST=http://influxdb:8086
+      - AGENT_MONITOR_PASSWORD=telegraf
+      - AGENT_MONITOR_USERNAME=telegraf
+      - CLIENT_NAME=carrefour
+      - CLIENT_TYPE=zabbix
+      - CLUSTER=robotito.lab.iometrics.io
+      - HOSTNAME=zabbix-gw-c4
+      - INPUT_PASSWORD=gw-c4-pass
+      - INPUT_USERNAME=gw-c4-user
+      - PROVE_MONITOR_DATABASE=sondas
+      - PROVE_MONITOR_HOST=http://influxdb:8086
+      - PROVE_MONITOR_PASSWORD=sondas
+      - PROVE_MONITOR_USERNAME=sondas
+      - ZABBIX_HOST=zabbix
+      - ZABBIX_HOST_PREFIX=functional..synthetix__
+      - ZABBIX_PORT=10051
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      ExposedPorts:
+        8092/udp: {}
+        8094/tcp: {}
+        8125/udp: {}
+      Hostname: zabbix-gw-c4
+      Image: nexusregistry.opensolutions.cloud/iometrics-telegraf-gw:latest@sha256:38af36a42b2382665f509bb75d497055fcefe3e9138ead86a501d1320a2bd306
+      Labels:
+        com.docker.stack.namespace: iometrics-synthetix-zabbixgw
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: 2zkn4u7pkbhvam638401wwvfx
+        com.docker.swarm.service.name: iometrics-synthetix-zabbixgw_zabbix-gw-c4
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: zf1pep45dqgpltg21ipp7qp1w
+        com.docker.swarm.task.name: iometrics-synthetix-zabbixgw_zabbix-gw-c4.1.zf1pep45dqgpltg21ipp7qp1w
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: ''
+    Created: '2022-04-26T14:58:32.170410819Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/3745bc3d51d07847b584689e57d61680f2faead6bf7eef089d1c4f4466166daa-init/diff:/var/lib/docker/overlay2/f6e0d2e10522c8f6064b913cb46e6ea7965f8ad56d2f7bb6aee248f3005f8f0d/diff:/var/lib/docker/overlay2/754ed454e59a6df2c23418025a11de8cd389999c89f4570d67202850b7255e8a/diff:/var/lib/docker/overlay2/4e324a393ad45acd94998cd32b02e5b759a70575f13a7e4d61207365760be0d8/diff:/var/lib/docker/overlay2/33fbfafd655518c8a5662ef8e8d79e5bd491f110a752b2b4d11b4984b6327277/diff:/var/lib/docker/overlay2/6357c9fef2def12a89a5de28ed7e549ef39970e979e48fc0c0f5c8ba508a0a11/diff:/var/lib/docker/overlay2/e9ec2562ae19beb76bc9ea209f2a9bab4c712cbc452ee4a7405294f7dd904824/diff
+        MergedDir: /var/lib/docker/overlay2/3745bc3d51d07847b584689e57d61680f2faead6bf7eef089d1c4f4466166daa/merged
+        UpperDir: /var/lib/docker/overlay2/3745bc3d51d07847b584689e57d61680f2faead6bf7eef089d1c4f4466166daa/diff
+        WorkDir: /var/lib/docker/overlay2/3745bc3d51d07847b584689e57d61680f2faead6bf7eef089d1c4f4466166daa/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a/hostname
+    HostsPath: /var/lib/docker/containers/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a/hosts
+    Id: 197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a
+    Image: sha256:d3eb0a7fb08d02be6df5e5d8eac58fd6a3d97cbbfc8dfb154a7942b74f77264c
+    LogPath: /var/lib/docker/containers/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a-json.log
+    MountLabel: ''
+    Mounts: []
+    Name: /iometrics-synthetix-zabbixgw_zabbix-gw-c4.1.zf1pep45dqgpltg21ipp7qp1w
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - 197d7bfae539
+          DriverOpts: null
+          EndpointID: d7011cce71b4f37f40767afe43601643306b75d3bb1123547571a0a39f73b8e8
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.22
+          IPAddress: 192.168.4.22
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:16
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports:
+        8092/udp: null
+        8094/tcp: null
+        8125/udp: null
+      SandboxID: 7cf897b69e6d91442c811460ac98926c851d635c7b5876780c01120ceba7d7fa
+      SandboxKey: /var/run/docker/netns/7cf897b69e6d
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 2829
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:35.926894398Z'
+      Status: running
+  - AppArmorProfile: docker-default
+    Args:
+    - -c
+    - /app/deployment/run.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /bin/sh
+      - -c
+      - /app/deployment/run.sh
+      Env:
+      - CONFIG_PATH=/app/config/config.yml
+      - DEBUG=False
+      - DJANGO_SECRET=the_sectet
+      - INFLUX_DB=sondas
+      - INFLUX_ORG="undefined"
+      - INFLUX_PASSWORD=admin
+      - INFLUX_TOKEN=admin:admin
+      - INFLUX_URL=http://influxdb:8086
+      - INFLUX_USER=admin
+      - POSTGRES_DB=reports
+      - POSTGRES_HOST=api-reporter-db
+      - POSTGRES_PASSWORD=admin
+      - POSTGRES_PORT=5432
+      - POSTGRES_USER=admin
+      - PROJECT_NAME=reports
+      - VISIBLE_NAME=iometrics-reports-api
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.12
+      - PYTHON_PIP_VERSION=21.2.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/c20b0cfd643cd4a19246ccf204e2997af70f6b21/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=fa6f3fb93cce234cd4e8dd2beb54a51ab9c247653b52855a48dd44e6b21ff28b
+      - PYTHONUNBUFFERED=1
+      Hostname: d9af2818dd47
+      Image: nexusregistry.opensolutions.cloud/iometrics-reports-api:0.2.0@sha256:251318e5f3012ee198bbda8615e5a25e3f5b7e78d9063d4ed95d947e9985917b
+      Labels:
+        com.docker.stack.namespace: iometrics-reporter
+        com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
+        com.docker.swarm.service.id: 44smkfxqlkwsywldlzecpz8vs
+        com.docker.swarm.service.name: iometrics-reporter_api-reporter
+        com.docker.swarm.task: ''
+        com.docker.swarm.task.id: u7ofji81lo2m8et3mccdvnya9
+        com.docker.swarm.task.name: iometrics-reporter_api-reporter.1.u7ofji81lo2m8et3mccdvnya9
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: /app
+    Created: '2022-04-26T14:58:32.139168553Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/4d2b772fbe4d6e59893564ee46472c40328b6930701d27995a8f84eee2fb0492-init/diff:/var/lib/docker/overlay2/a5f6129e1829eeb3db6f44890351d13b027f445ed34b84832f5cdaaf4eecfc5d/diff:/var/lib/docker/overlay2/696a11811953881d28b122ea78cac9c1a9d049d06ab119e195925707951257f7/diff:/var/lib/docker/overlay2/ca21abe5d706ad12989357241dd886f0dded9a039cbc29721f007e8897274037/diff:/var/lib/docker/overlay2/e5e00a7c22de761b0a00e7622033e968cc24610c3dacfc268646c63b30624150/diff:/var/lib/docker/overlay2/9baae4f5c43987e2e5f18c37d65f3a42f80ab67e13c2f7e97ae6d6212d298008/diff:/var/lib/docker/overlay2/86245cf52855badc4c7728b645327b3dbb4180e7c613fe927a43ad054c7bf107/diff:/var/lib/docker/overlay2/e0cc7e7cd693b2f905b7f8cbe5d426af923ccef498b42b14f7de3400a48039f9/diff:/var/lib/docker/overlay2/ef27cbccc9a1f3dc10c4656c6d041b8ea13536469f1331e3fe5a2475a473c8ae/diff:/var/lib/docker/overlay2/335b0aff5d293f39af577ec5acb0370c9d2efd669ec23dc6aae8980933f15c51/diff:/var/lib/docker/overlay2/97451a128b45ada6fa64a6ab767244d139f6b3eb64384e07cf005d977aa9e82e/diff:/var/lib/docker/overlay2/34c7889309c653ee601e2e559c26bfbbaeb1beb00f6cea5a67cf79ed820be5f3/diff:/var/lib/docker/overlay2/6534599c817e4349aa8184d38c29cbb463736e991aa7ae6149e6503e47d75c2f/diff:/var/lib/docker/overlay2/1842feadd3c48ff0ed0891ed43ed53c8526a47767b672a5be692f823959028f7/diff:/var/lib/docker/overlay2/0d80c04b52c5020a9fff38fb861299236d3440dc793248bfdbd8fce40f1911d3/diff:/var/lib/docker/overlay2/17303406407ac530d79da413de6bef0c0151447cff6b2ed9e5bd55ab75b6e3cb/diff:/var/lib/docker/overlay2/5476e3b6ce212f67771d09b0c3991e594b2c32e83f7a38aff551f8cde6477822/diff:/var/lib/docker/overlay2/b35d75043f9126e4c7d3b4ebd5dcf5e5bf0376fb011185878356ef78a0400ded/diff:/var/lib/docker/overlay2/51251e8f2c59118d5051d6858d75d7a9528800af88e28a8ce5bfc6037bb23aff/diff:/var/lib/docker/overlay2/4260980d71d22b9da6aeb5fd7a7d0390ad7a63762f782ba5e512542eee07efb5/diff:/var/lib/docker/overlay2/16034b5628ed069710d72755f014e19c2738f5e27c39807eea352d743a32b1c4/diff:/var/lib/docker/overlay2/8f668a8d30c490c3cd10d0785b3f14f23817dcb7c4eab6193528b31738d9ef24/diff:/var/lib/docker/overlay2/cb6b76270d5a16be67dfecbeb06f3a167fd9d45be171f2d46dff6878f4672e75/diff
+        MergedDir: /var/lib/docker/overlay2/4d2b772fbe4d6e59893564ee46472c40328b6930701d27995a8f84eee2fb0492/merged
+        UpperDir: /var/lib/docker/overlay2/4d2b772fbe4d6e59893564ee46472c40328b6930701d27995a8f84eee2fb0492/diff
+        WorkDir: /var/lib/docker/overlay2/4d2b772fbe4d6e59893564ee46472c40328b6930701d27995a8f84eee2fb0492/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: default
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      Mounts:
+      - Source: iometrics-reporter_media
+        Target: /app/media
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-reporter
+      - Source: iometrics-reporter_static
+        Target: /app/static
+        Type: volume
+        VolumeOptions:
+          Labels:
+            com.docker.stack.namespace: iometrics-reporter
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f/hostname
+    HostsPath: /var/lib/docker/containers/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f/hosts
+    Id: d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f
+    Image: sha256:ba8abc8188002cc73f7d1beb47144e893c8c0d09cb34668c40d0e8f2f756a68b
+    LogPath: /var/lib/docker/containers/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/media
+      Driver: local
+      Mode: z
+      Name: iometrics-reporter_media
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-reporter_media/_data
+      Type: volume
+    - Destination: /app/static
+      Driver: local
+      Mode: z
+      Name: iometrics-reporter_static
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/iometrics-reporter_static/_data
+      Type: volume
+    Name: /iometrics-reporter_api-reporter.1.u7ofji81lo2m8et3mccdvnya9
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        iometrics-public:
+          Aliases:
+          - d9af2818dd47
+          DriverOpts: null
+          EndpointID: 16f5495c7cc135ea47ba21758cd0e405a213d94ee7b6a123ceaf85b0315b5299
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig:
+            IPv4Address: 192.168.4.25
+          IPAddress: 192.168.4.25
+          IPPrefixLen: 24
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:0a:00:00:19
+          NetworkID: f1h1vvijaxvypulabix98fsue
+      Ports: {}
+      SandboxID: f4a42d18ad7a1594a8cc8a02207df5660f8017cb689e97e044ab9f56d761214a
+      SandboxKey: /var/run/docker/netns/f4a42d18ad7a
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 3014
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:58:38.853167441Z'
+      Status: running
+expected_result:
+- bindings: []
+  configuration:
+    datestyle: iso, mdy
+    default_text_search_config: pg_catalog.english
+    dynamic_shared_memory_type: posix
+    lc_messages: en_US.utf8
+    lc_monetary: en_US.utf8
+    lc_numeric: en_US.utf8
+    lc_time: en_US.utf8
+    listen_addresses: '*'
+    log_timezone: UTC
+    max_connections: '100'
+    max_wal_size: 1GB
+    min_wal_size: 80MB
+    shared_buffers: 128MB
+    timezone: UTC
+  discovery_time: '2022-06-02T14:25:49+02:00'
+  docker:
+    exposed_ports:
+      5432/tcp: {}
+    id: 2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839
+    image: postgres:12-alpine@sha256:de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
+    name: /iometrics-reporter_api-reporter-db.1.siynlece6pmr42vs3wkslfwej
+    network_mode: default
+    port_bindings: {}
+  extra_data:
+    active_databases: []
+    databases: []
+  files:
+  - path: /usr/local/bin/postgres
+    subtype: generic
+    type: binary
+  - name: postgresql.conf
+    path: /var/lib/postgresql/data
+    subtype: generic
+    type: conf
+  - path: /var/lib/postgresql/data
+    subtype: generic
+    type: data
+  listening_ports: []
+  packages: []
+  process:
+    children:
+    - children: []
+      cmdline: 'postgres: checkpointer'
+      cwd: /
+      pid: '4388'
+      ppid: '3572'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: background writer'
+      cwd: /
+      pid: '4389'
+      ppid: '3572'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: walwriter'
+      cwd: /
+      pid: '4390'
+      ppid: '3572'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: autovacuum launcher'
+      cwd: /
+      pid: '4391'
+      ppid: '3572'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: stats collector'
+      cwd: /
+      pid: '4392'
+      ppid: '3572'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: logical replication launcher'
+      cwd: /
+      pid: '4393'
+      ppid: '3572'
+      user: '70'
+    cmdline: postgres
+    cwd: /
+    pid: '3572'
+    ppid: '3466'
+    user: process_user
+  type: PostgreSQL Database
+  version:
+  - number: '12'
+    type: file
+  - number: '12.8'
+    type: active
+  - number: de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
+    type: docker
+- bindings: []
+  configuration:
+    datestyle: iso, mdy
+    default_text_search_config: pg_catalog.english
+    dynamic_shared_memory_type: posix
+    lc_messages: en_US.utf8
+    lc_monetary: en_US.utf8
+    lc_numeric: en_US.utf8
+    lc_time: en_US.utf8
+    listen_addresses: '*'
+    log_timezone: UTC
+    max_connections: '100'
+    max_wal_size: 1GB
+    min_wal_size: 80MB
+    shared_buffers: 128MB
+    timezone: UTC
+  discovery_time: '2022-06-02T14:25:52+02:00'
+  docker:
+    exposed_ports:
+      5432/tcp: {}
+    id: 2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac
+    image: postgres:12-alpine@sha256:de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
+    name: /iometrics-cicd_git-db.1.y6zi23c5jilcof2zl954u1u5z
+    network_mode: default
+    port_bindings: {}
+  extra_data:
+    active_databases:
+    - gitea
+    databases:
+    - gitea
+  files:
+  - path: /usr/local/bin/postgres
+    subtype: generic
+    type: binary
+  - name: postgresql.conf
+    path: /var/lib/postgresql/data
+    subtype: generic
+    type: conf
+  - path: /var/lib/postgresql/data
+    subtype: generic
+    type: data
+  listening_ports: []
+  packages: []
+  process:
+    children:
+    - children: []
+      cmdline: 'postgres: checkpointer'
+      cwd: /
+      pid: '4575'
+      ppid: '3818'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: background writer'
+      cwd: /
+      pid: '4576'
+      ppid: '3818'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: walwriter'
+      cwd: /
+      pid: '4577'
+      ppid: '3818'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: autovacuum launcher'
+      cwd: /
+      pid: '4578'
+      ppid: '3818'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: stats collector'
+      cwd: /
+      pid: '4579'
+      ppid: '3818'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: logical replication launcher'
+      cwd: /
+      pid: '4580'
+      ppid: '3818'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: admin gitea 192.168.4.167(52238) idle'
+      cwd: /
+      pid: '16571'
+      ppid: '3818'
+      user: '70'
+    - children: []
+      cmdline: 'postgres: admin gitea 192.168.4.167(43552) idle'
+      cwd: /
+      pid: '32387'
+      ppid: '3818'
+      user: '70'
+    cmdline: postgres
+    cwd: /
+    pid: '3818'
+    ppid: '3582'
+    user: '70'
+  type: PostgreSQL Database
+  version:
+  - number: '12'
+    type: file
+  - number: '12.8'
+    type: active
+  - number: de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
+    type: docker
 mocked_plugin_tasks:
-  Read process environment:
+  Add users from pg_hba, pg process and 'postgres':
     calls:
-      - expected_args:
-          pid: "3572"
-        execute_module_result:
-          failed: false
-          encoding: plain
-          content: "\
-            HOSTNAME=2b5cc9c1f3f3\0\
-            POSTGRES_PASSWORD=the_password\0\
-            PWD=/\0\
-            PG_SHA256=e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a\0\
-            HOME=/var/lib/postgresql\0\
-            LANG=en_US.utf8\0\
-            POSTGRES_INITDB_ARGS=\0\
-            PG_MAJOR=12\0\
-            PG_VERSION=12.8\0\
-            SHLVL=0\0\
-            POSTGRES_USER=admin\0\
-            PGDATA=/var/lib/postgresql/data\0\
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\0\
-            POSTGRES_DB=reports\0\
-          "
-      - expected_args:
-          pid: "3818"
-        execute_module_result:
-          failed: false
-          encoding: plain
-          content: "\
-            HOSTNAME=2f572d9641d8\0\
-            POSTGRES_PASSWORD=the_password\0\
-            PWD=/\0\
-            PG_SHA256=e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a\0\
-            HOME=/var/lib/postgresql\0\
-            LANG=en_US.utf8\0\
-            POSTGRES_INITDB_ARGS=\0\
-            PG_MAJOR=12\0\
-            PG_VERSION=12.8\0\
-            SHLVL=0\0\
-            POSTGRES_USER=admin\0\
-            PGDATA=/var/lib/postgresql/data\0\
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\0\
-            POSTGRES_DB=gitea\0\
-          "
+    - expected_args:
+        _connect_with_users:
+        - password: password_a
+          username: user_a
+        - password: password_b
+          username: user_b
+        - password: the_password
+          username: admin
+        - username: process_user
+    - expected_args:
+        _connect_with_users:
+        - password: password_a
+          username: user_a
+        - password: password_b
+          username: user_b
+        - password: the_password
+          username: admin
+        - username: process_user
+        - password: postgres
+          username: postgres
+    - expected_args:
+        _connect_with_users:
+        - password: password_a
+          username: user_a
+        - password: password_b
+          username: user_b
+        - password: the_password
+          username: admin
+        - password: postgres
+          username: postgres
   Attempt to extract conf path:
     expected_exception:
-      message: "'NoneType' object is not iterable"
-  Run which:
-    calls:
-      - expected_args:
-          hidden: false
-          in_docker: true
-          name: postgres
-          paths:
-            - /usr/local/sbin
-            - /usr/local/bin
-            - /usr/sbin
-            - /usr/bin
-            - /sbin
-            - /bin
-          windows_valid_extensions: null
-        execute_module_result:
-          failed: false
-          matched: 1
-          files:
-            - path: /proc/3572/root/usr/local/bin/postgres
-              isdir: false
-              xusr: true
-              xgrp: true
-              xoth: true
-      - expected_args:
-          hidden: false
-          in_docker: true
-          name: postgres
-          paths:
-            - /usr/local/sbin
-            - /usr/local/bin
-            - /usr/sbin
-            - /usr/bin
-            - /sbin
-            - /bin
-          windows_valid_extensions: null
-        execute_module_result:
-          failed: false
-          matched: 1
-          files:
-            - path: /proc/3818/root/usr/local/bin/postgres
-              isdir: false
-              xusr: true
-              xgrp: true
-              xoth: true
+      message: '''NoneType'' object is not iterable'
   Extract port:
     expected_exception:
-      message: "'NoneType' object is not iterable"
-  "Read configuration file as dict":
-    # Force only 1 call using number_of_calls
+      message: '''NoneType'' object is not iterable'
+  Get from child processes cmdline:
     calls:
-      - expected_args:
-          delegate_reading: false
-          file_path: /var/lib/postgresql/data/postgresql.conf
-          in_docker: true
-          parser: key_value
-          parser_params:
-            separators: [ "=", " " ]
-        expected_attributes:
-          register: result
-        plugin_result:
-          failed: false
-          parsed:
-            datestyle: 'iso, mdy'
-            default_text_search_config: pg_catalog.english
-            dynamic_shared_memory_type: posix
-            lc_messages: en_US.utf8
-            lc_monetary: en_US.utf8
-            lc_numeric: en_US.utf8
-            lc_time: en_US.utf8
-            listen_addresses: '*'
-            log_timezone: UTC
-            max_connections: '100'
-            max_wal_size: 1GB
-            min_wal_size: 80MB
-            shared_buffers: 128MB
-            timezone: UTC
-      - expected_args:
-          delegate_reading: false
-          file_path: /var/lib/postgresql/data/postgresql.conf
-          in_docker: true
-          parser: key_value
-          parser_params:
-            separators: [ "=", " " ]
-        expected_attributes:
-          register: result
-        plugin_result:
-          failed: false
-          parsed:
-            datestyle: 'iso, mdy'
-            default_text_search_config: pg_catalog.english
-            dynamic_shared_memory_type: posix
-            lc_messages: en_US.utf8
-            lc_monetary: en_US.utf8
-            lc_numeric: en_US.utf8
-            lc_time: en_US.utf8
-            listen_addresses: '*'
-            log_timezone: UTC
-            max_connections: '100'
-            max_wal_size: 1GB
-            min_wal_size: 80MB
-            shared_buffers: 128MB
-            timezone: UTC
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - run
+    - run
   Read VERSION file from path:
-    number_of_calls: 2
     expected_args:
       delegate_reading: false
       file_path: /var/lib/postgresql/data/PG_VERSION
       in_docker: true
       parser: null
       parser_params: null
+    number_of_calls: 2
     plugin_result:
+      content: '12'
       failed: false
-      content: "12"
-  Run command version:
-    number_of_calls: 2
-    expected_args:
-      argv:
-        - /usr/local/bin/postgres
-        - --version
-      cmd: null
-      in_docker: true
-    execute_module_result:
-      failed: false
-      stdout: postgres (PostgreSQL) 12.8
-  Get from child processes cmdline:
+  Read configuration file as dict:
     calls:
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - run
-      - run
+    - expected_args:
+        delegate_reading: false
+        file_path: /var/lib/postgresql/data/postgresql.conf
+        in_docker: true
+        parser: key_value
+        parser_params:
+          separators:
+          - '='
+          - ' '
+      expected_attributes:
+        register: result
+      plugin_result:
+        failed: false
+        parsed:
+          datestyle: iso, mdy
+          default_text_search_config: pg_catalog.english
+          dynamic_shared_memory_type: posix
+          lc_messages: en_US.utf8
+          lc_monetary: en_US.utf8
+          lc_numeric: en_US.utf8
+          lc_time: en_US.utf8
+          listen_addresses: '*'
+          log_timezone: UTC
+          max_connections: '100'
+          max_wal_size: 1GB
+          min_wal_size: 80MB
+          shared_buffers: 128MB
+          timezone: UTC
+    - expected_args:
+        delegate_reading: false
+        file_path: /var/lib/postgresql/data/postgresql.conf
+        in_docker: true
+        parser: key_value
+        parser_params:
+          separators:
+          - '='
+          - ' '
+      expected_attributes:
+        register: result
+      plugin_result:
+        failed: false
+        parsed:
+          datestyle: iso, mdy
+          default_text_search_config: pg_catalog.english
+          dynamic_shared_memory_type: posix
+          lc_messages: en_US.utf8
+          lc_monetary: en_US.utf8
+          lc_numeric: en_US.utf8
+          lc_time: en_US.utf8
+          listen_addresses: '*'
+          log_timezone: UTC
+          max_connections: '100'
+          max_wal_size: 1GB
+          min_wal_size: 80MB
+          shared_buffers: 128MB
+          timezone: UTC
   Read pg_hba file from path:
-    number_of_calls: 2
+    execute_module_result:
+      content: '# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+
+        # "local" is for Unix domain socket connections only
+
+        local   all             all                                     trust
+
+        # IPv4 local connections:
+
+        host    all             all             127.0.0.1/32            trust
+
+        # IPv6 local connections:
+
+        host    all             all             ::1/128                 trust
+
+        # Allow replication connections from localhost, by a user with the
+
+        # replication privilege.
+
+        local   replication     all                                     trust
+
+        host    replication     all             127.0.0.1/32            trust
+
+        host    replication     all             ::1/128                 trust'
+      encoding: plain
+      failed: false
     expected_args:
       delegate_reading: false
       file_path: /var/lib/postgresql/data/pg_hba.conf
       in_docker: true
       parser: null
       parser_params: null
-    execute_module_result:
-      failed: false
-      encoding: plain
-      content: |-
-        # TYPE  DATABASE        USER            ADDRESS                 METHOD
-        
-        # "local" is for Unix domain socket connections only
-        local   all             all                                     trust
-        # IPv4 local connections:
-        host    all             all             127.0.0.1/32            trust
-        # IPv6 local connections:
-        host    all             all             ::1/128                 trust
-        # Allow replication connections from localhost, by a user with the
-        # replication privilege.
-        local   replication     all                                     trust
-        host    replication     all             127.0.0.1/32            trust
-        host    replication     all             ::1/128                 trust
-  Add users from pg_hba, pg process and 'postgres':
+    number_of_calls: 2
+  Read process environment:
     calls:
-      - expected_args:
-          _connect_with_users:
-            - username: user_a
-              password: password_a
-            - username: user_b
-              password: password_b
-            - username: admin
-              password: the_password
-            - username: process_user
-      - expected_args:
-          _connect_with_users:
-            - username: user_a
-              password: password_a
-            - username: user_b
-              password: password_b
-            - username: admin
-              password: the_password
-            - username: process_user
-            - username: postgres
-              password: postgres
-      - expected_args:
-          _connect_with_users:
-            - username: user_a
-              password: password_a
-            - username: user_b
-              password: password_b
-            - username: admin
-              password: the_password
-            - username: postgres
-              password: postgres
-
+    - execute_module_result:
+        content: "HOSTNAME=2b5cc9c1f3f3\0POSTGRES_PASSWORD=the_password\0PWD=/\0PG_SHA256=e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a\0\
+          HOME=/var/lib/postgresql\0LANG=en_US.utf8\0POSTGRES_INITDB_ARGS=\0PG_MAJOR=12\0\
+          PG_VERSION=12.8\0SHLVL=0\0POSTGRES_USER=admin\0PGDATA=/var/lib/postgresql/data\0\
+          PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\0POSTGRES_DB=reports\0"
+        encoding: plain
+        failed: false
+      expected_args:
+        pid: '3572'
+    - execute_module_result:
+        content: "HOSTNAME=2f572d9641d8\0POSTGRES_PASSWORD=the_password\0PWD=/\0PG_SHA256=e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a\0\
+          HOME=/var/lib/postgresql\0LANG=en_US.utf8\0POSTGRES_INITDB_ARGS=\0PG_MAJOR=12\0\
+          PG_VERSION=12.8\0SHLVL=0\0POSTGRES_USER=admin\0PGDATA=/var/lib/postgresql/data\0\
+          PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\0POSTGRES_DB=gitea\0"
+        encoding: plain
+        failed: false
+      expected_args:
+        pid: '3818'
   Run command to get databases:
     calls:
-      - expected_args:
-          argv: null
-          cmd: >-
-            psql -U user_a -d postgres -w -t -A
-            -c 'select datname from pg_database;' -p 5432
-            -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - postgres
-            - template1
-            - template0
-      - expected_args:
-          argv: null
-          cmd: >-
-            psql -U user_a -d postgres -w -t -A
-            -c 'select datname from pg_database;' -p 5432
-            -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            su - user_a
-            -c 'psql -d postgres -w -t -A
-            -c "select datname from pg_database;" -p 5432
-            -h 127.0.0.1'
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            "/usr/local/binpsql.exe" -U user_a -d  postgres -w -t -A
-            -c "select datname from pg_database;" -p 5432
-            -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            psql -U user_b -d postgres -w -t -A
-            -c 'select datname from pg_database;' -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            su - user_b -c 'psql -d postgres -w -t -A -c "select datname from
-            pg_database;" -p 5432 -h 127.0.0.1'
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            "/usr/local/binpsql.exe" -U user_b -d  postgres -w -t -A -c "select
-            datname from pg_database;" -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            psql -U admin -d postgres -w -t -A
-            -c 'select datname from pg_database;' -p 5432
-            -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            su - admin
-            -c 'psql -d postgres -w -t -A
-            -c "select datname from pg_database;" -p 5432
-            -h 127.0.0.1'
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            "/usr/local/binpsql.exe" -U admin -d  postgres -w -t -A -c "select
-            datname from pg_database;" -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            psql -U postgres -d postgres -w -t -A -c 'select datname from
-            pg_database;' -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            su - postgres -c 'psql -d postgres -w -t -A -c "select datname from
-            pg_database;" -p 5432 -h 127.0.0.1'
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            "/usr/local/binpsql.exe" -U postgres -d  postgres -w -t -A -c "select
-            datname from pg_database;" -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            psql -U user_a -d gitea -w -t -A -c 'select datname from
-            pg_database;' -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            su - user_a
-            -c 'psql -d gitea -w -t -A
-            -c "select datname from pg_database;" -p 5432
-            -h 127.0.0.1'
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            "/usr/local/binpsql.exe" -U user_a -d  gitea -w -t -A -c "select
-            datname from pg_database;" -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            psql -U user_b -d gitea -w -t -A -c 'select datname from
-            pg_database;' -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - postgres
-            - template1
-            - template0
-            - gitea
-
-expected_result:
-  - bindings: [ ]
-    extra_data:
-      active_databases: [ ]
-      databases: [ ]
-    files:
-      - path: /usr/local/bin/postgres
-        subtype: generic
-        type: binary
-      - path: /var/lib/postgresql/data
-        name: postgresql.conf
-        subtype: generic
-        type: conf
-      - path: /var/lib/postgresql/data
-        subtype: generic
-        type: data
-    configuration:
-      datestyle: 'iso, mdy'
-      default_text_search_config: pg_catalog.english
-      dynamic_shared_memory_type: posix
-      lc_messages: en_US.utf8
-      lc_monetary: en_US.utf8
-      lc_numeric: en_US.utf8
-      lc_time: en_US.utf8
-      listen_addresses: '*'
-      log_timezone: UTC
-      max_connections: '100'
-      max_wal_size: 1GB
-      min_wal_size: 80MB
-      shared_buffers: 128MB
-      timezone: UTC
-    discovery_time: '2022-06-02T14:25:49+02:00'
-    docker:
-      exposed_ports:
-        5432/tcp: { }
-      id: 2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839
-      image: >-
-        postgres:12-alpine@sha256:de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
-      name: /iometrics-reporter_api-reporter-db.1.siynlece6pmr42vs3wkslfwej
-      network_mode: 'default'
-      port_bindings: { }
-    listening_ports: [ ]
-    type: PostgreSQL Database
-    packages: [ ]
-    process:
-      children:
-        - children: [ ]
-          cmdline: 'postgres: checkpointer'
-          pid: '4388'
-          ppid: '3572'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: background writer'
-          pid: '4389'
-          ppid: '3572'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: walwriter'
-          pid: '4390'
-          ppid: '3572'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: autovacuum launcher'
-          pid: '4391'
-          ppid: '3572'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: stats collector'
-          pid: '4392'
-          ppid: '3572'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: logical replication launcher'
-          pid: '4393'
-          ppid: '3572'
-          user: '70'
-      cmdline: postgres
-      pid: '3572'
-      ppid: '3466'
-      user: process_user
-    version:
-      - number: '12'
-        type: file
-      - number: '12.8'
-        type: active
-      - number: de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
-        type: docker
-  - bindings: [ ]
-    extra_data:
-      active_databases:
-        - gitea
-      databases:
-        - gitea
-    files:
-      - path: /usr/local/bin/postgres
-        subtype: generic
-        type: binary
-      - path: /var/lib/postgresql/data
-        name: postgresql.conf
-        subtype: generic
-        type: conf
-      - path: /var/lib/postgresql/data
-        subtype: generic
-        type: data
-    configuration:
-      datestyle: 'iso, mdy'
-      default_text_search_config: pg_catalog.english
-      dynamic_shared_memory_type: posix
-      lc_messages: en_US.utf8
-      lc_monetary: en_US.utf8
-      lc_numeric: en_US.utf8
-      lc_time: en_US.utf8
-      listen_addresses: '*'
-      log_timezone: UTC
-      max_connections: '100'
-      max_wal_size: 1GB
-      min_wal_size: 80MB
-      shared_buffers: 128MB
-      timezone: UTC
-    discovery_time: '2022-06-02T14:25:52+02:00'
-    docker:
-      exposed_ports:
-        5432/tcp: { }
-      id: 2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac
-      image: >-
-        postgres:12-alpine@sha256:de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
-      name: /iometrics-cicd_git-db.1.y6zi23c5jilcof2zl954u1u5z
-      network_mode: 'default'
-      port_bindings: { }
-    listening_ports: [ ]
-    type: PostgreSQL Database
-    packages: [ ]
-    process:
-      children:
-        - children: [ ]
-          cmdline: 'postgres: checkpointer'
-          pid: '4575'
-          ppid: '3818'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: background writer'
-          pid: '4576'
-          ppid: '3818'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: walwriter'
-          pid: '4577'
-          ppid: '3818'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: autovacuum launcher'
-          pid: '4578'
-          ppid: '3818'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: stats collector'
-          pid: '4579'
-          ppid: '3818'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: logical replication launcher'
-          pid: '4580'
-          ppid: '3818'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: admin gitea 192.168.4.167(52238) idle'
-          pid: '16571'
-          ppid: '3818'
-          user: '70'
-        - children: [ ]
-          cmdline: 'postgres: admin gitea 192.168.4.167(43552) idle'
-          pid: '32387'
-          ppid: '3818'
-          user: '70'
-      cmdline: postgres
-      pid: '3818'
-      ppid: '3582'
-      user: '70'
-    version:
-      - number: '12'
-        type: file
-      - number: '12.8'
-        type: active
-      - number: de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
-        type: docker
-
-software_list:
-  - cmd_regexp: 'postgres:'
-    name: PostgreSQL Database
-    pkg_regexp: postgresql.*-server|postgresql-\d
-    process_type: child
-    return_children: true
-    return_packages: true
-    vars:
-      ignore_databases:
+    - expected_args:
+        argv: null
+        cmd: psql -U user_a -d postgres -w -t -A -c 'select datname from pg_database;'
+          -p 5432 -h 127.0.0.1
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout_lines:
         - postgres
-        - template0
         - template1
-      connect_with_users: "{{ postgresql_monitor_users_info 
-        | default([{'username': postgresql_monitor_user | default('postgres'), 
-        'password': postgresql_monitor_pass | default('postgres')}]) }}"
-      sql_connection_extra_params: '-h 127.0.0.1'
-    custom_tasks:
-      - include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/postgresql.yaml"
-        name: Include postgres specific plugins
-
-
-processes:
-  - cmdline: /sbin/init
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '40'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '54'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '97'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '98'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '101'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '102'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '103'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '104'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '110'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '119'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '136'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '227'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '228'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '301'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '349'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '350'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '351'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '353'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '384'
-    ppid: '2'
-    user: root
-  - cmdline: /lib/systemd/systemd-journald
-    pid: '420'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '429'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '431'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '435'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '436'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '437'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '438'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '439'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/lvmetad -f
-    pid: '443'
-    ppid: '1'
-    user: root
-  - cmdline: /lib/systemd/systemd-udevd
-    pid: '452'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '535'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '536'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '537'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '538'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '539'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '540'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '541'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '542'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '543'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '544'
-    ppid: '2'
-    user: root
-  - cmdline: /lib/systemd/systemd-timesyncd
-    pid: '703'
-    ppid: '1'
-    user: systemd-timesync
-  - cmdline: /lib/systemd/systemd-networkd
-    pid: '777'
-    ppid: '1'
-    user: systemd-network
-  - cmdline: /lib/systemd/systemd-resolved
-    pid: '799'
-    ppid: '1'
-    user: systemd-resolve
-  - cmdline: /usr/bin/lxcfs /var/lib/lxcfs/
-    pid: '920'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation --syslog-only
-    pid: '926'
-    ppid: '1'
-    user: messagebus
-  - cmdline: /usr/lib/accountsservice/accounts-daemon
-    pid: '951'
-    ppid: '1'
-    user: root
-  - cmdline: /lib/systemd/systemd-logind
-    pid: '957'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/atd -f
-    pid: '975'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '994'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1004'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/python3
-      /usr/share/unattended-upgrades/unattended-upgrade-shutdown
-      --wait-for-signal
-    pid: '1018'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty -o -p -- \u --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1027'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty -o -p -- \u --noclear tty1 linux
-    pid: '1031'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/policykit-1/polkitd --no-debug
-    pid: '1032'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1066'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock
-      --storage-driver overlay2 --tlsverify --tlscacert /etc/docker/ca.pem
-      --tlscert /etc/docker/server.pem --tlskey /etc/docker/server-key.pem
-      --label provider=generic
-    pid: '1209'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '1279'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '2740'
-    ppid: '1004'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '2753'
-    ppid: '1004'
-    user: root
-  - cmdline: telegraf
-    pid: '2829'
-    ppid: '2753'
-    user: root
-  - cmdline: >-
-      grafana-server --homepath=/usr/share/grafana
-      --config=/etc/grafana/grafana.ini --packaging=docker
-      cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
-      cfg:default.paths.logs=/var/log/grafana
-      cfg:default.paths.plugins=/usr/share/grafana/plugins
-      cfg:default.paths.provisioning=/etc/grafana/provisioning
-    pid: '2841'
-    ppid: '2740'
-    user: '472'
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '2847'
-    ppid: '1004'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '2973'
-    ppid: '1004'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3013'
-    ppid: '1004'
-    user: root
-  - cmdline: /bin/sh -c /app/deployment/run.sh
-    pid: '3014'
-    ppid: '2847'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3034'
-    ppid: '1004'
-    user: root
-  - cmdline: telegraf
-    pid: '3112'
-    ppid: '2973'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3150'
-    ppid: '1004'
-    user: root
-  - cmdline: >-
-      /opt/bitnami/mariadb/sbin/mysqld
-      --defaults-file=/opt/bitnami/mariadb/conf/my.cnf
-      --basedir=/opt/bitnami/mariadb --datadir=/bitnami/mariadb/data
-      --socket=/opt/bitnami/mariadb/tmp/mysql.sock
-      --pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
-    pid: '3184'
-    ppid: '3013'
-    user: '1001'
-  - cmdline: ./bin/synthetix-agent
-    pid: '3217'
-    ppid: '3034'
-    user: root
-  - cmdline: >-
-      /opt/bitnami/java/bin/java
-      -Djava.util.logging.config.file=/opt/bitnami/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      -Djava.awt.headless=true -XX:+UseG1GC -Dfile.encoding=UTF-8
-      -Duser.home=/opt/bitnami/tomcat -Djdk.tls.ephemeralDHKeySize=2048
-      -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
-      -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
-      -Dignore.endorsed.dirs= -classpath
-      /opt/bitnami/tomcat/bin/bootstrap.jar:/opt/bitnami/tomcat/bin/tomcat-juli.jar
-      -Dcatalina.base=/opt/bitnami/tomcat -Dcatalina.home=/opt/bitnami/tomcat
-      -Djava.io.tmpdir=/opt/bitnami/tomcat/temp
-      org.apache.catalina.startup.Bootstrap start
-    pid: '3242'
-    ppid: '3150'
-    user: '1001'
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3307'
-    ppid: '1004'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3351'
-    ppid: '1004'
-    user: root
-  - cmdline: /bin/bash /entrypoint.sh
-    pid: '3380'
-    ppid: '3307'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3466'
-    ppid: '1004'
-    user: root
-  - cmdline: /bin/bash /entrypoint.sh
-    pid: '3480'
-    ppid: '3351'
-    user: '472'
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3535'
-    ppid: '1004'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3571'
-    ppid: '1004'
-    user: root
-  - cmdline: postgres
-    pid: '3572'
-    ppid: '3466'
-    user: process_user
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3582'
-    ppid: '1004'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '3685'
-    ppid: '1004'
-    user: root
-  - cmdline: /bin/s6-svscan /etc/s6
-    pid: '3784'
-    ppid: '3571'
-    user: root
-  - cmdline: postgres
-    pid: '3818'
-    ppid: '3582'
-    user: '70'
-  - cmdline: /usr/bin/zippersrv
-    pid: '3835'
-    ppid: '3535'
-    user: root
-  - cmdline: >-
-      grafana-server --homepath=/usr/share/grafana
-      --config=/etc/grafana/grafana.ini --packaging=docker
-      cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
-      cfg:default.paths.logs=/var/log/grafana
-      cfg:default.paths.plugins=/var/lib/grafana/plugins
-      cfg:default.paths.provisioning=/etc/grafana/provisioning
-    pid: '3849'
-    ppid: '3685'
-    user: '472'
-  - cmdline: /bin/bash /app/deployment/run.sh
-    pid: '4249'
-    ppid: '3014'
-    user: root
-  - cmdline: 'nginx: master process nginx'
-    pid: '4342'
-    ppid: '3380'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '4343'
-    ppid: '4342'
-    user: systemd-network
-  - cmdline: 'nginx: worker process'
-    pid: '4344'
-    ppid: '4342'
-    user: systemd-network
-  - cmdline: 'nginx: worker process'
-    pid: '4345'
-    ppid: '4342'
-    user: systemd-network
-  - cmdline: 'nginx: worker process'
-    pid: '4346'
-    ppid: '4342'
-    user: systemd-network
-  - cmdline: uwsgi --ini /app.ini
-    pid: '4347'
-    ppid: '3380'
-    user: root
-  - cmdline: 'postgres: checkpointer'
-    pid: '4388'
-    ppid: '3572'
-    user: '70'
-  - cmdline: 'postgres: background writer'
-    pid: '4389'
-    ppid: '3572'
-    user: '70'
-  - cmdline: 'postgres: walwriter'
-    pid: '4390'
-    ppid: '3572'
-    user: '70'
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '4391'
-    ppid: '3572'
-    user: '70'
-  - cmdline: 'postgres: stats collector'
-    pid: '4392'
-    ppid: '3572'
-    user: '70'
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '4393'
-    ppid: '3572'
-    user: '70'
-  - cmdline: >-
-      /opt/iometrics-synthetix-ui/bin/tunneld -log-level 1 -tlsCrt
-      /opt/tunneld/server.crt -tlsKey /opt/tunneld/server.key -httpsAddr 
-      -httpAddr  -tunnelAddr 0.0.0.0:5223 -portRange 6010:6050 -apiAddr :4823
-    pid: '4452'
-    ppid: '3480'
-    user: '472'
-  - cmdline: /usr/local/guacamole/sbin/guacd -b 0.0.0.0 -p 4822 -L info -f
-    pid: '4453'
-    ppid: '3480'
-    user: '472'
-  - cmdline: /opt/iometrics-synthetix-ui/bin/synthetix-ui
-    pid: '4454'
-    ppid: '3480'
-    user: '472'
-  - cmdline: 'postgres: checkpointer'
-    pid: '4575'
-    ppid: '3818'
-    user: '70'
-  - cmdline: 'postgres: background writer'
-    pid: '4576'
-    ppid: '3818'
-    user: '70'
-  - cmdline: 'postgres: walwriter'
-    pid: '4577'
-    ppid: '3818'
-    user: '70'
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '4578'
-    ppid: '3818'
-    user: '70'
-  - cmdline: 'postgres: stats collector'
-    pid: '4579'
-    ppid: '3818'
-    user: '70'
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '4580'
-    ppid: '3818'
-    user: '70'
-  - cmdline: uwsgi --ini /app.ini
-    pid: '4666'
-    ppid: '4347'
-    user: root
-  - cmdline: uwsgi --ini /app.ini
-    pid: '4667'
-    ppid: '4347'
-    user: root
-  - cmdline: uwsgi --ini /app.ini
-    pid: '4669'
-    ppid: '4347'
-    user: root
-  - cmdline: ''
-    pid: '4683'
-    ppid: '2'
-    user: root
-  - cmdline: s6-supervise gitea
-    pid: '4909'
-    ppid: '3784'
-    user: root
-  - cmdline: s6-supervise openssh
-    pid: '4910'
-    ppid: '3784'
-    user: root
-  - cmdline: /app/gitea/gitea web
-    pid: '4913'
-    ppid: '4909'
-    user: ubuntu
-  - cmdline: /usr/sbin/sshd -D -e
-    pid: '4914'
-    ppid: '4910'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '5481'
-    ppid: '1004'
-    user: root
-  - cmdline: ./agent
-    pid: '5508'
-    ppid: '5481'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn -w 2 -b :8000
-      --worker-tmp-dir /dev/shm --chdir /app/src -k
-      uvicorn.workers.UvicornWorker reports.asgi:application
-    pid: '5533'
-    ppid: '4249'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn -w 2 -b :8000
-      --worker-tmp-dir /dev/shm --chdir /app/src -k
-      uvicorn.workers.UvicornWorker reports.asgi:application
-    pid: '5576'
-    ppid: '5533'
-    user: root
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn -w 2 -b :8000
-      --worker-tmp-dir /dev/shm --chdir /app/src -k
-      uvicorn.workers.UvicornWorker reports.asgi:application
-    pid: '5577'
-    ppid: '5533'
-    user: root
-  - cmdline: /usr/sbin/cron -f
-    pid: '7269'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python3 /usr/bin/networkd-dispatcher --run-startup-triggers
-    pid: '11606'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '13708'
-    ppid: '1'
-    user: syslog
-  - cmdline: 'postgres: admin gitea 192.168.4.167(52238) idle'
-    pid: '16571'
-    ppid: '3818'
-    user: '70'
-  - cmdline: ''
-    pid: '17517'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19183'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23444'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23445'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26541'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27457'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27550'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27634'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28354'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28411'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28719'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28824'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29730'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29825'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: ubuntu [priv]'
-    pid: '30406'
-    ppid: '1066'
-    user: root
-  - cmdline: /lib/systemd/systemd --user
-    pid: '30408'
-    ppid: '1'
-    user: ubuntu
-  - cmdline: (sd-pam)
-    pid: '30409'
-    ppid: '30408'
-    user: ubuntu
-  - cmdline: 'sshd: ubuntu@pts/0'
-    pid: '30530'
-    ppid: '30406'
-    user: ubuntu
-  - cmdline: '-bash'
-    pid: '30531'
-    ppid: '30530'
-    user: ubuntu
-  - cmdline: sudo su -
-    pid: '30549'
-    ppid: '30531'
-    user: root
-  - cmdline: su -
-    pid: '30550'
-    ppid: '30549'
-    user: root
-  - cmdline: '-su'
-    pid: '30551'
-    ppid: '30550'
-    user: root
-  - cmdline: ''
-    pid: '31284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31456'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: ubuntu [priv]'
-    pid: '31531'
-    ppid: '1066'
-    user: root
-  - cmdline: 'sshd: ubuntu@pts/1'
-    pid: '31619'
-    ppid: '31531'
-    user: ubuntu
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-plnltjmmpjoylqcfppcdrqigblealuyg ; /usr/bin/python3
-      /home/ubuntu/.ansible/tmp/ansible-tmp-1654172735.6293702-12884-220436346408519/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '31781'
-    ppid: '31619'
-    user: ubuntu
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-plnltjmmpjoylqcfppcdrqigblealuyg ; /usr/bin/python3
-      /home/ubuntu/.ansible/tmp/ansible-tmp-1654172735.6293702-12884-220436346408519/AnsiballZ_process_facts.py
-    pid: '31782'
-    ppid: '31781'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-plnltjmmpjoylqcfppcdrqigblealuyg ;
-      /usr/bin/python3
-      /home/ubuntu/.ansible/tmp/ansible-tmp-1654172735.6293702-12884-220436346408519/AnsiballZ_process_facts.py
-    pid: '31783'
-    ppid: '31782'
-    user: root
-  - cmdline: >-
-      /usr/bin/python3
-      /home/ubuntu/.ansible/tmp/ansible-tmp-1654172735.6293702-12884-220436346408519/AnsiballZ_process_facts.py
-    pid: '31784'
-    ppid: '31783'
-    user: root
-  - cmdline: 'postgres: admin gitea 192.168.4.167(43552) idle'
-    pid: '32387'
-    ppid: '3818'
-    user: '70'
-tcp_listen:
-  - address: 127.0.0.53
-    name: systemd-resolve
-    pid: 799
-    port: 53
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:13 2022'
-    user: systemd-resolve
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1066
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:16 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 4000
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 10051
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 9092
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 2181
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 9094
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 9000
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 5000
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 2376
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 9001
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 3306
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 7946
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 2222
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 80
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 9009
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 9010
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1066
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:16 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 3000
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 8123
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 443
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 7070
-    protocol: tcp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
-udp_listen:
-  - address: 127.0.0.53
-    name: systemd-resolve
-    pid: 799
-    port: 53
-    protocol: udp
-    stime: 'Tue Apr 26 14:57:13 2022'
-    user: systemd-resolve
-  - address: 192.168.0.229
-    name: systemd-network
-    pid: 777
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 14:57:13 2022'
-    user: systemd-network
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 4789
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: dockerd
-    pid: 1209
-    port: 7946
-    protocol: udp
-    stime: 'Tue Apr 26 14:57:17 2022'
-    user: root
+        - template0
+    - expected_args:
+        argv: null
+        cmd: psql -U user_a -d postgres -w -t -A -c 'select datname from pg_database;'
+          -p 5432 -h 127.0.0.1
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: su - user_a -c 'psql -d postgres -w -t -A -c "select datname from pg_database;"
+          -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: '"/usr/local/binpsql.exe" -U user_a -d  postgres -w -t -A -c "select
+          datname from pg_database;" -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: psql -U user_b -d postgres -w -t -A -c 'select datname from pg_database;'
+          -p 5432 -h 127.0.0.1
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: su - user_b -c 'psql -d postgres -w -t -A -c "select datname from pg_database;"
+          -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: '"/usr/local/binpsql.exe" -U user_b -d  postgres -w -t -A -c "select
+          datname from pg_database;" -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: psql -U admin -d postgres -w -t -A -c 'select datname from pg_database;'
+          -p 5432 -h 127.0.0.1
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: su - admin -c 'psql -d postgres -w -t -A -c "select datname from pg_database;"
+          -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: '"/usr/local/binpsql.exe" -U admin -d  postgres -w -t -A -c "select datname
+          from pg_database;" -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: psql -U postgres -d postgres -w -t -A -c 'select datname from pg_database;'
+          -p 5432 -h 127.0.0.1
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: su - postgres -c 'psql -d postgres -w -t -A -c "select datname from pg_database;"
+          -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: '"/usr/local/binpsql.exe" -U postgres -d  postgres -w -t -A -c "select
+          datname from pg_database;" -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: psql -U user_a -d gitea -w -t -A -c 'select datname from pg_database;'
+          -p 5432 -h 127.0.0.1
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: su - user_a -c 'psql -d gitea -w -t -A -c "select datname from pg_database;"
+          -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: '"/usr/local/binpsql.exe" -U user_a -d  gitea -w -t -A -c "select datname
+          from pg_database;" -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: psql -U user_b -d gitea -w -t -A -c 'select datname from pg_database;'
+          -p 5432 -h 127.0.0.1
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - postgres
+        - template1
+        - template0
+        - gitea
+  Run command version:
+    execute_module_result:
+      failed: false
+      stdout: postgres (PostgreSQL) 12.8
+    expected_args:
+      argv:
+      - /usr/local/bin/postgres
+      - --version
+      cmd: null
+      in_docker: true
+    number_of_calls: 2
+  Run which:
+    calls:
+    - execute_module_result:
+        failed: false
+        files:
+        - isdir: false
+          path: /proc/3572/root/usr/local/bin/postgres
+          xgrp: true
+          xoth: true
+          xusr: true
+        matched: 1
+      expected_args:
+        hidden: false
+        in_docker: true
+        name: postgres
+        paths:
+        - /usr/local/sbin
+        - /usr/local/bin
+        - /usr/sbin
+        - /usr/bin
+        - /sbin
+        - /bin
+        windows_valid_extensions: null
+    - execute_module_result:
+        failed: false
+        files:
+        - isdir: false
+          path: /proc/3818/root/usr/local/bin/postgres
+          xgrp: true
+          xoth: true
+          xusr: true
+        matched: 1
+      expected_args:
+        hidden: false
+        in_docker: true
+        name: postgres
+        paths:
+        - /usr/local/sbin
+        - /usr/local/bin
+        - /usr/sbin
+        - /usr/bin
+        - /sbin
+        - /bin
+        windows_valid_extensions: null
 packages:
   accountsservice:
-    - arch: amd64
-      category: gnome
-      name: accountsservice
-      origin: Ubuntu
-      source: apt
-      version: 0.6.45-1ubuntu1.3
+  - arch: amd64
+    category: gnome
+    name: accountsservice
+    origin: Ubuntu
+    source: apt
+    version: 0.6.45-1ubuntu1.3
   acl:
-    - arch: amd64
-      category: utils
-      name: acl
-      origin: Ubuntu
-      source: apt
-      version: 2.2.52-3build1
+  - arch: amd64
+    category: utils
+    name: acl
+    origin: Ubuntu
+    source: apt
+    version: 2.2.52-3build1
   acpid:
-    - arch: amd64
-      category: admin
-      name: acpid
-      origin: Ubuntu
-      source: apt
-      version: '1:2.0.28-1ubuntu1'
+  - arch: amd64
+    category: admin
+    name: acpid
+    origin: Ubuntu
+    source: apt
+    version: 1:2.0.28-1ubuntu1
   adduser:
-    - arch: all
-      category: admin
-      name: adduser
-      origin: Ubuntu
-      source: apt
-      version: 3.116ubuntu1
+  - arch: all
+    category: admin
+    name: adduser
+    origin: Ubuntu
+    source: apt
+    version: 3.116ubuntu1
   apparmor:
-    - arch: amd64
-      category: admin
-      name: apparmor
-      origin: Ubuntu
-      source: apt
-      version: 2.12-4ubuntu5.1
+  - arch: amd64
+    category: admin
+    name: apparmor
+    origin: Ubuntu
+    source: apt
+    version: 2.12-4ubuntu5.1
   apport:
-    - arch: all
-      category: utils
-      name: apport
-      origin: Ubuntu
-      source: apt
-      version: 2.20.9-0ubuntu7.28
+  - arch: all
+    category: utils
+    name: apport
+    origin: Ubuntu
+    source: apt
+    version: 2.20.9-0ubuntu7.28
   apport-symptoms:
-    - arch: all
-      category: utils
-      name: apport-symptoms
-      origin: Ubuntu
-      source: apt
-      version: '0.20'
+  - arch: all
+    category: utils
+    name: apport-symptoms
+    origin: Ubuntu
+    source: apt
+    version: '0.20'
   apt:
-    - arch: amd64
-      category: admin
-      name: apt
-      origin: Ubuntu
-      source: apt
-      version: 1.6.12ubuntu0.2
+  - arch: amd64
+    category: admin
+    name: apt
+    origin: Ubuntu
+    source: apt
+    version: 1.6.12ubuntu0.2
   apt-transport-https:
-    - arch: all
-      category: oldlibs
-      name: apt-transport-https
-      origin: ''
-      source: apt
-      version: 1.6.13
+  - arch: all
+    category: oldlibs
+    name: apt-transport-https
+    origin: ''
+    source: apt
+    version: 1.6.13
   apt-utils:
-    - arch: amd64
-      category: admin
-      name: apt-utils
-      origin: Ubuntu
-      source: apt
-      version: 1.6.12ubuntu0.2
+  - arch: amd64
+    category: admin
+    name: apt-utils
+    origin: Ubuntu
+    source: apt
+    version: 1.6.12ubuntu0.2
   at:
-    - arch: amd64
-      category: admin
-      name: at
-      origin: Ubuntu
-      source: apt
-      version: 3.1.20-3.1ubuntu2
+  - arch: amd64
+    category: admin
+    name: at
+    origin: Ubuntu
+    source: apt
+    version: 3.1.20-3.1ubuntu2
   aufs-tools:
-    - arch: amd64
-      category: universe/kernel
-      name: aufs-tools
-      origin: Ubuntu
-      source: apt
-      version: '1:4.9+20170918-1ubuntu1'
+  - arch: amd64
+    category: universe/kernel
+    name: aufs-tools
+    origin: Ubuntu
+    source: apt
+    version: 1:4.9+20170918-1ubuntu1
   base-files:
-    - arch: amd64
-      category: admin
-      name: base-files
-      origin: ''
-      source: apt
-      version: 10.1ubuntu2.9
+  - arch: amd64
+    category: admin
+    name: base-files
+    origin: ''
+    source: apt
+    version: 10.1ubuntu2.9
   base-passwd:
-    - arch: amd64
-      category: admin
-      name: base-passwd
-      origin: Ubuntu
-      source: apt
-      version: 3.5.44
+  - arch: amd64
+    category: admin
+    name: base-passwd
+    origin: Ubuntu
+    source: apt
+    version: 3.5.44
   bash:
-    - arch: amd64
-      category: shells
-      name: bash
-      origin: Ubuntu
-      source: apt
-      version: 4.4.18-2ubuntu1.3
+  - arch: amd64
+    category: shells
+    name: bash
+    origin: Ubuntu
+    source: apt
+    version: 4.4.18-2ubuntu1.3
   bash-completion:
-    - arch: all
-      category: shells
-      name: bash-completion
-      origin: Ubuntu
-      source: apt
-      version: '1:2.8-1ubuntu1'
+  - arch: all
+    category: shells
+    name: bash-completion
+    origin: Ubuntu
+    source: apt
+    version: 1:2.8-1ubuntu1
   bc:
-    - arch: amd64
-      category: math
-      name: bc
-      origin: Ubuntu
-      source: apt
-      version: 1.07.1-2
+  - arch: amd64
+    category: math
+    name: bc
+    origin: Ubuntu
+    source: apt
+    version: 1.07.1-2
   bcache-tools:
-    - arch: amd64
-      category: utils
-      name: bcache-tools
-      origin: Ubuntu
-      source: apt
-      version: 1.0.8-2build1
+  - arch: amd64
+    category: utils
+    name: bcache-tools
+    origin: Ubuntu
+    source: apt
+    version: 1.0.8-2build1
   bind9-host:
-    - arch: amd64
-      category: net
-      name: bind9-host
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: net
+    name: bind9-host
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   bsdmainutils:
-    - arch: amd64
-      category: utils
-      name: bsdmainutils
-      origin: Ubuntu
-      source: apt
-      version: 11.1.2ubuntu1
+  - arch: amd64
+    category: utils
+    name: bsdmainutils
+    origin: Ubuntu
+    source: apt
+    version: 11.1.2ubuntu1
   bsdutils:
-    - arch: amd64
-      category: utils
-      name: bsdutils
-      origin: Ubuntu
-      source: apt
-      version: '1:2.31.1-0.4ubuntu3.7'
+  - arch: amd64
+    category: utils
+    name: bsdutils
+    origin: Ubuntu
+    source: apt
+    version: 1:2.31.1-0.4ubuntu3.7
   btrfs-progs:
-    - arch: amd64
-      category: admin
-      name: btrfs-progs
-      origin: Ubuntu
-      source: apt
-      version: 4.15.1-1build1
+  - arch: amd64
+    category: admin
+    name: btrfs-progs
+    origin: Ubuntu
+    source: apt
+    version: 4.15.1-1build1
   btrfs-tools:
-    - arch: amd64
-      category: admin
-      name: btrfs-tools
-      origin: Ubuntu
-      source: apt
-      version: 4.15.1-1build1
+  - arch: amd64
+    category: admin
+    name: btrfs-tools
+    origin: Ubuntu
+    source: apt
+    version: 4.15.1-1build1
   busybox-initramfs:
-    - arch: amd64
-      category: shells
-      name: busybox-initramfs
-      origin: Ubuntu
-      source: apt
-      version: '1:1.27.2-2ubuntu3.4'
+  - arch: amd64
+    category: shells
+    name: busybox-initramfs
+    origin: Ubuntu
+    source: apt
+    version: 1:1.27.2-2ubuntu3.4
   busybox-static:
-    - arch: amd64
-      category: shells
-      name: busybox-static
-      origin: Ubuntu
-      source: apt
-      version: '1:1.27.2-2ubuntu3.4'
+  - arch: amd64
+    category: shells
+    name: busybox-static
+    origin: Ubuntu
+    source: apt
+    version: 1:1.27.2-2ubuntu3.4
   byobu:
-    - arch: all
-      category: misc
-      name: byobu
-      origin: Ubuntu
-      source: apt
-      version: 5.125-0ubuntu1
+  - arch: all
+    category: misc
+    name: byobu
+    origin: Ubuntu
+    source: apt
+    version: 5.125-0ubuntu1
   bzip2:
-    - arch: amd64
-      category: utils
-      name: bzip2
-      origin: Ubuntu
-      source: apt
-      version: 1.0.6-8.1ubuntu0.2
+  - arch: amd64
+    category: utils
+    name: bzip2
+    origin: Ubuntu
+    source: apt
+    version: 1.0.6-8.1ubuntu0.2
   ca-certificates:
-    - arch: all
-      category: misc
-      name: ca-certificates
-      origin: Ubuntu
-      source: apt
-      version: 20210119~18.04.2
+  - arch: all
+    category: misc
+    name: ca-certificates
+    origin: Ubuntu
+    source: apt
+    version: 20210119~18.04.2
   cgroupfs-mount:
-    - arch: all
-      category: universe/admin
-      name: cgroupfs-mount
-      origin: Ubuntu
-      source: apt
-      version: '1.4'
+  - arch: all
+    category: universe/admin
+    name: cgroupfs-mount
+    origin: Ubuntu
+    source: apt
+    version: '1.4'
   cloud-guest-utils:
-    - arch: all
-      category: admin
-      name: cloud-guest-utils
-      origin: Ubuntu
-      source: apt
-      version: 0.30-0ubuntu5
+  - arch: all
+    category: admin
+    name: cloud-guest-utils
+    origin: Ubuntu
+    source: apt
+    version: 0.30-0ubuntu5
   cloud-init:
-    - arch: all
-      category: admin
-      name: cloud-init
-      origin: ''
-      source: apt
-      version: 20.2-45-g5f7825e2-0ubuntu1~18.04.1
+  - arch: all
+    category: admin
+    name: cloud-init
+    origin: ''
+    source: apt
+    version: 20.2-45-g5f7825e2-0ubuntu1~18.04.1
   cloud-initramfs-copymods:
-    - arch: all
-      category: admin
-      name: cloud-initramfs-copymods
-      origin: Ubuntu
-      source: apt
-      version: 0.40ubuntu1.1
+  - arch: all
+    category: admin
+    name: cloud-initramfs-copymods
+    origin: Ubuntu
+    source: apt
+    version: 0.40ubuntu1.1
   cloud-initramfs-dyn-netconf:
-    - arch: all
-      category: admin
-      name: cloud-initramfs-dyn-netconf
-      origin: Ubuntu
-      source: apt
-      version: 0.40ubuntu1.1
+  - arch: all
+    category: admin
+    name: cloud-initramfs-dyn-netconf
+    origin: Ubuntu
+    source: apt
+    version: 0.40ubuntu1.1
   command-not-found:
-    - arch: all
-      category: admin
-      name: command-not-found
-      origin: ''
-      source: apt
-      version: 18.04.5
+  - arch: all
+    category: admin
+    name: command-not-found
+    origin: ''
+    source: apt
+    version: 18.04.5
   command-not-found-data:
-    - arch: amd64
-      category: admin
-      name: command-not-found-data
-      origin: ''
-      source: apt
-      version: 18.04.5
+  - arch: amd64
+    category: admin
+    name: command-not-found-data
+    origin: ''
+    source: apt
+    version: 18.04.5
   console-setup:
-    - arch: all
-      category: utils
-      name: console-setup
-      origin: Ubuntu
-      source: apt
-      version: 1.178ubuntu2.9
+  - arch: all
+    category: utils
+    name: console-setup
+    origin: Ubuntu
+    source: apt
+    version: 1.178ubuntu2.9
   console-setup-linux:
-    - arch: all
-      category: utils
-      name: console-setup-linux
-      origin: Ubuntu
-      source: apt
-      version: 1.178ubuntu2.9
+  - arch: all
+    category: utils
+    name: console-setup-linux
+    origin: Ubuntu
+    source: apt
+    version: 1.178ubuntu2.9
   containerd.io:
-    - arch: amd64
-      category: devel
-      name: containerd.io
-      origin: Docker
-      source: apt
-      version: 1.4.4-1
+  - arch: amd64
+    category: devel
+    name: containerd.io
+    origin: Docker
+    source: apt
+    version: 1.4.4-1
   coreutils:
-    - arch: amd64
-      category: utils
-      name: coreutils
-      origin: Ubuntu
-      source: apt
-      version: 8.28-1ubuntu1
+  - arch: amd64
+    category: utils
+    name: coreutils
+    origin: Ubuntu
+    source: apt
+    version: 8.28-1ubuntu1
   cpio:
-    - arch: amd64
-      category: utils
-      name: cpio
-      origin: Ubuntu
-      source: apt
-      version: 2.12+dfsg-6ubuntu0.18.04.4
+  - arch: amd64
+    category: utils
+    name: cpio
+    origin: Ubuntu
+    source: apt
+    version: 2.12+dfsg-6ubuntu0.18.04.4
   cron:
-    - arch: amd64
-      category: admin
-      name: cron
-      origin: Ubuntu
-      source: apt
-      version: 3.0pl1-128.1ubuntu1.2
+  - arch: amd64
+    category: admin
+    name: cron
+    origin: Ubuntu
+    source: apt
+    version: 3.0pl1-128.1ubuntu1.2
   cryptsetup:
-    - arch: amd64
-      category: admin
-      name: cryptsetup
-      origin: ''
-      source: apt
-      version: '2:2.0.2-1ubuntu1.1'
+  - arch: amd64
+    category: admin
+    name: cryptsetup
+    origin: ''
+    source: apt
+    version: 2:2.0.2-1ubuntu1.1
   cryptsetup-bin:
-    - arch: amd64
-      category: admin
-      name: cryptsetup-bin
-      origin: ''
-      source: apt
-      version: '2:2.0.2-1ubuntu1.1'
+  - arch: amd64
+    category: admin
+    name: cryptsetup-bin
+    origin: ''
+    source: apt
+    version: 2:2.0.2-1ubuntu1.1
   curl:
-    - arch: amd64
-      category: web
-      name: curl
-      origin: Ubuntu
-      source: apt
-      version: 7.58.0-2ubuntu3.18
+  - arch: amd64
+    category: web
+    name: curl
+    origin: Ubuntu
+    source: apt
+    version: 7.58.0-2ubuntu3.18
   dash:
-    - arch: amd64
-      category: shells
-      name: dash
-      origin: Ubuntu
-      source: apt
-      version: 0.5.8-2.10
+  - arch: amd64
+    category: shells
+    name: dash
+    origin: Ubuntu
+    source: apt
+    version: 0.5.8-2.10
   dbus:
-    - arch: amd64
-      category: devel
-      name: dbus
-      origin: Ubuntu
-      source: apt
-      version: 1.12.2-1ubuntu1.3
+  - arch: amd64
+    category: devel
+    name: dbus
+    origin: Ubuntu
+    source: apt
+    version: 1.12.2-1ubuntu1.3
   dbus-user-session:
-    - arch: amd64
-      category: admin
-      name: dbus-user-session
-      origin: Ubuntu
-      source: apt
-      version: 1.12.2-1ubuntu1.3
+  - arch: amd64
+    category: admin
+    name: dbus-user-session
+    origin: Ubuntu
+    source: apt
+    version: 1.12.2-1ubuntu1.3
   debconf:
-    - arch: all
-      category: admin
-      name: debconf
-      origin: Ubuntu
-      source: apt
-      version: 1.5.66ubuntu1
+  - arch: all
+    category: admin
+    name: debconf
+    origin: Ubuntu
+    source: apt
+    version: 1.5.66ubuntu1
   debconf-i18n:
-    - arch: all
-      category: admin
-      name: debconf-i18n
-      origin: Ubuntu
-      source: apt
-      version: 1.5.66ubuntu1
+  - arch: all
+    category: admin
+    name: debconf-i18n
+    origin: Ubuntu
+    source: apt
+    version: 1.5.66ubuntu1
   debianutils:
-    - arch: amd64
-      category: utils
-      name: debianutils
-      origin: Ubuntu
-      source: apt
-      version: 4.8.4
+  - arch: amd64
+    category: utils
+    name: debianutils
+    origin: Ubuntu
+    source: apt
+    version: 4.8.4
   diffutils:
-    - arch: amd64
-      category: utils
-      name: diffutils
-      origin: Ubuntu
-      source: apt
-      version: '1:3.6-1'
+  - arch: amd64
+    category: utils
+    name: diffutils
+    origin: Ubuntu
+    source: apt
+    version: 1:3.6-1
   dirmngr:
-    - arch: amd64
-      category: utils
-      name: dirmngr
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: dirmngr
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   distro-info-data:
-    - arch: all
-      category: devel
-      name: distro-info-data
-      origin: Ubuntu
-      source: apt
-      version: 0.37ubuntu0.14
+  - arch: all
+    category: devel
+    name: distro-info-data
+    origin: Ubuntu
+    source: apt
+    version: 0.37ubuntu0.14
   dmeventd:
-    - arch: amd64
-      category: admin
-      name: dmeventd
-      origin: Ubuntu
-      source: apt
-      version: '2:1.02.145-4.1ubuntu3.18.04.3'
+  - arch: amd64
+    category: admin
+    name: dmeventd
+    origin: Ubuntu
+    source: apt
+    version: 2:1.02.145-4.1ubuntu3.18.04.3
   dmidecode:
-    - arch: amd64
-      category: utils
-      name: dmidecode
-      origin: Ubuntu
-      source: apt
-      version: 3.1-1ubuntu0.1
+  - arch: amd64
+    category: utils
+    name: dmidecode
+    origin: Ubuntu
+    source: apt
+    version: 3.1-1ubuntu0.1
   dmsetup:
-    - arch: amd64
-      category: admin
-      name: dmsetup
-      origin: Ubuntu
-      source: apt
-      version: '2:1.02.145-4.1ubuntu3.18.04.3'
+  - arch: amd64
+    category: admin
+    name: dmsetup
+    origin: Ubuntu
+    source: apt
+    version: 2:1.02.145-4.1ubuntu3.18.04.3
   dns-root-data:
-    - arch: all
-      category: misc
-      name: dns-root-data
-      origin: Ubuntu
-      source: apt
-      version: '2018013001'
+  - arch: all
+    category: misc
+    name: dns-root-data
+    origin: Ubuntu
+    source: apt
+    version: '2018013001'
   dnsmasq-base:
-    - arch: amd64
-      category: net
-      name: dnsmasq-base
-      origin: Ubuntu
-      source: apt
-      version: 2.79-1ubuntu0.6
+  - arch: amd64
+    category: net
+    name: dnsmasq-base
+    origin: Ubuntu
+    source: apt
+    version: 2.79-1ubuntu0.6
   dnsutils:
-    - arch: amd64
-      category: net
-      name: dnsutils
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: net
+    name: dnsutils
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   docker-ce:
-    - arch: amd64
-      category: admin
-      name: docker-ce
-      origin: Docker
-      source: apt
-      version: '5:19.03.4~3-0~ubuntu-bionic'
+  - arch: amd64
+    category: admin
+    name: docker-ce
+    origin: Docker
+    source: apt
+    version: 5:19.03.4~3-0~ubuntu-bionic
   docker-ce-cli:
-    - arch: amd64
-      category: admin
-      name: docker-ce-cli
-      origin: Docker
-      source: apt
-      version: '5:19.03.4~3-0~ubuntu-bionic'
+  - arch: amd64
+    category: admin
+    name: docker-ce-cli
+    origin: Docker
+    source: apt
+    version: 5:19.03.4~3-0~ubuntu-bionic
   dosfstools:
-    - arch: amd64
-      category: otherosfs
-      name: dosfstools
-      origin: Ubuntu
-      source: apt
-      version: 4.1-1
+  - arch: amd64
+    category: otherosfs
+    name: dosfstools
+    origin: Ubuntu
+    source: apt
+    version: 4.1-1
   dpkg:
-    - arch: amd64
-      category: admin
-      name: dpkg
-      origin: Ubuntu
-      source: apt
-      version: 1.19.0.5ubuntu2.4
+  - arch: amd64
+    category: admin
+    name: dpkg
+    origin: Ubuntu
+    source: apt
+    version: 1.19.0.5ubuntu2.4
   e2fsprogs:
-    - arch: amd64
-      category: admin
-      name: e2fsprogs
-      origin: Ubuntu
-      source: apt
-      version: 1.44.1-1ubuntu1.3
+  - arch: amd64
+    category: admin
+    name: e2fsprogs
+    origin: Ubuntu
+    source: apt
+    version: 1.44.1-1ubuntu1.3
   eatmydata:
-    - arch: all
-      category: utils
-      name: eatmydata
-      origin: Ubuntu
-      source: apt
-      version: 105-6
+  - arch: all
+    category: utils
+    name: eatmydata
+    origin: Ubuntu
+    source: apt
+    version: 105-6
   ebtables:
-    - arch: amd64
-      category: net
-      name: ebtables
-      origin: Ubuntu
-      source: apt
-      version: 2.0.10.4-3.5ubuntu2.18.04.3
+  - arch: amd64
+    category: net
+    name: ebtables
+    origin: Ubuntu
+    source: apt
+    version: 2.0.10.4-3.5ubuntu2.18.04.3
   ed:
-    - arch: amd64
-      category: editors
-      name: ed
-      origin: Ubuntu
-      source: apt
-      version: 1.10-2.1
+  - arch: amd64
+    category: editors
+    name: ed
+    origin: Ubuntu
+    source: apt
+    version: 1.10-2.1
   efibootmgr:
-    - arch: amd64
-      category: admin
-      name: efibootmgr
-      origin: Ubuntu
-      source: apt
-      version: 15-1
+  - arch: amd64
+    category: admin
+    name: efibootmgr
+    origin: Ubuntu
+    source: apt
+    version: 15-1
   eject:
-    - arch: amd64
-      category: utils
-      name: eject
-      origin: Ubuntu
-      source: apt
-      version: 2.1.5+deb1+cvs20081104-13.2
+  - arch: amd64
+    category: utils
+    name: eject
+    origin: Ubuntu
+    source: apt
+    version: 2.1.5+deb1+cvs20081104-13.2
   ethtool:
-    - arch: amd64
-      category: utils
-      name: ethtool
-      origin: Ubuntu
-      source: apt
-      version: '1:4.15-0ubuntu1'
+  - arch: amd64
+    category: utils
+    name: ethtool
+    origin: Ubuntu
+    source: apt
+    version: 1:4.15-0ubuntu1
   fdisk:
-    - arch: amd64
-      category: utils
-      name: fdisk
-      origin: Ubuntu
-      source: apt
-      version: 2.31.1-0.4ubuntu3.7
+  - arch: amd64
+    category: utils
+    name: fdisk
+    origin: Ubuntu
+    source: apt
+    version: 2.31.1-0.4ubuntu3.7
   file:
-    - arch: amd64
-      category: utils
-      name: file
-      origin: Ubuntu
-      source: apt
-      version: '1:5.32-2ubuntu0.4'
+  - arch: amd64
+    category: utils
+    name: file
+    origin: Ubuntu
+    source: apt
+    version: 1:5.32-2ubuntu0.4
   findutils:
-    - arch: amd64
-      category: utils
-      name: findutils
-      origin: Ubuntu
-      source: apt
-      version: 4.6.0+git+20170828-2
+  - arch: amd64
+    category: utils
+    name: findutils
+    origin: Ubuntu
+    source: apt
+    version: 4.6.0+git+20170828-2
   fonts-ubuntu-console:
-    - arch: all
-      category: fonts
-      name: fonts-ubuntu-console
-      origin: Ubuntu
-      source: apt
-      version: 0.83-2
+  - arch: all
+    category: fonts
+    name: fonts-ubuntu-console
+    origin: Ubuntu
+    source: apt
+    version: 0.83-2
   friendly-recovery:
-    - arch: all
-      category: admin
-      name: friendly-recovery
-      origin: ''
-      source: apt
-      version: 0.2.38ubuntu1.1
+  - arch: all
+    category: admin
+    name: friendly-recovery
+    origin: ''
+    source: apt
+    version: 0.2.38ubuntu1.1
   ftp:
-    - arch: amd64
-      category: net
-      name: ftp
-      origin: Ubuntu
-      source: apt
-      version: 0.17-34
+  - arch: amd64
+    category: net
+    name: ftp
+    origin: Ubuntu
+    source: apt
+    version: 0.17-34
   fuse:
-    - arch: amd64
-      category: utils
-      name: fuse
-      origin: Ubuntu
-      source: apt
-      version: 2.9.7-1ubuntu1
+  - arch: amd64
+    category: utils
+    name: fuse
+    origin: Ubuntu
+    source: apt
+    version: 2.9.7-1ubuntu1
   gawk:
-    - arch: amd64
-      category: interpreters
-      name: gawk
-      origin: Ubuntu
-      source: apt
-      version: '1:4.1.4+dfsg-1build1'
+  - arch: amd64
+    category: interpreters
+    name: gawk
+    origin: Ubuntu
+    source: apt
+    version: 1:4.1.4+dfsg-1build1
   gcc-8-base:
-    - arch: amd64
-      category: libs
-      name: gcc-8-base
-      origin: Ubuntu
-      source: apt
-      version: 8.4.0-1ubuntu1~18.04
+  - arch: amd64
+    category: libs
+    name: gcc-8-base
+    origin: Ubuntu
+    source: apt
+    version: 8.4.0-1ubuntu1~18.04
   gdisk:
-    - arch: amd64
-      category: admin
-      name: gdisk
-      origin: Ubuntu
-      source: apt
-      version: 1.0.3-1
+  - arch: amd64
+    category: admin
+    name: gdisk
+    origin: Ubuntu
+    source: apt
+    version: 1.0.3-1
   geoip-database:
-    - arch: all
-      category: net
-      name: geoip-database
-      origin: Ubuntu
-      source: apt
-      version: 20180315-1
+  - arch: all
+    category: net
+    name: geoip-database
+    origin: Ubuntu
+    source: apt
+    version: 20180315-1
   gettext-base:
-    - arch: amd64
-      category: utils
-      name: gettext-base
-      origin: Ubuntu
-      source: apt
-      version: 0.19.8.1-6ubuntu0.3
+  - arch: amd64
+    category: utils
+    name: gettext-base
+    origin: Ubuntu
+    source: apt
+    version: 0.19.8.1-6ubuntu0.3
   gir1.2-glib-2.0:
-    - arch: amd64
-      category: introspection
-      name: gir1.2-glib-2.0
-      origin: Ubuntu
-      source: apt
-      version: 1.56.1-1
+  - arch: amd64
+    category: introspection
+    name: gir1.2-glib-2.0
+    origin: Ubuntu
+    source: apt
+    version: 1.56.1-1
   git:
-    - arch: amd64
-      category: vcs
-      name: git
-      origin: Ubuntu
-      source: apt
-      version: '1:2.17.1-1ubuntu0.11'
+  - arch: amd64
+    category: vcs
+    name: git
+    origin: Ubuntu
+    source: apt
+    version: 1:2.17.1-1ubuntu0.11
   git-man:
-    - arch: all
-      category: vcs
-      name: git-man
-      origin: Ubuntu
-      source: apt
-      version: '1:2.17.1-1ubuntu0.11'
+  - arch: all
+    category: vcs
+    name: git-man
+    origin: Ubuntu
+    source: apt
+    version: 1:2.17.1-1ubuntu0.11
   gnupg:
-    - arch: amd64
-      category: utils
-      name: gnupg
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: gnupg
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   gnupg-l10n:
-    - arch: all
-      category: utils
-      name: gnupg-l10n
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: all
+    category: utils
+    name: gnupg-l10n
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   gnupg-utils:
-    - arch: amd64
-      category: utils
-      name: gnupg-utils
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: gnupg-utils
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   gpg:
-    - arch: amd64
-      category: utils
-      name: gpg
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: gpg
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   gpg-agent:
-    - arch: amd64
-      category: utils
-      name: gpg-agent
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: gpg-agent
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   gpg-wks-client:
-    - arch: amd64
-      category: utils
-      name: gpg-wks-client
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: gpg-wks-client
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   gpg-wks-server:
-    - arch: amd64
-      category: utils
-      name: gpg-wks-server
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: gpg-wks-server
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   gpgconf:
-    - arch: amd64
-      category: utils
-      name: gpgconf
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: gpgconf
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   gpgsm:
-    - arch: amd64
-      category: utils
-      name: gpgsm
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: gpgsm
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   gpgv:
-    - arch: amd64
-      category: utils
-      name: gpgv
-      origin: Ubuntu
-      source: apt
-      version: 2.2.4-1ubuntu1.5
+  - arch: amd64
+    category: utils
+    name: gpgv
+    origin: Ubuntu
+    source: apt
+    version: 2.2.4-1ubuntu1.5
   grep:
-    - arch: amd64
-      category: utils
-      name: grep
-      origin: Ubuntu
-      source: apt
-      version: 3.1-2build1
+  - arch: amd64
+    category: utils
+    name: grep
+    origin: Ubuntu
+    source: apt
+    version: 3.1-2build1
   groff-base:
-    - arch: amd64
-      category: text
-      name: groff-base
-      origin: Ubuntu
-      source: apt
-      version: 1.22.3-10
+  - arch: amd64
+    category: text
+    name: groff-base
+    origin: Ubuntu
+    source: apt
+    version: 1.22.3-10
   grub-common:
-    - arch: amd64
-      category: admin
-      name: grub-common
-      origin: Ubuntu
-      source: apt
-      version: 2.02-2ubuntu8.23
+  - arch: amd64
+    category: admin
+    name: grub-common
+    origin: Ubuntu
+    source: apt
+    version: 2.02-2ubuntu8.23
   grub-efi-amd64:
-    - arch: amd64
-      category: admin
-      name: grub-efi-amd64
-      origin: Ubuntu
-      source: apt
-      version: 2.04-1ubuntu44.1.2
+  - arch: amd64
+    category: admin
+    name: grub-efi-amd64
+    origin: Ubuntu
+    source: apt
+    version: 2.04-1ubuntu44.1.2
   grub-efi-amd64-bin:
-    - arch: amd64
-      category: admin
-      name: grub-efi-amd64-bin
-      origin: Ubuntu
-      source: apt
-      version: 2.04-1ubuntu44.1.2
+  - arch: amd64
+    category: admin
+    name: grub-efi-amd64-bin
+    origin: Ubuntu
+    source: apt
+    version: 2.04-1ubuntu44.1.2
   grub-efi-amd64-signed:
-    - arch: amd64
-      category: utils
-      name: grub-efi-amd64-signed
-      origin: Ubuntu
-      source: apt
-      version: 1.167~18.04.5+2.04-1ubuntu44.1.2
+  - arch: amd64
+    category: utils
+    name: grub-efi-amd64-signed
+    origin: Ubuntu
+    source: apt
+    version: 1.167~18.04.5+2.04-1ubuntu44.1.2
   grub-legacy-ec2:
-    - arch: all
-      category: admin
-      name: grub-legacy-ec2
-      origin: Ubuntu
-      source: apt
-      version: '1:1'
+  - arch: all
+    category: admin
+    name: grub-legacy-ec2
+    origin: Ubuntu
+    source: apt
+    version: '1:1'
   grub2-common:
-    - arch: amd64
-      category: admin
-      name: grub2-common
-      origin: Ubuntu
-      source: apt
-      version: 2.02-2ubuntu8.23
+  - arch: amd64
+    category: admin
+    name: grub2-common
+    origin: Ubuntu
+    source: apt
+    version: 2.02-2ubuntu8.23
   gzip:
-    - arch: amd64
-      category: utils
-      name: gzip
-      origin: Ubuntu
-      source: apt
-      version: 1.6-5ubuntu1.2
+  - arch: amd64
+    category: utils
+    name: gzip
+    origin: Ubuntu
+    source: apt
+    version: 1.6-5ubuntu1.2
   hdparm:
-    - arch: amd64
-      category: admin
-      name: hdparm
-      origin: Ubuntu
-      source: apt
-      version: 9.54+ds-1
+  - arch: amd64
+    category: admin
+    name: hdparm
+    origin: Ubuntu
+    source: apt
+    version: 9.54+ds-1
   hostname:
-    - arch: amd64
-      category: admin
-      name: hostname
-      origin: Ubuntu
-      source: apt
-      version: '3.20'
+  - arch: amd64
+    category: admin
+    name: hostname
+    origin: Ubuntu
+    source: apt
+    version: '3.20'
   htop:
-    - arch: amd64
-      category: utils
-      name: htop
-      origin: Ubuntu
-      source: apt
-      version: 2.1.0-3
+  - arch: amd64
+    category: utils
+    name: htop
+    origin: Ubuntu
+    source: apt
+    version: 2.1.0-3
   info:
-    - arch: amd64
-      category: doc
-      name: info
-      origin: Ubuntu
-      source: apt
-      version: 6.5.0.dfsg.1-2
+  - arch: amd64
+    category: doc
+    name: info
+    origin: Ubuntu
+    source: apt
+    version: 6.5.0.dfsg.1-2
   init:
-    - arch: amd64
-      category: metapackages
-      name: init
-      origin: Ubuntu
-      source: apt
-      version: '1.51'
+  - arch: amd64
+    category: metapackages
+    name: init
+    origin: Ubuntu
+    source: apt
+    version: '1.51'
   init-system-helpers:
-    - arch: all
-      category: admin
-      name: init-system-helpers
-      origin: Ubuntu
-      source: apt
-      version: '1.51'
+  - arch: all
+    category: admin
+    name: init-system-helpers
+    origin: Ubuntu
+    source: apt
+    version: '1.51'
   initramfs-tools:
-    - arch: all
-      category: utils
-      name: initramfs-tools
-      origin: ''
-      source: apt
-      version: 0.130ubuntu3.9
+  - arch: all
+    category: utils
+    name: initramfs-tools
+    origin: ''
+    source: apt
+    version: 0.130ubuntu3.9
   initramfs-tools-bin:
-    - arch: amd64
-      category: utils
-      name: initramfs-tools-bin
-      origin: ''
-      source: apt
-      version: 0.130ubuntu3.9
+  - arch: amd64
+    category: utils
+    name: initramfs-tools-bin
+    origin: ''
+    source: apt
+    version: 0.130ubuntu3.9
   initramfs-tools-core:
-    - arch: all
-      category: utils
-      name: initramfs-tools-core
-      origin: ''
-      source: apt
-      version: 0.130ubuntu3.9
+  - arch: all
+    category: utils
+    name: initramfs-tools-core
+    origin: ''
+    source: apt
+    version: 0.130ubuntu3.9
   install-info:
-    - arch: amd64
-      category: doc
-      name: install-info
-      origin: Ubuntu
-      source: apt
-      version: 6.5.0.dfsg.1-2
+  - arch: amd64
+    category: doc
+    name: install-info
+    origin: Ubuntu
+    source: apt
+    version: 6.5.0.dfsg.1-2
   iproute2:
-    - arch: amd64
-      category: net
-      name: iproute2
-      origin: ''
-      source: apt
-      version: 4.15.0-2ubuntu1.2
+  - arch: amd64
+    category: net
+    name: iproute2
+    origin: ''
+    source: apt
+    version: 4.15.0-2ubuntu1.2
   iptables:
-    - arch: amd64
-      category: net
-      name: iptables
-      origin: Ubuntu
-      source: apt
-      version: 1.6.1-2ubuntu2
+  - arch: amd64
+    category: net
+    name: iptables
+    origin: Ubuntu
+    source: apt
+    version: 1.6.1-2ubuntu2
   iputils-ping:
-    - arch: amd64
-      category: net
-      name: iputils-ping
-      origin: Ubuntu
-      source: apt
-      version: '3:20161105-1ubuntu3'
+  - arch: amd64
+    category: net
+    name: iputils-ping
+    origin: Ubuntu
+    source: apt
+    version: 3:20161105-1ubuntu3
   iputils-tracepath:
-    - arch: amd64
-      category: net
-      name: iputils-tracepath
-      origin: Ubuntu
-      source: apt
-      version: '3:20161105-1ubuntu3'
+  - arch: amd64
+    category: net
+    name: iputils-tracepath
+    origin: Ubuntu
+    source: apt
+    version: 3:20161105-1ubuntu3
   irqbalance:
-    - arch: amd64
-      category: utils
-      name: irqbalance
-      origin: Ubuntu
-      source: apt
-      version: 1.3.0-0.1ubuntu0.18.04.1
+  - arch: amd64
+    category: utils
+    name: irqbalance
+    origin: Ubuntu
+    source: apt
+    version: 1.3.0-0.1ubuntu0.18.04.1
   isc-dhcp-client:
-    - arch: amd64
-      category: net
-      name: isc-dhcp-client
-      origin: Ubuntu
-      source: apt
-      version: 4.3.5-3ubuntu7.3
+  - arch: amd64
+    category: net
+    name: isc-dhcp-client
+    origin: Ubuntu
+    source: apt
+    version: 4.3.5-3ubuntu7.3
   isc-dhcp-common:
-    - arch: amd64
-      category: net
-      name: isc-dhcp-common
-      origin: Ubuntu
-      source: apt
-      version: 4.3.5-3ubuntu7.3
+  - arch: amd64
+    category: net
+    name: isc-dhcp-common
+    origin: Ubuntu
+    source: apt
+    version: 4.3.5-3ubuntu7.3
   iso-codes:
-    - arch: all
-      category: libs
-      name: iso-codes
-      origin: Ubuntu
-      source: apt
-      version: 3.79-1
+  - arch: all
+    category: libs
+    name: iso-codes
+    origin: Ubuntu
+    source: apt
+    version: 3.79-1
   kbd:
-    - arch: amd64
-      category: utils
-      name: kbd
-      origin: Ubuntu
-      source: apt
-      version: 2.0.4-2ubuntu1
+  - arch: amd64
+    category: utils
+    name: kbd
+    origin: Ubuntu
+    source: apt
+    version: 2.0.4-2ubuntu1
   keyboard-configuration:
-    - arch: all
-      category: utils
-      name: keyboard-configuration
-      origin: Ubuntu
-      source: apt
-      version: 1.178ubuntu2.9
+  - arch: all
+    category: utils
+    name: keyboard-configuration
+    origin: Ubuntu
+    source: apt
+    version: 1.178ubuntu2.9
   klibc-utils:
-    - arch: amd64
-      category: libs
-      name: klibc-utils
-      origin: Ubuntu
-      source: apt
-      version: 2.0.4-9ubuntu2.1
+  - arch: amd64
+    category: libs
+    name: klibc-utils
+    origin: Ubuntu
+    source: apt
+    version: 2.0.4-9ubuntu2.1
   kmod:
-    - arch: amd64
-      category: admin
-      name: kmod
-      origin: Ubuntu
-      source: apt
-      version: 24-1ubuntu3.5
+  - arch: amd64
+    category: admin
+    name: kmod
+    origin: Ubuntu
+    source: apt
+    version: 24-1ubuntu3.5
   krb5-locales:
-    - arch: all
-      category: localization
-      name: krb5-locales
-      origin: Ubuntu
-      source: apt
-      version: 1.16-2ubuntu0.2
+  - arch: all
+    category: localization
+    name: krb5-locales
+    origin: Ubuntu
+    source: apt
+    version: 1.16-2ubuntu0.2
   landscape-common:
-    - arch: amd64
-      category: admin
-      name: landscape-common
-      origin: ''
-      source: apt
-      version: 18.01-0ubuntu3.5
+  - arch: amd64
+    category: admin
+    name: landscape-common
+    origin: ''
+    source: apt
+    version: 18.01-0ubuntu3.5
   language-selector-common:
-    - arch: all
-      category: admin
-      name: language-selector-common
-      origin: Ubuntu
-      source: apt
-      version: 0.188.3
+  - arch: all
+    category: admin
+    name: language-selector-common
+    origin: Ubuntu
+    source: apt
+    version: 0.188.3
   less:
-    - arch: amd64
-      category: text
-      name: less
-      origin: Ubuntu
-      source: apt
-      version: 487-0.1
+  - arch: amd64
+    category: text
+    name: less
+    origin: Ubuntu
+    source: apt
+    version: 487-0.1
   libaccountsservice0:
-    - arch: amd64
-      category: libs
-      name: libaccountsservice0
-      origin: Ubuntu
-      source: apt
-      version: 0.6.45-1ubuntu1.3
+  - arch: amd64
+    category: libs
+    name: libaccountsservice0
+    origin: Ubuntu
+    source: apt
+    version: 0.6.45-1ubuntu1.3
   libacl1:
-    - arch: amd64
-      category: libs
-      name: libacl1
-      origin: Ubuntu
-      source: apt
-      version: 2.2.52-3build1
+  - arch: amd64
+    category: libs
+    name: libacl1
+    origin: Ubuntu
+    source: apt
+    version: 2.2.52-3build1
   libapparmor1:
-    - arch: amd64
-      category: libs
-      name: libapparmor1
-      origin: Ubuntu
-      source: apt
-      version: 2.12-4ubuntu5.1
+  - arch: amd64
+    category: libs
+    name: libapparmor1
+    origin: Ubuntu
+    source: apt
+    version: 2.12-4ubuntu5.1
   libapt-inst2.0:
-    - arch: amd64
-      category: libs
-      name: libapt-inst2.0
-      origin: Ubuntu
-      source: apt
-      version: 1.6.12ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libapt-inst2.0
+    origin: Ubuntu
+    source: apt
+    version: 1.6.12ubuntu0.2
   libapt-pkg5.0:
-    - arch: amd64
-      category: libs
-      name: libapt-pkg5.0
-      origin: Ubuntu
-      source: apt
-      version: 1.6.12ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libapt-pkg5.0
+    origin: Ubuntu
+    source: apt
+    version: 1.6.12ubuntu0.2
   libargon2-0:
-    - arch: amd64
-      category: libs
-      name: libargon2-0
-      origin: Ubuntu
-      source: apt
-      version: 0~20161029-1.1
+  - arch: amd64
+    category: libs
+    name: libargon2-0
+    origin: Ubuntu
+    source: apt
+    version: 0~20161029-1.1
   libasn1-8-heimdal:
-    - arch: amd64
-      category: libs
-      name: libasn1-8-heimdal
-      origin: Ubuntu
-      source: apt
-      version: 7.5.0+dfsg-1
+  - arch: amd64
+    category: libs
+    name: libasn1-8-heimdal
+    origin: Ubuntu
+    source: apt
+    version: 7.5.0+dfsg-1
   libassuan0:
-    - arch: amd64
-      category: libs
-      name: libassuan0
-      origin: Ubuntu
-      source: apt
-      version: 2.5.1-2
+  - arch: amd64
+    category: libs
+    name: libassuan0
+    origin: Ubuntu
+    source: apt
+    version: 2.5.1-2
   libatm1:
-    - arch: amd64
-      category: libs
-      name: libatm1
-      origin: Ubuntu
-      source: apt
-      version: '1:2.5.1-2build1'
+  - arch: amd64
+    category: libs
+    name: libatm1
+    origin: Ubuntu
+    source: apt
+    version: 1:2.5.1-2build1
   libattr1:
-    - arch: amd64
-      category: libs
-      name: libattr1
-      origin: Ubuntu
-      source: apt
-      version: '1:2.4.47-2build1'
+  - arch: amd64
+    category: libs
+    name: libattr1
+    origin: Ubuntu
+    source: apt
+    version: 1:2.4.47-2build1
   libaudit-common:
-    - arch: all
-      category: libs
-      name: libaudit-common
-      origin: Ubuntu
-      source: apt
-      version: '1:2.8.2-1ubuntu1'
+  - arch: all
+    category: libs
+    name: libaudit-common
+    origin: Ubuntu
+    source: apt
+    version: 1:2.8.2-1ubuntu1
   libaudit1:
-    - arch: amd64
-      category: libs
-      name: libaudit1
-      origin: Ubuntu
-      source: apt
-      version: '1:2.8.2-1ubuntu1'
+  - arch: amd64
+    category: libs
+    name: libaudit1
+    origin: Ubuntu
+    source: apt
+    version: 1:2.8.2-1ubuntu1
   libbind9-160:
-    - arch: amd64
-      category: libs
-      name: libbind9-160
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: libs
+    name: libbind9-160
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   libblkid1:
-    - arch: amd64
-      category: libs
-      name: libblkid1
-      origin: Ubuntu
-      source: apt
-      version: 2.31.1-0.4ubuntu3.7
+  - arch: amd64
+    category: libs
+    name: libblkid1
+    origin: Ubuntu
+    source: apt
+    version: 2.31.1-0.4ubuntu3.7
   libbsd0:
-    - arch: amd64
-      category: libs
-      name: libbsd0
-      origin: Ubuntu
-      source: apt
-      version: 0.8.7-1ubuntu0.1
+  - arch: amd64
+    category: libs
+    name: libbsd0
+    origin: Ubuntu
+    source: apt
+    version: 0.8.7-1ubuntu0.1
   libbz2-1.0:
-    - arch: amd64
-      category: libs
-      name: libbz2-1.0
-      origin: Ubuntu
-      source: apt
-      version: 1.0.6-8.1ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libbz2-1.0
+    origin: Ubuntu
+    source: apt
+    version: 1.0.6-8.1ubuntu0.2
   libc-bin:
-    - arch: amd64
-      category: libs
-      name: libc-bin
-      origin: Ubuntu
-      source: apt
-      version: 2.27-3ubuntu1.5
+  - arch: amd64
+    category: libs
+    name: libc-bin
+    origin: Ubuntu
+    source: apt
+    version: 2.27-3ubuntu1.5
   libc6:
-    - arch: amd64
-      category: libs
-      name: libc6
-      origin: Ubuntu
-      source: apt
-      version: 2.27-3ubuntu1.5
+  - arch: amd64
+    category: libs
+    name: libc6
+    origin: Ubuntu
+    source: apt
+    version: 2.27-3ubuntu1.5
   libcap-ng0:
-    - arch: amd64
-      category: libs
-      name: libcap-ng0
-      origin: Ubuntu
-      source: apt
-      version: 0.7.7-3.1
+  - arch: amd64
+    category: libs
+    name: libcap-ng0
+    origin: Ubuntu
+    source: apt
+    version: 0.7.7-3.1
   libcap2:
-    - arch: amd64
-      category: libs
-      name: libcap2
-      origin: Ubuntu
-      source: apt
-      version: '1:2.25-1.2'
+  - arch: amd64
+    category: libs
+    name: libcap2
+    origin: Ubuntu
+    source: apt
+    version: 1:2.25-1.2
   libcap2-bin:
-    - arch: amd64
-      category: utils
-      name: libcap2-bin
-      origin: Ubuntu
-      source: apt
-      version: '1:2.25-1.2'
+  - arch: amd64
+    category: utils
+    name: libcap2-bin
+    origin: Ubuntu
+    source: apt
+    version: 1:2.25-1.2
   libcom-err2:
-    - arch: amd64
-      category: libs
-      name: libcom-err2
-      origin: Ubuntu
-      source: apt
-      version: 1.44.1-1ubuntu1.3
+  - arch: amd64
+    category: libs
+    name: libcom-err2
+    origin: Ubuntu
+    source: apt
+    version: 1.44.1-1ubuntu1.3
   libcryptsetup12:
-    - arch: amd64
-      category: libs
-      name: libcryptsetup12
-      origin: ''
-      source: apt
-      version: '2:2.0.2-1ubuntu1.1'
+  - arch: amd64
+    category: libs
+    name: libcryptsetup12
+    origin: ''
+    source: apt
+    version: 2:2.0.2-1ubuntu1.1
   libcurl3-gnutls:
-    - arch: amd64
-      category: libs
-      name: libcurl3-gnutls
-      origin: Ubuntu
-      source: apt
-      version: 7.58.0-2ubuntu3.18
+  - arch: amd64
+    category: libs
+    name: libcurl3-gnutls
+    origin: Ubuntu
+    source: apt
+    version: 7.58.0-2ubuntu3.18
   libcurl4:
-    - arch: amd64
-      category: libs
-      name: libcurl4
-      origin: Ubuntu
-      source: apt
-      version: 7.58.0-2ubuntu3.18
+  - arch: amd64
+    category: libs
+    name: libcurl4
+    origin: Ubuntu
+    source: apt
+    version: 7.58.0-2ubuntu3.18
   libdb5.3:
-    - arch: amd64
-      category: libs
-      name: libdb5.3
-      origin: Ubuntu
-      source: apt
-      version: 5.3.28-13.1ubuntu1.1
+  - arch: amd64
+    category: libs
+    name: libdb5.3
+    origin: Ubuntu
+    source: apt
+    version: 5.3.28-13.1ubuntu1.1
   libdbus-1-3:
-    - arch: amd64
-      category: libs
-      name: libdbus-1-3
-      origin: Ubuntu
-      source: apt
-      version: 1.12.2-1ubuntu1.3
+  - arch: amd64
+    category: libs
+    name: libdbus-1-3
+    origin: Ubuntu
+    source: apt
+    version: 1.12.2-1ubuntu1.3
   libdebconfclient0:
-    - arch: amd64
-      category: libs
-      name: libdebconfclient0
-      origin: Ubuntu
-      source: apt
-      version: 0.213ubuntu1
+  - arch: amd64
+    category: libs
+    name: libdebconfclient0
+    origin: Ubuntu
+    source: apt
+    version: 0.213ubuntu1
   libdevmapper-event1.02.1:
-    - arch: amd64
-      category: libs
-      name: libdevmapper-event1.02.1
-      origin: Ubuntu
-      source: apt
-      version: '2:1.02.145-4.1ubuntu3.18.04.3'
+  - arch: amd64
+    category: libs
+    name: libdevmapper-event1.02.1
+    origin: Ubuntu
+    source: apt
+    version: 2:1.02.145-4.1ubuntu3.18.04.3
   libdevmapper1.02.1:
-    - arch: amd64
-      category: libs
-      name: libdevmapper1.02.1
-      origin: Ubuntu
-      source: apt
-      version: '2:1.02.145-4.1ubuntu3.18.04.3'
+  - arch: amd64
+    category: libs
+    name: libdevmapper1.02.1
+    origin: Ubuntu
+    source: apt
+    version: 2:1.02.145-4.1ubuntu3.18.04.3
   libdns-export1100:
-    - arch: amd64
-      category: libs
-      name: libdns-export1100
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: libs
+    name: libdns-export1100
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   libdns1100:
-    - arch: amd64
-      category: libs
-      name: libdns1100
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: libs
+    name: libdns1100
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   libdrm-common:
-    - arch: all
-      category: libs
-      name: libdrm-common
-      origin: Ubuntu
-      source: apt
-      version: 2.4.101-2~18.04.1
+  - arch: all
+    category: libs
+    name: libdrm-common
+    origin: Ubuntu
+    source: apt
+    version: 2.4.101-2~18.04.1
   libdrm2:
-    - arch: amd64
-      category: libs
-      name: libdrm2
-      origin: Ubuntu
-      source: apt
-      version: 2.4.101-2~18.04.1
+  - arch: amd64
+    category: libs
+    name: libdrm2
+    origin: Ubuntu
+    source: apt
+    version: 2.4.101-2~18.04.1
   libdumbnet1:
-    - arch: amd64
-      category: libs
-      name: libdumbnet1
-      origin: Ubuntu
-      source: apt
-      version: 1.12-7build1
+  - arch: amd64
+    category: libs
+    name: libdumbnet1
+    origin: Ubuntu
+    source: apt
+    version: 1.12-7build1
   libeatmydata1:
-    - arch: amd64
-      category: utils
-      name: libeatmydata1
-      origin: Ubuntu
-      source: apt
-      version: 105-6
+  - arch: amd64
+    category: utils
+    name: libeatmydata1
+    origin: Ubuntu
+    source: apt
+    version: 105-6
   libedit2:
-    - arch: amd64
-      category: libs
-      name: libedit2
-      origin: Ubuntu
-      source: apt
-      version: 3.1-20170329-1
+  - arch: amd64
+    category: libs
+    name: libedit2
+    origin: Ubuntu
+    source: apt
+    version: 3.1-20170329-1
   libefiboot1:
-    - arch: amd64
-      category: libs
-      name: libefiboot1
-      origin: Ubuntu
-      source: apt
-      version: 34-1
+  - arch: amd64
+    category: libs
+    name: libefiboot1
+    origin: Ubuntu
+    source: apt
+    version: 34-1
   libefivar1:
-    - arch: amd64
-      category: libs
-      name: libefivar1
-      origin: Ubuntu
-      source: apt
-      version: 34-1
+  - arch: amd64
+    category: libs
+    name: libefivar1
+    origin: Ubuntu
+    source: apt
+    version: 34-1
   libelf1:
-    - arch: amd64
-      category: libs
-      name: libelf1
-      origin: Ubuntu
-      source: apt
-      version: 0.170-0.4ubuntu0.1
+  - arch: amd64
+    category: libs
+    name: libelf1
+    origin: Ubuntu
+    source: apt
+    version: 0.170-0.4ubuntu0.1
   liberror-perl:
-    - arch: all
-      category: perl
-      name: liberror-perl
-      origin: Ubuntu
-      source: apt
-      version: 0.17025-1
+  - arch: all
+    category: perl
+    name: liberror-perl
+    origin: Ubuntu
+    source: apt
+    version: 0.17025-1
   libestr0:
-    - arch: amd64
-      category: libs
-      name: libestr0
-      origin: Ubuntu
-      source: apt
-      version: 0.1.10-2.1
+  - arch: amd64
+    category: libs
+    name: libestr0
+    origin: Ubuntu
+    source: apt
+    version: 0.1.10-2.1
   libevent-2.1-6:
-    - arch: amd64
-      category: libs
-      name: libevent-2.1-6
-      origin: Ubuntu
-      source: apt
-      version: 2.1.8-stable-4build1
+  - arch: amd64
+    category: libs
+    name: libevent-2.1-6
+    origin: Ubuntu
+    source: apt
+    version: 2.1.8-stable-4build1
   libexpat1:
-    - arch: amd64
-      category: libs
-      name: libexpat1
-      origin: Ubuntu
-      source: apt
-      version: 2.2.5-3ubuntu0.7
+  - arch: amd64
+    category: libs
+    name: libexpat1
+    origin: Ubuntu
+    source: apt
+    version: 2.2.5-3ubuntu0.7
   libext2fs2:
-    - arch: amd64
-      category: libs
-      name: libext2fs2
-      origin: Ubuntu
-      source: apt
-      version: 1.44.1-1ubuntu1.3
+  - arch: amd64
+    category: libs
+    name: libext2fs2
+    origin: Ubuntu
+    source: apt
+    version: 1.44.1-1ubuntu1.3
   libfastjson4:
-    - arch: amd64
-      category: libs
-      name: libfastjson4
-      origin: Ubuntu
-      source: apt
-      version: 0.99.8-2
+  - arch: amd64
+    category: libs
+    name: libfastjson4
+    origin: Ubuntu
+    source: apt
+    version: 0.99.8-2
   libfdisk1:
-    - arch: amd64
-      category: libs
-      name: libfdisk1
-      origin: Ubuntu
-      source: apt
-      version: 2.31.1-0.4ubuntu3.7
+  - arch: amd64
+    category: libs
+    name: libfdisk1
+    origin: Ubuntu
+    source: apt
+    version: 2.31.1-0.4ubuntu3.7
   libffi6:
-    - arch: amd64
-      category: libs
-      name: libffi6
-      origin: Ubuntu
-      source: apt
-      version: 3.2.1-8
+  - arch: amd64
+    category: libs
+    name: libffi6
+    origin: Ubuntu
+    source: apt
+    version: 3.2.1-8
   libfreetype6:
-    - arch: amd64
-      category: libs
-      name: libfreetype6
-      origin: Ubuntu
-      source: apt
-      version: 2.8.1-2ubuntu2.1
+  - arch: amd64
+    category: libs
+    name: libfreetype6
+    origin: Ubuntu
+    source: apt
+    version: 2.8.1-2ubuntu2.1
   libfribidi0:
-    - arch: amd64
-      category: libs
-      name: libfribidi0
-      origin: Ubuntu
-      source: apt
-      version: 0.19.7-2ubuntu0.1
+  - arch: amd64
+    category: libs
+    name: libfribidi0
+    origin: Ubuntu
+    source: apt
+    version: 0.19.7-2ubuntu0.1
   libfuse2:
-    - arch: amd64
-      category: libs
-      name: libfuse2
-      origin: Ubuntu
-      source: apt
-      version: 2.9.7-1ubuntu1
+  - arch: amd64
+    category: libs
+    name: libfuse2
+    origin: Ubuntu
+    source: apt
+    version: 2.9.7-1ubuntu1
   libgcc1:
-    - arch: amd64
-      category: libs
-      name: libgcc1
-      origin: Ubuntu
-      source: apt
-      version: '1:8.4.0-1ubuntu1~18.04'
+  - arch: amd64
+    category: libs
+    name: libgcc1
+    origin: Ubuntu
+    source: apt
+    version: 1:8.4.0-1ubuntu1~18.04
   libgcrypt20:
-    - arch: amd64
-      category: libs
-      name: libgcrypt20
-      origin: Ubuntu
-      source: apt
-      version: 1.8.1-4ubuntu1.3
+  - arch: amd64
+    category: libs
+    name: libgcrypt20
+    origin: Ubuntu
+    source: apt
+    version: 1.8.1-4ubuntu1.3
   libgdbm-compat4:
-    - arch: amd64
-      category: libs
-      name: libgdbm-compat4
-      origin: Ubuntu
-      source: apt
-      version: 1.14.1-6
+  - arch: amd64
+    category: libs
+    name: libgdbm-compat4
+    origin: Ubuntu
+    source: apt
+    version: 1.14.1-6
   libgdbm5:
-    - arch: amd64
-      category: libs
-      name: libgdbm5
-      origin: Ubuntu
-      source: apt
-      version: 1.14.1-6
+  - arch: amd64
+    category: libs
+    name: libgdbm5
+    origin: Ubuntu
+    source: apt
+    version: 1.14.1-6
   libgeoip1:
-    - arch: amd64
-      category: libs
-      name: libgeoip1
-      origin: Ubuntu
-      source: apt
-      version: 1.6.12-1
+  - arch: amd64
+    category: libs
+    name: libgeoip1
+    origin: Ubuntu
+    source: apt
+    version: 1.6.12-1
   libgirepository-1.0-1:
-    - arch: amd64
-      category: libs
-      name: libgirepository-1.0-1
-      origin: Ubuntu
-      source: apt
-      version: 1.56.1-1
+  - arch: amd64
+    category: libs
+    name: libgirepository-1.0-1
+    origin: Ubuntu
+    source: apt
+    version: 1.56.1-1
   libglib2.0-0:
-    - arch: amd64
-      category: libs
-      name: libglib2.0-0
-      origin: Ubuntu
-      source: apt
-      version: 2.56.4-0ubuntu0.18.04.9
+  - arch: amd64
+    category: libs
+    name: libglib2.0-0
+    origin: Ubuntu
+    source: apt
+    version: 2.56.4-0ubuntu0.18.04.9
   libglib2.0-data:
-    - arch: all
-      category: misc
-      name: libglib2.0-data
-      origin: Ubuntu
-      source: apt
-      version: 2.56.4-0ubuntu0.18.04.9
+  - arch: all
+    category: misc
+    name: libglib2.0-data
+    origin: Ubuntu
+    source: apt
+    version: 2.56.4-0ubuntu0.18.04.9
   libgmp10:
-    - arch: amd64
-      category: libs
-      name: libgmp10
-      origin: Ubuntu
-      source: apt
-      version: '2:6.1.2+dfsg-2'
+  - arch: amd64
+    category: libs
+    name: libgmp10
+    origin: Ubuntu
+    source: apt
+    version: 2:6.1.2+dfsg-2
   libgnutls30:
-    - arch: amd64
-      category: libs
-      name: libgnutls30
-      origin: ''
-      source: apt
-      version: 3.5.18-1ubuntu1.4
+  - arch: amd64
+    category: libs
+    name: libgnutls30
+    origin: ''
+    source: apt
+    version: 3.5.18-1ubuntu1.4
   libgpg-error0:
-    - arch: amd64
-      category: libs
-      name: libgpg-error0
-      origin: Ubuntu
-      source: apt
-      version: 1.27-6
+  - arch: amd64
+    category: libs
+    name: libgpg-error0
+    origin: Ubuntu
+    source: apt
+    version: 1.27-6
   libgpm2:
-    - arch: amd64
-      category: libs
-      name: libgpm2
-      origin: Ubuntu
-      source: apt
-      version: 1.20.7-5
+  - arch: amd64
+    category: libs
+    name: libgpm2
+    origin: Ubuntu
+    source: apt
+    version: 1.20.7-5
   libgssapi-krb5-2:
-    - arch: amd64
-      category: libs
-      name: libgssapi-krb5-2
-      origin: Ubuntu
-      source: apt
-      version: 1.16-2ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libgssapi-krb5-2
+    origin: Ubuntu
+    source: apt
+    version: 1.16-2ubuntu0.2
   libgssapi3-heimdal:
-    - arch: amd64
-      category: libs
-      name: libgssapi3-heimdal
-      origin: Ubuntu
-      source: apt
-      version: 7.5.0+dfsg-1
+  - arch: amd64
+    category: libs
+    name: libgssapi3-heimdal
+    origin: Ubuntu
+    source: apt
+    version: 7.5.0+dfsg-1
   libhcrypto4-heimdal:
-    - arch: amd64
-      category: libs
-      name: libhcrypto4-heimdal
-      origin: Ubuntu
-      source: apt
-      version: 7.5.0+dfsg-1
+  - arch: amd64
+    category: libs
+    name: libhcrypto4-heimdal
+    origin: Ubuntu
+    source: apt
+    version: 7.5.0+dfsg-1
   libheimbase1-heimdal:
-    - arch: amd64
-      category: libs
-      name: libheimbase1-heimdal
-      origin: Ubuntu
-      source: apt
-      version: 7.5.0+dfsg-1
+  - arch: amd64
+    category: libs
+    name: libheimbase1-heimdal
+    origin: Ubuntu
+    source: apt
+    version: 7.5.0+dfsg-1
   libheimntlm0-heimdal:
-    - arch: amd64
-      category: libs
-      name: libheimntlm0-heimdal
-      origin: Ubuntu
-      source: apt
-      version: 7.5.0+dfsg-1
+  - arch: amd64
+    category: libs
+    name: libheimntlm0-heimdal
+    origin: Ubuntu
+    source: apt
+    version: 7.5.0+dfsg-1
   libhogweed4:
-    - arch: amd64
-      category: libs
-      name: libhogweed4
-      origin: Ubuntu
-      source: apt
-      version: 3.4.1-0ubuntu0.18.04.1
+  - arch: amd64
+    category: libs
+    name: libhogweed4
+    origin: Ubuntu
+    source: apt
+    version: 3.4.1-0ubuntu0.18.04.1
   libhx509-5-heimdal:
-    - arch: amd64
-      category: libs
-      name: libhx509-5-heimdal
-      origin: Ubuntu
-      source: apt
-      version: 7.5.0+dfsg-1
+  - arch: amd64
+    category: libs
+    name: libhx509-5-heimdal
+    origin: Ubuntu
+    source: apt
+    version: 7.5.0+dfsg-1
   libicu60:
-    - arch: amd64
-      category: libs
-      name: libicu60
-      origin: Ubuntu
-      source: apt
-      version: 60.2-3ubuntu3.2
+  - arch: amd64
+    category: libs
+    name: libicu60
+    origin: Ubuntu
+    source: apt
+    version: 60.2-3ubuntu3.2
   libidn11:
-    - arch: amd64
-      category: libs
-      name: libidn11
-      origin: Ubuntu
-      source: apt
-      version: 1.33-2.1ubuntu1.2
+  - arch: amd64
+    category: libs
+    name: libidn11
+    origin: Ubuntu
+    source: apt
+    version: 1.33-2.1ubuntu1.2
   libidn2-0:
-    - arch: amd64
-      category: libs
-      name: libidn2-0
-      origin: Ubuntu
-      source: apt
-      version: 2.0.4-1.1ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libidn2-0
+    origin: Ubuntu
+    source: apt
+    version: 2.0.4-1.1ubuntu0.2
   libip4tc0:
-    - arch: amd64
-      category: libs
-      name: libip4tc0
-      origin: Ubuntu
-      source: apt
-      version: 1.6.1-2ubuntu2
+  - arch: amd64
+    category: libs
+    name: libip4tc0
+    origin: Ubuntu
+    source: apt
+    version: 1.6.1-2ubuntu2
   libip6tc0:
-    - arch: amd64
-      category: libs
-      name: libip6tc0
-      origin: Ubuntu
-      source: apt
-      version: 1.6.1-2ubuntu2
+  - arch: amd64
+    category: libs
+    name: libip6tc0
+    origin: Ubuntu
+    source: apt
+    version: 1.6.1-2ubuntu2
   libiptc0:
-    - arch: amd64
-      category: libs
-      name: libiptc0
-      origin: Ubuntu
-      source: apt
-      version: 1.6.1-2ubuntu2
+  - arch: amd64
+    category: libs
+    name: libiptc0
+    origin: Ubuntu
+    source: apt
+    version: 1.6.1-2ubuntu2
   libirs160:
-    - arch: amd64
-      category: libs
-      name: libirs160
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: libs
+    name: libirs160
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   libisc-export169:
-    - arch: amd64
-      category: libs
-      name: libisc-export169
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: libs
+    name: libisc-export169
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   libisc169:
-    - arch: amd64
-      category: libs
-      name: libisc169
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: libs
+    name: libisc169
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   libisccc160:
-    - arch: amd64
-      category: libs
-      name: libisccc160
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: libs
+    name: libisccc160
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   libisccfg160:
-    - arch: amd64
-      category: libs
-      name: libisccfg160
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: libs
+    name: libisccfg160
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   libisns0:
-    - arch: amd64
-      category: libs
-      name: libisns0
-      origin: Ubuntu
-      source: apt
-      version: 0.97-2build1
+  - arch: amd64
+    category: libs
+    name: libisns0
+    origin: Ubuntu
+    source: apt
+    version: 0.97-2build1
   libjson-c3:
-    - arch: amd64
-      category: libs
-      name: libjson-c3
-      origin: Ubuntu
-      source: apt
-      version: 0.12.1-1.3ubuntu0.3
+  - arch: amd64
+    category: libs
+    name: libjson-c3
+    origin: Ubuntu
+    source: apt
+    version: 0.12.1-1.3ubuntu0.3
   libk5crypto3:
-    - arch: amd64
-      category: libs
-      name: libk5crypto3
-      origin: Ubuntu
-      source: apt
-      version: 1.16-2ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libk5crypto3
+    origin: Ubuntu
+    source: apt
+    version: 1.16-2ubuntu0.2
   libkeyutils1:
-    - arch: amd64
-      category: misc
-      name: libkeyutils1
-      origin: Ubuntu
-      source: apt
-      version: 1.5.9-9.2ubuntu2
+  - arch: amd64
+    category: misc
+    name: libkeyutils1
+    origin: Ubuntu
+    source: apt
+    version: 1.5.9-9.2ubuntu2
   libklibc:
-    - arch: amd64
-      category: libs
-      name: libklibc
-      origin: Ubuntu
-      source: apt
-      version: 2.0.4-9ubuntu2.1
+  - arch: amd64
+    category: libs
+    name: libklibc
+    origin: Ubuntu
+    source: apt
+    version: 2.0.4-9ubuntu2.1
   libkmod2:
-    - arch: amd64
-      category: libs
-      name: libkmod2
-      origin: Ubuntu
-      source: apt
-      version: 24-1ubuntu3.5
+  - arch: amd64
+    category: libs
+    name: libkmod2
+    origin: Ubuntu
+    source: apt
+    version: 24-1ubuntu3.5
   libkrb5-26-heimdal:
-    - arch: amd64
-      category: libs
-      name: libkrb5-26-heimdal
-      origin: Ubuntu
-      source: apt
-      version: 7.5.0+dfsg-1
+  - arch: amd64
+    category: libs
+    name: libkrb5-26-heimdal
+    origin: Ubuntu
+    source: apt
+    version: 7.5.0+dfsg-1
   libkrb5-3:
-    - arch: amd64
-      category: libs
-      name: libkrb5-3
-      origin: Ubuntu
-      source: apt
-      version: 1.16-2ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libkrb5-3
+    origin: Ubuntu
+    source: apt
+    version: 1.16-2ubuntu0.2
   libkrb5support0:
-    - arch: amd64
-      category: libs
-      name: libkrb5support0
-      origin: Ubuntu
-      source: apt
-      version: 1.16-2ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libkrb5support0
+    origin: Ubuntu
+    source: apt
+    version: 1.16-2ubuntu0.2
   libksba8:
-    - arch: amd64
-      category: libs
-      name: libksba8
-      origin: Ubuntu
-      source: apt
-      version: 1.3.5-2
+  - arch: amd64
+    category: libs
+    name: libksba8
+    origin: Ubuntu
+    source: apt
+    version: 1.3.5-2
   libldap-2.4-2:
-    - arch: amd64
-      category: libs
-      name: libldap-2.4-2
-      origin: Ubuntu
-      source: apt
-      version: 2.4.45+dfsg-1ubuntu1.11
+  - arch: amd64
+    category: libs
+    name: libldap-2.4-2
+    origin: Ubuntu
+    source: apt
+    version: 2.4.45+dfsg-1ubuntu1.11
   libldap-common:
-    - arch: all
-      category: libs
-      name: libldap-common
-      origin: Ubuntu
-      source: apt
-      version: 2.4.45+dfsg-1ubuntu1.11
+  - arch: all
+    category: libs
+    name: libldap-common
+    origin: Ubuntu
+    source: apt
+    version: 2.4.45+dfsg-1ubuntu1.11
   liblocale-gettext-perl:
-    - arch: amd64
-      category: perl
-      name: liblocale-gettext-perl
-      origin: Ubuntu
-      source: apt
-      version: 1.07-3build2
+  - arch: amd64
+    category: perl
+    name: liblocale-gettext-perl
+    origin: Ubuntu
+    source: apt
+    version: 1.07-3build2
   libltdl7:
-    - arch: amd64
-      category: libs
-      name: libltdl7
-      origin: Ubuntu
-      source: apt
-      version: 2.4.6-2
+  - arch: amd64
+    category: libs
+    name: libltdl7
+    origin: Ubuntu
+    source: apt
+    version: 2.4.6-2
   liblvm2app2.2:
-    - arch: amd64
-      category: libs
-      name: liblvm2app2.2
-      origin: Ubuntu
-      source: apt
-      version: 2.02.176-4.1ubuntu3.18.04.3
+  - arch: amd64
+    category: libs
+    name: liblvm2app2.2
+    origin: Ubuntu
+    source: apt
+    version: 2.02.176-4.1ubuntu3.18.04.3
   liblvm2cmd2.02:
-    - arch: amd64
-      category: libs
-      name: liblvm2cmd2.02
-      origin: Ubuntu
-      source: apt
-      version: 2.02.176-4.1ubuntu3.18.04.3
+  - arch: amd64
+    category: libs
+    name: liblvm2cmd2.02
+    origin: Ubuntu
+    source: apt
+    version: 2.02.176-4.1ubuntu3.18.04.3
   liblwres160:
-    - arch: amd64
-      category: libs
-      name: liblwres160
-      origin: Ubuntu
-      source: apt
-      version: '1:9.11.3+dfsg-1ubuntu1.17'
+  - arch: amd64
+    category: libs
+    name: liblwres160
+    origin: Ubuntu
+    source: apt
+    version: 1:9.11.3+dfsg-1ubuntu1.17
   liblxc-common:
-    - arch: amd64
-      category: admin
-      name: liblxc-common
-      origin: Ubuntu
-      source: apt
-      version: 3.0.3-0ubuntu1~18.04.1
+  - arch: amd64
+    category: admin
+    name: liblxc-common
+    origin: Ubuntu
+    source: apt
+    version: 3.0.3-0ubuntu1~18.04.1
   liblxc1:
-    - arch: amd64
-      category: admin
-      name: liblxc1
-      origin: Ubuntu
-      source: apt
-      version: 3.0.3-0ubuntu1~18.04.1
+  - arch: amd64
+    category: admin
+    name: liblxc1
+    origin: Ubuntu
+    source: apt
+    version: 3.0.3-0ubuntu1~18.04.1
   liblz4-1:
-    - arch: amd64
-      category: libs
-      name: liblz4-1
-      origin: Ubuntu
-      source: apt
-      version: 0.0~r131-2ubuntu3.1
+  - arch: amd64
+    category: libs
+    name: liblz4-1
+    origin: Ubuntu
+    source: apt
+    version: 0.0~r131-2ubuntu3.1
   liblzma5:
-    - arch: amd64
-      category: libs
-      name: liblzma5
-      origin: Ubuntu
-      source: apt
-      version: 5.2.2-1.3ubuntu0.1
+  - arch: amd64
+    category: libs
+    name: liblzma5
+    origin: Ubuntu
+    source: apt
+    version: 5.2.2-1.3ubuntu0.1
   liblzo2-2:
-    - arch: amd64
-      category: libs
-      name: liblzo2-2
-      origin: Ubuntu
-      source: apt
-      version: 2.08-1.2
+  - arch: amd64
+    category: libs
+    name: liblzo2-2
+    origin: Ubuntu
+    source: apt
+    version: 2.08-1.2
   libmagic-mgc:
-    - arch: amd64
-      category: libs
-      name: libmagic-mgc
-      origin: Ubuntu
-      source: apt
-      version: '1:5.32-2ubuntu0.4'
+  - arch: amd64
+    category: libs
+    name: libmagic-mgc
+    origin: Ubuntu
+    source: apt
+    version: 1:5.32-2ubuntu0.4
   libmagic1:
-    - arch: amd64
-      category: libs
-      name: libmagic1
-      origin: Ubuntu
-      source: apt
-      version: '1:5.32-2ubuntu0.4'
+  - arch: amd64
+    category: libs
+    name: libmagic1
+    origin: Ubuntu
+    source: apt
+    version: 1:5.32-2ubuntu0.4
   libmnl0:
-    - arch: amd64
-      category: libs
-      name: libmnl0
-      origin: Ubuntu
-      source: apt
-      version: 1.0.4-2
+  - arch: amd64
+    category: libs
+    name: libmnl0
+    origin: Ubuntu
+    source: apt
+    version: 1.0.4-2
   libmount1:
-    - arch: amd64
-      category: libs
-      name: libmount1
-      origin: Ubuntu
-      source: apt
-      version: 2.31.1-0.4ubuntu3.7
+  - arch: amd64
+    category: libs
+    name: libmount1
+    origin: Ubuntu
+    source: apt
+    version: 2.31.1-0.4ubuntu3.7
   libmpdec2:
-    - arch: amd64
-      category: libs
-      name: libmpdec2
-      origin: Ubuntu
-      source: apt
-      version: 2.4.2-1ubuntu1
+  - arch: amd64
+    category: libs
+    name: libmpdec2
+    origin: Ubuntu
+    source: apt
+    version: 2.4.2-1ubuntu1
   libmpfr6:
-    - arch: amd64
-      category: libs
-      name: libmpfr6
-      origin: Ubuntu
-      source: apt
-      version: 4.0.1-1
+  - arch: amd64
+    category: libs
+    name: libmpfr6
+    origin: Ubuntu
+    source: apt
+    version: 4.0.1-1
   libmspack0:
-    - arch: amd64
-      category: libs
-      name: libmspack0
-      origin: Ubuntu
-      source: apt
-      version: 0.6-3ubuntu0.3
+  - arch: amd64
+    category: libs
+    name: libmspack0
+    origin: Ubuntu
+    source: apt
+    version: 0.6-3ubuntu0.3
   libncurses5:
-    - arch: amd64
-      category: libs
-      name: libncurses5
-      origin: Ubuntu
-      source: apt
-      version: 6.1-1ubuntu1.18.04
+  - arch: amd64
+    category: libs
+    name: libncurses5
+    origin: Ubuntu
+    source: apt
+    version: 6.1-1ubuntu1.18.04
   libncursesw5:
-    - arch: amd64
-      category: libs
-      name: libncursesw5
-      origin: Ubuntu
-      source: apt
-      version: 6.1-1ubuntu1.18.04
+  - arch: amd64
+    category: libs
+    name: libncursesw5
+    origin: Ubuntu
+    source: apt
+    version: 6.1-1ubuntu1.18.04
   libnetfilter-conntrack3:
-    - arch: amd64
-      category: libs
-      name: libnetfilter-conntrack3
-      origin: Ubuntu
-      source: apt
-      version: 1.0.6-2
+  - arch: amd64
+    category: libs
+    name: libnetfilter-conntrack3
+    origin: Ubuntu
+    source: apt
+    version: 1.0.6-2
   libnetplan0:
-    - arch: amd64
-      category: net
-      name: libnetplan0
-      origin: ''
-      source: apt
-      version: 0.99-0ubuntu3~18.04.3
+  - arch: amd64
+    category: net
+    name: libnetplan0
+    origin: ''
+    source: apt
+    version: 0.99-0ubuntu3~18.04.3
   libnettle6:
-    - arch: amd64
-      category: libs
-      name: libnettle6
-      origin: Ubuntu
-      source: apt
-      version: 3.4.1-0ubuntu0.18.04.1
+  - arch: amd64
+    category: libs
+    name: libnettle6
+    origin: Ubuntu
+    source: apt
+    version: 3.4.1-0ubuntu0.18.04.1
   libnewt0.52:
-    - arch: amd64
-      category: libs
-      name: libnewt0.52
-      origin: Ubuntu
-      source: apt
-      version: 0.52.20-1ubuntu1
+  - arch: amd64
+    category: libs
+    name: libnewt0.52
+    origin: Ubuntu
+    source: apt
+    version: 0.52.20-1ubuntu1
   libnfnetlink0:
-    - arch: amd64
-      category: libs
-      name: libnfnetlink0
-      origin: Ubuntu
-      source: apt
-      version: 1.0.1-3
+  - arch: amd64
+    category: libs
+    name: libnfnetlink0
+    origin: Ubuntu
+    source: apt
+    version: 1.0.1-3
   libnghttp2-14:
-    - arch: amd64
-      category: libs
-      name: libnghttp2-14
-      origin: Ubuntu
-      source: apt
-      version: 1.30.0-1ubuntu1
+  - arch: amd64
+    category: libs
+    name: libnghttp2-14
+    origin: Ubuntu
+    source: apt
+    version: 1.30.0-1ubuntu1
   libnih1:
-    - arch: amd64
-      category: libs
-      name: libnih1
-      origin: Ubuntu
-      source: apt
-      version: 1.0.3-6ubuntu2
+  - arch: amd64
+    category: libs
+    name: libnih1
+    origin: Ubuntu
+    source: apt
+    version: 1.0.3-6ubuntu2
   libnpth0:
-    - arch: amd64
-      category: libs
-      name: libnpth0
-      origin: Ubuntu
-      source: apt
-      version: 1.5-3
+  - arch: amd64
+    category: libs
+    name: libnpth0
+    origin: Ubuntu
+    source: apt
+    version: 1.5-3
   libnss-systemd:
-    - arch: amd64
-      category: admin
-      name: libnss-systemd
-      origin: Ubuntu
-      source: apt
-      version: 237-3ubuntu10.50
+  - arch: amd64
+    category: admin
+    name: libnss-systemd
+    origin: Ubuntu
+    source: apt
+    version: 237-3ubuntu10.50
   libntfs-3g88:
-    - arch: amd64
-      category: libs
-      name: libntfs-3g88
-      origin: Ubuntu
-      source: apt
-      version: '1:2017.3.23-2ubuntu0.18.04.3'
+  - arch: amd64
+    category: libs
+    name: libntfs-3g88
+    origin: Ubuntu
+    source: apt
+    version: 1:2017.3.23-2ubuntu0.18.04.3
   libnuma1:
-    - arch: amd64
-      category: libs
-      name: libnuma1
-      origin: Ubuntu
-      source: apt
-      version: 2.0.11-2.1ubuntu0.1
+  - arch: amd64
+    category: libs
+    name: libnuma1
+    origin: Ubuntu
+    source: apt
+    version: 2.0.11-2.1ubuntu0.1
   libp11-kit0:
-    - arch: amd64
-      category: libs
-      name: libp11-kit0
-      origin: Ubuntu
-      source: apt
-      version: 0.23.9-2ubuntu0.1
+  - arch: amd64
+    category: libs
+    name: libp11-kit0
+    origin: Ubuntu
+    source: apt
+    version: 0.23.9-2ubuntu0.1
   libpam-cap:
-    - arch: amd64
-      category: libs
-      name: libpam-cap
-      origin: Ubuntu
-      source: apt
-      version: '1:2.25-1.2'
+  - arch: amd64
+    category: libs
+    name: libpam-cap
+    origin: Ubuntu
+    source: apt
+    version: 1:2.25-1.2
   libpam-modules:
-    - arch: amd64
-      category: admin
-      name: libpam-modules
-      origin: ''
-      source: apt
-      version: 1.1.8-3.6ubuntu2.18.04.1
+  - arch: amd64
+    category: admin
+    name: libpam-modules
+    origin: ''
+    source: apt
+    version: 1.1.8-3.6ubuntu2.18.04.1
   libpam-modules-bin:
-    - arch: amd64
-      category: admin
-      name: libpam-modules-bin
-      origin: ''
-      source: apt
-      version: 1.1.8-3.6ubuntu2.18.04.1
+  - arch: amd64
+    category: admin
+    name: libpam-modules-bin
+    origin: ''
+    source: apt
+    version: 1.1.8-3.6ubuntu2.18.04.1
   libpam-runtime:
-    - arch: all
-      category: admin
-      name: libpam-runtime
-      origin: ''
-      source: apt
-      version: 1.1.8-3.6ubuntu2.18.04.1
+  - arch: all
+    category: admin
+    name: libpam-runtime
+    origin: ''
+    source: apt
+    version: 1.1.8-3.6ubuntu2.18.04.1
   libpam-systemd:
-    - arch: amd64
-      category: admin
-      name: libpam-systemd
-      origin: Ubuntu
-      source: apt
-      version: 237-3ubuntu10.50
+  - arch: amd64
+    category: admin
+    name: libpam-systemd
+    origin: Ubuntu
+    source: apt
+    version: 237-3ubuntu10.50
   libpam0g:
-    - arch: amd64
-      category: libs
-      name: libpam0g
-      origin: ''
-      source: apt
-      version: 1.1.8-3.6ubuntu2.18.04.1
+  - arch: amd64
+    category: libs
+    name: libpam0g
+    origin: ''
+    source: apt
+    version: 1.1.8-3.6ubuntu2.18.04.1
   libparted2:
-    - arch: amd64
-      category: libs
-      name: libparted2
-      origin: Ubuntu
-      source: apt
-      version: 3.2-20ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libparted2
+    origin: Ubuntu
+    source: apt
+    version: 3.2-20ubuntu0.2
   libpcap0.8:
-    - arch: amd64
-      category: libs
-      name: libpcap0.8
-      origin: Ubuntu
-      source: apt
-      version: 1.8.1-6ubuntu1.18.04.1
+  - arch: amd64
+    category: libs
+    name: libpcap0.8
+    origin: Ubuntu
+    source: apt
+    version: 1.8.1-6ubuntu1.18.04.1
   libpci3:
-    - arch: amd64
-      category: libs
-      name: libpci3
-      origin: Ubuntu
-      source: apt
-      version: '1:3.5.2-1ubuntu1.1'
+  - arch: amd64
+    category: libs
+    name: libpci3
+    origin: Ubuntu
+    source: apt
+    version: 1:3.5.2-1ubuntu1.1
   libpcre3:
-    - arch: amd64
-      category: libs
-      name: libpcre3
-      origin: Ubuntu
-      source: apt
-      version: '2:8.39-9ubuntu0.1'
+  - arch: amd64
+    category: libs
+    name: libpcre3
+    origin: Ubuntu
+    source: apt
+    version: 2:8.39-9ubuntu0.1
   libperl5.26:
-    - arch: amd64
-      category: libs
-      name: libperl5.26
-      origin: Ubuntu
-      source: apt
-      version: 5.26.1-6ubuntu0.5
+  - arch: amd64
+    category: libs
+    name: libperl5.26
+    origin: Ubuntu
+    source: apt
+    version: 5.26.1-6ubuntu0.5
   libpipeline1:
-    - arch: amd64
-      category: libs
-      name: libpipeline1
-      origin: Ubuntu
-      source: apt
-      version: 1.5.0-1
+  - arch: amd64
+    category: libs
+    name: libpipeline1
+    origin: Ubuntu
+    source: apt
+    version: 1.5.0-1
   libplymouth4:
-    - arch: amd64
-      category: libs
-      name: libplymouth4
-      origin: Ubuntu
-      source: apt
-      version: 0.9.3-1ubuntu7.18.04.2
+  - arch: amd64
+    category: libs
+    name: libplymouth4
+    origin: Ubuntu
+    source: apt
+    version: 0.9.3-1ubuntu7.18.04.2
   libpng16-16:
-    - arch: amd64
-      category: libs
-      name: libpng16-16
-      origin: Ubuntu
-      source: apt
-      version: 1.6.34-1ubuntu0.18.04.2
+  - arch: amd64
+    category: libs
+    name: libpng16-16
+    origin: Ubuntu
+    source: apt
+    version: 1.6.34-1ubuntu0.18.04.2
   libpolkit-agent-1-0:
-    - arch: amd64
-      category: libs
-      name: libpolkit-agent-1-0
-      origin: Ubuntu
-      source: apt
-      version: 0.105-20ubuntu0.18.04.6
+  - arch: amd64
+    category: libs
+    name: libpolkit-agent-1-0
+    origin: Ubuntu
+    source: apt
+    version: 0.105-20ubuntu0.18.04.6
   libpolkit-backend-1-0:
-    - arch: amd64
-      category: libs
-      name: libpolkit-backend-1-0
-      origin: Ubuntu
-      source: apt
-      version: 0.105-20ubuntu0.18.04.6
+  - arch: amd64
+    category: libs
+    name: libpolkit-backend-1-0
+    origin: Ubuntu
+    source: apt
+    version: 0.105-20ubuntu0.18.04.6
   libpolkit-gobject-1-0:
-    - arch: amd64
-      category: libs
-      name: libpolkit-gobject-1-0
-      origin: Ubuntu
-      source: apt
-      version: 0.105-20ubuntu0.18.04.6
+  - arch: amd64
+    category: libs
+    name: libpolkit-gobject-1-0
+    origin: Ubuntu
+    source: apt
+    version: 0.105-20ubuntu0.18.04.6
   libpopt0:
-    - arch: amd64
-      category: libs
-      name: libpopt0
-      origin: Ubuntu
-      source: apt
-      version: 1.16-11
+  - arch: amd64
+    category: libs
+    name: libpopt0
+    origin: Ubuntu
+    source: apt
+    version: 1.16-11
   libprocps6:
-    - arch: amd64
-      category: libs
-      name: libprocps6
-      origin: Ubuntu
-      source: apt
-      version: '2:3.3.12-3ubuntu1.2'
+  - arch: amd64
+    category: libs
+    name: libprocps6
+    origin: Ubuntu
+    source: apt
+    version: 2:3.3.12-3ubuntu1.2
   libpsl5:
-    - arch: amd64
-      category: libs
-      name: libpsl5
-      origin: Ubuntu
-      source: apt
-      version: 0.19.1-5build1
+  - arch: amd64
+    category: libs
+    name: libpsl5
+    origin: Ubuntu
+    source: apt
+    version: 0.19.1-5build1
   libpython3-stdlib:
-    - arch: amd64
-      category: python
-      name: libpython3-stdlib
-      origin: Ubuntu
-      source: apt
-      version: 3.6.7-1~18.04
+  - arch: amd64
+    category: python
+    name: libpython3-stdlib
+    origin: Ubuntu
+    source: apt
+    version: 3.6.7-1~18.04
   libpython3.6:
-    - arch: amd64
-      category: libs
-      name: libpython3.6
-      origin: Ubuntu
-      source: apt
-      version: 3.6.9-1~18.04ubuntu1.7
+  - arch: amd64
+    category: libs
+    name: libpython3.6
+    origin: Ubuntu
+    source: apt
+    version: 3.6.9-1~18.04ubuntu1.7
   libpython3.6-minimal:
-    - arch: amd64
-      category: python
-      name: libpython3.6-minimal
-      origin: Ubuntu
-      source: apt
-      version: 3.6.9-1~18.04ubuntu1.7
+  - arch: amd64
+    category: python
+    name: libpython3.6-minimal
+    origin: Ubuntu
+    source: apt
+    version: 3.6.9-1~18.04ubuntu1.7
   libpython3.6-stdlib:
-    - arch: amd64
-      category: python
-      name: libpython3.6-stdlib
-      origin: Ubuntu
-      source: apt
-      version: 3.6.9-1~18.04ubuntu1.7
+  - arch: amd64
+    category: python
+    name: libpython3.6-stdlib
+    origin: Ubuntu
+    source: apt
+    version: 3.6.9-1~18.04ubuntu1.7
   libreadline5:
-    - arch: amd64
-      category: libs
-      name: libreadline5
-      origin: Ubuntu
-      source: apt
-      version: 5.2+dfsg-3build1
+  - arch: amd64
+    category: libs
+    name: libreadline5
+    origin: Ubuntu
+    source: apt
+    version: 5.2+dfsg-3build1
   libreadline7:
-    - arch: amd64
-      category: libs
-      name: libreadline7
-      origin: Ubuntu
-      source: apt
-      version: 7.0-3
+  - arch: amd64
+    category: libs
+    name: libreadline7
+    origin: Ubuntu
+    source: apt
+    version: 7.0-3
   libroken18-heimdal:
-    - arch: amd64
-      category: libs
-      name: libroken18-heimdal
-      origin: Ubuntu
-      source: apt
-      version: 7.5.0+dfsg-1
+  - arch: amd64
+    category: libs
+    name: libroken18-heimdal
+    origin: Ubuntu
+    source: apt
+    version: 7.5.0+dfsg-1
   librtmp1:
-    - arch: amd64
-      category: libs
-      name: librtmp1
-      origin: Ubuntu
-      source: apt
-      version: 2.4+20151223.gitfa8646d.1-1
+  - arch: amd64
+    category: libs
+    name: librtmp1
+    origin: Ubuntu
+    source: apt
+    version: 2.4+20151223.gitfa8646d.1-1
   libsasl2-2:
-    - arch: amd64
-      category: libs
-      name: libsasl2-2
-      origin: Ubuntu
-      source: apt
-      version: 2.1.27~101-g0780600+dfsg-3ubuntu2.4
+  - arch: amd64
+    category: libs
+    name: libsasl2-2
+    origin: Ubuntu
+    source: apt
+    version: 2.1.27~101-g0780600+dfsg-3ubuntu2.4
   libsasl2-modules:
-    - arch: amd64
-      category: devel
-      name: libsasl2-modules
-      origin: Ubuntu
-      source: apt
-      version: 2.1.27~101-g0780600+dfsg-3ubuntu2.4
+  - arch: amd64
+    category: devel
+    name: libsasl2-modules
+    origin: Ubuntu
+    source: apt
+    version: 2.1.27~101-g0780600+dfsg-3ubuntu2.4
   libsasl2-modules-db:
-    - arch: amd64
-      category: libs
-      name: libsasl2-modules-db
-      origin: Ubuntu
-      source: apt
-      version: 2.1.27~101-g0780600+dfsg-3ubuntu2.4
+  - arch: amd64
+    category: libs
+    name: libsasl2-modules-db
+    origin: Ubuntu
+    source: apt
+    version: 2.1.27~101-g0780600+dfsg-3ubuntu2.4
   libseccomp2:
-    - arch: amd64
-      category: libs
-      name: libseccomp2
-      origin: Ubuntu
-      source: apt
-      version: 2.5.1-1ubuntu1~18.04.2
+  - arch: amd64
+    category: libs
+    name: libseccomp2
+    origin: Ubuntu
+    source: apt
+    version: 2.5.1-1ubuntu1~18.04.2
   libselinux1:
-    - arch: amd64
-      category: libs
-      name: libselinux1
-      origin: Ubuntu
-      source: apt
-      version: 2.7-2build2
+  - arch: amd64
+    category: libs
+    name: libselinux1
+    origin: Ubuntu
+    source: apt
+    version: 2.7-2build2
   libsemanage-common:
-    - arch: all
-      category: libs
-      name: libsemanage-common
-      origin: Ubuntu
-      source: apt
-      version: 2.7-2build2
+  - arch: all
+    category: libs
+    name: libsemanage-common
+    origin: Ubuntu
+    source: apt
+    version: 2.7-2build2
   libsemanage1:
-    - arch: amd64
-      category: libs
-      name: libsemanage1
-      origin: Ubuntu
-      source: apt
-      version: 2.7-2build2
+  - arch: amd64
+    category: libs
+    name: libsemanage1
+    origin: Ubuntu
+    source: apt
+    version: 2.7-2build2
   libsepol1:
-    - arch: amd64
-      category: libs
-      name: libsepol1
-      origin: Ubuntu
-      source: apt
-      version: 2.7-1ubuntu0.1
+  - arch: amd64
+    category: libs
+    name: libsepol1
+    origin: Ubuntu
+    source: apt
+    version: 2.7-1ubuntu0.1
   libsigsegv2:
-    - arch: amd64
-      category: libs
-      name: libsigsegv2
-      origin: Ubuntu
-      source: apt
-      version: 2.12-1
+  - arch: amd64
+    category: libs
+    name: libsigsegv2
+    origin: Ubuntu
+    source: apt
+    version: 2.12-1
   libslang2:
-    - arch: amd64
-      category: libs
-      name: libslang2
-      origin: Ubuntu
-      source: apt
-      version: 2.3.1a-3ubuntu1
+  - arch: amd64
+    category: libs
+    name: libslang2
+    origin: Ubuntu
+    source: apt
+    version: 2.3.1a-3ubuntu1
   libsmartcols1:
-    - arch: amd64
-      category: libs
-      name: libsmartcols1
-      origin: Ubuntu
-      source: apt
-      version: 2.31.1-0.4ubuntu3.7
+  - arch: amd64
+    category: libs
+    name: libsmartcols1
+    origin: Ubuntu
+    source: apt
+    version: 2.31.1-0.4ubuntu3.7
   libsqlite3-0:
-    - arch: amd64
-      category: libs
-      name: libsqlite3-0
-      origin: Ubuntu
-      source: apt
-      version: 3.22.0-1ubuntu0.5
+  - arch: amd64
+    category: libs
+    name: libsqlite3-0
+    origin: Ubuntu
+    source: apt
+    version: 3.22.0-1ubuntu0.5
   libss2:
-    - arch: amd64
-      category: libs
-      name: libss2
-      origin: Ubuntu
-      source: apt
-      version: 1.44.1-1ubuntu1.3
+  - arch: amd64
+    category: libs
+    name: libss2
+    origin: Ubuntu
+    source: apt
+    version: 1.44.1-1ubuntu1.3
   libssl1.0.0:
-    - arch: amd64
-      category: libs
-      name: libssl1.0.0
-      origin: Ubuntu
-      source: apt
-      version: 1.0.2n-1ubuntu5.9
+  - arch: amd64
+    category: libs
+    name: libssl1.0.0
+    origin: Ubuntu
+    source: apt
+    version: 1.0.2n-1ubuntu5.9
   libssl1.1:
-    - arch: amd64
-      category: libs
-      name: libssl1.1
-      origin: Ubuntu
-      source: apt
-      version: 1.1.1-1ubuntu2.1~18.04.17
+  - arch: amd64
+    category: libs
+    name: libssl1.1
+    origin: Ubuntu
+    source: apt
+    version: 1.1.1-1ubuntu2.1~18.04.17
   libstdc++6:
-    - arch: amd64
-      category: libs
-      name: libstdc++6
-      origin: Ubuntu
-      source: apt
-      version: 8.4.0-1ubuntu1~18.04
+  - arch: amd64
+    category: libs
+    name: libstdc++6
+    origin: Ubuntu
+    source: apt
+    version: 8.4.0-1ubuntu1~18.04
   libsystemd0:
-    - arch: amd64
-      category: libs
-      name: libsystemd0
-      origin: Ubuntu
-      source: apt
-      version: 237-3ubuntu10.50
+  - arch: amd64
+    category: libs
+    name: libsystemd0
+    origin: Ubuntu
+    source: apt
+    version: 237-3ubuntu10.50
   libtasn1-6:
-    - arch: amd64
-      category: libs
-      name: libtasn1-6
-      origin: Ubuntu
-      source: apt
-      version: 4.13-2
+  - arch: amd64
+    category: libs
+    name: libtasn1-6
+    origin: Ubuntu
+    source: apt
+    version: 4.13-2
   libtext-charwidth-perl:
-    - arch: amd64
-      category: perl
-      name: libtext-charwidth-perl
-      origin: Ubuntu
-      source: apt
-      version: 0.04-7.1
+  - arch: amd64
+    category: perl
+    name: libtext-charwidth-perl
+    origin: Ubuntu
+    source: apt
+    version: 0.04-7.1
   libtext-iconv-perl:
-    - arch: amd64
-      category: perl
-      name: libtext-iconv-perl
-      origin: Ubuntu
-      source: apt
-      version: 1.7-5build6
+  - arch: amd64
+    category: perl
+    name: libtext-iconv-perl
+    origin: Ubuntu
+    source: apt
+    version: 1.7-5build6
   libtext-wrapi18n-perl:
-    - arch: all
-      category: perl
-      name: libtext-wrapi18n-perl
-      origin: Ubuntu
-      source: apt
-      version: 0.06-7.1
+  - arch: all
+    category: perl
+    name: libtext-wrapi18n-perl
+    origin: Ubuntu
+    source: apt
+    version: 0.06-7.1
   libtinfo5:
-    - arch: amd64
-      category: libs
-      name: libtinfo5
-      origin: Ubuntu
-      source: apt
-      version: 6.1-1ubuntu1.18.04
+  - arch: amd64
+    category: libs
+    name: libtinfo5
+    origin: Ubuntu
+    source: apt
+    version: 6.1-1ubuntu1.18.04
   libudev1:
-    - arch: amd64
-      category: libs
-      name: libudev1
-      origin: Ubuntu
-      source: apt
-      version: 237-3ubuntu10.50
+  - arch: amd64
+    category: libs
+    name: libudev1
+    origin: Ubuntu
+    source: apt
+    version: 237-3ubuntu10.50
   libunistring2:
-    - arch: amd64
-      category: libs
-      name: libunistring2
-      origin: Ubuntu
-      source: apt
-      version: 0.9.9-0ubuntu2
+  - arch: amd64
+    category: libs
+    name: libunistring2
+    origin: Ubuntu
+    source: apt
+    version: 0.9.9-0ubuntu2
   libunwind8:
-    - arch: amd64
-      category: libs
-      name: libunwind8
-      origin: Ubuntu
-      source: apt
-      version: 1.2.1-8
+  - arch: amd64
+    category: libs
+    name: libunwind8
+    origin: Ubuntu
+    source: apt
+    version: 1.2.1-8
   libusb-1.0-0:
-    - arch: amd64
-      category: libs
-      name: libusb-1.0-0
-      origin: Ubuntu
-      source: apt
-      version: '2:1.0.21-2'
+  - arch: amd64
+    category: libs
+    name: libusb-1.0-0
+    origin: Ubuntu
+    source: apt
+    version: 2:1.0.21-2
   libutempter0:
-    - arch: amd64
-      category: libs
-      name: libutempter0
-      origin: Ubuntu
-      source: apt
-      version: 1.1.6-3
+  - arch: amd64
+    category: libs
+    name: libutempter0
+    origin: Ubuntu
+    source: apt
+    version: 1.1.6-3
   libuuid1:
-    - arch: amd64
-      category: libs
-      name: libuuid1
-      origin: Ubuntu
-      source: apt
-      version: 2.31.1-0.4ubuntu3.7
+  - arch: amd64
+    category: libs
+    name: libuuid1
+    origin: Ubuntu
+    source: apt
+    version: 2.31.1-0.4ubuntu3.7
   libuv1:
-    - arch: amd64
-      category: libs
-      name: libuv1
-      origin: Ubuntu
-      source: apt
-      version: 1.18.0-3
+  - arch: amd64
+    category: libs
+    name: libuv1
+    origin: Ubuntu
+    source: apt
+    version: 1.18.0-3
   libwind0-heimdal:
-    - arch: amd64
-      category: libs
-      name: libwind0-heimdal
-      origin: Ubuntu
-      source: apt
-      version: 7.5.0+dfsg-1
+  - arch: amd64
+    category: libs
+    name: libwind0-heimdal
+    origin: Ubuntu
+    source: apt
+    version: 7.5.0+dfsg-1
   libwrap0:
-    - arch: amd64
-      category: libs
-      name: libwrap0
-      origin: Ubuntu
-      source: apt
-      version: 7.6.q-27
+  - arch: amd64
+    category: libs
+    name: libwrap0
+    origin: Ubuntu
+    source: apt
+    version: 7.6.q-27
   libx11-6:
-    - arch: amd64
-      category: libs
-      name: libx11-6
-      origin: Ubuntu
-      source: apt
-      version: '2:1.6.4-3ubuntu0.4'
+  - arch: amd64
+    category: libs
+    name: libx11-6
+    origin: Ubuntu
+    source: apt
+    version: 2:1.6.4-3ubuntu0.4
   libx11-data:
-    - arch: all
-      category: x11
-      name: libx11-data
-      origin: Ubuntu
-      source: apt
-      version: '2:1.6.4-3ubuntu0.4'
+  - arch: all
+    category: x11
+    name: libx11-data
+    origin: Ubuntu
+    source: apt
+    version: 2:1.6.4-3ubuntu0.4
   libxau6:
-    - arch: amd64
-      category: libs
-      name: libxau6
-      origin: Ubuntu
-      source: apt
-      version: '1:1.0.8-1ubuntu1'
+  - arch: amd64
+    category: libs
+    name: libxau6
+    origin: Ubuntu
+    source: apt
+    version: 1:1.0.8-1ubuntu1
   libxcb1:
-    - arch: amd64
-      category: libs
-      name: libxcb1
-      origin: Ubuntu
-      source: apt
-      version: 1.13-2~ubuntu18.04
+  - arch: amd64
+    category: libs
+    name: libxcb1
+    origin: Ubuntu
+    source: apt
+    version: 1.13-2~ubuntu18.04
   libxdmcp6:
-    - arch: amd64
-      category: libs
-      name: libxdmcp6
-      origin: Ubuntu
-      source: apt
-      version: '1:1.1.2-3'
+  - arch: amd64
+    category: libs
+    name: libxdmcp6
+    origin: Ubuntu
+    source: apt
+    version: 1:1.1.2-3
   libxext6:
-    - arch: amd64
-      category: libs
-      name: libxext6
-      origin: Ubuntu
-      source: apt
-      version: '2:1.3.3-1'
+  - arch: amd64
+    category: libs
+    name: libxext6
+    origin: Ubuntu
+    source: apt
+    version: 2:1.3.3-1
   libxml2:
-    - arch: amd64
-      category: libs
-      name: libxml2
-      origin: Ubuntu
-      source: apt
-      version: 2.9.4+dfsg1-6.1ubuntu1.6
+  - arch: amd64
+    category: libs
+    name: libxml2
+    origin: Ubuntu
+    source: apt
+    version: 2.9.4+dfsg1-6.1ubuntu1.6
   libxmlsec1:
-    - arch: amd64
-      category: libs
-      name: libxmlsec1
-      origin: Ubuntu
-      source: apt
-      version: 1.2.25-1build1
+  - arch: amd64
+    category: libs
+    name: libxmlsec1
+    origin: Ubuntu
+    source: apt
+    version: 1.2.25-1build1
   libxmlsec1-openssl:
-    - arch: amd64
-      category: libs
-      name: libxmlsec1-openssl
-      origin: Ubuntu
-      source: apt
-      version: 1.2.25-1build1
+  - arch: amd64
+    category: libs
+    name: libxmlsec1-openssl
+    origin: Ubuntu
+    source: apt
+    version: 1.2.25-1build1
   libxmuu1:
-    - arch: amd64
-      category: libs
-      name: libxmuu1
-      origin: Ubuntu
-      source: apt
-      version: '2:1.1.2-2'
+  - arch: amd64
+    category: libs
+    name: libxmuu1
+    origin: Ubuntu
+    source: apt
+    version: 2:1.1.2-2
   libxslt1.1:
-    - arch: amd64
-      category: libs
-      name: libxslt1.1
-      origin: Ubuntu
-      source: apt
-      version: 1.1.29-5ubuntu0.2
+  - arch: amd64
+    category: libs
+    name: libxslt1.1
+    origin: Ubuntu
+    source: apt
+    version: 1.1.29-5ubuntu0.2
   libxtables12:
-    - arch: amd64
-      category: libs
-      name: libxtables12
-      origin: Ubuntu
-      source: apt
-      version: 1.6.1-2ubuntu2
+  - arch: amd64
+    category: libs
+    name: libxtables12
+    origin: Ubuntu
+    source: apt
+    version: 1.6.1-2ubuntu2
   libyaml-0-2:
-    - arch: amd64
-      category: libs
-      name: libyaml-0-2
-      origin: Ubuntu
-      source: apt
-      version: 0.1.7-2ubuntu3
+  - arch: amd64
+    category: libs
+    name: libyaml-0-2
+    origin: Ubuntu
+    source: apt
+    version: 0.1.7-2ubuntu3
   libzstd1:
-    - arch: amd64
-      category: libs
-      name: libzstd1
-      origin: Ubuntu
-      source: apt
-      version: 1.3.3+dfsg-2ubuntu1.2
+  - arch: amd64
+    category: libs
+    name: libzstd1
+    origin: Ubuntu
+    source: apt
+    version: 1.3.3+dfsg-2ubuntu1.2
   linux-base:
-    - arch: all
-      category: kernel
-      name: linux-base
-      origin: Ubuntu
-      source: apt
-      version: 4.5ubuntu1.2
+  - arch: all
+    category: kernel
+    name: linux-base
+    origin: Ubuntu
+    source: apt
+    version: 4.5ubuntu1.2
   linux-headers-4.15.0-176:
-    - arch: all
-      category: devel
-      name: linux-headers-4.15.0-176
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-176.185
+  - arch: all
+    category: devel
+    name: linux-headers-4.15.0-176
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-176.185
   linux-headers-4.15.0-176-generic:
-    - arch: amd64
-      category: devel
-      name: linux-headers-4.15.0-176-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-176.185
+  - arch: amd64
+    category: devel
+    name: linux-headers-4.15.0-176-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-176.185
   linux-headers-4.15.0-177:
-    - arch: all
-      category: devel
-      name: linux-headers-4.15.0-177
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-177.186
+  - arch: all
+    category: devel
+    name: linux-headers-4.15.0-177
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-177.186
   linux-headers-4.15.0-177-generic:
-    - arch: amd64
-      category: devel
-      name: linux-headers-4.15.0-177-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-177.186
+  - arch: amd64
+    category: devel
+    name: linux-headers-4.15.0-177-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-177.186
   linux-headers-4.15.0-180:
-    - arch: all
-      category: devel
-      name: linux-headers-4.15.0-180
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-180.189
+  - arch: all
+    category: devel
+    name: linux-headers-4.15.0-180
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-180.189
   linux-headers-4.15.0-180-generic:
-    - arch: amd64
-      category: devel
-      name: linux-headers-4.15.0-180-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-180.189
+  - arch: amd64
+    category: devel
+    name: linux-headers-4.15.0-180-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-180.189
   linux-headers-generic:
-    - arch: amd64
-      category: devel
-      name: linux-headers-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0.180.169
+  - arch: amd64
+    category: devel
+    name: linux-headers-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0.180.169
   linux-headers-virtual:
-    - arch: amd64
-      category: devel
-      name: linux-headers-virtual
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0.180.169
+  - arch: amd64
+    category: devel
+    name: linux-headers-virtual
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0.180.169
   linux-image-4.15.0-176-generic:
-    - arch: amd64
-      category: kernel
-      name: linux-image-4.15.0-176-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-176.185
+  - arch: amd64
+    category: kernel
+    name: linux-image-4.15.0-176-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-176.185
   linux-image-4.15.0-177-generic:
-    - arch: amd64
-      category: kernel
-      name: linux-image-4.15.0-177-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-177.186
+  - arch: amd64
+    category: kernel
+    name: linux-image-4.15.0-177-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-177.186
   linux-image-4.15.0-180-generic:
-    - arch: amd64
-      category: kernel
-      name: linux-image-4.15.0-180-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-180.189
+  - arch: amd64
+    category: kernel
+    name: linux-image-4.15.0-180-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-180.189
   linux-image-virtual:
-    - arch: amd64
-      category: kernel
-      name: linux-image-virtual
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0.180.169
+  - arch: amd64
+    category: kernel
+    name: linux-image-virtual
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0.180.169
   linux-modules-4.15.0-176-generic:
-    - arch: amd64
-      category: kernel
-      name: linux-modules-4.15.0-176-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-176.185
+  - arch: amd64
+    category: kernel
+    name: linux-modules-4.15.0-176-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-176.185
   linux-modules-4.15.0-177-generic:
-    - arch: amd64
-      category: kernel
-      name: linux-modules-4.15.0-177-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-177.186
+  - arch: amd64
+    category: kernel
+    name: linux-modules-4.15.0-177-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-177.186
   linux-modules-4.15.0-180-generic:
-    - arch: amd64
-      category: kernel
-      name: linux-modules-4.15.0-180-generic
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0-180.189
+  - arch: amd64
+    category: kernel
+    name: linux-modules-4.15.0-180-generic
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0-180.189
   linux-virtual:
-    - arch: amd64
-      category: kernel
-      name: linux-virtual
-      origin: Ubuntu
-      source: apt
-      version: 4.15.0.180.169
+  - arch: amd64
+    category: kernel
+    name: linux-virtual
+    origin: Ubuntu
+    source: apt
+    version: 4.15.0.180.169
   locales:
-    - arch: all
-      category: libs
-      name: locales
-      origin: Ubuntu
-      source: apt
-      version: 2.27-3ubuntu1.5
+  - arch: all
+    category: libs
+    name: locales
+    origin: Ubuntu
+    source: apt
+    version: 2.27-3ubuntu1.5
   login:
-    - arch: amd64
-      category: admin
-      name: login
-      origin: Ubuntu
-      source: apt
-      version: '1:4.5-1ubuntu2.2'
+  - arch: amd64
+    category: admin
+    name: login
+    origin: Ubuntu
+    source: apt
+    version: 1:4.5-1ubuntu2.2
   logrotate:
-    - arch: amd64
-      category: admin
-      name: logrotate
-      origin: Ubuntu
-      source: apt
-      version: 3.11.0-0.1ubuntu1
+  - arch: amd64
+    category: admin
+    name: logrotate
+    origin: Ubuntu
+    source: apt
+    version: 3.11.0-0.1ubuntu1
   lsb-base:
-    - arch: all
-      category: misc
-      name: lsb-base
-      origin: Ubuntu
-      source: apt
-      version: 9.20170808ubuntu1
+  - arch: all
+    category: misc
+    name: lsb-base
+    origin: Ubuntu
+    source: apt
+    version: 9.20170808ubuntu1
   lsb-release:
-    - arch: all
-      category: misc
-      name: lsb-release
-      origin: Ubuntu
-      source: apt
-      version: 9.20170808ubuntu1
+  - arch: all
+    category: misc
+    name: lsb-release
+    origin: Ubuntu
+    source: apt
+    version: 9.20170808ubuntu1
   lshw:
-    - arch: amd64
-      category: utils
-      name: lshw
-      origin: ''
-      source: apt
-      version: 02.18-0.1ubuntu6.18.04.1
+  - arch: amd64
+    category: utils
+    name: lshw
+    origin: ''
+    source: apt
+    version: 02.18-0.1ubuntu6.18.04.1
   lsof:
-    - arch: amd64
-      category: utils
-      name: lsof
-      origin: Ubuntu
-      source: apt
-      version: 4.89+dfsg-0.1
+  - arch: amd64
+    category: utils
+    name: lsof
+    origin: Ubuntu
+    source: apt
+    version: 4.89+dfsg-0.1
   ltrace:
-    - arch: amd64
-      category: utils
-      name: ltrace
-      origin: Ubuntu
-      source: apt
-      version: 0.7.3-6ubuntu1
+  - arch: amd64
+    category: utils
+    name: ltrace
+    origin: Ubuntu
+    source: apt
+    version: 0.7.3-6ubuntu1
   lvm2:
-    - arch: amd64
-      category: admin
-      name: lvm2
-      origin: Ubuntu
-      source: apt
-      version: 2.02.176-4.1ubuntu3.18.04.3
+  - arch: amd64
+    category: admin
+    name: lvm2
+    origin: Ubuntu
+    source: apt
+    version: 2.02.176-4.1ubuntu3.18.04.3
   lxcfs:
-    - arch: amd64
-      category: admin
-      name: lxcfs
-      origin: Ubuntu
-      source: apt
-      version: 3.0.3-0ubuntu1~18.04.2
+  - arch: amd64
+    category: admin
+    name: lxcfs
+    origin: Ubuntu
+    source: apt
+    version: 3.0.3-0ubuntu1~18.04.2
   lxd:
-    - arch: amd64
-      category: admin
-      name: lxd
-      origin: ''
-      source: apt
-      version: 3.0.3-0ubuntu1~18.04.1
+  - arch: amd64
+    category: admin
+    name: lxd
+    origin: ''
+    source: apt
+    version: 3.0.3-0ubuntu1~18.04.1
   lxd-client:
-    - arch: amd64
-      category: admin
-      name: lxd-client
-      origin: ''
-      source: apt
-      version: 3.0.3-0ubuntu1~18.04.1
+  - arch: amd64
+    category: admin
+    name: lxd-client
+    origin: ''
+    source: apt
+    version: 3.0.3-0ubuntu1~18.04.1
   man-db:
-    - arch: amd64
-      category: doc
-      name: man-db
-      origin: Ubuntu
-      source: apt
-      version: 2.8.3-2ubuntu0.1
+  - arch: amd64
+    category: doc
+    name: man-db
+    origin: Ubuntu
+    source: apt
+    version: 2.8.3-2ubuntu0.1
   manpages:
-    - arch: all
-      category: doc
-      name: manpages
-      origin: Ubuntu
-      source: apt
-      version: 4.15-1
+  - arch: all
+    category: doc
+    name: manpages
+    origin: Ubuntu
+    source: apt
+    version: 4.15-1
   mawk:
-    - arch: amd64
-      category: utils
-      name: mawk
-      origin: Ubuntu
-      source: apt
-      version: 1.3.3-17ubuntu3
+  - arch: amd64
+    category: utils
+    name: mawk
+    origin: Ubuntu
+    source: apt
+    version: 1.3.3-17ubuntu3
   mdadm:
-    - arch: amd64
-      category: admin
-      name: mdadm
-      origin: Ubuntu
-      source: apt
-      version: 4.1~rc1-3~ubuntu18.04.4
+  - arch: amd64
+    category: admin
+    name: mdadm
+    origin: Ubuntu
+    source: apt
+    version: 4.1~rc1-3~ubuntu18.04.4
   mime-support:
-    - arch: all
-      category: net
-      name: mime-support
-      origin: Ubuntu
-      source: apt
-      version: 3.60ubuntu1
+  - arch: all
+    category: net
+    name: mime-support
+    origin: Ubuntu
+    source: apt
+    version: 3.60ubuntu1
   mlocate:
-    - arch: amd64
-      category: utils
-      name: mlocate
-      origin: Ubuntu
-      source: apt
-      version: 0.26-2ubuntu3.1
+  - arch: amd64
+    category: utils
+    name: mlocate
+    origin: Ubuntu
+    source: apt
+    version: 0.26-2ubuntu3.1
   mokutil:
-    - arch: amd64
-      category: admin
-      name: mokutil
-      origin: Ubuntu
-      source: apt
-      version: 0.3.0+1538710437.fb6250f-0ubuntu2~18.04.1
+  - arch: amd64
+    category: admin
+    name: mokutil
+    origin: Ubuntu
+    source: apt
+    version: 0.3.0+1538710437.fb6250f-0ubuntu2~18.04.1
   mount:
-    - arch: amd64
-      category: admin
-      name: mount
-      origin: Ubuntu
-      source: apt
-      version: 2.31.1-0.4ubuntu3.7
+  - arch: amd64
+    category: admin
+    name: mount
+    origin: Ubuntu
+    source: apt
+    version: 2.31.1-0.4ubuntu3.7
   mtr-tiny:
-    - arch: amd64
-      category: net
-      name: mtr-tiny
-      origin: Ubuntu
-      source: apt
-      version: 0.92-1
+  - arch: amd64
+    category: net
+    name: mtr-tiny
+    origin: Ubuntu
+    source: apt
+    version: 0.92-1
   multiarch-support:
-    - arch: amd64
-      category: libs
-      name: multiarch-support
-      origin: Ubuntu
-      source: apt
-      version: 2.27-3ubuntu1.5
+  - arch: amd64
+    category: libs
+    name: multiarch-support
+    origin: Ubuntu
+    source: apt
+    version: 2.27-3ubuntu1.5
   nano:
-    - arch: amd64
-      category: editors
-      name: nano
-      origin: Ubuntu
-      source: apt
-      version: 2.9.3-2
+  - arch: amd64
+    category: editors
+    name: nano
+    origin: Ubuntu
+    source: apt
+    version: 2.9.3-2
   ncurses-base:
-    - arch: all
-      category: utils
-      name: ncurses-base
-      origin: Ubuntu
-      source: apt
-      version: 6.1-1ubuntu1.18.04
+  - arch: all
+    category: utils
+    name: ncurses-base
+    origin: Ubuntu
+    source: apt
+    version: 6.1-1ubuntu1.18.04
   ncurses-bin:
-    - arch: amd64
-      category: utils
-      name: ncurses-bin
-      origin: Ubuntu
-      source: apt
-      version: 6.1-1ubuntu1.18.04
+  - arch: amd64
+    category: utils
+    name: ncurses-bin
+    origin: Ubuntu
+    source: apt
+    version: 6.1-1ubuntu1.18.04
   ncurses-term:
-    - arch: all
-      category: admin
-      name: ncurses-term
-      origin: Ubuntu
-      source: apt
-      version: 6.1-1ubuntu1.18.04
+  - arch: all
+    category: admin
+    name: ncurses-term
+    origin: Ubuntu
+    source: apt
+    version: 6.1-1ubuntu1.18.04
   net-tools:
-    - arch: amd64
-      category: net
-      name: net-tools
-      origin: Ubuntu
-      source: apt
-      version: 1.60+git20161116.90da8a0-1ubuntu1
+  - arch: amd64
+    category: net
+    name: net-tools
+    origin: Ubuntu
+    source: apt
+    version: 1.60+git20161116.90da8a0-1ubuntu1
   netbase:
-    - arch: all
-      category: admin
-      name: netbase
-      origin: Ubuntu
-      source: apt
-      version: '5.4'
+  - arch: all
+    category: admin
+    name: netbase
+    origin: Ubuntu
+    source: apt
+    version: '5.4'
   netcat-openbsd:
-    - arch: amd64
-      category: net
-      name: netcat-openbsd
-      origin: Ubuntu
-      source: apt
-      version: 1.187-1ubuntu0.1
+  - arch: amd64
+    category: net
+    name: netcat-openbsd
+    origin: Ubuntu
+    source: apt
+    version: 1.187-1ubuntu0.1
   netplan.io:
-    - arch: amd64
-      category: net
-      name: netplan.io
-      origin: ''
-      source: apt
-      version: 0.99-0ubuntu3~18.04.3
+  - arch: amd64
+    category: net
+    name: netplan.io
+    origin: ''
+    source: apt
+    version: 0.99-0ubuntu3~18.04.3
   networkd-dispatcher:
-    - arch: all
-      category: utils
-      name: networkd-dispatcher
-      origin: Ubuntu
-      source: apt
-      version: 1.7-0ubuntu3.5
+  - arch: all
+    category: utils
+    name: networkd-dispatcher
+    origin: Ubuntu
+    source: apt
+    version: 1.7-0ubuntu3.5
   nplan:
-    - arch: all
-      category: net
-      name: nplan
-      origin: ''
-      source: apt
-      version: 0.99-0ubuntu3~18.04.3
+  - arch: all
+    category: net
+    name: nplan
+    origin: ''
+    source: apt
+    version: 0.99-0ubuntu3~18.04.3
   ntfs-3g:
-    - arch: amd64
-      category: otherosfs
-      name: ntfs-3g
-      origin: Ubuntu
-      source: apt
-      version: '1:2017.3.23-2ubuntu0.18.04.3'
+  - arch: amd64
+    category: otherosfs
+    name: ntfs-3g
+    origin: Ubuntu
+    source: apt
+    version: 1:2017.3.23-2ubuntu0.18.04.3
   open-iscsi:
-    - arch: amd64
-      category: net
-      name: open-iscsi
-      origin: ''
-      source: apt
-      version: 2.0.874-5ubuntu2.10
+  - arch: amd64
+    category: net
+    name: open-iscsi
+    origin: ''
+    source: apt
+    version: 2.0.874-5ubuntu2.10
   open-vm-tools:
-    - arch: amd64
-      category: admin
-      name: open-vm-tools
-      origin: Ubuntu
-      source: apt
-      version: '2:11.0.5-4ubuntu0.18.04.1'
+  - arch: amd64
+    category: admin
+    name: open-vm-tools
+    origin: Ubuntu
+    source: apt
+    version: 2:11.0.5-4ubuntu0.18.04.1
   openssh-client:
-    - arch: amd64
-      category: net
-      name: openssh-client
-      origin: Ubuntu
-      source: apt
-      version: '1:7.6p1-4ubuntu0.5'
+  - arch: amd64
+    category: net
+    name: openssh-client
+    origin: Ubuntu
+    source: apt
+    version: 1:7.6p1-4ubuntu0.5
   openssh-server:
-    - arch: amd64
-      category: net
-      name: openssh-server
-      origin: Ubuntu
-      source: apt
-      version: '1:7.6p1-4ubuntu0.5'
+  - arch: amd64
+    category: net
+    name: openssh-server
+    origin: Ubuntu
+    source: apt
+    version: 1:7.6p1-4ubuntu0.5
   openssh-sftp-server:
-    - arch: amd64
-      category: net
-      name: openssh-sftp-server
-      origin: Ubuntu
-      source: apt
-      version: '1:7.6p1-4ubuntu0.5'
+  - arch: amd64
+    category: net
+    name: openssh-sftp-server
+    origin: Ubuntu
+    source: apt
+    version: 1:7.6p1-4ubuntu0.5
   openssl:
-    - arch: amd64
-      category: utils
-      name: openssl
-      origin: Ubuntu
-      source: apt
-      version: 1.1.1-1ubuntu2.1~18.04.17
+  - arch: amd64
+    category: utils
+    name: openssl
+    origin: Ubuntu
+    source: apt
+    version: 1.1.1-1ubuntu2.1~18.04.17
   os-prober:
-    - arch: amd64
-      category: utils
-      name: os-prober
-      origin: Ubuntu
-      source: apt
-      version: 1.74ubuntu1
+  - arch: amd64
+    category: utils
+    name: os-prober
+    origin: Ubuntu
+    source: apt
+    version: 1.74ubuntu1
   overlayroot:
-    - arch: all
-      category: admin
-      name: overlayroot
-      origin: Ubuntu
-      source: apt
-      version: 0.40ubuntu1.1
+  - arch: all
+    category: admin
+    name: overlayroot
+    origin: Ubuntu
+    source: apt
+    version: 0.40ubuntu1.1
   parted:
-    - arch: amd64
-      category: admin
-      name: parted
-      origin: Ubuntu
-      source: apt
-      version: 3.2-20ubuntu0.2
+  - arch: amd64
+    category: admin
+    name: parted
+    origin: Ubuntu
+    source: apt
+    version: 3.2-20ubuntu0.2
   passwd:
-    - arch: amd64
-      category: admin
-      name: passwd
-      origin: Ubuntu
-      source: apt
-      version: '1:4.5-1ubuntu2.2'
+  - arch: amd64
+    category: admin
+    name: passwd
+    origin: Ubuntu
+    source: apt
+    version: 1:4.5-1ubuntu2.2
   pastebinit:
-    - arch: all
-      category: misc
-      name: pastebinit
-      origin: Ubuntu
-      source: apt
-      version: 1.5-2
+  - arch: all
+    category: misc
+    name: pastebinit
+    origin: Ubuntu
+    source: apt
+    version: 1.5-2
   patch:
-    - arch: amd64
-      category: utils
-      name: patch
-      origin: Ubuntu
-      source: apt
-      version: 2.7.6-2ubuntu1.1
+  - arch: amd64
+    category: utils
+    name: patch
+    origin: Ubuntu
+    source: apt
+    version: 2.7.6-2ubuntu1.1
   pciutils:
-    - arch: amd64
-      category: admin
-      name: pciutils
-      origin: Ubuntu
-      source: apt
-      version: '1:3.5.2-1ubuntu1.1'
+  - arch: amd64
+    category: admin
+    name: pciutils
+    origin: Ubuntu
+    source: apt
+    version: 1:3.5.2-1ubuntu1.1
   perl:
-    - arch: amd64
-      category: perl
-      name: perl
-      origin: Ubuntu
-      source: apt
-      version: 5.26.1-6ubuntu0.5
+  - arch: amd64
+    category: perl
+    name: perl
+    origin: Ubuntu
+    source: apt
+    version: 5.26.1-6ubuntu0.5
   perl-base:
-    - arch: amd64
-      category: perl
-      name: perl-base
-      origin: Ubuntu
-      source: apt
-      version: 5.26.1-6ubuntu0.5
+  - arch: amd64
+    category: perl
+    name: perl-base
+    origin: Ubuntu
+    source: apt
+    version: 5.26.1-6ubuntu0.5
   perl-modules-5.26:
-    - arch: all
-      category: perl
-      name: perl-modules-5.26
-      origin: Ubuntu
-      source: apt
-      version: 5.26.1-6ubuntu0.5
+  - arch: all
+    category: perl
+    name: perl-modules-5.26
+    origin: Ubuntu
+    source: apt
+    version: 5.26.1-6ubuntu0.5
   pigz:
-    - arch: amd64
-      category: universe/utils
-      name: pigz
-      origin: Ubuntu
-      source: apt
-      version: 2.4-1
+  - arch: amd64
+    category: universe/utils
+    name: pigz
+    origin: Ubuntu
+    source: apt
+    version: 2.4-1
   pinentry-curses:
-    - arch: amd64
-      category: utils
-      name: pinentry-curses
-      origin: Ubuntu
-      source: apt
-      version: 1.1.0-1
+  - arch: amd64
+    category: utils
+    name: pinentry-curses
+    origin: Ubuntu
+    source: apt
+    version: 1.1.0-1
   plymouth:
-    - arch: amd64
-      category: x11
-      name: plymouth
-      origin: Ubuntu
-      source: apt
-      version: 0.9.3-1ubuntu7.18.04.2
+  - arch: amd64
+    category: x11
+    name: plymouth
+    origin: Ubuntu
+    source: apt
+    version: 0.9.3-1ubuntu7.18.04.2
   plymouth-theme-ubuntu-text:
-    - arch: amd64
-      category: x11
-      name: plymouth-theme-ubuntu-text
-      origin: Ubuntu
-      source: apt
-      version: 0.9.3-1ubuntu7.18.04.2
+  - arch: amd64
+    category: x11
+    name: plymouth-theme-ubuntu-text
+    origin: Ubuntu
+    source: apt
+    version: 0.9.3-1ubuntu7.18.04.2
   policykit-1:
-    - arch: amd64
-      category: admin
-      name: policykit-1
-      origin: Ubuntu
-      source: apt
-      version: 0.105-20ubuntu0.18.04.6
+  - arch: amd64
+    category: admin
+    name: policykit-1
+    origin: Ubuntu
+    source: apt
+    version: 0.105-20ubuntu0.18.04.6
   pollinate:
-    - arch: all
-      category: admin
-      name: pollinate
-      origin: ''
-      source: apt
-      version: 4.33-0ubuntu1~18.04.1
+  - arch: all
+    category: admin
+    name: pollinate
+    origin: ''
+    source: apt
+    version: 4.33-0ubuntu1~18.04.1
   popularity-contest:
-    - arch: all
-      category: misc
-      name: popularity-contest
-      origin: Ubuntu
-      source: apt
-      version: 1.66ubuntu1
+  - arch: all
+    category: misc
+    name: popularity-contest
+    origin: Ubuntu
+    source: apt
+    version: 1.66ubuntu1
   powermgmt-base:
-    - arch: all
-      category: utils
-      name: powermgmt-base
-      origin: Ubuntu
-      source: apt
-      version: '1.33'
+  - arch: all
+    category: utils
+    name: powermgmt-base
+    origin: Ubuntu
+    source: apt
+    version: '1.33'
   procps:
-    - arch: amd64
-      category: admin
-      name: procps
-      origin: Ubuntu
-      source: apt
-      version: '2:3.3.12-3ubuntu1.2'
+  - arch: amd64
+    category: admin
+    name: procps
+    origin: Ubuntu
+    source: apt
+    version: 2:3.3.12-3ubuntu1.2
   psmisc:
-    - arch: amd64
-      category: admin
-      name: psmisc
-      origin: Ubuntu
-      source: apt
-      version: 23.1-1ubuntu0.1
+  - arch: amd64
+    category: admin
+    name: psmisc
+    origin: Ubuntu
+    source: apt
+    version: 23.1-1ubuntu0.1
   publicsuffix:
-    - arch: all
-      category: net
-      name: publicsuffix
-      origin: Ubuntu
-      source: apt
-      version: 20180223.1310-1
+  - arch: all
+    category: net
+    name: publicsuffix
+    origin: Ubuntu
+    source: apt
+    version: 20180223.1310-1
   python-apt-common:
-    - arch: all
-      category: python
-      name: python-apt-common
-      origin: Ubuntu
-      source: apt
-      version: 1.6.5ubuntu0.5
+  - arch: all
+    category: python
+    name: python-apt-common
+    origin: Ubuntu
+    source: apt
+    version: 1.6.5ubuntu0.5
   python3:
-    - arch: amd64
-      category: python
-      name: python3
-      origin: Ubuntu
-      source: apt
-      version: 3.6.7-1~18.04
+  - arch: amd64
+    category: python
+    name: python3
+    origin: Ubuntu
+    source: apt
+    version: 3.6.7-1~18.04
   python3-apport:
-    - arch: all
-      category: python
-      name: python3-apport
-      origin: Ubuntu
-      source: apt
-      version: 2.20.9-0ubuntu7.28
+  - arch: all
+    category: python
+    name: python3-apport
+    origin: Ubuntu
+    source: apt
+    version: 2.20.9-0ubuntu7.28
   python3-apt:
-    - arch: amd64
-      category: python
-      name: python3-apt
-      origin: Ubuntu
-      source: apt
-      version: 1.6.5ubuntu0.5
+  - arch: amd64
+    category: python
+    name: python3-apt
+    origin: Ubuntu
+    source: apt
+    version: 1.6.5ubuntu0.5
   python3-asn1crypto:
-    - arch: all
-      category: python
-      name: python3-asn1crypto
-      origin: Ubuntu
-      source: apt
-      version: 0.24.0-1
+  - arch: all
+    category: python
+    name: python3-asn1crypto
+    origin: Ubuntu
+    source: apt
+    version: 0.24.0-1
   python3-attr:
-    - arch: all
-      category: python
-      name: python3-attr
-      origin: Ubuntu
-      source: apt
-      version: 17.4.0-2
+  - arch: all
+    category: python
+    name: python3-attr
+    origin: Ubuntu
+    source: apt
+    version: 17.4.0-2
   python3-automat:
-    - arch: all
-      category: python
-      name: python3-automat
-      origin: Ubuntu
-      source: apt
-      version: 0.6.0-1
+  - arch: all
+    category: python
+    name: python3-automat
+    origin: Ubuntu
+    source: apt
+    version: 0.6.0-1
   python3-blinker:
-    - arch: all
-      category: python
-      name: python3-blinker
-      origin: Ubuntu
-      source: apt
-      version: 1.4+dfsg1-0.1
+  - arch: all
+    category: python
+    name: python3-blinker
+    origin: Ubuntu
+    source: apt
+    version: 1.4+dfsg1-0.1
   python3-certifi:
-    - arch: all
-      category: python
-      name: python3-certifi
-      origin: Ubuntu
-      source: apt
-      version: 2018.1.18-2
+  - arch: all
+    category: python
+    name: python3-certifi
+    origin: Ubuntu
+    source: apt
+    version: 2018.1.18-2
   python3-cffi-backend:
-    - arch: amd64
-      category: python
-      name: python3-cffi-backend
-      origin: Ubuntu
-      source: apt
-      version: 1.11.5-1
+  - arch: amd64
+    category: python
+    name: python3-cffi-backend
+    origin: Ubuntu
+    source: apt
+    version: 1.11.5-1
   python3-chardet:
-    - arch: all
-      category: python
-      name: python3-chardet
-      origin: Ubuntu
-      source: apt
-      version: 3.0.4-1
+  - arch: all
+    category: python
+    name: python3-chardet
+    origin: Ubuntu
+    source: apt
+    version: 3.0.4-1
   python3-click:
-    - arch: all
-      category: python
-      name: python3-click
-      origin: Ubuntu
-      source: apt
-      version: 6.7-3
+  - arch: all
+    category: python
+    name: python3-click
+    origin: Ubuntu
+    source: apt
+    version: 6.7-3
   python3-colorama:
-    - arch: all
-      category: python
-      name: python3-colorama
-      origin: Ubuntu
-      source: apt
-      version: 0.3.7-1
+  - arch: all
+    category: python
+    name: python3-colorama
+    origin: Ubuntu
+    source: apt
+    version: 0.3.7-1
   python3-commandnotfound:
-    - arch: all
-      category: python
-      name: python3-commandnotfound
-      origin: ''
-      source: apt
-      version: 18.04.5
+  - arch: all
+    category: python
+    name: python3-commandnotfound
+    origin: ''
+    source: apt
+    version: 18.04.5
   python3-configobj:
-    - arch: all
-      category: python
-      name: python3-configobj
-      origin: Ubuntu
-      source: apt
-      version: 5.0.6-2
+  - arch: all
+    category: python
+    name: python3-configobj
+    origin: Ubuntu
+    source: apt
+    version: 5.0.6-2
   python3-constantly:
-    - arch: all
-      category: python
-      name: python3-constantly
-      origin: Ubuntu
-      source: apt
-      version: 15.1.0-1
+  - arch: all
+    category: python
+    name: python3-constantly
+    origin: Ubuntu
+    source: apt
+    version: 15.1.0-1
   python3-cryptography:
-    - arch: amd64
-      category: python
-      name: python3-cryptography
-      origin: Ubuntu
-      source: apt
-      version: 2.1.4-1ubuntu1.4
+  - arch: amd64
+    category: python
+    name: python3-cryptography
+    origin: Ubuntu
+    source: apt
+    version: 2.1.4-1ubuntu1.4
   python3-dbus:
-    - arch: amd64
-      category: python
-      name: python3-dbus
-      origin: Ubuntu
-      source: apt
-      version: 1.2.6-1
+  - arch: amd64
+    category: python
+    name: python3-dbus
+    origin: Ubuntu
+    source: apt
+    version: 1.2.6-1
   python3-debconf:
-    - arch: all
-      category: python
-      name: python3-debconf
-      origin: Ubuntu
-      source: apt
-      version: 1.5.66ubuntu1
+  - arch: all
+    category: python
+    name: python3-debconf
+    origin: Ubuntu
+    source: apt
+    version: 1.5.66ubuntu1
   python3-debian:
-    - arch: all
-      category: python
-      name: python3-debian
-      origin: Ubuntu
-      source: apt
-      version: 0.1.32
+  - arch: all
+    category: python
+    name: python3-debian
+    origin: Ubuntu
+    source: apt
+    version: 0.1.32
   python3-distro-info:
-    - arch: all
-      category: python
-      name: python3-distro-info
-      origin: Ubuntu
-      source: apt
-      version: 0.18ubuntu0.18.04.1
+  - arch: all
+    category: python
+    name: python3-distro-info
+    origin: Ubuntu
+    source: apt
+    version: 0.18ubuntu0.18.04.1
   python3-distupgrade:
-    - arch: all
-      category: python
-      name: python3-distupgrade
-      origin: ''
-      source: apt
-      version: '1:18.04.38'
+  - arch: all
+    category: python
+    name: python3-distupgrade
+    origin: ''
+    source: apt
+    version: 1:18.04.38
   python3-gdbm:
-    - arch: amd64
-      category: python
-      name: python3-gdbm
-      origin: Ubuntu
-      source: apt
-      version: 3.6.9-1~18.04
+  - arch: amd64
+    category: python
+    name: python3-gdbm
+    origin: Ubuntu
+    source: apt
+    version: 3.6.9-1~18.04
   python3-gi:
-    - arch: amd64
-      category: python
-      name: python3-gi
-      origin: Ubuntu
-      source: apt
-      version: 3.26.1-2ubuntu1
+  - arch: amd64
+    category: python
+    name: python3-gi
+    origin: Ubuntu
+    source: apt
+    version: 3.26.1-2ubuntu1
   python3-httplib2:
-    - arch: all
-      category: python
-      name: python3-httplib2
-      origin: Ubuntu
-      source: apt
-      version: 0.9.2+dfsg-1ubuntu0.2
+  - arch: all
+    category: python
+    name: python3-httplib2
+    origin: Ubuntu
+    source: apt
+    version: 0.9.2+dfsg-1ubuntu0.2
   python3-hyperlink:
-    - arch: all
-      category: python
-      name: python3-hyperlink
-      origin: Ubuntu
-      source: apt
-      version: 17.3.1-2
+  - arch: all
+    category: python
+    name: python3-hyperlink
+    origin: Ubuntu
+    source: apt
+    version: 17.3.1-2
   python3-idna:
-    - arch: all
-      category: python
-      name: python3-idna
-      origin: Ubuntu
-      source: apt
-      version: 2.6-1
+  - arch: all
+    category: python
+    name: python3-idna
+    origin: Ubuntu
+    source: apt
+    version: 2.6-1
   python3-incremental:
-    - arch: all
-      category: python
-      name: python3-incremental
-      origin: Ubuntu
-      source: apt
-      version: 16.10.1-3
+  - arch: all
+    category: python
+    name: python3-incremental
+    origin: Ubuntu
+    source: apt
+    version: 16.10.1-3
   python3-jinja2:
-    - arch: all
-      category: python
-      name: python3-jinja2
-      origin: Ubuntu
-      source: apt
-      version: 2.10-1ubuntu0.18.04.1
+  - arch: all
+    category: python
+    name: python3-jinja2
+    origin: Ubuntu
+    source: apt
+    version: 2.10-1ubuntu0.18.04.1
   python3-json-pointer:
-    - arch: all
-      category: python
-      name: python3-json-pointer
-      origin: Ubuntu
-      source: apt
-      version: 1.10-1
+  - arch: all
+    category: python
+    name: python3-json-pointer
+    origin: Ubuntu
+    source: apt
+    version: 1.10-1
   python3-jsonpatch:
-    - arch: all
-      category: python
-      name: python3-jsonpatch
-      origin: Ubuntu
-      source: apt
-      version: 1.19+really1.16-1fakesync1
+  - arch: all
+    category: python
+    name: python3-jsonpatch
+    origin: Ubuntu
+    source: apt
+    version: 1.19+really1.16-1fakesync1
   python3-jsonschema:
-    - arch: all
-      category: python
-      name: python3-jsonschema
-      origin: Ubuntu
-      source: apt
-      version: 2.6.0-2
+  - arch: all
+    category: python
+    name: python3-jsonschema
+    origin: Ubuntu
+    source: apt
+    version: 2.6.0-2
   python3-jwt:
-    - arch: all
-      category: python
-      name: python3-jwt
-      origin: Ubuntu
-      source: apt
-      version: 1.5.3+ds1-1
+  - arch: all
+    category: python
+    name: python3-jwt
+    origin: Ubuntu
+    source: apt
+    version: 1.5.3+ds1-1
   python3-markupsafe:
-    - arch: amd64
-      category: python
-      name: python3-markupsafe
-      origin: Ubuntu
-      source: apt
-      version: 1.0-1build1
+  - arch: amd64
+    category: python
+    name: python3-markupsafe
+    origin: Ubuntu
+    source: apt
+    version: 1.0-1build1
   python3-minimal:
-    - arch: amd64
-      category: python
-      name: python3-minimal
-      origin: Ubuntu
-      source: apt
-      version: 3.6.7-1~18.04
+  - arch: amd64
+    category: python
+    name: python3-minimal
+    origin: Ubuntu
+    source: apt
+    version: 3.6.7-1~18.04
   python3-netifaces:
-    - arch: amd64
-      category: python
-      name: python3-netifaces
-      origin: Ubuntu
-      source: apt
-      version: 0.10.4-0.1build4
+  - arch: amd64
+    category: python
+    name: python3-netifaces
+    origin: Ubuntu
+    source: apt
+    version: 0.10.4-0.1build4
   python3-newt:
-    - arch: amd64
-      category: python
-      name: python3-newt
-      origin: Ubuntu
-      source: apt
-      version: 0.52.20-1ubuntu1
+  - arch: amd64
+    category: python
+    name: python3-newt
+    origin: Ubuntu
+    source: apt
+    version: 0.52.20-1ubuntu1
   python3-oauthlib:
-    - arch: all
-      category: python
-      name: python3-oauthlib
-      origin: Ubuntu
-      source: apt
-      version: 2.0.6-1
+  - arch: all
+    category: python
+    name: python3-oauthlib
+    origin: Ubuntu
+    source: apt
+    version: 2.0.6-1
   python3-openssl:
-    - arch: all
-      category: python
-      name: python3-openssl
-      origin: Ubuntu
-      source: apt
-      version: 17.5.0-1ubuntu1
+  - arch: all
+    category: python
+    name: python3-openssl
+    origin: Ubuntu
+    source: apt
+    version: 17.5.0-1ubuntu1
   python3-pam:
-    - arch: amd64
-      category: python
-      name: python3-pam
-      origin: Ubuntu
-      source: apt
-      version: 0.4.2-13.2ubuntu4
+  - arch: amd64
+    category: python
+    name: python3-pam
+    origin: Ubuntu
+    source: apt
+    version: 0.4.2-13.2ubuntu4
   python3-pkg-resources:
-    - arch: all
-      category: python
-      name: python3-pkg-resources
-      origin: Ubuntu
-      source: apt
-      version: 39.0.1-2
+  - arch: all
+    category: python
+    name: python3-pkg-resources
+    origin: Ubuntu
+    source: apt
+    version: 39.0.1-2
   python3-problem-report:
-    - arch: all
-      category: python
-      name: python3-problem-report
-      origin: Ubuntu
-      source: apt
-      version: 2.20.9-0ubuntu7.28
+  - arch: all
+    category: python
+    name: python3-problem-report
+    origin: Ubuntu
+    source: apt
+    version: 2.20.9-0ubuntu7.28
   python3-pyasn1:
-    - arch: all
-      category: python
-      name: python3-pyasn1
-      origin: Ubuntu
-      source: apt
-      version: 0.4.2-3
+  - arch: all
+    category: python
+    name: python3-pyasn1
+    origin: Ubuntu
+    source: apt
+    version: 0.4.2-3
   python3-pyasn1-modules:
-    - arch: all
-      category: python
-      name: python3-pyasn1-modules
-      origin: Ubuntu
-      source: apt
-      version: 0.2.1-0.2
+  - arch: all
+    category: python
+    name: python3-pyasn1-modules
+    origin: Ubuntu
+    source: apt
+    version: 0.2.1-0.2
   python3-requests:
-    - arch: all
-      category: python
-      name: python3-requests
-      origin: Ubuntu
-      source: apt
-      version: 2.18.4-2ubuntu0.1
+  - arch: all
+    category: python
+    name: python3-requests
+    origin: Ubuntu
+    source: apt
+    version: 2.18.4-2ubuntu0.1
   python3-requests-unixsocket:
-    - arch: all
-      category: python
-      name: python3-requests-unixsocket
-      origin: Ubuntu
-      source: apt
-      version: 0.1.5-3
+  - arch: all
+    category: python
+    name: python3-requests-unixsocket
+    origin: Ubuntu
+    source: apt
+    version: 0.1.5-3
   python3-serial:
-    - arch: all
-      category: python
-      name: python3-serial
-      origin: Ubuntu
-      source: apt
-      version: 3.4-2
+  - arch: all
+    category: python
+    name: python3-serial
+    origin: Ubuntu
+    source: apt
+    version: 3.4-2
   python3-service-identity:
-    - arch: all
-      category: python
-      name: python3-service-identity
-      origin: Ubuntu
-      source: apt
-      version: 16.0.0-2
+  - arch: all
+    category: python
+    name: python3-service-identity
+    origin: Ubuntu
+    source: apt
+    version: 16.0.0-2
   python3-six:
-    - arch: all
-      category: python
-      name: python3-six
-      origin: Ubuntu
-      source: apt
-      version: 1.11.0-2
+  - arch: all
+    category: python
+    name: python3-six
+    origin: Ubuntu
+    source: apt
+    version: 1.11.0-2
   python3-software-properties:
-    - arch: all
-      category: python
-      name: python3-software-properties
-      origin: Ubuntu
-      source: apt
-      version: 0.96.24.32.14
+  - arch: all
+    category: python
+    name: python3-software-properties
+    origin: Ubuntu
+    source: apt
+    version: 0.96.24.32.14
   python3-systemd:
-    - arch: amd64
-      category: python
-      name: python3-systemd
-      origin: Ubuntu
-      source: apt
-      version: 234-1build1
+  - arch: amd64
+    category: python
+    name: python3-systemd
+    origin: Ubuntu
+    source: apt
+    version: 234-1build1
   python3-twisted:
-    - arch: all
-      category: python
-      name: python3-twisted
-      origin: Ubuntu
-      source: apt
-      version: 17.9.0-2ubuntu0.3
+  - arch: all
+    category: python
+    name: python3-twisted
+    origin: Ubuntu
+    source: apt
+    version: 17.9.0-2ubuntu0.3
   python3-twisted-bin:
-    - arch: amd64
-      category: python
-      name: python3-twisted-bin
-      origin: Ubuntu
-      source: apt
-      version: 17.9.0-2ubuntu0.3
+  - arch: amd64
+    category: python
+    name: python3-twisted-bin
+    origin: Ubuntu
+    source: apt
+    version: 17.9.0-2ubuntu0.3
   python3-update-manager:
-    - arch: all
-      category: python
-      name: python3-update-manager
-      origin: Ubuntu
-      source: apt
-      version: '1:18.04.11.13'
+  - arch: all
+    category: python
+    name: python3-update-manager
+    origin: Ubuntu
+    source: apt
+    version: 1:18.04.11.13
   python3-urllib3:
-    - arch: all
-      category: python
-      name: python3-urllib3
-      origin: Ubuntu
-      source: apt
-      version: 1.22-1ubuntu0.18.04.2
+  - arch: all
+    category: python
+    name: python3-urllib3
+    origin: Ubuntu
+    source: apt
+    version: 1.22-1ubuntu0.18.04.2
   python3-yaml:
-    - arch: amd64
-      category: python
-      name: python3-yaml
-      origin: Ubuntu
-      source: apt
-      version: 3.12-1build2
+  - arch: amd64
+    category: python
+    name: python3-yaml
+    origin: Ubuntu
+    source: apt
+    version: 3.12-1build2
   python3-zope.interface:
-    - arch: amd64
-      category: zope
-      name: python3-zope.interface
-      origin: Ubuntu
-      source: apt
-      version: 4.3.2-1build2
+  - arch: amd64
+    category: zope
+    name: python3-zope.interface
+    origin: Ubuntu
+    source: apt
+    version: 4.3.2-1build2
   python3.6:
-    - arch: amd64
-      category: python
-      name: python3.6
-      origin: Ubuntu
-      source: apt
-      version: 3.6.9-1~18.04ubuntu1.7
+  - arch: amd64
+    category: python
+    name: python3.6
+    origin: Ubuntu
+    source: apt
+    version: 3.6.9-1~18.04ubuntu1.7
   python3.6-minimal:
-    - arch: amd64
-      category: python
-      name: python3.6-minimal
-      origin: Ubuntu
-      source: apt
-      version: 3.6.9-1~18.04ubuntu1.7
+  - arch: amd64
+    category: python
+    name: python3.6-minimal
+    origin: Ubuntu
+    source: apt
+    version: 3.6.9-1~18.04ubuntu1.7
   readline-common:
-    - arch: all
-      category: utils
-      name: readline-common
-      origin: Ubuntu
-      source: apt
-      version: 7.0-3
+  - arch: all
+    category: utils
+    name: readline-common
+    origin: Ubuntu
+    source: apt
+    version: 7.0-3
   rsync:
-    - arch: amd64
-      category: net
-      name: rsync
-      origin: Ubuntu
-      source: apt
-      version: 3.1.2-2.1ubuntu1.4
+  - arch: amd64
+    category: net
+    name: rsync
+    origin: Ubuntu
+    source: apt
+    version: 3.1.2-2.1ubuntu1.4
   rsyslog:
-    - arch: amd64
-      category: admin
-      name: rsyslog
-      origin: Ubuntu
-      source: apt
-      version: 8.32.0-1ubuntu4.2
+  - arch: amd64
+    category: admin
+    name: rsyslog
+    origin: Ubuntu
+    source: apt
+    version: 8.32.0-1ubuntu4.2
   run-one:
-    - arch: all
-      category: admin
-      name: run-one
-      origin: Ubuntu
-      source: apt
-      version: 1.17-0ubuntu1
+  - arch: all
+    category: admin
+    name: run-one
+    origin: Ubuntu
+    source: apt
+    version: 1.17-0ubuntu1
   sbsigntool:
-    - arch: amd64
-      category: utils
-      name: sbsigntool
-      origin: Ubuntu
-      source: apt
-      version: 0.6-3.2ubuntu2
+  - arch: amd64
+    category: utils
+    name: sbsigntool
+    origin: Ubuntu
+    source: apt
+    version: 0.6-3.2ubuntu2
   screen:
-    - arch: amd64
-      category: misc
-      name: screen
-      origin: Ubuntu
-      source: apt
-      version: 4.6.2-1ubuntu1.1
+  - arch: amd64
+    category: misc
+    name: screen
+    origin: Ubuntu
+    source: apt
+    version: 4.6.2-1ubuntu1.1
   secureboot-db:
-    - arch: amd64
-      category: utils
-      name: secureboot-db
-      origin: Ubuntu
-      source: apt
-      version: 1.4~ubuntu0.18.04.1
+  - arch: amd64
+    category: utils
+    name: secureboot-db
+    origin: Ubuntu
+    source: apt
+    version: 1.4~ubuntu0.18.04.1
   sed:
-    - arch: amd64
-      category: utils
-      name: sed
-      origin: Ubuntu
-      source: apt
-      version: 4.4-2
+  - arch: amd64
+    category: utils
+    name: sed
+    origin: Ubuntu
+    source: apt
+    version: 4.4-2
   sensible-utils:
-    - arch: all
-      category: utils
-      name: sensible-utils
-      origin: Ubuntu
-      source: apt
-      version: 0.0.12
+  - arch: all
+    category: utils
+    name: sensible-utils
+    origin: Ubuntu
+    source: apt
+    version: 0.0.12
   shared-mime-info:
-    - arch: amd64
-      category: misc
-      name: shared-mime-info
-      origin: Ubuntu
-      source: apt
-      version: 1.9-2
+  - arch: amd64
+    category: misc
+    name: shared-mime-info
+    origin: Ubuntu
+    source: apt
+    version: 1.9-2
   shim:
-    - arch: amd64
-      category: admin
-      name: shim
-      origin: ''
-      source: apt
-      version: 15+1533136590.3beb971-0ubuntu1
+  - arch: amd64
+    category: admin
+    name: shim
+    origin: ''
+    source: apt
+    version: 15+1533136590.3beb971-0ubuntu1
   shim-signed:
-    - arch: amd64
-      category: utils
-      name: shim-signed
-      origin: ''
-      source: apt
-      version: 1.37~18.04.6+15+1533136590.3beb971-0ubuntu1
+  - arch: amd64
+    category: utils
+    name: shim-signed
+    origin: ''
+    source: apt
+    version: 1.37~18.04.6+15+1533136590.3beb971-0ubuntu1
   snapd:
-    - arch: amd64
-      category: devel
-      name: snapd
-      origin: Ubuntu
-      source: apt
-      version: 2.54.3+18.04.2ubuntu0.2
+  - arch: amd64
+    category: devel
+    name: snapd
+    origin: Ubuntu
+    source: apt
+    version: 2.54.3+18.04.2ubuntu0.2
   software-properties-common:
-    - arch: all
-      category: admin
-      name: software-properties-common
-      origin: Ubuntu
-      source: apt
-      version: 0.96.24.32.14
+  - arch: all
+    category: admin
+    name: software-properties-common
+    origin: Ubuntu
+    source: apt
+    version: 0.96.24.32.14
   sosreport:
-    - arch: amd64
-      category: admin
-      name: sosreport
-      origin: ''
-      source: apt
-      version: 3.9.1-1ubuntu0.18.04.2
+  - arch: amd64
+    category: admin
+    name: sosreport
+    origin: ''
+    source: apt
+    version: 3.9.1-1ubuntu0.18.04.2
   squashfs-tools:
-    - arch: amd64
-      category: admin
-      name: squashfs-tools
-      origin: Ubuntu
-      source: apt
-      version: '1:4.3-6ubuntu0.18.04.4'
+  - arch: amd64
+    category: admin
+    name: squashfs-tools
+    origin: Ubuntu
+    source: apt
+    version: 1:4.3-6ubuntu0.18.04.4
   ssh-import-id:
-    - arch: all
-      category: misc
-      name: ssh-import-id
-      origin: Ubuntu
-      source: apt
-      version: 5.7-0ubuntu1.1
+  - arch: all
+    category: misc
+    name: ssh-import-id
+    origin: Ubuntu
+    source: apt
+    version: 5.7-0ubuntu1.1
   strace:
-    - arch: amd64
-      category: utils
-      name: strace
-      origin: Ubuntu
-      source: apt
-      version: 4.21-1ubuntu1
+  - arch: amd64
+    category: utils
+    name: strace
+    origin: Ubuntu
+    source: apt
+    version: 4.21-1ubuntu1
   sudo:
-    - arch: amd64
-      category: admin
-      name: sudo
-      origin: Ubuntu
-      source: apt
-      version: 1.8.21p2-3ubuntu1.4
+  - arch: amd64
+    category: admin
+    name: sudo
+    origin: Ubuntu
+    source: apt
+    version: 1.8.21p2-3ubuntu1.4
   systemd:
-    - arch: amd64
-      category: admin
-      name: systemd
-      origin: Ubuntu
-      source: apt
-      version: 237-3ubuntu10.50
+  - arch: amd64
+    category: admin
+    name: systemd
+    origin: Ubuntu
+    source: apt
+    version: 237-3ubuntu10.50
   systemd-sysv:
-    - arch: amd64
-      category: admin
-      name: systemd-sysv
-      origin: Ubuntu
-      source: apt
-      version: 237-3ubuntu10.50
+  - arch: amd64
+    category: admin
+    name: systemd-sysv
+    origin: Ubuntu
+    source: apt
+    version: 237-3ubuntu10.50
   sysvinit-utils:
-    - arch: amd64
-      category: admin
-      name: sysvinit-utils
-      origin: Ubuntu
-      source: apt
-      version: 2.88dsf-59.10ubuntu1
+  - arch: amd64
+    category: admin
+    name: sysvinit-utils
+    origin: Ubuntu
+    source: apt
+    version: 2.88dsf-59.10ubuntu1
   tar:
-    - arch: amd64
-      category: utils
-      name: tar
-      origin: Ubuntu
-      source: apt
-      version: 1.29b-2ubuntu0.3
+  - arch: amd64
+    category: utils
+    name: tar
+    origin: Ubuntu
+    source: apt
+    version: 1.29b-2ubuntu0.3
   tcpdump:
-    - arch: amd64
-      category: net
-      name: tcpdump
-      origin: Ubuntu
-      source: apt
-      version: 4.9.3-0ubuntu0.18.04.2
+  - arch: amd64
+    category: net
+    name: tcpdump
+    origin: Ubuntu
+    source: apt
+    version: 4.9.3-0ubuntu0.18.04.2
   telnet:
-    - arch: amd64
-      category: net
-      name: telnet
-      origin: Ubuntu
-      source: apt
-      version: 0.17-41
+  - arch: amd64
+    category: net
+    name: telnet
+    origin: Ubuntu
+    source: apt
+    version: 0.17-41
   time:
-    - arch: amd64
-      category: utils
-      name: time
-      origin: Ubuntu
-      source: apt
-      version: 1.7-25.1build1
+  - arch: amd64
+    category: utils
+    name: time
+    origin: Ubuntu
+    source: apt
+    version: 1.7-25.1build1
   tmux:
-    - arch: amd64
-      category: admin
-      name: tmux
-      origin: Ubuntu
-      source: apt
-      version: 2.6-3ubuntu0.2
+  - arch: amd64
+    category: admin
+    name: tmux
+    origin: Ubuntu
+    source: apt
+    version: 2.6-3ubuntu0.2
   tzdata:
-    - arch: all
-      category: libs
-      name: tzdata
-      origin: Ubuntu
-      source: apt
-      version: 2022a-0ubuntu0.18.04
+  - arch: all
+    category: libs
+    name: tzdata
+    origin: Ubuntu
+    source: apt
+    version: 2022a-0ubuntu0.18.04
   ubuntu-advantage-tools:
-    - arch: all
-      category: misc
-      name: ubuntu-advantage-tools
-      origin: Ubuntu
-      source: apt
-      version: '17'
+  - arch: all
+    category: misc
+    name: ubuntu-advantage-tools
+    origin: Ubuntu
+    source: apt
+    version: '17'
   ubuntu-keyring:
-    - arch: all
-      category: misc
-      name: ubuntu-keyring
-      origin: ''
-      source: apt
-      version: 2018.09.18.1~18.04.0
+  - arch: all
+    category: misc
+    name: ubuntu-keyring
+    origin: ''
+    source: apt
+    version: 2018.09.18.1~18.04.0
   ubuntu-minimal:
-    - arch: amd64
-      category: metapackages
-      name: ubuntu-minimal
-      origin: ''
-      source: apt
-      version: 1.417.4
+  - arch: amd64
+    category: metapackages
+    name: ubuntu-minimal
+    origin: ''
+    source: apt
+    version: 1.417.4
   ubuntu-release-upgrader-core:
-    - arch: all
-      category: admin
-      name: ubuntu-release-upgrader-core
-      origin: ''
-      source: apt
-      version: '1:18.04.38'
+  - arch: all
+    category: admin
+    name: ubuntu-release-upgrader-core
+    origin: ''
+    source: apt
+    version: 1:18.04.38
   ubuntu-server:
-    - arch: amd64
-      category: metapackages
-      name: ubuntu-server
-      origin: ''
-      source: apt
-      version: 1.417.4
+  - arch: amd64
+    category: metapackages
+    name: ubuntu-server
+    origin: ''
+    source: apt
+    version: 1.417.4
   ubuntu-standard:
-    - arch: amd64
-      category: metapackages
-      name: ubuntu-standard
-      origin: ''
-      source: apt
-      version: 1.417.4
+  - arch: amd64
+    category: metapackages
+    name: ubuntu-standard
+    origin: ''
+    source: apt
+    version: 1.417.4
   ucf:
-    - arch: all
-      category: utils
-      name: ucf
-      origin: Ubuntu
-      source: apt
-      version: '3.0038'
+  - arch: all
+    category: utils
+    name: ucf
+    origin: Ubuntu
+    source: apt
+    version: '3.0038'
   udev:
-    - arch: amd64
-      category: admin
-      name: udev
-      origin: Ubuntu
-      source: apt
-      version: 237-3ubuntu10.50
+  - arch: amd64
+    category: admin
+    name: udev
+    origin: Ubuntu
+    source: apt
+    version: 237-3ubuntu10.50
   ufw:
-    - arch: all
-      category: admin
-      name: ufw
-      origin: ''
-      source: apt
-      version: 0.36-0ubuntu0.18.04.1
+  - arch: all
+    category: admin
+    name: ufw
+    origin: ''
+    source: apt
+    version: 0.36-0ubuntu0.18.04.1
   uidmap:
-    - arch: amd64
-      category: admin
-      name: uidmap
-      origin: Ubuntu
-      source: apt
-      version: '1:4.5-1ubuntu2.2'
+  - arch: amd64
+    category: admin
+    name: uidmap
+    origin: Ubuntu
+    source: apt
+    version: 1:4.5-1ubuntu2.2
   unattended-upgrades:
-    - arch: all
-      category: admin
-      name: unattended-upgrades
-      origin: Ubuntu
-      source: apt
-      version: 1.1ubuntu1.18.04.14
+  - arch: all
+    category: admin
+    name: unattended-upgrades
+    origin: Ubuntu
+    source: apt
+    version: 1.1ubuntu1.18.04.14
   update-manager-core:
-    - arch: all
-      category: admin
-      name: update-manager-core
-      origin: Ubuntu
-      source: apt
-      version: '1:18.04.11.13'
+  - arch: all
+    category: admin
+    name: update-manager-core
+    origin: Ubuntu
+    source: apt
+    version: 1:18.04.11.13
   update-notifier-common:
-    - arch: all
-      category: gnome
-      name: update-notifier-common
-      origin: ''
-      source: apt
-      version: 3.192.1.7
+  - arch: all
+    category: gnome
+    name: update-notifier-common
+    origin: ''
+    source: apt
+    version: 3.192.1.7
   ureadahead:
-    - arch: amd64
-      category: admin
-      name: ureadahead
-      origin: Ubuntu
-      source: apt
-      version: 0.100.0-21
+  - arch: amd64
+    category: admin
+    name: ureadahead
+    origin: Ubuntu
+    source: apt
+    version: 0.100.0-21
   usbutils:
-    - arch: amd64
-      category: utils
-      name: usbutils
-      origin: Ubuntu
-      source: apt
-      version: '1:007-4build1'
+  - arch: amd64
+    category: utils
+    name: usbutils
+    origin: Ubuntu
+    source: apt
+    version: 1:007-4build1
   util-linux:
-    - arch: amd64
-      category: utils
-      name: util-linux
-      origin: Ubuntu
-      source: apt
-      version: 2.31.1-0.4ubuntu3.7
+  - arch: amd64
+    category: utils
+    name: util-linux
+    origin: Ubuntu
+    source: apt
+    version: 2.31.1-0.4ubuntu3.7
   uuid-runtime:
-    - arch: amd64
-      category: libs
-      name: uuid-runtime
-      origin: Ubuntu
-      source: apt
-      version: 2.31.1-0.4ubuntu3.7
+  - arch: amd64
+    category: libs
+    name: uuid-runtime
+    origin: Ubuntu
+    source: apt
+    version: 2.31.1-0.4ubuntu3.7
   vim:
-    - arch: amd64
-      category: editors
-      name: vim
-      origin: Ubuntu
-      source: apt
-      version: '2:8.0.1453-1ubuntu1.8'
+  - arch: amd64
+    category: editors
+    name: vim
+    origin: Ubuntu
+    source: apt
+    version: 2:8.0.1453-1ubuntu1.8
   vim-common:
-    - arch: all
-      category: editors
-      name: vim-common
-      origin: Ubuntu
-      source: apt
-      version: '2:8.0.1453-1ubuntu1.8'
+  - arch: all
+    category: editors
+    name: vim-common
+    origin: Ubuntu
+    source: apt
+    version: 2:8.0.1453-1ubuntu1.8
   vim-runtime:
-    - arch: all
-      category: editors
-      name: vim-runtime
-      origin: Ubuntu
-      source: apt
-      version: '2:8.0.1453-1ubuntu1.8'
+  - arch: all
+    category: editors
+    name: vim-runtime
+    origin: Ubuntu
+    source: apt
+    version: 2:8.0.1453-1ubuntu1.8
   vim-tiny:
-    - arch: amd64
-      category: editors
-      name: vim-tiny
-      origin: Ubuntu
-      source: apt
-      version: '2:8.0.1453-1ubuntu1.8'
+  - arch: amd64
+    category: editors
+    name: vim-tiny
+    origin: Ubuntu
+    source: apt
+    version: 2:8.0.1453-1ubuntu1.8
   wget:
-    - arch: amd64
-      category: web
-      name: wget
-      origin: Ubuntu
-      source: apt
-      version: 1.19.4-1ubuntu2.2
+  - arch: amd64
+    category: web
+    name: wget
+    origin: Ubuntu
+    source: apt
+    version: 1.19.4-1ubuntu2.2
   whiptail:
-    - arch: amd64
-      category: utils
-      name: whiptail
-      origin: Ubuntu
-      source: apt
-      version: 0.52.20-1ubuntu1
+  - arch: amd64
+    category: utils
+    name: whiptail
+    origin: Ubuntu
+    source: apt
+    version: 0.52.20-1ubuntu1
   xauth:
-    - arch: amd64
-      category: x11
-      name: xauth
-      origin: Ubuntu
-      source: apt
-      version: '1:1.0.10-1'
+  - arch: amd64
+    category: x11
+    name: xauth
+    origin: Ubuntu
+    source: apt
+    version: 1:1.0.10-1
   xdelta3:
-    - arch: amd64
-      category: utils
-      name: xdelta3
-      origin: Ubuntu
-      source: apt
-      version: 3.0.11-dfsg-1ubuntu1
+  - arch: amd64
+    category: utils
+    name: xdelta3
+    origin: Ubuntu
+    source: apt
+    version: 3.0.11-dfsg-1ubuntu1
   xdg-user-dirs:
-    - arch: amd64
-      category: utils
-      name: xdg-user-dirs
-      origin: Ubuntu
-      source: apt
-      version: 0.17-1ubuntu1
+  - arch: amd64
+    category: utils
+    name: xdg-user-dirs
+    origin: Ubuntu
+    source: apt
+    version: 0.17-1ubuntu1
   xfsprogs:
-    - arch: amd64
-      category: admin
-      name: xfsprogs
-      origin: Ubuntu
-      source: apt
-      version: 4.9.0+nmu1ubuntu2
+  - arch: amd64
+    category: admin
+    name: xfsprogs
+    origin: Ubuntu
+    source: apt
+    version: 4.9.0+nmu1ubuntu2
   xkb-data:
-    - arch: all
-      category: x11
-      name: xkb-data
-      origin: Ubuntu
-      source: apt
-      version: 2.23.1-1ubuntu1.18.04.1
+  - arch: all
+    category: x11
+    name: xkb-data
+    origin: Ubuntu
+    source: apt
+    version: 2.23.1-1ubuntu1.18.04.1
   xxd:
-    - arch: amd64
-      category: editors
-      name: xxd
-      origin: Ubuntu
-      source: apt
-      version: '2:8.0.1453-1ubuntu1.8'
+  - arch: amd64
+    category: editors
+    name: xxd
+    origin: Ubuntu
+    source: apt
+    version: 2:8.0.1453-1ubuntu1.8
   xz-utils:
-    - arch: amd64
-      category: utils
-      name: xz-utils
-      origin: Ubuntu
-      source: apt
-      version: 5.2.2-1.3ubuntu0.1
+  - arch: amd64
+    category: utils
+    name: xz-utils
+    origin: Ubuntu
+    source: apt
+    version: 5.2.2-1.3ubuntu0.1
   zerofree:
-    - arch: amd64
-      category: admin
-      name: zerofree
-      origin: Ubuntu
-      source: apt
-      version: 1.0.4-1
+  - arch: amd64
+    category: admin
+    name: zerofree
+    origin: Ubuntu
+    source: apt
+    version: 1.0.4-1
   zlib1g:
-    - arch: amd64
-      category: libs
-      name: zlib1g
-      origin: Ubuntu
-      source: apt
-      version: '1:1.2.11.dfsg-0ubuntu2.1'
-dockers:
-  containers:
-    - AppArmorProfile: docker-default
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - ./agent
-        Env:
-          - AGENT_CLUSTER_ADDR=tasks.agent
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-        Hostname: 51b871604742
-        Image: 'portainer/agent:1.5.1'
-        Labels:
-          com.docker.stack.namespace: iometrics-infrabase
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: zv63ez6d7np17nhba28sfzcta
-          com.docker.swarm.service.name: iometrics-infrabase_agent
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: htwtsb7ml6p5ynviol7o0toc6
-          com.docker.swarm.task.name: >-
-            iometrics-infrabase_agent.wh12ct3jzpllqaj4mv233ey4f.htwtsb7ml6p5ynviol7o0toc6
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: /app
-      Created: '2022-04-26T14:58:49.594174611Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/e641ecda862d1dca612f30d132d2f4a7f3b428ad608b9db7261122be6ab671dd-init/diff:/var/lib/docker/overlay2/80a892dff2eb793bc1c241b2f11645c9f168b020142621ca85c7794012c1c9e5/diff:/var/lib/docker/overlay2/e20f364832b775bae223881abc805b1ab493959e18d606ca68960cc5ce1ba911/diff:/var/lib/docker/overlay2/27c537348347b2b75a1ed0826a682fd208a72841c7b151793b2f8600c8c49bfe/diff:/var/lib/docker/overlay2/4d90fe38400d770794d3ac1ac5be31209408bcc8d66e8d944201815fc0f670f3/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/e641ecda862d1dca612f30d132d2f4a7f3b428ad608b9db7261122be6ab671dd/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/e641ecda862d1dca612f30d132d2f4a7f3b428ad608b9db7261122be6ab671dd/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/e641ecda862d1dca612f30d132d2f4a7f3b428ad608b9db7261122be6ab671dd/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: /var/run/docker.sock
-            Target: /var/run/docker.sock
-            Type: bind
-          - Source: /var/lib/docker/volumes
-            Target: /var/lib/docker/volumes
-            Type: bind
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23/hosts
-      Id: 51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23
-      Image: 'sha256:5b96aa0902cb3584c223e512b3488e4db66f4e43f642a66ba78ac58047d9df10'
-      LogPath: >-
-        /var/lib/docker/containers/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/run/docker.sock
-          Mode: ''
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/docker.sock
-          Type: bind
-        - Destination: /var/lib/docker/volumes
-          Mode: ''
-          Propagation: rslave
-          RW: true
-          Source: /var/lib/docker/volumes
-          Type: bind
-      Name: >-
-        /iometrics-infrabase_agent.wh12ct3jzpllqaj4mv233ey4f.htwtsb7ml6p5ynviol7o0toc6
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - 51b871604742
-            DriverOpts: null
-            EndpointID: d2bd4a26839ef39a2d801fae724d8d5d1bcd9e193b698c395755126a73093cb0
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.49
-            IPAddress: 192.168.4.49
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:31'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports: { }
-        SandboxID: c2e1ebf2941fa4fb42261fef92040ad5f6be771658a2ce727a9e3f6bd6e8e238
-        SandboxKey: /var/run/docker/netns/c2e1ebf2941f
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: ./agent
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 5508
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:54.130089375Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - GF_ANALITICS_REPORTING_ENABLED=false
-          - >-
-            GF_INSTALL_PLUGINS=grafana-clock-panel,grafana-simple-json-datasource,alexanderzobnin-zabbix-app
-            3.10.0,flant-statusmap-panel,snuids-trafficlights-panel,natel-discrete-panel
-          - GF_LOG_CONSOLE_FORMAT=json
-          - >-
-            GF_LOG_FILTERS=alerting.notifier:debug,alerting.notifier.slack:debug,auth:debug
-          - GF_SECURITY_ADMIN_PASSWORD=admin
-          - GF_SECURITY_ADMIN_USER=admin
-          - GF_SERVER_DOMAIN=grafanac4.robotito.lab.iometrics.io
-          - 'GF_SERVER_ROOT_URL=https://grafanac4.robotito.lab.iometrics.io'
-          - GF_SERVER_ROUTER_LOGGING=true
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PLUGINS=/var/lib/grafana/plugins
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-        ExposedPorts:
-          3000/tcp: { }
-        Hostname: 857aa9d4f13e
-        Image: 'grafana/grafana:5.4.2'
-        Labels:
-          com.docker.stack.namespace: iometrics-zabbix-gw
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: o6d6z5zd36c3gfcgp0ck4w311
-          com.docker.swarm.service.name: iometrics-zabbix-gw_grafana
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: rgov6pf309hemkdkx3qg9rci0
-          com.docker.swarm.task.name: iometrics-zabbix-gw_grafana.1.rgov6pf309hemkdkx3qg9rci0
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes: null
-        WorkingDir: /usr/share/grafana
-      Created: '2022-04-26T14:58:34.408632045Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/5180c79bb3a87b177f6d9cbce73efb685d78eaf91c4e3ed1c64fdb225a07bb85-init/diff:/var/lib/docker/overlay2/8a91025aab8b9ff9fdcaff873c6552834950816ce4d344c3461303490eb6d965/diff:/var/lib/docker/overlay2/cc996ab9fabf0542fdc09c792d8f907a944180924fa3eec6f94db2757f5f246a/diff:/var/lib/docker/overlay2/54e93bedf43af593f00e45025bffed735f26b9f0f749fb80ed505fdf47b8453c/diff:/var/lib/docker/overlay2/770916c068ba6f58bd4a7a9be20d406d0f5d4988e2160fccdfd5242acb28b792/diff:/var/lib/docker/overlay2/18c9784de782dea92d578e00440c8d3b3f5b47aea10691ec8738809fce4f3e02/diff:/var/lib/docker/overlay2/dfbe518aad7b4fa7a09494a73507d53f307eecabe6c44e0bd5c5c5b4bf8a878a/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/5180c79bb3a87b177f6d9cbce73efb685d78eaf91c4e3ed1c64fdb225a07bb85/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/5180c79bb3a87b177f6d9cbce73efb685d78eaf91c4e3ed1c64fdb225a07bb85/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/5180c79bb3a87b177f6d9cbce73efb685d78eaf91c4e3ed1c64fdb225a07bb85/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: iometrics-zabbix-gw_grafanac4-data
-            Target: /var/lib/grafana
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-zabbix-gw
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8/hosts
-      Id: 857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8
-      Image: 'sha256:6f18ddf9e552921525b5279cddd90bf5fe778c5f20ac3a27fd1a0e32f1763fe6'
-      LogPath: >-
-        /var/lib/docker/containers/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/grafana
-          Driver: local
-          Mode: z
-          Name: iometrics-zabbix-gw_grafanac4-data
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/iometrics-zabbix-gw_grafanac4-data/_data
-          Type: volume
-      Name: /iometrics-zabbix-gw_grafana.1.rgov6pf309hemkdkx3qg9rci0
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - 857aa9d4f13e
-            DriverOpts: null
-            EndpointID: fedba26314f48fb417358fc4f68d7e9e59bc45664d83bac801528a0c4284861e
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.15
-            IPAddress: 192.168.4.15
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:0f'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          3000/tcp: null
-        SandboxID: 25d21a12dbd35600ce36dd506235ccc7bb9b5f495decd27256bca5bd7e60deaf
-        SandboxKey: /var/run/docker/netns/25d21a12dbd3
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3849
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:40.1468933Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_DB=gitea
-          - POSTGRES_PASSWORD=admin
-          - POSTGRES_USER=admin
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.8
-          - >-
-            PG_SHA256=e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: { }
-        Hostname: 2f572d9641d8
-        Image: >-
-          postgres:12-alpine@sha256:de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
-        Labels:
-          com.docker.stack.namespace: iometrics-cicd
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: sl6p3tfi11qy2a4ilydeh2906
-          com.docker.swarm.service.name: iometrics-cicd_git-db
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: y6zi23c5jilcof2zl954u1u5z
-          com.docker.swarm.task.name: iometrics-cicd_git-db.1.y6zi23c5jilcof2zl954u1u5z
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /var/lib/postgresql/data: { }
-        WorkingDir: ''
-      Created: '2022-04-26T14:58:34.177932791Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/0015303b3f5ae8b5b276abd206b8aa784fd60a4e56b543d8e80458acd5d5f067-init/diff:/var/lib/docker/overlay2/7430b814543c8e92e23d3bad2878bc918c3f0ee7d76cf6672a42e7541c8ff098/diff:/var/lib/docker/overlay2/b9e33979729ec5acf69c47e206c4a3b8855f968fee959105bd36b9e00e02a068/diff:/var/lib/docker/overlay2/8a732ae77f1797777ebaef206c5307963336f211df988f57942f52b3ffc4cf45/diff:/var/lib/docker/overlay2/a5a3474e844bd3bc888b72a4ef47d42334549eb7ad65412003f4a00849ba6cc2/diff:/var/lib/docker/overlay2/8451823ccf17f8d05e52bea00201534e3aea451155c7d140635e2efd541c0757/diff:/var/lib/docker/overlay2/fc4197e07029dc453276b12b55d7ed31c4249e2145c2121e124fbd77f89c1868/diff:/var/lib/docker/overlay2/fbfd0fdd04a9b9622cdd56b32aa4bcb6ad2b8353fdf78a81743010cb2d59aecd/diff:/var/lib/docker/overlay2/1755d933ee03247981a8cbd22753cb4d98060b0cc15aef77f6060f2222ea76b2/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/0015303b3f5ae8b5b276abd206b8aa784fd60a4e56b543d8e80458acd5d5f067/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/0015303b3f5ae8b5b276abd206b8aa784fd60a4e56b543d8e80458acd5d5f067/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/0015303b3f5ae8b5b276abd206b8aa784fd60a4e56b543d8e80458acd5d5f067/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: iometrics-cicd_gitea-db
-            Target: /var/lib/postgresql/data
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-cicd
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac/hosts
-      Id: 2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac
-      Image: 'sha256:d029edc386822ae1bb9c649cd81770e43ff615472c83a262b08cacfdd9c20d3c'
-      LogPath: >-
-        /var/lib/docker/containers/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/postgresql/data
-          Driver: local
-          Mode: z
-          Name: iometrics-cicd_gitea-db
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/iometrics-cicd_gitea-db/_data
-          Type: volume
-      Name: /iometrics-cicd_git-db.1.y6zi23c5jilcof2zl954u1u5z
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - 2f572d9641d8
-            DriverOpts: null
-            EndpointID: 01706899cd0c2d2fed9ca28a30f41961455f9cc37c64cef0f7148233f7857871
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.18
-            IPAddress: 192.168.4.18
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:12'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          5432/tcp: null
-        SandboxID: 2aef9381f2a2518a1af90080cee4368db33a22f920fc398a7ddb53edf4054050
-        SandboxKey: /var/run/docker/netns/2aef9381f2a2
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3818
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:41.008493294Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /usr/bin/zippersrv
-        Env:
-          - ENDPOINT=minio.robotito.lab.iometrics.io
-          - KEY=admin
-          - SECRET=the_secret
-          - SECURE=true
-          - SSL_SKIP_VERIFY=true
-          - TRACE=true
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-        Hostname: 78bc3826302f
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-synthetix-miniozipper:0.1@sha256:ad29666dea6d814b2974a1f7c5b786f983fd81eaf3112af57b8d479cac72ca71
-        Labels:
-          com.docker.stack.namespace: iometrics-cicd
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: wcz8kqfmpnj67lgo2yqiy0701
-          com.docker.swarm.service.name: iometrics-cicd_miniozipper
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: zkhlqnwpqxrvl907dxfz5i9iu
-          com.docker.swarm.task.name: iometrics-cicd_miniozipper.1.zkhlqnwpqxrvl907dxfz5i9iu
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: ''
-      Created: '2022-04-26T14:58:34.117137559Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/6eeb8dc63440dbe98d1dca26334540c283b1cafe8e33ecaf883218d092c48671-init/diff:/var/lib/docker/overlay2/a770f644bc6e8af73f4b92973855d61f470e34f2406de46e1338489abedb96be/diff:/var/lib/docker/overlay2/f10065e6f4eabeb7ed781ac10116d5f9c59fd591d75f426b3df199a1f27d0a0e/diff:/var/lib/docker/overlay2/176912bdc0e6dc7d5c1d6e81ce623215c36d702d56ba32fe223efeb1a12f7ffb/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/6eeb8dc63440dbe98d1dca26334540c283b1cafe8e33ecaf883218d092c48671/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/6eeb8dc63440dbe98d1dca26334540c283b1cafe8e33ecaf883218d092c48671/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/6eeb8dc63440dbe98d1dca26334540c283b1cafe8e33ecaf883218d092c48671/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19/hosts
-      Id: 78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19
-      Image: 'sha256:61fe57b566f7b2bb12a5d4903fd5641fc30893485ab42e48882f4d457a96d6b0'
-      LogPath: >-
-        /var/lib/docker/containers/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19-json.log
-      MountLabel: ''
-      Mounts: [ ]
-      Name: /iometrics-cicd_miniozipper.1.zkhlqnwpqxrvl907dxfz5i9iu
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - 78bc3826302f
-            DriverOpts: null
-            EndpointID: 041be94001cfe78b1b1a66414c285ba89788aef650471de5cb7f0d2b0ab1a2cf
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.19
-            IPAddress: 192.168.4.19
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:13'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports: { }
-        SandboxID: 2fbef10c83428b7d81c7a5bcd8274fd7641794e564752ba85bc72ebdb6198745
-        SandboxKey: /var/run/docker/netns/2fbef10c8342
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/bin/zippersrv
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3835
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:42.059212004Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_DB=reports
-          - POSTGRES_PASSWORD=admin
-          - POSTGRES_USER=admin
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.8
-          - >-
-            PG_SHA256=e26401e090c34ccb15ffb33a111f340833833535a7b7c5cd11cd88ab57d9c62a
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: { }
-        Hostname: 2b5cc9c1f3f3
-        Image: >-
-          postgres:12-alpine@sha256:de0effb7ca62f396168f4d3c35d9042e2a9d4da23e424daa90fee19859b57012
-        Labels:
-          com.docker.stack.namespace: iometrics-reporter
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: zptaxb22an2qd5kgl2g90p9ha
-          com.docker.swarm.service.name: iometrics-reporter_api-reporter-db
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: siynlece6pmr42vs3wkslfwej
-          com.docker.swarm.task.name: iometrics-reporter_api-reporter-db.1.siynlece6pmr42vs3wkslfwej
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /var/lib/postgresql/data: { }
-        WorkingDir: ''
-      Created: '2022-04-26T14:58:33.309205335Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/f870f1df5dc2f52c9ab442606653e7ffed63196736959f434d5ddcdc5a94365f-init/diff:/var/lib/docker/overlay2/7430b814543c8e92e23d3bad2878bc918c3f0ee7d76cf6672a42e7541c8ff098/diff:/var/lib/docker/overlay2/b9e33979729ec5acf69c47e206c4a3b8855f968fee959105bd36b9e00e02a068/diff:/var/lib/docker/overlay2/8a732ae77f1797777ebaef206c5307963336f211df988f57942f52b3ffc4cf45/diff:/var/lib/docker/overlay2/a5a3474e844bd3bc888b72a4ef47d42334549eb7ad65412003f4a00849ba6cc2/diff:/var/lib/docker/overlay2/8451823ccf17f8d05e52bea00201534e3aea451155c7d140635e2efd541c0757/diff:/var/lib/docker/overlay2/fc4197e07029dc453276b12b55d7ed31c4249e2145c2121e124fbd77f89c1868/diff:/var/lib/docker/overlay2/fbfd0fdd04a9b9622cdd56b32aa4bcb6ad2b8353fdf78a81743010cb2d59aecd/diff:/var/lib/docker/overlay2/1755d933ee03247981a8cbd22753cb4d98060b0cc15aef77f6060f2222ea76b2/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/f870f1df5dc2f52c9ab442606653e7ffed63196736959f434d5ddcdc5a94365f/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/f870f1df5dc2f52c9ab442606653e7ffed63196736959f434d5ddcdc5a94365f/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/f870f1df5dc2f52c9ab442606653e7ffed63196736959f434d5ddcdc5a94365f/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: iometrics-reporter_pgdata
-            Target: /var/lib/postgresql/data/
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-reporter
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839/hosts
-      Id: 2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839
-      Image: 'sha256:d029edc386822ae1bb9c649cd81770e43ff615472c83a262b08cacfdd9c20d3c'
-      LogPath: >-
-        /var/lib/docker/containers/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/postgresql/data
-          Driver: local
-          Mode: z
-          Name: iometrics-reporter_pgdata
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/iometrics-reporter_pgdata/_data
-          Type: volume
-      Name: /iometrics-reporter_api-reporter-db.1.siynlece6pmr42vs3wkslfwej
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - 2b5cc9c1f3f3
-            DriverOpts: null
-            EndpointID: 4c518ed87d2f51f9a36be297b168bd07c79a555782ae84518f2bdd038f4389f0
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.16
-            IPAddress: 192.168.4.16
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:10'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          5432/tcp: null
-        SandboxID: df5dadbd8a2e46a704df14e79fe54ef805fcb86280b466575382731a473be123
-        SandboxKey: /var/run/docker/netns/df5dadbd8a2e
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3572
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:38.481019162Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /entrypoint.sh
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - SYUI_GENERAL_LOGLEVEL=debug
-          - SYUI_GENERAL_LOGMODE=console
-          - SYUI_HTTP_ADMIN_PASSWORD=admin
-          - SYUI_HTTP_ADMIN_USER=admin
-          - SYUI_HTTP_WS_PUBLIC_URL=syui.robotito.lab.iometrics.io
-          - SYUI_INFLUX_DB=sondas
-          - SYUI_INFLUX_HOST=influxdb
-          - SYUI_INFLUX_ID=syui
-          - SYUI_INFLUX_PASS=sondas
-          - SYUI_INFLUX_PORT=8086
-          - SYUI_INFLUX_USER=sondas
-          - SYUI_TUNNEL_DEFAULTS_SSH_PASSWORD=syUI
-          - SYUI_TUNNEL_DEFAULTS_SSH_USERNAME=synthetix
-          - TZ=Europe/Madrid
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - LC_ALL=C.UTF-8
-          - LD_LIBRARY_PATH=/usr/local/guacamole/lib
-          - GUACD_LOG_LEVEL=info
-          - PATHS_HOME=/opt/iometrics-synthetix-ui/
-          - SYUI_GENERAL_DATADIR=/opt/iometrics-synthetix-ui//data/
-          - SYUI_GENERAL_LOGDIR=/opt/iometrics-synthetix-ui//log/
-        ExposedPorts:
-          4822/tcp: { }
-          5090/tcp: { }
-        Hostname: d769662f72d3
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-synthetix-ui:0.1@sha256:936bb335dcfdd9cf77194a55cc00b0af9465f4010001b767656b2c769867a497
-        Labels:
-          com.docker.stack.namespace: iometrics-ui
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: bldqs9xmx2r0fhciytjv3j3vt
-          com.docker.swarm.service.name: iometrics-ui_syui
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: p8a37fsybhj3vc2rzxkr7tv0e
-          com.docker.swarm.task.name: iometrics-ui_syui.1.p8a37fsybhj3vc2rzxkr7tv0e
-          maintainer: Datadope team <hello@datadope.io>
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: synui
-        Volumes: null
-        WorkingDir: /opt/iometrics-synthetix-ui
-      Created: '2022-04-26T14:58:33.272242021Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/26f59a6eccd92f11b8c27ab0694f5bfd5a3186180775a2201e5053c7b0ebf643-init/diff:/var/lib/docker/overlay2/354d6e470c7ee87edff88f5bf4f6481d6907e00d5d2f4e8bb0dfb22e1da33be9/diff:/var/lib/docker/overlay2/ac798d815bb57299db6ae2e0ef634695eaacd3fab0c3311b1f9273aa12f8d2e2/diff:/var/lib/docker/overlay2/511d48a012d48d8b97352e36afe6d76b6edaf0c682cb57ea9ce95c6df7f8d779/diff:/var/lib/docker/overlay2/a9b29fd17c08b625fa1496a66e1a395dd4587bee0bbf8d50bce5e6ef1859ad04/diff:/var/lib/docker/overlay2/6dd88ce122ec147dbbdb452acfa76535662824d4d1860461fef5531f7e5e636a/diff:/var/lib/docker/overlay2/b7bf1215e99d3d5b4b470c4ccd91cfa2501f27ca6986a8e8baa117a13491e635/diff:/var/lib/docker/overlay2/c89e11572d1651660eea863e0b56619196eaba8d9ba9c6e907b1a114b4a1525f/diff:/var/lib/docker/overlay2/06aff82af5e3fc061f32433afef5b00dfcadfb35f9076f1a05417ba7df1bfcc0/diff:/var/lib/docker/overlay2/d78b4d05356aa0578ecc73b5c1a8aca281d4d6d727edb5391b64eefb07809ae2/diff:/var/lib/docker/overlay2/37f13e635e553fc33718307f7f5f4a5809de4f875bca532a81ad922ac4ac6ce4/diff:/var/lib/docker/overlay2/1f13da162409aa6daec69282a3ab39273a4747d204894ee06e878940ebaf9dfb/diff:/var/lib/docker/overlay2/2f3d6af2a0094499eddf10a8d6d5b9c8e1353eca31e47338cc97981108d43b31/diff:/var/lib/docker/overlay2/0220f3d43627d5f9e8eac4f30580707a9e791a8eaa87907900a21a3ac238ee1b/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/26f59a6eccd92f11b8c27ab0694f5bfd5a3186180775a2201e5053c7b0ebf643/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/26f59a6eccd92f11b8c27ab0694f5bfd5a3186180775a2201e5053c7b0ebf643/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/26f59a6eccd92f11b8c27ab0694f5bfd5a3186180775a2201e5053c7b0ebf643/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: iometrics-ui_synthetix-ui-data
-            Target: /opt/iometrics-synthetix-ui/data
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-ui
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a/hosts
-      Id: d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a
-      Image: 'sha256:8cfda68421ccc9937ed90ab44b64e72b0ce4acfcc85bc803656c00ef0a5fb807'
-      LogPath: >-
-        /var/lib/docker/containers/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /opt/iometrics-synthetix-ui/data
-          Driver: local
-          Mode: z
-          Name: iometrics-ui_synthetix-ui-data
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/iometrics-ui_synthetix-ui-data/_data
-          Type: volume
-      Name: /iometrics-ui_syui.1.p8a37fsybhj3vc2rzxkr7tv0e
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - d769662f72d3
-            DriverOpts: null
-            EndpointID: 38869dbd22a59b74e1ba98e2fb803cf1a0030e7baa15ed74e954bebf866b3b05
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.23
-            IPAddress: 192.168.4.23
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:17'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          4822/tcp: null
-          5090/tcp: null
-        SandboxID: f61355e89ac445126a47aae000e450dcda53c71de6470c188ddf4791fa2d42fc
-        SandboxKey: /var/run/docker/netns/f61355e89ac4
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3480
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:40.492687878Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - GF_ANALITICS_REPORTING_ENABLED=false
-          - GF_LOG_CONSOLE_FORMAT=json
-          - >-
-            GF_LOG_FILTERS=alerting.notifier:debug,alerting.notifier.slack:debug,auth:debug
-          - GF_SECURITY_ADMIN_PASSWORD=admin
-          - GF_SECURITY_ADMIN_USER=admin
-          - GF_SERVER_DOMAIN=iometrics-ui.robotito.lab.iometrics.io
-          - 'GF_SERVER_ROOT_URL=https://iometrics-ui.robotito.lab.iometrics.io'
-          - GF_SERVER_ROUTER_LOGGING=true
-          - TZ="Europe/Madrid"
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-          - GF_RENDERER_PLUGIN_CHROME_BIN=/usr/bin/chromium-browser
-        ExposedPorts:
-          3000/tcp: { }
-        Hostname: 879dd93dd234
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2.3_0.16@sha256:13be599d28d1be08722e0c28fdaf30adf81a636af0768cb1234066c840b0f19b
-        Labels:
-          com.docker.stack.namespace: iometrics-influxdb-grafana
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: x7j3dee8x9xwtm2kek1o6dtaw
-          com.docker.swarm.service.name: iometrics-influxdb-grafana_grafana
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: s5zrbl40wdkqzmjcohve8xmmg
-          com.docker.swarm.task.name: iometrics-influxdb-grafana_grafana.1.s5zrbl40wdkqzmjcohve8xmmg
-          maintainer: Grafana team <hello@grafana.com>
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes: null
-        WorkingDir: /usr/share/grafana
-      Created: '2022-04-26T14:58:33.238325683Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/192248d38a38825d7f6145a20dbf6f08fa7f2bab09221e2c6ed0043762c80df5-init/diff:/var/lib/docker/overlay2/06067347ce85197709e15ced1440324e840442d735f71b39dc085bf8235304d0/diff:/var/lib/docker/overlay2/6b76e23dd25a0e741318cc0fc144a84d56489d054e5216bfbfc9184cffda97e3/diff:/var/lib/docker/overlay2/dc516c2970c8fef2c9eaeddaeb7d1989e876274251c48165ec4937a415509d78/diff:/var/lib/docker/overlay2/009a10252e10cdbcf082de884d2854adf81c1c031aac81e127b1c020a851632d/diff:/var/lib/docker/overlay2/0ac04c1610f9dee024851a3c1ba58ea16cd7cd6df396838acc51379eb4842e5e/diff:/var/lib/docker/overlay2/296155f1b193499b6ddb98fea687d3c0ae4fb17b814eceb91e4b16c6064c3cbf/diff:/var/lib/docker/overlay2/da219d320c57b9e2d73e30fc0d138c96ca6bc6b689a6e250fd6e9a9cff36dbb1/diff:/var/lib/docker/overlay2/96e904899a7a251682b87ad6f5926d46793da5da873e26caa908f895109aac23/diff:/var/lib/docker/overlay2/9ec33c55d0db535901f8a7781a4a73e3f6269d2fa84d47478a0fca9d8631a703/diff:/var/lib/docker/overlay2/bb84ca10caa02a052fbc954a97be6248bcd599e52a5ac26b61f1796d146dd453/diff:/var/lib/docker/overlay2/a3c15e84b817a672e5a1273b2640aa4cabd2cf63c30f83fbaa91c2ed676c8032/diff:/var/lib/docker/overlay2/e8f912b3144df4b93b971d88091fb2c5d76e66c61ee92df4af5030726617a21d/diff:/var/lib/docker/overlay2/2c2e5ae28a8424053718d87fb1d3e1dfc57bfecfc4ed2a927fa3a2635b61fdaa/diff:/var/lib/docker/overlay2/de45a85d9813ee0d784e0436c3654cd56f980c80da111f0bb45e8d667f6970e2/diff:/var/lib/docker/overlay2/3e99629fb7ac7eae632355e7708c20f0747a423d81352b9c418d877883fdac43/diff:/var/lib/docker/overlay2/054e6b34f419919cd17764132bc0f3347ca7d8ebe83afb8a7b2823902760b455/diff:/var/lib/docker/overlay2/ec99b1f554cb5c83a3a4855a2b4d6f5faa6203d00014030b2d3addd843ee2307/diff:/var/lib/docker/overlay2/322029f4255d6c5b3882de711401da2345fbaaa39016aa40688673ea4b0e979b/diff:/var/lib/docker/overlay2/16ffdc9ffd366b5d296609f90f91c5ed14bee3bbc231c1dd72c7ac4d30d6fc57/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/192248d38a38825d7f6145a20dbf6f08fa7f2bab09221e2c6ed0043762c80df5/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/192248d38a38825d7f6145a20dbf6f08fa7f2bab09221e2c6ed0043762c80df5/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/192248d38a38825d7f6145a20dbf6f08fa7f2bab09221e2c6ed0043762c80df5/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: iometrics-influxdb-grafana_grafana-data
-            Target: /var/lib/grafana
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-influxdb-grafana
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72/hosts
-      Id: 879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72
-      Image: 'sha256:d36044c3cbb465635be7c762365fb265c68ae316568a0a609cf8f46b4c31ce2c'
-      LogPath: >-
-        /var/lib/docker/containers/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/lib/grafana
-          Driver: local
-          Mode: z
-          Name: iometrics-influxdb-grafana_grafana-data
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/iometrics-influxdb-grafana_grafana-data/_data
-          Type: volume
-      Name: /iometrics-influxdb-grafana_grafana.1.s5zrbl40wdkqzmjcohve8xmmg
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - 879dd93dd234
-            DriverOpts: null
-            EndpointID: 8a5fd555ccce13ac8635ee2c8b0ec939fdde19cb472128bd71617837e4df2297
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.26
-            IPAddress: 192.168.4.26
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:1a'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          3000/tcp: null
-        SandboxID: c9dcd06bc72075e6b7c7a59311354b3b8d46f84de8b8c7f328a47cf3a47a1188
-        SandboxKey: /var/run/docker/netns/c9dcd06bc720
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 2841
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:37.813771612Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /entrypoint.sh
-        Env:
-          - LOGLEVEL=DEBUG
-          - 'NOBITA_IMAGE=nexusregistry.opensolutions.cloud/tokiov1/nobita:0.1.14'
-          - ZABBIX_GROUP_ID=15
-          - ZABBIX_PASS=zabbix
-          - ZABBIX_SERVER=zabbix
-          - ZABBIX_TEMPLATE_ID=10264
-          - 'ZABBIX_URL=http://zabbix/api_jsonrpc.php'
-          - ZABBIX_USER=Admin
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - APP_DIR=/app
-          - NOBITA_DELETE_CONTAINER=true
-          - ROBOTFRAMEWORK_TEST_PATH=/opt/robotframework/tests
-        ExposedPorts:
-          80/tcp: { }
-        Hostname: 01dacf67f658
-        Image: >-
-          nexusregistry.opensolutions.cloud/tokiov1/doraemon:0.1.12@sha256:30a93b0f309fe7e86dc468099d0571fbb5e54a386b1551eac36ee2911f5395e3
-        Labels:
-          com.docker.stack.namespace: iometrics-tokiov1
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: 21rxw3957oetw2rhcrwl85zxy
-          com.docker.swarm.service.name: iometrics-tokiov1_doraemon
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: y5qfta29vj3dysshtzlh27os6
-          com.docker.swarm.task.name: iometrics-tokiov1_doraemon.1.y5qfta29vj3dysshtzlh27os6
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          '[/app]': { }
-        WorkingDir: /app
-      Created: '2022-04-26T14:58:32.420641996Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/3f9c4264296036526fdf3122cb35b5496a5e82b48667592ad548205197bdd928-init/diff:/var/lib/docker/overlay2/e0fa9b6c33a5233d56b98b0ef967436cd243c23fbbf90dffec127435049fa94c/diff:/var/lib/docker/overlay2/f2f695f510d597b62698eda69b20466341231a6650a8ac39f2382701033185a5/diff:/var/lib/docker/overlay2/9470c69741b8b1efec5beaac235e3e71b319555ee07f8dd6a83f1505d9207d2a/diff:/var/lib/docker/overlay2/f573056a516fe87ed9e8e24feb55c07531bd743318e8a918398795670de320bf/diff:/var/lib/docker/overlay2/11e25e640ae0118f09e9059fca35bb34fe18ddd28abac4aa7c4cfe26b8026f72/diff:/var/lib/docker/overlay2/e0c0c4615c41516033dc99b72a99e790a4b9bfcd7b0872fbe8aea0d8ed4de0fe/diff:/var/lib/docker/overlay2/ce00982fa2585615b36a285318149926a84ce1f1919858bc03af462cbdb3826a/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/3f9c4264296036526fdf3122cb35b5496a5e82b48667592ad548205197bdd928/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/3f9c4264296036526fdf3122cb35b5496a5e82b48667592ad548205197bdd928/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/3f9c4264296036526fdf3122cb35b5496a5e82b48667592ad548205197bdd928/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: /var/run/docker.sock
-            Target: /var/run/docker.sock
-            Type: bind
-          - Source: /opt/robotframework/tests
-            Target: /opt/robotframework/tests
-            Type: bind
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce/hosts
-      Id: 01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce
-      Image: 'sha256:4a76f535ab746d6787d84889a59a65dec896c888bec9b20797c08e6d67b0dab4'
-      LogPath: >-
-        /var/lib/docker/containers/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/run/docker.sock
-          Mode: ''
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/docker.sock
-          Type: bind
-        - Destination: /opt/robotframework/tests
-          Mode: ''
-          Propagation: rprivate
-          RW: true
-          Source: /opt/robotframework/tests
-          Type: bind
-        - Destination: '[/app]'
-          Driver: local
-          Mode: ''
-          Name: f3f659a45f46ac548a9590cbc4796a902ecb2b992aece00ff75a1df7585f2b12
-          Propagation: ''
-          RW: true
-          Source: >-
-            /var/lib/docker/volumes/f3f659a45f46ac548a9590cbc4796a902ecb2b992aece00ff75a1df7585f2b12/_data
-          Type: volume
-      Name: /iometrics-tokiov1_doraemon.1.y5qfta29vj3dysshtzlh27os6
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - 01dacf67f658
-            DriverOpts: null
-            EndpointID: 02d7cc1a5d3a03f8e5ed9fdd28b6107acb8606beb4e3d4c0c54d05752c70ae24
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.17
-            IPAddress: 192.168.4.17
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:11'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          80/tcp: null
-        SandboxID: d89f428f7b5da99d2a91bdeae474d5b9b02d7e2552b6face97a800acad735e83
-        SandboxKey: /var/run/docker/netns/d89f428f7b5d
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3380
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:39.427858261Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args:
-        - /opt/bitnami/scripts/tomcat/run.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /opt/bitnami/scripts/tomcat/run.sh
-        Domainname: ''
-        Entrypoint:
-          - /opt/bitnami/scripts/jasperreports/entrypoint.sh
-        Env:
-          - ALLOW_EMPTY_PASSWORD=yes
-          - JASPERREPORTS_DATABASE_NAME=jasperreport
-          - JASPERREPORTS_DATABASE_USER=admin
-          - JASPERREPORTS_PASSWORD=admin
-          - JASPERREPORTS_USERNAME=admin
-          - MARIADB_HOST=mariadb
-          - MARIADB_PORT_NUMBER=3306
-          - TZ="Europe/Madrid"
-          - >-
-            PATH=/opt/bitnami/java/bin:/opt/bitnami/tomcat/bin:/opt/bitnami/mysql/bin:/opt/bitnami/git/bin:/opt/bitnami/common/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - HOME=/
-          - OS_ARCH=amd64
-          - OS_FLAVOUR=debian-10
-          - OS_NAME=linux
-          - BITNAMI_APP_NAME=jasperreports
-          - BITNAMI_IMAGE_VERSION=7.8.0-debian-10-r322
-          - MARIADB_ROOT_PASSWORD=
-          - MARIADB_ROOT_USER=root
-          - MYSQL_CLIENT_CREATE_DATABASE_NAME=
-          - MYSQL_CLIENT_CREATE_DATABASE_PASSWORD=
-          - MYSQL_CLIENT_CREATE_DATABASE_PRIVILEGES=ALL
-          - MYSQL_CLIENT_CREATE_DATABASE_USER=
-          - MYSQL_CLIENT_ENABLE_SSL=no
-          - MYSQL_CLIENT_SSL_CA_FILE=
-        ExposedPorts:
-          8009/tcp: { }
-          8080/tcp: { }
-          8443/tcp: { }
-        Hostname: cdb768fd554e
-        Image: >-
-          bitnami/jasperreports:7-debian-10@sha256:79688cbe1217ab27ddec20a33a34ff449fbe3a3ee4bfc342cce0e1bc49a4c24c
-        Labels:
-          com.docker.stack.namespace: iometrics-reporter
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: c4j05xv0edxsvo0xz152on1xf
-          com.docker.swarm.service.name: iometrics-reporter_jasperreports
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: 5q63h0wg3e0vykeww8r6vytpz
-          com.docker.swarm.task.name: iometrics-reporter_jasperreports.1.5q63h0wg3e0vykeww8r6vytpz
-          maintainer: Bitnami <containers@bitnami.com>
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: '1001'
-        Volumes: null
-        WorkingDir: ''
-      Created: '2022-04-26T14:58:32.417192319Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/15532e05b91dfd64cff90b986ef94e67ec6b8cd827b7718c68081b0730bc0055-init/diff:/var/lib/docker/overlay2/381189b72bd5fb3646fe8313ec0382563fa1c82cbc14297ab66a3c2e174c0024/diff:/var/lib/docker/overlay2/ec81616ad58a19087927ee1539869ec80b496addcbd484a78556c91e0c8c1f4d/diff:/var/lib/docker/overlay2/bfea1030abaf8711e35e73207f761e495bf6c405b163c231caee970d781155db/diff:/var/lib/docker/overlay2/0575075cb2d6e153151759f4d537b665870e7a617b60625308f78f5d2add95aa/diff:/var/lib/docker/overlay2/a7a4c8647c4f3256540edac046bba045c9e89e26fe4692f8729c2d2d927b9a5b/diff:/var/lib/docker/overlay2/3236c64a445b65ae11fc54c7dfdd8e12a6ad120613a63db3ff382e074484dedc/diff:/var/lib/docker/overlay2/5469ddf4621e7fee374511e4b5bf5df8d7add91e6ed14813f49c35d7cf058bcd/diff:/var/lib/docker/overlay2/95a0109c88499fb73e231fea68fd8a50644ab5ec78c22927b5f6ad8f6dffb255/diff:/var/lib/docker/overlay2/1017c2e98c414e568e8dfb0ec581e8bb4bbaef8cc26a9f34345a026907650153/diff:/var/lib/docker/overlay2/f8e4f4f57bc111e0b42602559ee5a563e88f803d6477faf7ddc3938be4ae0d8d/diff:/var/lib/docker/overlay2/c03248c6b0f4506110c4331e61a754062f460ff49173f71cd490f20e43c975df/diff:/var/lib/docker/overlay2/9e73143bde40de50785dbec9f55b17bdc4c71135361b696e3b27bf889d66b7cb/diff:/var/lib/docker/overlay2/a8e8bf4f3018978b500affeb1c977ae1fc9e2ed68a1987ee16988bcc04519922/diff:/var/lib/docker/overlay2/26a334fee69317bf7aaa0d2ea738778c1cd604b78e8505ddf9612a117109aa50/diff:/var/lib/docker/overlay2/d6022d7f3341bc30a594cebed98e0f7563c19316ca7bc8a2828fb263a5925984/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/15532e05b91dfd64cff90b986ef94e67ec6b8cd827b7718c68081b0730bc0055/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/15532e05b91dfd64cff90b986ef94e67ec6b8cd827b7718c68081b0730bc0055/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/15532e05b91dfd64cff90b986ef94e67ec6b8cd827b7718c68081b0730bc0055/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: iometrics-reporter_jasperreports_data
-            Target: /bitnami
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-reporter
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4/hosts
-      Id: cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4
-      Image: 'sha256:271280ba9644a0a71b1c650fcd117d77afaa5f8baac17a0f31a91968fdd6a8ef'
-      LogPath: >-
-        /var/lib/docker/containers/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /bitnami
-          Driver: local
-          Mode: z
-          Name: iometrics-reporter_jasperreports_data
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/iometrics-reporter_jasperreports_data/_data
-          Type: volume
-      Name: /iometrics-reporter_jasperreports.1.5q63h0wg3e0vykeww8r6vytpz
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - cdb768fd554e
-            DriverOpts: null
-            EndpointID: 5fc6b71f8201a2f86b627168135a8f2f8666ca245265d3b4ea0ef7268a94802d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.21
-            IPAddress: 192.168.4.21
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:15'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          8009/tcp: null
-          8080/tcp: null
-          8443/tcp: null
-        SandboxID: 58e7593dddba78cf1314b5bf286027701a2c277002a18baa878148aab1621f94
-        SandboxKey: /var/run/docker/netns/58e7593dddba
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /opt/bitnami/scripts/jasperreports/entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3242
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:44.066964241Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args:
-        - /bin/s6-svscan
-        - /etc/s6
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/s6-svscan
-          - /etc/s6
-        Domainname: ''
-        Entrypoint:
-          - /usr/bin/entrypoint
-        Env:
-          - 'DB_HOST=git-db:5432'
-          - DB_NAME=gitea
-          - DB_PASSWD=admin
-          - DB_TYPE=postgres
-          - DB_USER=admin
-          - SKIP_TLS_VERIFY=true
-          - SSH_DOMAIN=git.robotito.lab.iometrics.io
-          - USER_GID=1000
-          - USER_UID=1000
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - USER=git
-          - GITEA_CUSTOM=/data/gitea
-        ExposedPorts:
-          22/tcp: { }
-          3000/tcp: { }
-        Hostname: 8c55132b38ba
-        Image: >-
-          gitea/gitea:1.11.4@sha256:5f4470925ea02b0a6c518e1d6658f2b39c0c4fb60600915c388331b19b5f97dd
-        Labels:
-          com.docker.stack.namespace: iometrics-cicd
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: x5t22c0qj2puvia30103if0l2
-          com.docker.swarm.service.name: iometrics-cicd_git
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: c01gjdokgyg4g92sb657mg2d3
-          com.docker.swarm.task.name: iometrics-cicd_git.1.c01gjdokgyg4g92sb657mg2d3
-          maintainer: maintainers@gitea.io
-          org.label-schema.build-date: '2020-04-01T17:13:06Z'
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.vcs-ref: 3afbbfe921c5fb5b71555ffdf60bcdbb8b227d8a
-          org.label-schema.vcs-url: 'https://github.com/go-gitea/gitea.git'
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: { }
-        WorkingDir: ''
-      Created: '2022-04-26T14:58:32.32067015Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/5a61df80c21a3a5bd09cf536dceb5ad2d6c9a4fb2f28401c15fa174e574432c2-init/diff:/var/lib/docker/overlay2/05bdb218c8021e608f313ad7c58fdcf433fda3ad24bb101bcb5a9788ee15f913/diff:/var/lib/docker/overlay2/9baf0e2eac3bf90813d0373b3545ce535cc093c97be98aa155130a283661469b/diff:/var/lib/docker/overlay2/823e10125c5b65c55ea3b916f1d4be281facabcee516de6bb6305c9c7da6d3e1/diff:/var/lib/docker/overlay2/0963476208f641b2861f54c53f2210c8b3b5835d8acc09b69261b6503b1224c2/diff:/var/lib/docker/overlay2/4f16b1b02abacb254a016b9758908bc97c198fb8cf91362f2b42e2b14b6c0e59/diff:/var/lib/docker/overlay2/c2c6ee6e6f1813b910ae7c4bc8e4c7092265792e2fbc51cdbc5e0379eaf948e1/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/5a61df80c21a3a5bd09cf536dceb5ad2d6c9a4fb2f28401c15fa174e574432c2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/5a61df80c21a3a5bd09cf536dceb5ad2d6c9a4fb2f28401c15fa174e574432c2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/5a61df80c21a3a5bd09cf536dceb5ad2d6c9a4fb2f28401c15fa174e574432c2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: iometrics-cicd_gitea-data
-            Target: /data
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-cicd
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec/hosts
-      Id: 8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec
-      Image: 'sha256:194c2480b6fbff60d3f9bf4b18beea94d82c787497b1a60ce569ddb48643dcce'
-      LogPath: >-
-        /var/lib/docker/containers/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data
-          Driver: local
-          Mode: z
-          Name: iometrics-cicd_gitea-data
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/iometrics-cicd_gitea-data/_data
-          Type: volume
-      Name: /iometrics-cicd_git.1.c01gjdokgyg4g92sb657mg2d3
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          ingress:
-            Aliases:
-              - 8c55132b38ba
-            DriverOpts: null
-            EndpointID: 1ae5c1684cd9e526d3ad44461114d9868f37301b328f2df9d77868c36fdbbd1b
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.10.10
-            IPAddress: 192.168.10.10
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:ff:00:0a'
-            NetworkID: 8mvsot5titaaepgeuh3z5d6el
-          iometrics-public:
-            Aliases:
-              - 8c55132b38ba
-            DriverOpts: null
-            EndpointID: e6c58716836f77eaa4dc6d23021e214d3f7ec26bd53c7e055182b74f048146ee
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.28
-            IPAddress: 192.168.4.28
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:1c'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          22/tcp: null
-          3000/tcp: null
-        SandboxID: d98e7a6c2aaf7b146db63923c336b11583f91d0ad4915b21c02312bdc8e372a8
-        SandboxKey: /var/run/docker/netns/d98e7a6c2aaf
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/bin/entrypoint
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3784
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:44.941616583Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args:
-        - telegraf
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - telegraf
-        Domainname: ''
-        Entrypoint:
-          - /entrypoint.sh
-        Env:
-          - AGENT_MONITOR_DATABASE=telegraf
-          - 'AGENT_MONITOR_HOST=http://influxdb:8086'
-          - AGENT_MONITOR_PASSWORD=telegraf
-          - AGENT_MONITOR_USERNAME=telegraf
-          - CLIENT_NAME=iometrics
-          - CLIENT_TYPE=infraestructure
-          - CLUSTER=robotito.lab.iometrics.io
-          - HOSTNAME=synthetix-worker01
-          - HOST_MOUNT_PREFIX=/hostfs
-          - HOST_PROC=/hostfs/proc
-          - INFRA_MONITOR_DATABASE=swarm
-          - 'INFRA_MONITOR_HOST=http://influxdb:8086'
-          - INFRA_MONITOR_PASSWORD=swarm
-          - INFRA_MONITOR_USERNAME=swarm
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - TELEGRAF_VERSION=1.18.2
-        ExposedPorts:
-          8092/udp: { }
-          8094/tcp: { }
-          8125/udp: { }
-        Hostname: wh12ct3jzpllqaj4mv233ey4f
-        Image: >-
-          telegraf:latest@sha256:bbe1dcfda1a7c5ab9c03abd3014874ea78edd64dbbf8e09880b1d78bec4ae6ff
-        Labels:
-          com.docker.stack.namespace: iometrics-influxdb-grafana
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: n7snet96arr2vwb2988cji3ej
-          com.docker.swarm.service.name: iometrics-influxdb-grafana_telegraf
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: fwkcidtl0wrghgri2podb7wbm
-          com.docker.swarm.task.name: >-
-            iometrics-influxdb-grafana_telegraf.wh12ct3jzpllqaj4mv233ey4f.fwkcidtl0wrghgri2podb7wbm
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: ''
-      Created: '2022-04-26T14:58:32.284749778Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/dd2e83b1258964407377e36296e3891cd8e7763928576dce6496b9b4b80f2496-init/diff:/var/lib/docker/overlay2/71ffb2821d15bbe09f3970691db55e745537d7011178c561356eff7c94c1b65d/diff:/var/lib/docker/overlay2/e707e1ce5f6d7c852af13510744ab1f22b867895ebc2401954bf18ec9beaa2a8/diff:/var/lib/docker/overlay2/69bb4d9d1e3ccdb5c87394c0fe19802ea613e068d8cbee3a8f34733a2048662f/diff:/var/lib/docker/overlay2/40c6a882ac823e75c33e28db30b10bf17b2f7f746e6315d4e594a4c5813e3272/diff:/var/lib/docker/overlay2/6030db9539e5eba21394fc5f6c84913911d47b9d6f8a627cb1b0b452190520f7/diff:/var/lib/docker/overlay2/bcd13b47b64c2b2d938ac00a950727beefcc423178625d366f4e4837a3ab5888/diff:/var/lib/docker/overlay2/7f07db2d4d9e64706002df00bb03b55e4959b62b0d0e38b41a0038db1f71297f/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/dd2e83b1258964407377e36296e3891cd8e7763928576dce6496b9b4b80f2496/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/dd2e83b1258964407377e36296e3891cd8e7763928576dce6496b9b4b80f2496/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/dd2e83b1258964407377e36296e3891cd8e7763928576dce6496b9b4b80f2496/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - ReadOnly: true
-            Source: /
-            Target: /hostfs
-            Type: bind
-          - Source: /var/run/docker.sock
-            Target: /var/run/docker.sock
-            Type: bind
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272/hosts
-      Id: f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272
-      Image: 'sha256:c09835a46c6a12928f91f8450f7aaba668b0210ca4b4efc2e9404ad9307d036c'
-      LogPath: >-
-        /var/lib/docker/containers/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /hostfs
-          Mode: ''
-          Propagation: rslave
-          RW: false
-          Source: /
-          Type: bind
-        - Destination: /var/run/docker.sock
-          Mode: ''
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/docker.sock
-          Type: bind
-      Name: >-
-        /iometrics-influxdb-grafana_telegraf.wh12ct3jzpllqaj4mv233ey4f.fwkcidtl0wrghgri2podb7wbm
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - f8d0dafa40a0
-            DriverOpts: null
-            EndpointID: 8efad8a405d4bb9835a4dfcb4f0e6fadc72fffdf7337438be6e0bae7c79c0b2a
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.46
-            IPAddress: 192.168.4.46
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:2e'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          8092/udp: null
-          8094/tcp: null
-          8125/udp: null
-        SandboxID: d81bb311b7bdebe5d5f26684df3ffb31bc8ef1bb258371aebab436145f2445f7
-        SandboxKey: /var/run/docker/netns/d81bb311b7bd
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3112
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:38.760432309Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args:
-        - /opt/bitnami/scripts/mariadb/run.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /opt/bitnami/scripts/mariadb/run.sh
-        Domainname: ''
-        Entrypoint:
-          - /opt/bitnami/scripts/mariadb/entrypoint.sh
-        Env:
-          - ALLOW_EMPTY_PASSWORD=yes
-          - MARIADB_DATABASE=jasperreport
-          - MARIADB_USER=admin
-          - >-
-            PATH=/opt/bitnami/common/bin:/opt/bitnami/mariadb/bin:/opt/bitnami/mariadb/sbin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - HOME=/
-          - OS_ARCH=amd64
-          - OS_FLAVOUR=debian-10
-          - OS_NAME=linux
-          - BITNAMI_APP_NAME=mariadb
-          - BITNAMI_IMAGE_VERSION=10.3.31-debian-10-r33
-        ExposedPorts:
-          3306/tcp: { }
-        Hostname: 8071bb422bac
-        Image: >-
-          bitnami/mariadb:10.3-debian-10@sha256:ce8a9c2db3e868f440dc4e15f6bb80871388d3798939c6ad0a14269727fb935d
-        Labels:
-          com.docker.stack.namespace: iometrics-reporter
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: xvywi6ktad7s9jot8ha6y2qxj
-          com.docker.swarm.service.name: iometrics-reporter_mariadb
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: jococetrpj2hs7ius7c6mkxf5
-          com.docker.swarm.task.name: iometrics-reporter_mariadb.1.jococetrpj2hs7ius7c6mkxf5
-          maintainer: Bitnami <containers@bitnami.com>
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: '1001'
-        Volumes: null
-        WorkingDir: ''
-      Created: '2022-04-26T14:58:32.255743503Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/19ac661ee97a08f8a1d44687008b6b0076b35923cb2b19148e27cd4b7662cb22-init/diff:/var/lib/docker/overlay2/5db53748954d97cd1ef4005914eed0322f2078a55dfaa61af8d086618b488aae/diff:/var/lib/docker/overlay2/8e7ed2e7ffe4a6bc328004ab4a7fe5673d6469b72a5f9ffc2bc7cba36abbb363/diff:/var/lib/docker/overlay2/62b25b57f464f3cb683127ebc29148ac52997c20bf79869d61d9616280da3e3c/diff:/var/lib/docker/overlay2/a7b3e558376c755b47d6064040dcedd05cab7fd146f23b6b6b40633cfdcd3a37/diff:/var/lib/docker/overlay2/8a1c5bd77f1d7f2c1b24c8bc54c39ce204a01b531d4e6d20eaa1bfb43d2793d2/diff:/var/lib/docker/overlay2/bf55c9843ef497be08ec5e0160797da5aa9d42c5057068cb2f065552a024dc41/diff:/var/lib/docker/overlay2/7a815ccceb764fe4e989f5a7c817ae8aff03292eae66cf94c7f161166498e59d/diff:/var/lib/docker/overlay2/06e6a6ac463782ae9b4b554de2defe652a2cf646ebbadd24627864bf6d18e4a2/diff:/var/lib/docker/overlay2/fc7740507940da47ea924acc3caee0907ed8a1c30c8a7def799c50eec2c4b621/diff:/var/lib/docker/overlay2/d6022d7f3341bc30a594cebed98e0f7563c19316ca7bc8a2828fb263a5925984/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/19ac661ee97a08f8a1d44687008b6b0076b35923cb2b19148e27cd4b7662cb22/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/19ac661ee97a08f8a1d44687008b6b0076b35923cb2b19148e27cd4b7662cb22/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/19ac661ee97a08f8a1d44687008b6b0076b35923cb2b19148e27cd4b7662cb22/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: iometrics-reporter_mariadb_data
-            Target: /bitnami
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-reporter
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e/hosts
-      Id: 8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e
-      Image: 'sha256:7318d6f52b002fffaa05d851ec647cc981ababd9319f8da4487babd992a53ea2'
-      LogPath: >-
-        /var/lib/docker/containers/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /bitnami
-          Driver: local
-          Mode: z
-          Name: iometrics-reporter_mariadb_data
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/iometrics-reporter_mariadb_data/_data
-          Type: volume
-      Name: /iometrics-reporter_mariadb.1.jococetrpj2hs7ius7c6mkxf5
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - 8071bb422bac
-            DriverOpts: null
-            EndpointID: af07f30c6e05169605d3ba106ca9a6b9df43d5d606c43c18e212581a03cfeaab
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.20
-            IPAddress: 192.168.4.20
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:14'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          3306/tcp: null
-        SandboxID: 18b3cb3f5649461f1c8e4a73ac453409200f72a1eaf8a8c0fd6994c69f5e9fd3
-        SandboxKey: /var/run/docker/netns/18b3cb3f5649
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /opt/bitnami/scripts/mariadb/entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3184
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:38.170800352Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - ./bin/synthetix-agent
-        Env:
-          - SYA_AGENT_CLONE_IMAGE=alpine/git
-          - 'SYA_AGENT_EXTRA_ENV=GIT_SSL_NO_VERIFY:"true",TEST_VAR:"mytest"'
-          - SYA_AGENT_EXTRA_NETWORKS=iometrics-public
-          - SYA_AGENT_LOG_EXTRA_ON_FILES=false
-          - SYA_AGENT_LOG_LEVEL=debug
-          - SYA_AGENT_MAX_PARALLEL_EXEC=20
-          - 'SYA_MANAGER_ENDPOINT=https://sym:7070'
-          - SYA_MANAGER_PASSWORD=admin
-          - SYA_MANAGER_SKIP_TLS_VERIFY=true
-          - SYA_NODEID=synthetix-worker01
-          - TZ=Europe/Madrid
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - PATHS_HOME=/opt/iometrics-synthetix-agent/
-        Hostname: synthetix-worker01
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-synthetix-agent:0.6.0@sha256:20e652769dccc49bb65527b0d67f949264d1daee8f338ae4a69b68093792acb5
-        Labels:
-          com.docker.stack.namespace: iometrics-cicd
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: 1l57fyo6z9nl94r5xepjbqz57
-          com.docker.swarm.service.name: iometrics-cicd_sya
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: isx6lr7eq7lhfd8ydzvktbzs3
-          com.docker.swarm.task.name: >-
-            iometrics-cicd_sya.wh12ct3jzpllqaj4mv233ey4f.isx6lr7eq7lhfd8ydzvktbzs3
-          maintainer: Datadope team <hello@datadope.io>
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: /opt/iometrics-synthetix-agent
-      Created: '2022-04-26T14:58:32.205472884Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/821d27d31217988044bc4bf681c17b4f7d2a633d92c9255f12e01fa1ec8586f5-init/diff:/var/lib/docker/overlay2/7c0f66c943350b58106a7e28331439e175588e8eb4d267acb5bd81a94bf4769b/diff:/var/lib/docker/overlay2/a7cbd4f757675c74d9f1c3522db76c99c5d12fb86d5b5418230485e30c7710a4/diff:/var/lib/docker/overlay2/37ad486043fbbc2ae00636fd3547ea2a56bd4d9e972e1654ae99137ac3f84634/diff:/var/lib/docker/overlay2/a997600d0ae26706e04b08d3a7391f76405aec12da65cdcecc0fcdd0e6ed318e/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/821d27d31217988044bc4bf681c17b4f7d2a633d92c9255f12e01fa1ec8586f5/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/821d27d31217988044bc4bf681c17b4f7d2a633d92c9255f12e01fa1ec8586f5/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/821d27d31217988044bc4bf681c17b4f7d2a633d92c9255f12e01fa1ec8586f5/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: /var/run/docker.sock
-            Target: /var/run/docker.sock
-            Type: bind
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733/hosts
-      Id: dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733
-      Image: 'sha256:9f76922121ae515bca5f2a65836ba0075102ad819fafe49aaef5e88ea3fdeac6'
-      LogPath: >-
-        /var/lib/docker/containers/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/run/docker.sock
-          Mode: ''
-          Propagation: rprivate
-          RW: true
-          Source: /var/run/docker.sock
-          Type: bind
-      Name: /iometrics-cicd_sya.wh12ct3jzpllqaj4mv233ey4f.isx6lr7eq7lhfd8ydzvktbzs3
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - dbce739954ef
-            DriverOpts: null
-            EndpointID: 0e3376430c2c41cda7e392bf6e734f6fa5f37cf047f1e5f469a7fcc4029adade
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.43
-            IPAddress: 192.168.4.43
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:2b'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports: { }
-        SandboxID: 2b496e9f6bdc8d81990c775d2c6c840791a63e6cb093054586903ea1ec617411
-        SandboxKey: /var/run/docker/netns/2b496e9f6bdc
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: ./bin/synthetix-agent
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3217
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:37.290708838Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args:
-        - telegraf
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - telegraf
-        Domainname: ''
-        Entrypoint:
-          - /entrypoint.sh
-        Env:
-          - AGENT_MONITOR_DATABASE=telegraf
-          - 'AGENT_MONITOR_HOST=http://influxdb:8086'
-          - AGENT_MONITOR_PASSWORD=telegraf
-          - AGENT_MONITOR_USERNAME=telegraf
-          - CLIENT_NAME=carrefour
-          - CLIENT_TYPE=zabbix
-          - CLUSTER=robotito.lab.iometrics.io
-          - HOSTNAME=zabbix-gw-c4
-          - INPUT_PASSWORD=gw-c4-pass
-          - INPUT_USERNAME=gw-c4-user
-          - PROVE_MONITOR_DATABASE=sondas
-          - 'PROVE_MONITOR_HOST=http://influxdb:8086'
-          - PROVE_MONITOR_PASSWORD=sondas
-          - PROVE_MONITOR_USERNAME=sondas
-          - ZABBIX_HOST=zabbix
-          - ZABBIX_HOST_PREFIX=functional..synthetix__
-          - ZABBIX_PORT=10051
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-        ExposedPorts:
-          8092/udp: { }
-          8094/tcp: { }
-          8125/udp: { }
-        Hostname: zabbix-gw-c4
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-telegraf-gw:latest@sha256:38af36a42b2382665f509bb75d497055fcefe3e9138ead86a501d1320a2bd306
-        Labels:
-          com.docker.stack.namespace: iometrics-synthetix-zabbixgw
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: 2zkn4u7pkbhvam638401wwvfx
-          com.docker.swarm.service.name: iometrics-synthetix-zabbixgw_zabbix-gw-c4
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: zf1pep45dqgpltg21ipp7qp1w
-          com.docker.swarm.task.name: >-
-            iometrics-synthetix-zabbixgw_zabbix-gw-c4.1.zf1pep45dqgpltg21ipp7qp1w
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: ''
-      Created: '2022-04-26T14:58:32.170410819Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/3745bc3d51d07847b584689e57d61680f2faead6bf7eef089d1c4f4466166daa-init/diff:/var/lib/docker/overlay2/f6e0d2e10522c8f6064b913cb46e6ea7965f8ad56d2f7bb6aee248f3005f8f0d/diff:/var/lib/docker/overlay2/754ed454e59a6df2c23418025a11de8cd389999c89f4570d67202850b7255e8a/diff:/var/lib/docker/overlay2/4e324a393ad45acd94998cd32b02e5b759a70575f13a7e4d61207365760be0d8/diff:/var/lib/docker/overlay2/33fbfafd655518c8a5662ef8e8d79e5bd491f110a752b2b4d11b4984b6327277/diff:/var/lib/docker/overlay2/6357c9fef2def12a89a5de28ed7e549ef39970e979e48fc0c0f5c8ba508a0a11/diff:/var/lib/docker/overlay2/e9ec2562ae19beb76bc9ea209f2a9bab4c712cbc452ee4a7405294f7dd904824/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/3745bc3d51d07847b584689e57d61680f2faead6bf7eef089d1c4f4466166daa/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/3745bc3d51d07847b584689e57d61680f2faead6bf7eef089d1c4f4466166daa/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/3745bc3d51d07847b584689e57d61680f2faead6bf7eef089d1c4f4466166daa/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a/hosts
-      Id: 197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a
-      Image: 'sha256:d3eb0a7fb08d02be6df5e5d8eac58fd6a3d97cbbfc8dfb154a7942b74f77264c'
-      LogPath: >-
-        /var/lib/docker/containers/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a-json.log
-      MountLabel: ''
-      Mounts: [ ]
-      Name: /iometrics-synthetix-zabbixgw_zabbix-gw-c4.1.zf1pep45dqgpltg21ipp7qp1w
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - 197d7bfae539
-            DriverOpts: null
-            EndpointID: d7011cce71b4f37f40767afe43601643306b75d3bb1123547571a0a39f73b8e8
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.22
-            IPAddress: 192.168.4.22
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:16'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports:
-          8092/udp: null
-          8094/tcp: null
-          8125/udp: null
-        SandboxID: 7cf897b69e6d91442c811460ac98926c851d635c7b5876780c01120ceba7d7fa
-        SandboxKey: /var/run/docker/netns/7cf897b69e6d
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 2829
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:35.926894398Z'
-        Status: running
-    - AppArmorProfile: docker-default
-      Args:
-        - '-c'
-        - /app/deployment/run.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /bin/sh
-          - '-c'
-          - /app/deployment/run.sh
-        Env:
-          - CONFIG_PATH=/app/config/config.yml
-          - DEBUG=False
-          - DJANGO_SECRET=the_sectet
-          - INFLUX_DB=sondas
-          - INFLUX_ORG="undefined"
-          - INFLUX_PASSWORD=admin
-          - 'INFLUX_TOKEN=admin:admin'
-          - 'INFLUX_URL=http://influxdb:8086'
-          - INFLUX_USER=admin
-          - POSTGRES_DB=reports
-          - POSTGRES_HOST=api-reporter-db
-          - POSTGRES_PASSWORD=admin
-          - POSTGRES_PORT=5432
-          - POSTGRES_USER=admin
-          - PROJECT_NAME=reports
-          - VISIBLE_NAME=iometrics-reports-api
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.12
-          - PYTHON_PIP_VERSION=21.2.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/c20b0cfd643cd4a19246ccf204e2997af70f6b21/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=fa6f3fb93cce234cd4e8dd2beb54a51ab9c247653b52855a48dd44e6b21ff28b
-          - PYTHONUNBUFFERED=1
-        Hostname: d9af2818dd47
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-reports-api:0.2.0@sha256:251318e5f3012ee198bbda8615e5a25e3f5b7e78d9063d4ed95d947e9985917b
-        Labels:
-          com.docker.stack.namespace: iometrics-reporter
-          com.docker.swarm.node.id: wh12ct3jzpllqaj4mv233ey4f
-          com.docker.swarm.service.id: 44smkfxqlkwsywldlzecpz8vs
-          com.docker.swarm.service.name: iometrics-reporter_api-reporter
-          com.docker.swarm.task: ''
-          com.docker.swarm.task.id: u7ofji81lo2m8et3mccdvnya9
-          com.docker.swarm.task.name: iometrics-reporter_api-reporter.1.u7ofji81lo2m8et3mccdvnya9
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: /app
-      Created: '2022-04-26T14:58:32.139168553Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/4d2b772fbe4d6e59893564ee46472c40328b6930701d27995a8f84eee2fb0492-init/diff:/var/lib/docker/overlay2/a5f6129e1829eeb3db6f44890351d13b027f445ed34b84832f5cdaaf4eecfc5d/diff:/var/lib/docker/overlay2/696a11811953881d28b122ea78cac9c1a9d049d06ab119e195925707951257f7/diff:/var/lib/docker/overlay2/ca21abe5d706ad12989357241dd886f0dded9a039cbc29721f007e8897274037/diff:/var/lib/docker/overlay2/e5e00a7c22de761b0a00e7622033e968cc24610c3dacfc268646c63b30624150/diff:/var/lib/docker/overlay2/9baae4f5c43987e2e5f18c37d65f3a42f80ab67e13c2f7e97ae6d6212d298008/diff:/var/lib/docker/overlay2/86245cf52855badc4c7728b645327b3dbb4180e7c613fe927a43ad054c7bf107/diff:/var/lib/docker/overlay2/e0cc7e7cd693b2f905b7f8cbe5d426af923ccef498b42b14f7de3400a48039f9/diff:/var/lib/docker/overlay2/ef27cbccc9a1f3dc10c4656c6d041b8ea13536469f1331e3fe5a2475a473c8ae/diff:/var/lib/docker/overlay2/335b0aff5d293f39af577ec5acb0370c9d2efd669ec23dc6aae8980933f15c51/diff:/var/lib/docker/overlay2/97451a128b45ada6fa64a6ab767244d139f6b3eb64384e07cf005d977aa9e82e/diff:/var/lib/docker/overlay2/34c7889309c653ee601e2e559c26bfbbaeb1beb00f6cea5a67cf79ed820be5f3/diff:/var/lib/docker/overlay2/6534599c817e4349aa8184d38c29cbb463736e991aa7ae6149e6503e47d75c2f/diff:/var/lib/docker/overlay2/1842feadd3c48ff0ed0891ed43ed53c8526a47767b672a5be692f823959028f7/diff:/var/lib/docker/overlay2/0d80c04b52c5020a9fff38fb861299236d3440dc793248bfdbd8fce40f1911d3/diff:/var/lib/docker/overlay2/17303406407ac530d79da413de6bef0c0151447cff6b2ed9e5bd55ab75b6e3cb/diff:/var/lib/docker/overlay2/5476e3b6ce212f67771d09b0c3991e594b2c32e83f7a38aff551f8cde6477822/diff:/var/lib/docker/overlay2/b35d75043f9126e4c7d3b4ebd5dcf5e5bf0376fb011185878356ef78a0400ded/diff:/var/lib/docker/overlay2/51251e8f2c59118d5051d6858d75d7a9528800af88e28a8ce5bfc6037bb23aff/diff:/var/lib/docker/overlay2/4260980d71d22b9da6aeb5fd7a7d0390ad7a63762f782ba5e512542eee07efb5/diff:/var/lib/docker/overlay2/16034b5628ed069710d72755f014e19c2738f5e27c39807eea352d743a32b1c4/diff:/var/lib/docker/overlay2/8f668a8d30c490c3cd10d0785b3f14f23817dcb7c4eab6193528b31738d9ef24/diff:/var/lib/docker/overlay2/cb6b76270d5a16be67dfecbeb06f3a167fd9d45be171f2d46dff6878f4672e75/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/4d2b772fbe4d6e59893564ee46472c40328b6930701d27995a8f84eee2fb0492/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/4d2b772fbe4d6e59893564ee46472c40328b6930701d27995a8f84eee2fb0492/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/4d2b772fbe4d6e59893564ee46472c40328b6930701d27995a8f84eee2fb0492/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: default
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        Mounts:
-          - Source: iometrics-reporter_media
-            Target: /app/media
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-reporter
-          - Source: iometrics-reporter_static
-            Target: /app/static
-            Type: volume
-            VolumeOptions:
-              Labels:
-                com.docker.stack.namespace: iometrics-reporter
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f/hosts
-      Id: d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f
-      Image: 'sha256:ba8abc8188002cc73f7d1beb47144e893c8c0d09cb34668c40d0e8f2f756a68b'
-      LogPath: >-
-        /var/lib/docker/containers/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/media
-          Driver: local
-          Mode: z
-          Name: iometrics-reporter_media
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/iometrics-reporter_media/_data
-          Type: volume
-        - Destination: /app/static
-          Driver: local
-          Mode: z
-          Name: iometrics-reporter_static
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/iometrics-reporter_static/_data
-          Type: volume
-      Name: /iometrics-reporter_api-reporter.1.u7ofji81lo2m8et3mccdvnya9
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          iometrics-public:
-            Aliases:
-              - d9af2818dd47
-            DriverOpts: null
-            EndpointID: 16f5495c7cc135ea47ba21758cd0e405a213d94ee7b6a123ceaf85b0315b5299
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig:
-              IPv4Address: 192.168.4.25
-            IPAddress: 192.168.4.25
-            IPPrefixLen: 24
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:0a:00:00:19'
-            NetworkID: f1h1vvijaxvypulabix98fsue
-        Ports: { }
-        SandboxID: f4a42d18ad7a1594a8cc8a02207df5660f8017cb689e97e044ab9f56d761214a
-        SandboxKey: /var/run/docker/netns/f4a42d18ad7a
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 3014
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:58:38.853167441Z'
-        Status: running
+  - arch: amd64
+    category: libs
+    name: zlib1g
+    origin: Ubuntu
+    source: apt
+    version: 1:1.2.11.dfsg-0ubuntu2.1
+processes:
+- cmdline: /sbin/init
+  cwd: /sbin/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '40'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '54'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '97'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '98'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '101'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '102'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '103'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '104'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '110'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '119'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '136'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '227'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '228'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '301'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '349'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '350'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '351'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '353'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '384'
+  ppid: '2'
+  user: root
+- cmdline: /lib/systemd/systemd-journald
+  cwd: /lib/systemd/
+  pid: '420'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '429'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '431'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '435'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '436'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '437'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '438'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '439'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/lvmetad -f
+  cwd: /sbin/
+  pid: '443'
+  ppid: '1'
+  user: root
+- cmdline: /lib/systemd/systemd-udevd
+  cwd: /lib/systemd/
+  pid: '452'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '535'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '536'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '537'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '538'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '539'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '540'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '541'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '542'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '543'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '544'
+  ppid: '2'
+  user: root
+- cmdline: /lib/systemd/systemd-timesyncd
+  cwd: /lib/systemd/
+  pid: '703'
+  ppid: '1'
+  user: systemd-timesync
+- cmdline: /lib/systemd/systemd-networkd
+  cwd: /lib/systemd/
+  pid: '777'
+  ppid: '1'
+  user: systemd-network
+- cmdline: /lib/systemd/systemd-resolved
+  cwd: /lib/systemd/
+  pid: '799'
+  ppid: '1'
+  user: systemd-resolve
+- cmdline: /usr/bin/lxcfs /var/lib/lxcfs/
+  cwd: /usr/bin/
+  pid: '920'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation --syslog-only'
+  cwd: /usr/bin/
+  pid: '926'
+  ppid: '1'
+  user: messagebus
+- cmdline: /usr/lib/accountsservice/accounts-daemon
+  cwd: /usr/lib/accountsservice/
+  pid: '951'
+  ppid: '1'
+  user: root
+- cmdline: /lib/systemd/systemd-logind
+  cwd: /lib/systemd/
+  pid: '957'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/atd -f
+  cwd: /usr/sbin/
+  pid: '975'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '994'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1004'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python3 /usr/share/unattended-upgrades/unattended-upgrade-shutdown
+    --wait-for-signal
+  cwd: /usr/bin/
+  pid: '1018'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty -o -p -- \u --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1027'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty -o -p -- \u --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1031'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/policykit-1/polkitd --no-debug
+  cwd: /usr/lib/policykit-1/
+  pid: '1032'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1066'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix:///var/run/docker.sock --storage-driver
+    overlay2 --tlsverify --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/server.pem
+    --tlskey /etc/docker/server-key.pem --label provider=generic
+  cwd: /usr/bin/
+  pid: '1209'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1279'
+  ppid: '2'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/879dd93dd2348955975b5acc6108fc9e6a63ec1182c303857319bff4e7ec8e72
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '2740'
+  ppid: '1004'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/197d7bfae5396f8465d07a90f546fee3ca13adb3146ec7ade01857e619bf369a
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '2753'
+  ppid: '1004'
+  user: root
+- cmdline: telegraf
+  cwd: /
+  pid: '2829'
+  ppid: '2753'
+  user: root
+- cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini
+    --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
+    cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/usr/share/grafana/plugins
+    cfg:default.paths.provisioning=/etc/grafana/provisioning
+  cwd: /
+  pid: '2841'
+  ppid: '2740'
+  user: '472'
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d9af2818dd476fc522a5a76ba6dcf29b69b36922debc20fa41ff5b3dd4878d3f
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '2847'
+  ppid: '1004'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/f8d0dafa40a04b717a427c22ccb586bd103a263a8d4b634bc5068e005a0ca272
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '2973'
+  ppid: '1004'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/8071bb422bac33d3ec00dfcf6dc83fd1f4603fd10a60249d8522830ac0e7d31e
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3013'
+  ppid: '1004'
+  user: root
+- cmdline: /bin/sh -c /app/deployment/run.sh
+  cwd: /bin/
+  pid: '3014'
+  ppid: '2847'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/dbce739954eff7f2dd4e346d1d4ccf9803aaa58655a8250e012a677d72da8733
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3034'
+  ppid: '1004'
+  user: root
+- cmdline: telegraf
+  cwd: /
+  pid: '3112'
+  ppid: '2973'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/cdb768fd554e82e3bb5daf2ed158445bbd461cdccfe1b96dda5e8bee7bf576b4
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3150'
+  ppid: '1004'
+  user: root
+- cmdline: /opt/bitnami/mariadb/sbin/mysqld --defaults-file=/opt/bitnami/mariadb/conf/my.cnf
+    --basedir=/opt/bitnami/mariadb --datadir=/bitnami/mariadb/data --socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    --pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+  cwd: /opt/bitnami/mariadb/sbin/
+  pid: '3184'
+  ppid: '3013'
+  user: '1001'
+- cmdline: ./bin/synthetix-agent
+  cwd: ./bin/
+  pid: '3217'
+  ppid: '3034'
+  user: root
+- cmdline: /opt/bitnami/java/bin/java -Djava.util.logging.config.file=/opt/bitnami/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Djava.awt.headless=true
+    -XX:+UseG1GC -Dfile.encoding=UTF-8 -Duser.home=/opt/bitnami/tomcat -Djdk.tls.ephemeralDHKeySize=2048
+    -Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
+    -Dignore.endorsed.dirs= -classpath /opt/bitnami/tomcat/bin/bootstrap.jar:/opt/bitnami/tomcat/bin/tomcat-juli.jar
+    -Dcatalina.base=/opt/bitnami/tomcat -Dcatalina.home=/opt/bitnami/tomcat -Djava.io.tmpdir=/opt/bitnami/tomcat/temp
+    org.apache.catalina.startup.Bootstrap start
+  cwd: /opt/bitnami/java/bin/
+  pid: '3242'
+  ppid: '3150'
+  user: '1001'
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/01dacf67f6584834e3deddaa3829bc10b4baf10fc56d19af79450c27d12e92ce
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3307'
+  ppid: '1004'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/d769662f72d3da325633035306a4f0635f76cf938a57111e67f06b62166dc08a
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3351'
+  ppid: '1004'
+  user: root
+- cmdline: /bin/bash /entrypoint.sh
+  cwd: /bin/
+  pid: '3380'
+  ppid: '3307'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/2b5cc9c1f3f340894b86a3f97fc0662f82611a8eadc90b1b39b0d28d10ca5839
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3466'
+  ppid: '1004'
+  user: root
+- cmdline: /bin/bash /entrypoint.sh
+  cwd: /bin/
+  pid: '3480'
+  ppid: '3351'
+  user: '472'
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/78bc3826302f5680cd5d96e2cd43d34989563fafa95eb62bac04dd9a13e06b19
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3535'
+  ppid: '1004'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/8c55132b38ba352a37cd7a18b2485a0943dbabc482a920c9e0426f38e9765eec
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3571'
+  ppid: '1004'
+  user: root
+- cmdline: postgres
+  cwd: /
+  pid: '3572'
+  ppid: '3466'
+  user: process_user
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/2f572d9641d8e26d0f26317252b3ac91e17a94ab477db77554b7baaad4db08ac
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3582'
+  ppid: '1004'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/857aa9d4f13e90dce898dd1b080e2cdb8eedd0d343b5688c60fea1fb48fec8e8
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '3685'
+  ppid: '1004'
+  user: root
+- cmdline: /bin/s6-svscan /etc/s6
+  cwd: /bin/
+  pid: '3784'
+  ppid: '3571'
+  user: root
+- cmdline: postgres
+  cwd: /
+  pid: '3818'
+  ppid: '3582'
+  user: '70'
+- cmdline: /usr/bin/zippersrv
+  cwd: /usr/bin/
+  pid: '3835'
+  ppid: '3535'
+  user: root
+- cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini
+    --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
+    cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/var/lib/grafana/plugins
+    cfg:default.paths.provisioning=/etc/grafana/provisioning
+  cwd: /
+  pid: '3849'
+  ppid: '3685'
+  user: '472'
+- cmdline: /bin/bash /app/deployment/run.sh
+  cwd: /bin/
+  pid: '4249'
+  ppid: '3014'
+  user: root
+- cmdline: 'nginx: master process nginx'
+  cwd: /
+  pid: '4342'
+  ppid: '3380'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '4343'
+  ppid: '4342'
+  user: systemd-network
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '4344'
+  ppid: '4342'
+  user: systemd-network
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '4345'
+  ppid: '4342'
+  user: systemd-network
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '4346'
+  ppid: '4342'
+  user: systemd-network
+- cmdline: uwsgi --ini /app.ini
+  cwd: /
+  pid: '4347'
+  ppid: '3380'
+  user: root
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '4388'
+  ppid: '3572'
+  user: '70'
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '4389'
+  ppid: '3572'
+  user: '70'
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '4390'
+  ppid: '3572'
+  user: '70'
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '4391'
+  ppid: '3572'
+  user: '70'
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '4392'
+  ppid: '3572'
+  user: '70'
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '4393'
+  ppid: '3572'
+  user: '70'
+- cmdline: /opt/iometrics-synthetix-ui/bin/tunneld -log-level 1 -tlsCrt /opt/tunneld/server.crt
+    -tlsKey /opt/tunneld/server.key -httpsAddr  -httpAddr  -tunnelAddr 0.0.0.0:5223
+    -portRange 6010:6050 -apiAddr :4823
+  cwd: /opt/iometrics-synthetix-ui/bin/
+  pid: '4452'
+  ppid: '3480'
+  user: '472'
+- cmdline: /usr/local/guacamole/sbin/guacd -b 0.0.0.0 -p 4822 -L info -f
+  cwd: /usr/local/guacamole/sbin/
+  pid: '4453'
+  ppid: '3480'
+  user: '472'
+- cmdline: /opt/iometrics-synthetix-ui/bin/synthetix-ui
+  cwd: /opt/iometrics-synthetix-ui/bin/
+  pid: '4454'
+  ppid: '3480'
+  user: '472'
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '4575'
+  ppid: '3818'
+  user: '70'
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '4576'
+  ppid: '3818'
+  user: '70'
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '4577'
+  ppid: '3818'
+  user: '70'
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '4578'
+  ppid: '3818'
+  user: '70'
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '4579'
+  ppid: '3818'
+  user: '70'
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '4580'
+  ppid: '3818'
+  user: '70'
+- cmdline: uwsgi --ini /app.ini
+  cwd: /
+  pid: '4666'
+  ppid: '4347'
+  user: root
+- cmdline: uwsgi --ini /app.ini
+  cwd: /
+  pid: '4667'
+  ppid: '4347'
+  user: root
+- cmdline: uwsgi --ini /app.ini
+  cwd: /
+  pid: '4669'
+  ppid: '4347'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4683'
+  ppid: '2'
+  user: root
+- cmdline: s6-supervise gitea
+  cwd: /
+  pid: '4909'
+  ppid: '3784'
+  user: root
+- cmdline: s6-supervise openssh
+  cwd: /
+  pid: '4910'
+  ppid: '3784'
+  user: root
+- cmdline: /app/gitea/gitea web
+  cwd: /app/gitea/
+  pid: '4913'
+  ppid: '4909'
+  user: ubuntu
+- cmdline: /usr/sbin/sshd -D -e
+  cwd: /usr/sbin/
+  pid: '4914'
+  ppid: '4910'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/51b87160474261dc838003f4045325deec91e9327c37bf72ef234aaa0461da23
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '5481'
+  ppid: '1004'
+  user: root
+- cmdline: ./agent
+  cwd: ./
+  pid: '5508'
+  ppid: '5481'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn -w 2 -b :8000 --worker-tmp-dir
+    /dev/shm --chdir /app/src -k uvicorn.workers.UvicornWorker reports.asgi:application
+  cwd: /usr/local/bin/
+  pid: '5533'
+  ppid: '4249'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn -w 2 -b :8000 --worker-tmp-dir
+    /dev/shm --chdir /app/src -k uvicorn.workers.UvicornWorker reports.asgi:application
+  cwd: /usr/local/bin/
+  pid: '5576'
+  ppid: '5533'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn -w 2 -b :8000 --worker-tmp-dir
+    /dev/shm --chdir /app/src -k uvicorn.workers.UvicornWorker reports.asgi:application
+  cwd: /usr/local/bin/
+  pid: '5577'
+  ppid: '5533'
+  user: root
+- cmdline: /usr/sbin/cron -f
+  cwd: /usr/sbin/
+  pid: '7269'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python3 /usr/bin/networkd-dispatcher --run-startup-triggers
+  cwd: /usr/bin/
+  pid: '11606'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '13708'
+  ppid: '1'
+  user: syslog
+- cmdline: 'postgres: admin gitea 192.168.4.167(52238) idle'
+  cwd: /
+  pid: '16571'
+  ppid: '3818'
+  user: '70'
+- cmdline: ''
+  cwd: /
+  pid: '17517'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19183'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23444'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23445'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26541'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27457'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27550'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27634'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28354'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28411'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28719'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28824'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29730'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29825'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: ubuntu [priv]'
+  cwd: /
+  pid: '30406'
+  ppid: '1066'
+  user: root
+- cmdline: /lib/systemd/systemd --user
+  cwd: /lib/systemd/
+  pid: '30408'
+  ppid: '1'
+  user: ubuntu
+- cmdline: (sd-pam)
+  cwd: /
+  pid: '30409'
+  ppid: '30408'
+  user: ubuntu
+- cmdline: 'sshd: ubuntu@pts/0'
+  cwd: /
+  pid: '30530'
+  ppid: '30406'
+  user: ubuntu
+- cmdline: -bash
+  cwd: /
+  pid: '30531'
+  ppid: '30530'
+  user: ubuntu
+- cmdline: sudo su -
+  cwd: /
+  pid: '30549'
+  ppid: '30531'
+  user: root
+- cmdline: su -
+  cwd: /
+  pid: '30550'
+  ppid: '30549'
+  user: root
+- cmdline: -su
+  cwd: /
+  pid: '30551'
+  ppid: '30550'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31456'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: ubuntu [priv]'
+  cwd: /
+  pid: '31531'
+  ppid: '1066'
+  user: root
+- cmdline: 'sshd: ubuntu@pts/1'
+  cwd: /
+  pid: '31619'
+  ppid: '31531'
+  user: ubuntu
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-plnltjmmpjoylqcfppcdrqigblealuyg
+    ; /usr/bin/python3 /home/ubuntu/.ansible/tmp/ansible-tmp-1654172735.6293702-12884-220436346408519/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '31781'
+  ppid: '31619'
+  user: ubuntu
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-plnltjmmpjoylqcfppcdrqigblealuyg
+    ; /usr/bin/python3 /home/ubuntu/.ansible/tmp/ansible-tmp-1654172735.6293702-12884-220436346408519/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '31782'
+  ppid: '31781'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-plnltjmmpjoylqcfppcdrqigblealuyg ; /usr/bin/python3
+    /home/ubuntu/.ansible/tmp/ansible-tmp-1654172735.6293702-12884-220436346408519/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '31783'
+  ppid: '31782'
+  user: root
+- cmdline: /usr/bin/python3 /home/ubuntu/.ansible/tmp/ansible-tmp-1654172735.6293702-12884-220436346408519/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '31784'
+  ppid: '31783'
+  user: root
+- cmdline: 'postgres: admin gitea 192.168.4.167(43552) idle'
+  cwd: /
+  pid: '32387'
+  ppid: '3818'
+  user: '70'
+software_list:
+- cmd_regexp: 'postgres:'
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/postgresql.yaml
+    name: Include postgres specific plugins
+  name: PostgreSQL Database
+  pkg_regexp: postgresql.*-server|postgresql-\d
+  process_type: child
+  return_children: true
+  return_packages: true
+  vars:
+    connect_with_users: '{{ postgresql_monitor_users_info | default([{''username'':
+      postgresql_monitor_user | default(''postgres''), ''password'': postgresql_monitor_pass
+      | default(''postgres'')}]) }}'
+    ignore_databases:
+    - postgres
+    - template0
+    - template1
+    sql_connection_extra_params: -h 127.0.0.1
+task_vars:
+  postgresql_monitor_users_info:
+  - password: password_a
+    username: user_a
+  - password: password_b
+    username: user_b
+tcp_listen:
+- address: 127.0.0.53
+  name: systemd-resolve
+  pid: 799
+  port: 53
+  protocol: tcp
+  stime: Tue Apr 26 14:57:13 2022
+  user: systemd-resolve
+- address: 0.0.0.0
+  name: sshd
+  pid: 1066
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:57:16 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 4000
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 10051
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 9092
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 2181
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 9094
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 9000
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 5000
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 2376
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 9001
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 3306
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 7946
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 2222
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 80
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 9009
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 9010
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1066
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:57:16 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 3000
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 8123
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 443
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 7070
+  protocol: tcp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root
+udp_listen:
+- address: 127.0.0.53
+  name: systemd-resolve
+  pid: 799
+  port: 53
+  protocol: udp
+  stime: Tue Apr 26 14:57:13 2022
+  user: systemd-resolve
+- address: 192.168.0.229
+  name: systemd-network
+  pid: 777
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 14:57:13 2022
+  user: systemd-network
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 4789
+  protocol: udp
+  stime: ''
+  user: ''
+- address: '::'
+  name: dockerd
+  pid: 1209
+  port: 7946
+  protocol: udp
+  stime: Tue Apr 26 14:57:17 2022
+  user: root

--- a/tests/unit/plugins/action/auto/resources/postgres/postgres12_centos7.6_docker.yaml
+++ b/tests/unit/plugins/action/auto/resources/postgres/postgres12_centos7.6_docker.yaml
@@ -1,75 +1,1239 @@
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.8.2-d9b0d2f
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-05-26T07:49:05.896112055Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86-init/diff:/var/lib/docker/overlay2/395a0a098af3a906d0b43de3a008385a50d078a5c9c9be9ad290d1ba93fc9d54/diff:/var/lib/docker/overlay2/ef530f145d37479125854996544e943962d75b907389895e832a53f5bf1be0b4/diff:/var/lib/docker/overlay2/aacd9f48b7c7d9206a74c249bc83b6afec331f8973755cc84b91520222113c6a/diff:/var/lib/docker/overlay2/a653e007a808f014a3cdf2a62cf8867245a62cc468322211674f6eb7075edc2d/diff:/var/lib/docker/overlay2/1df1b451d3b0c7cd3356a603610b5f2b30b61bfe47d8b9c3311abac0715bc2c9/diff:/var/lib/docker/overlay2/41f757a985196fb2658fe9b64ee03906a9ef3273caa4cf533f46815ca685387e/diff:/var/lib/docker/overlay2/9d09467ed70aad7f2334135a687a8531961e6224b24d4162233f2e7385da8cac/diff:/var/lib/docker/overlay2/5fb73472da8826e8cd0d3142ce1eb014d2a8168164a20b0c39bee7718165927e/diff:/var/lib/docker/overlay2/e95c88109a4dfa0d00c885520d4c0e9891bd674f28a2074d4ab71bc6aea3ccbf/diff:/var/lib/docker/overlay2/00e551e532ee647bfbfd6d50ed3c40c11afaad3cb2e4c30509423cc14066f9de/diff:/var/lib/docker/overlay2/dffc514cc11477c207690cc5bc501f8c70136a8783ce74836ccbb5db910b3bcb/diff:/var/lib/docker/overlay2/4f6545d825e9673d1a62dbcf4449ed28ce76b02513b8094f2b3f60a0b806160e/diff
+        MergedDir: /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/merged
+        UpperDir: /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/diff
+        WorkDir: /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/hostname
+    HostsPath: /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/hosts
+    Id: 6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775
+    Image: sha256:8e094d91d6749ce8d3ce1b45436a5b500647b9c0e52a7ee00e97f7a21f4cc878
+    LogPath: /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: f6cf94112a5fe8c1be26b086499ae97180987e487b317299594f8c58b9435ae2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: a6c1d1d1c4a924d01c263853345912f759d51fdfff59de9a26988318585a01ca
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-05-26T07:49:09.083806407Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 24640
+      Restarting: false
+      Running: true
+      StartedAt: '2022-05-26T07:49:11.400392642Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=the_password
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ''
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: c42d8151ce0001c84aadac96da9f71d50557f48a620639abf1fd192a4f85d1d8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 1
+      FinishedAt: '2022-05-30T09:02:31.005737147Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 0
+      Restarting: false
+      Running: false
+      StartedAt: '2022-05-30T09:02:29.925376525Z'
+      Status: exited
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 5432
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 5432
+    protocol: tcp
+  configuration:
+    datestyle: iso, mdy
+    default_text_search_config: pg_catalog.english
+    dynamic_shared_memory_type: posix
+    lc_messages: en_US.utf8
+    lc_monetary: en_US.utf8
+    lc_numeric: en_US.utf8
+    lc_time: en_US.utf8
+    listen_addresses: '*'
+    log_timezone: Europe/Madrid
+    max_connections: '100'
+    max_wal_size: 1GB
+    min_wal_size: 80MB
+    shared_buffers: 128MB
+    timezone: Europe/Madrid
+  discovery_time: '2022-05-30T11:02:38+02:00'
+  docker:
+    exposed_ports:
+      5432/tcp: {}
+    id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    image: nexusregistry.opensolutions.cloud/postgres:12
+    name: /postgres-grafana
+    network_mode: host
+    port_bindings: {}
+  extra_data:
+    active_databases:
+    - grafana
+    databases:
+    - grafana
+    - grafana_migration
+  files:
+  - path: /usr/lib/postgresql/12/bin/postgres
+    subtype: generic
+    type: binary
+  - name: postgresql.conf
+    path: /var/lib/postgresql/data
+    subtype: generic
+    type: conf
+  - path: /var/lib/postgresql/data
+    subtype: generic
+    type: data
+  listening_ports:
+  - 5432
+  packages: []
+  process:
+    children:
+    - children: []
+      cmdline: 'postgres: grafana grafana 127.0.0.1(33778) idle'
+      cwd: /
+      pid: '10411'
+      ppid: '10435'
+      user: polkitd
+    - children: []
+      cmdline: 'postgres: grafana grafana 127.0.0.1(33782) idle'
+      cwd: /
+      pid: '10413'
+      ppid: '10435'
+      user: polkitd
+    - children: []
+      cmdline: 'postgres: checkpointer'
+      cwd: /
+      pid: '10848'
+      ppid: '10435'
+      user: polkitd
+    - children: []
+      cmdline: 'postgres: background writer'
+      cwd: /
+      pid: '10849'
+      ppid: '10435'
+      user: polkitd
+    - children: []
+      cmdline: 'postgres: walwriter'
+      cwd: /
+      pid: '10850'
+      ppid: '10435'
+      user: polkitd
+    - children: []
+      cmdline: 'postgres: autovacuum launcher'
+      cwd: /
+      pid: '10851'
+      ppid: '10435'
+      user: polkitd
+    - children: []
+      cmdline: 'postgres: stats collector'
+      cwd: /
+      pid: '10852'
+      ppid: '10435'
+      user: polkitd
+    - children: []
+      cmdline: 'postgres: logical replication launcher'
+      cwd: /
+      pid: '10853'
+      ppid: '10435'
+      user: polkitd
+    cmdline: postgres
+    cwd: /
+    listening_ports:
+    - 5432
+    pid: '10435'
+    ppid: '10256'
+    user: polkitd
+  type: PostgreSQL Database
+  version:
+  - number: '12'
+    type: docker
+  - number: '12'
+    type: file
+  - number: '12.5'
+    type: active
 mocked_plugin_tasks:
-  Get file permissions:
-    fail: Should not be called
-  Run which:
-    number_of_calls: 1
-    expected_args:
-      hidden: false
-      in_docker: true
-      name: postgres
-      paths:
-        - /usr/local/sbin
-        - /usr/local/bin
-        - /usr/sbin
-        - /usr/bin
-        - /sbin
-        - /bin
-        - /usr/lib/postgresql/12/bin
-      windows_valid_extensions: null
-    execute_module_result:
-      failed: false
-      matched: 1
-      files:
-        - path: /proc/10435/root/usr/lib/postgresql/12/bin/postgres
-          isdir: false
-          xusr: true
-          xgrp: true
-          xoth: true
-
   Add version from file to the instance:
     expected_args:
-      version_type: "file"
       version_number: '12'
+      version_type: file
   Attempt to extract conf path:
     expected_exception:
-      message: "'NoneType' object is not iterable"
-  Read process environment:
+      message: '''NoneType'' object is not iterable'
+  Extract port:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+  Get file permissions:
+    fail: Should not be called
+  Get from child processes cmdline:
+    calls:
+    - run
+    - run
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+  Read VERSION file from path:
     expected_args:
-      pid: '10435'
+      delegate_reading: false
+      file_path: /var/lib/postgresql/data/PG_VERSION
+      in_docker: true
+      parser: null
+      parser_params: null
     plugin_result:
-      failed: False
-      parsed:
-        HOSTNAME: grafana01.novalocal
-        PWD: '/'
-        TZ: Europe/Madrid
-        HOME: /var/lib/postgresql
-        LANG: en_US.utf8
-        GOSU_VERSION: 1.12
-        POSTGRES_INITDB_ARGS:
-        PG_MAJOR: 12
-        PG_VERSION: 12.5-1.pgdg100+1
-        SHLVL: 0
-        POSTGRES_USER: postgres
-        PGDATA: /var/lib/postgresql/data
-        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-        POSTGRES_DB: grafana
-
-  "Read configuration file as dict":
-    # Force only 1 call using number_of_calls
-    number_of_calls: 1
+      content: '12'
+      failed: false
+  Read configuration file as dict:
     expected_args:
       delegate_reading: false
       file_path: /var/lib/postgresql/data/postgresql.conf
       in_docker: true
       parser: key_value
       parser_params:
-        separators: [ "=", " " ]
+        separators:
+        - '='
+        - ' '
     expected_attributes:
       register: result
+    number_of_calls: 1
     plugin_result:
       failed: false
       parsed:
-        datestyle: 'iso, mdy'
+        datestyle: iso, mdy
         default_text_search_config: pg_catalog.english
         dynamic_shared_memory_type: posix
         lc_messages: en_US.utf8
@@ -83,16 +1247,6 @@ mocked_plugin_tasks:
         min_wal_size: 80MB
         shared_buffers: 128MB
         timezone: Europe/Madrid
-  Read VERSION file from path:
-    expected_args:
-      delegate_reading: false
-      file_path: /var/lib/postgresql/data/PG_VERSION
-      in_docker: true
-      parser: null
-      parser_params: null
-    plugin_result:
-      failed: false
-      content: "12"
   Read pg_hba file from path:
     expected_args:
       delegate_reading: false
@@ -101,4541 +1255,3454 @@ mocked_plugin_tasks:
       parser: null
       parser_params: null
     plugin_result:
-      failed: false
-      content: |-
-        # TYPE  DATABASE        USER            ADDRESS                 METHOD
-        
-        # "local" is for Unix domain socket connections only
-        local   all             all                                     trust
-        # IPv4 local connections:
-        host    all             all             127.0.0.1/32            trust
-        # IPv6 local connections:
-        host    all             all             ::1/128                 trust
-        # Allow replication connections from localhost, by a user with the
-        # replication privilege.
-        local   replication     all                                     trust
-        host    replication     all             127.0.0.1/32            trust
-        host    replication     all             ::1/128                 trust
-        
-        host all all all md5
+      content: '# TYPE  DATABASE        USER            ADDRESS                 METHOD
 
+
+        # "local" is for Unix domain socket connections only
+
+        local   all             all                                     trust
+
+        # IPv4 local connections:
+
+        host    all             all             127.0.0.1/32            trust
+
+        # IPv6 local connections:
+
+        host    all             all             ::1/128                 trust
+
+        # Allow replication connections from localhost, by a user with the
+
+        # replication privilege.
+
+        local   replication     all                                     trust
+
+        host    replication     all             127.0.0.1/32            trust
+
+        host    replication     all             ::1/128                 trust
+
+
+        host all all all md5'
+      failed: false
+  Read process environment:
+    expected_args:
+      pid: '10435'
+    plugin_result:
+      failed: false
+      parsed:
+        GOSU_VERSION: 1.12
+        HOME: /var/lib/postgresql
+        HOSTNAME: grafana01.novalocal
+        LANG: en_US.utf8
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+        PGDATA: /var/lib/postgresql/data
+        PG_MAJOR: 12
+        PG_VERSION: 12.5-1.pgdg100+1
+        POSTGRES_DB: grafana
+        POSTGRES_INITDB_ARGS: null
+        POSTGRES_USER: postgres
+        PWD: /
+        SHLVL: 0
+        TZ: Europe/Madrid
+  Run command to get databases:
+    calls:
+    - plugin_result:
+        failed: true
+    - plugin_result:
+        failed: false
+        stdout_lines:
+        - postgres
+        - template1
+        - template0
+        - grafana
+        - grafana_migration
   Run command version:
     expected_args:
       argv:
-        - /usr/lib/postgresql/12/bin/postgres
-        - --version
+      - /usr/lib/postgresql/12/bin/postgres
+      - --version
       cmd: null
       in_docker: true
     plugin_result:
       failed: false
       stdout: postgres (PostgreSQL) 12.5-1
-  Extract port:
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-  Get from child processes cmdline:
-    calls:
-      - run
-      - run
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-  "Run command to get databases":
-    calls:
-      - plugin_result:
-          failed: true
-      - plugin_result:
-          failed: false
-          stdout_lines:
-            - postgres
-            - template1
-            - template0
-            - grafana
-            - grafana_migration
-
-task_vars:
-  postgresql_monitor_user: the_postgres_user
-  postgresql_monitor_pass: the_password
-
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 5432
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 5432
-        protocol: 'tcp'
-    extra_data:
-      active_databases:
-        - grafana
-      databases:
-        - grafana
-        - grafana_migration
-    files:
-      - path: /usr/lib/postgresql/12/bin/postgres
-        subtype: generic
-        type: binary
-      - path: /var/lib/postgresql/data
-        name: postgresql.conf
-        subtype: generic
-        type: conf
-      - path: /var/lib/postgresql/data
-        subtype: generic
-        type: data
-    configuration:
-      datestyle: 'iso, mdy'
-      default_text_search_config: pg_catalog.english
-      dynamic_shared_memory_type: posix
-      lc_messages: en_US.utf8
-      lc_monetary: en_US.utf8
-      lc_numeric: en_US.utf8
-      lc_time: en_US.utf8
-      listen_addresses: '*'
-      log_timezone: Europe/Madrid
-      max_connections: '100'
-      max_wal_size: 1GB
-      min_wal_size: 80MB
-      shared_buffers: 128MB
-      timezone: Europe/Madrid
-    discovery_time: '2022-05-30T11:02:38+02:00'
-    docker:
-      exposed_ports:
-        5432/tcp: { }
-      id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      image: 'nexusregistry.opensolutions.cloud/postgres:12'
-      name: /postgres-grafana
-      network_mode: 'host'
-      port_bindings: { }
-    listening_ports:
-      - 5432
-    type: PostgreSQL Database
-    packages: [ ]
-    process:
-      children:
-        - children: [ ]
-          cmdline: 'postgres: grafana grafana 127.0.0.1(33778) idle'
-          pid: '10411'
-          ppid: '10435'
-          user: polkitd
-        - children: [ ]
-          cmdline: 'postgres: grafana grafana 127.0.0.1(33782) idle'
-          pid: '10413'
-          ppid: '10435'
-          user: polkitd
-        - children: [ ]
-          cmdline: 'postgres: checkpointer'
-          pid: '10848'
-          ppid: '10435'
-          user: polkitd
-        - children: [ ]
-          cmdline: 'postgres: background writer'
-          pid: '10849'
-          ppid: '10435'
-          user: polkitd
-        - children: [ ]
-          cmdline: 'postgres: walwriter'
-          pid: '10850'
-          ppid: '10435'
-          user: polkitd
-        - children: [ ]
-          cmdline: 'postgres: autovacuum launcher'
-          pid: '10851'
-          ppid: '10435'
-          user: polkitd
-        - children: [ ]
-          cmdline: 'postgres: stats collector'
-          pid: '10852'
-          ppid: '10435'
-          user: polkitd
-        - children: [ ]
-          cmdline: 'postgres: logical replication launcher'
-          pid: '10853'
-          ppid: '10435'
-          user: polkitd
-      cmdline: postgres
-      listening_ports:
-        - 5432
-      pid: '10435'
-      ppid: '10256'
-      user: polkitd
-    version:
-      - type: docker
-        number: '12'
-      - type: file
-        number: '12'
-      - type: active
-        number: '12.5'
-
-software_list:
-  - cmd_regexp: 'postgres:'
-    name: PostgreSQL Database
-    pkg_regexp: postgresql.*-server|postgresql-\d
-    custom_tasks:
-      - include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/postgresql.yaml"
-        name: Include postgres specific plugins
-    process_type: child
-    return_children: true
-    return_packages: true
-    vars:
-      ignore_databases:
-        - postgres
-        - template0
-        - template1
-      connect_with_users: "{{ postgresql_monitor_users_info 
-        | default([{'username': postgresql_monitor_user | default('postgres'), 
-        'password': postgresql_monitor_pass | default('postgres')}]) }}"
-      sql_connection_extra_params: '-h 127.0.0.1'
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
-        ExposedPorts:
-          3003/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.8.2-d9b0d2f
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: { }
-        WorkingDir: /usr/src/app
-      Created: '2022-05-26T07:49:05.896112055Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86-init/diff:/var/lib/docker/overlay2/395a0a098af3a906d0b43de3a008385a50d078a5c9c9be9ad290d1ba93fc9d54/diff:/var/lib/docker/overlay2/ef530f145d37479125854996544e943962d75b907389895e832a53f5bf1be0b4/diff:/var/lib/docker/overlay2/aacd9f48b7c7d9206a74c249bc83b6afec331f8973755cc84b91520222113c6a/diff:/var/lib/docker/overlay2/a653e007a808f014a3cdf2a62cf8867245a62cc468322211674f6eb7075edc2d/diff:/var/lib/docker/overlay2/1df1b451d3b0c7cd3356a603610b5f2b30b61bfe47d8b9c3311abac0715bc2c9/diff:/var/lib/docker/overlay2/41f757a985196fb2658fe9b64ee03906a9ef3273caa4cf533f46815ca685387e/diff:/var/lib/docker/overlay2/9d09467ed70aad7f2334135a687a8531961e6224b24d4162233f2e7385da8cac/diff:/var/lib/docker/overlay2/5fb73472da8826e8cd0d3142ce1eb014d2a8168164a20b0c39bee7718165927e/diff:/var/lib/docker/overlay2/e95c88109a4dfa0d00c885520d4c0e9891bd674f28a2074d4ab71bc6aea3ccbf/diff:/var/lib/docker/overlay2/00e551e532ee647bfbfd6d50ed3c40c11afaad3cb2e4c30509423cc14066f9de/diff:/var/lib/docker/overlay2/dffc514cc11477c207690cc5bc501f8c70136a8783ce74836ccbb5db910b3bcb/diff:/var/lib/docker/overlay2/4f6545d825e9673d1a62dbcf4449ed28ce76b02513b8094f2b3f60a0b806160e/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/91e998a50ec9ccefd6f7fed45e5d1a2cf073a967d2f066f43554be0fff8abb86/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/hosts
-      Id: 6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775
-      Image: 'sha256:8e094d91d6749ce8d3ce1b45436a5b500647b9c0e52a7ee00e97f7a21f4cc878'
-      LogPath: >-
-        /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: f6cf94112a5fe8c1be26b086499ae97180987e487b317299594f8c58b9435ae2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: a6c1d1d1c4a924d01c263853345912f759d51fdfff59de9a26988318585a01ca
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-05-26T07:49:09.083806407Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 24640
-        Restarting: false
-        Running: true
-        StartedAt: '2022-05-26T07:49:11.400392642Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /var/lib/grafana: { }
-          /var/log/grafana: { }
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=the_password
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: { }
-          /var/lib/postgresql/data: { }
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/nginx: { }
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: { }
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ''
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: c42d8151ce0001c84aadac96da9f71d50557f48a620639abf1fd192a4f85d1d8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 1
-        FinishedAt: '2022-05-30T09:02:31.005737147Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 0
-        Restarting: false
-        Running: false
-        StartedAt: '2022-05-30T09:02:29.925376525Z'
-        Status: exited
+  Run which:
+    execute_module_result:
+      failed: false
+      files:
+      - isdir: false
+        path: /proc/10435/root/usr/lib/postgresql/12/bin/postgres
+        xgrp: true
+        xoth: true
+        xusr: true
+      matched: 1
+    expected_args:
+      hidden: false
+      in_docker: true
+      name: postgres
+      paths:
+      - /usr/local/sbin
+      - /usr/local/bin
+      - /usr/sbin
+      - /usr/bin
+      - /sbin
+      - /bin
+      - /usr/lib/postgresql/12/bin
+      windows_valid_extensions: null
+    number_of_calls: 1
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.3.1p1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 3.el7
-      source: rpm
-      version: '1.217'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 22.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '40'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '100'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '261'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '313'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '377'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '393'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '477'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '543'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '566'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '719'
-    ppid: '1'
-    user: dbus
-  - cmdline: ''
-    pid: '721'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '728'
-    ppid: '1'
-    user: chrony
-  - cmdline: /sbin/rpcbind -w
-    pid: '730'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '734'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '738'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '750'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H grafana01 eth0
-    pid: '978'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1038'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '1041'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1044'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '1054'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '1055'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '1056'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '1057'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '1058'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '1059'
-    ppid: '1054'
-    user: zabbix
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1143'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1148'
-    ppid: '1143'
-    user: postfix
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1182'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1184'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1187'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1198'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1199'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1208'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '3894'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5906'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7040'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10256'
-    ppid: '1044'
-    user: root
-  - cmdline: 'postgres: grafana grafana 127.0.0.1(33778) idle'
-    pid: '10411'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: grafana grafana 127.0.0.1(33782) idle'
-    pid: '10413'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: postgres
-    pid: '10435'
-    ppid: '10256'
-    user: polkitd
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10463'
-    ppid: '1044'
-    user: root
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '10501'
-    ppid: '10463'
-    user: root
-  - cmdline: 'nginx: worker process'
-    pid: '10612'
-    ppid: '10501'
-    user: '101'
-  - cmdline: /usr/bin/docker start -a nginx
-    pid: '10630'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a postgres-grafana
-    pid: '10633'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: checkpointer'
-    pid: '10848'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: background writer'
-    pid: '10849'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: walwriter'
-    pid: '10850'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: autovacuum launcher'
-    pid: '10851'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: stats collector'
-    pid: '10852'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: 'postgres: logical replication launcher'
-    pid: '10853'
-    ppid: '10435'
-    user: polkitd
-  - cmdline: /usr/bin/docker start -a grafana
-    pid: '10854'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '10860'
-    ppid: '1044'
-    user: root
-  - cmdline: >-
-      grafana-server --homepath=/usr/share/grafana
-      --config=/etc/grafana/grafana.ini --packaging=docker
-      cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
-      cfg:default.paths.logs=/var/log/grafana
-      cfg:default.paths.plugins=/usr/share/grafana/plugins
-      cfg:default.paths.provisioning=/etc/grafana/provisioning
-    pid: '10876'
-    ppid: '10860'
-    user: grafana
-  - cmdline: pickup -l -t unix -u
-    pid: '13449'
-    ppid: '1143'
-    user: postfix
-  - cmdline: ''
-    pid: '17035'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19060'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-visualizer-api
-    pid: '24573'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '24624'
-    ppid: '1044'
-    user: root
-  - cmdline: python ./main.py
-    pid: '24640'
-    ppid: '24624'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '25180'
-    ppid: '1187'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '25197'
-    ppid: '25180'
-    user: centos
-  - cmdline: ''
-    pid: '26468'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1653901311
-    pid: '27554'
-    ppid: '1041'
-    user: root
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-nsymwfibcumcmiqajimcfydylvjwyfou ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1653901328.804746-21656-13272864877402/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '28162'
-    ppid: '25197'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-nsymwfibcumcmiqajimcfydylvjwyfou ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1653901328.804746-21656-13272864877402/AnsiballZ_process_facts.py
-    pid: '28177'
-    ppid: '28162'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-nsymwfibcumcmiqajimcfydylvjwyfou ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1653901328.804746-21656-13272864877402/AnsiballZ_process_facts.py
-    pid: '28178'
-    ppid: '28177'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1653901328.804746-21656-13272864877402/AnsiballZ_process_facts.py
-    pid: '28179'
-    ppid: '28178'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '32177'
-    ppid: '1187'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '32185'
-    ppid: '32177'
-    user: centos
-  - cmdline: '-bash'
-    pid: '32195'
-    ppid: '32185'
-    user: centos
-  - cmdline: sudo su -
-    pid: '32306'
-    ppid: '32195'
-    user: root
-  - cmdline: su -
-    pid: '32307'
-    ppid: '32306'
-    user: root
-  - cmdline: '-bash'
-    pid: '32308'
-    ppid: '32307'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1143
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: python
-    pid: 24640
-    port: 3004
-    protocol: tcp
-    stime: 'Thu May 26 07:49:10 2022'
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 1054
-    port: 10050
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:27 2022'
-    user: zabbix
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:33 2022'
-    user: root
-  - address: 0.0.0.0
-    name: postgres
-    pid: 10435
-    port: 5432
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:50 2022'
-    user: polkitd
-  - address: '::1'
-    name: master
-    pid: 1143
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:33 2022'
-    user: root
-  - address: '::'
-    name: grafana-serve
-    pid: 10876
-    port: 3000
-    protocol: tcp
-    stime: 'Tue Apr 26 15:57:06 2022'
-    user: grafana
-  - address: '::'
-    name: postgres
-    pid: 10435
-    port: 5432
-    protocol: tcp
-    stime: 'Tue Apr 26 15:56:50 2022'
-    user: polkitd
-udp_listen:
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.3.1p1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 3.el7
+    source: rpm
+    version: '1.217'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 22.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '40'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '100'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '261'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '377'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '393'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '477'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '543'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '566'
+  ppid: '2'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '719'
+  ppid: '1'
+  user: dbus
+- cmdline: ''
+  cwd: /
+  pid: '721'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '728'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '730'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '734'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '738'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '750'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H grafana01 eth0
+  cwd: /sbin/
+  pid: '978'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1038'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1041'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1044'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '1054'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1055'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1056'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1057'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1058'
+  ppid: '1054'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1059'
+  ppid: '1054'
+  user: zabbix
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1143'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1148'
+  ppid: '1143'
+  user: postfix
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1182'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1184'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1187'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1198'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1199'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1208'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3894'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5906'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7040'
+  ppid: '2'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10256'
+  ppid: '1044'
+  user: root
+- cmdline: 'postgres: grafana grafana 127.0.0.1(33778) idle'
+  cwd: /
+  pid: '10411'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: grafana grafana 127.0.0.1(33782) idle'
+  cwd: /
+  pid: '10413'
+  ppid: '10435'
+  user: polkitd
+- cmdline: postgres
+  cwd: /
+  pid: '10435'
+  ppid: '10256'
+  user: polkitd
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10463'
+  ppid: '1044'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '10501'
+  ppid: '10463'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '10612'
+  ppid: '10501'
+  user: '101'
+- cmdline: /usr/bin/docker start -a nginx
+  cwd: /usr/bin/
+  pid: '10630'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a postgres-grafana
+  cwd: /usr/bin/
+  pid: '10633'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '10848'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '10849'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '10850'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '10851'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '10852'
+  ppid: '10435'
+  user: polkitd
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '10853'
+  ppid: '10435'
+  user: polkitd
+- cmdline: /usr/bin/docker start -a grafana
+  cwd: /usr/bin/
+  pid: '10854'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '10860'
+  ppid: '1044'
+  user: root
+- cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini
+    --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
+    cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/usr/share/grafana/plugins
+    cfg:default.paths.provisioning=/etc/grafana/provisioning
+  cwd: /
+  pid: '10876'
+  ppid: '10860'
+  user: grafana
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '13449'
+  ppid: '1143'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '17035'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19060'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-visualizer-api
+  cwd: /usr/bin/
+  pid: '24573'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/6821a35aa3ce2dcf0d94b6e610f3fbcd5e956369add79165a017cc3eb044f775
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '24624'
+  ppid: '1044'
+  user: root
+- cmdline: python ./main.py
+  cwd: /
+  pid: '24640'
+  ppid: '24624'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '25180'
+  ppid: '1187'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '25197'
+  ppid: '25180'
+  user: centos
+- cmdline: ''
+  cwd: /
+  pid: '26468'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1653901311
+  cwd: /usr/lib64/sa/
+  pid: '27554'
+  ppid: '1041'
+  user: root
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-nsymwfibcumcmiqajimcfydylvjwyfou
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1653901328.804746-21656-13272864877402/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '28162'
+  ppid: '25197'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-nsymwfibcumcmiqajimcfydylvjwyfou
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1653901328.804746-21656-13272864877402/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '28177'
+  ppid: '28162'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-nsymwfibcumcmiqajimcfydylvjwyfou ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1653901328.804746-21656-13272864877402/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '28178'
+  ppid: '28177'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1653901328.804746-21656-13272864877402/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '28179'
+  ppid: '28178'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '32177'
+  ppid: '1187'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '32185'
+  ppid: '32177'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '32195'
+  ppid: '32185'
+  user: centos
+- cmdline: sudo su -
+  cwd: /
+  pid: '32306'
+  ppid: '32195'
+  user: root
+- cmdline: su -
+  cwd: /
+  pid: '32307'
+  ppid: '32306'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '32308'
+  ppid: '32307'
+  user: root
+software_list:
+- cmd_regexp: 'postgres:'
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/postgresql.yaml
+    name: Include postgres specific plugins
+  name: PostgreSQL Database
+  pkg_regexp: postgresql.*-server|postgresql-\d
+  process_type: child
+  return_children: true
+  return_packages: true
+  vars:
+    connect_with_users: '{{ postgresql_monitor_users_info | default([{''username'':
+      postgresql_monitor_user | default(''postgres''), ''password'': postgresql_monitor_pass
+      | default(''postgres'')}]) }}'
+    ignore_databases:
+    - postgres
+    - template0
+    - template1
+    sql_connection_extra_params: -h 127.0.0.1
+task_vars:
+  postgresql_monitor_pass: the_password
+  postgresql_monitor_user: the_postgres_user
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1143
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: python
+  pid: 24640
+  port: 3004
+  protocol: tcp
+  stime: Thu May 26 07:49:10 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 1054
+  port: 10050
+  protocol: tcp
+  stime: Tue Apr 26 15:55:27 2022
+  user: zabbix
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:33 2022
+  user: root
+- address: 0.0.0.0
+  name: postgres
+  pid: 10435
+  port: 5432
+  protocol: tcp
+  stime: Tue Apr 26 15:56:50 2022
+  user: polkitd
+- address: ::1
+  name: master
+  pid: 1143
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:33 2022
+  user: root
+- address: '::'
+  name: grafana-serve
+  pid: 10876
+  port: 3000
+  protocol: tcp
+  stime: Tue Apr 26 15:57:06 2022
+  user: grafana
+- address: '::'
+  name: postgres
+  pid: 10435
+  port: 5432
+  protocol: tcp
+  stime: Tue Apr 26 15:56:50 2022
+  user: polkitd
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/postgres/wserver2012R2St_postgres14.2.yaml
+++ b/tests/unit/plugins/action/auto/resources/postgres/wserver2012R2St_postgres14.2.yaml
@@ -1,2656 +1,2906 @@
+dockers: {}
+task_vars:
+  ansible_facts:
+    os_family: windows
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 5432
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 5432
+    protocol: tcp
+  configuration:
+    datestyle: iso, mdy
+    default_text_search_config: pg_catalog.english
+    dynamic_shared_memory_type: windows
+    lc_messages: English_United States.1252
+    lc_monetary: English_United States.1252
+    lc_numeric: English_United States.1252
+    lc_time: English_United States.1252
+    listen_addresses: '*'
+    log_destination: stderr
+    log_file_mode: '0640'
+    log_timezone: UTC
+    logging_collector: 'on'
+    max_connections: '100'
+    max_wal_size: 1GB
+    min_wal_size: 80MB
+    port: '5432'
+    shared_buffers: 128MB
+    timezone: UTC
+  discovery_time: '2023-01-13T12:27:22+02:00'
+  extra_data:
+    active_databases: []
+    databases: []
+  files:
+  - path: 'C:\Program Files\PostgreSQL\14\bin\postgres.exe'
+    subtype: generic
+    type: binary
+  - name: postgresql.conf
+    path: 'C:\Program Files\PostgreSQL\14\data'
+    subtype: generic
+    type: conf
+  - path: 'C:\Program Files\PostgreSQL\14\data'
+    subtype: generic
+    type: data
+  listening_ports:
+  - 5432
+  packages: []
+  process:
+    children:
+    - children: []
+      cmdline: 'C:\windows\system32\conhost.exe 0x4'
+      cwd: 'C:\windows\system32\'
+      pid: '1640'
+      ppid: '1628'
+      user: NT AUTHORITY\NETWORK SERVICE
+    - children: []
+      cmdline: 'C:/Program Files/PostgreSQL/14/bin/postgres.exe --forklog 5308 5312 0'
+      cwd: 'C:/Program Files/PostgreSQL/14/bin/'
+      pid: '1908'
+      ppid: '1628'
+      user: NT AUTHORITY\NETWORK SERVICE
+    - children: []
+      cmdline: 'C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkboot 5212 -x5'
+      cwd: 'C:/Program Files/PostgreSQL/14/bin/'
+      pid: '1028'
+      ppid: '1628'
+      user: NT AUTHORITY\NETWORK SERVICE
+    - children: []
+      cmdline: 'C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkboot 5224 -x3'
+      cwd: 'C:/Program Files/PostgreSQL/14/bin/'
+      pid: '72'
+      ppid: '1628'
+      user: NT AUTHORITY\NETWORK SERVICE
+    - children: []
+      cmdline: 'C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkboot 5204 -x6'
+      cwd: 'C:/Program Files/PostgreSQL/14/bin/'
+      pid: '224'
+      ppid: '1628'
+      user: NT AUTHORITY\NETWORK SERVICE
+    - children: []
+      cmdline: 'C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkavlauncher 5196'
+      cwd: 'C:/Program Files/PostgreSQL/14/bin/'
+      pid: '1312'
+      ppid: '1628'
+      user: NT AUTHORITY\NETWORK SERVICE
+    - children: []
+      cmdline: 'C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkcol 5188'
+      cwd: 'C:/Program Files/PostgreSQL/14/bin/'
+      pid: '1336'
+      ppid: '1628'
+      user: NT AUTHORITY\NETWORK SERVICE
+    - children: []
+      cmdline: 'C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkbgworker=0 5180'
+      cwd: 'C:/Program Files/PostgreSQL/14/bin/'
+      pid: '1468'
+      ppid: '1628'
+      user: NT AUTHORITY\NETWORK SERVICE
+    cmdline: 'C:\Program Files\PostgreSQL\14\bin\postgres.exe -D C:\Program Files\PostgreSQL\14\data'
+    cwd: 'C:\Program Files\PostgreSQL\14\bin\'
+    listening_ports:
+    - 5432
+    pid: '1628'
+    ppid: '1432'
+    user: NT AUTHORITY\NETWORK SERVICE
+  type: PostgreSQL Database
+  version:
+  - number: '14'
+    type: file
+  - number: '14.2'
+    type: active
 mocked_plugin_tasks:
-  Read process environment:
+  Add users from pg_hba, pg process and 'postgres':
     calls:
-      - expected_args:
-          pid: "1628"
-        execute_module_result:
-          failed: true
+    - expected_args:
+        _connect_with_users:
+        - password: password
+          username: postgres
+        - username: NT AUTHORITY\NETWORK SERVICE
   Attempt to extract conf path:
     expected_module_result:
       failed: false
   Extract port:
     expected_exception:
-      message: "'NoneType' object is not iterable"
-  Read configuration file as dict:
+      message: '''NoneType'' object is not iterable'
+  Get from child processes cmdline:
     calls:
-      - expected_args:
-          delegate_reading: false
-          file_path: C:\Program Files\PostgreSQL\14\data/postgresql.conf
-          in_docker: true
-          parser: key_value
-          parser_params:
-            separators: [ "=", " " ]
-        expected_attributes:
-          register: result
-        plugin_result:
-          failed: false
-          parsed:
-            datestyle: iso, mdy
-            default_text_search_config: pg_catalog.english
-            dynamic_shared_memory_type: windows
-            lc_messages: English_United States.1252
-            lc_monetary: English_United States.1252
-            lc_numeric: English_United States.1252
-            lc_time: English_United States.1252
-            listen_addresses: '*'
-            log_destination: stderr
-            log_file_mode: '0640'
-            log_timezone: UTC
-            logging_collector: 'on'
-            max_connections: '100'
-            max_wal_size: 1GB
-            min_wal_size: 80MB
-            port: '5432'
-            shared_buffers: 128MB
-            timezone: UTC
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
+  Get user if available:
+    calls:
+    - expected_exception:
+        message: '''NoneType'' object is not iterable'
   Read VERSION file from path:
-    number_of_calls: 1
     expected_args:
       delegate_reading: false
       file_path: C:\Program Files\PostgreSQL\14\data/PG_VERSION
       in_docker: true
       parser: null
       parser_params: null
+    number_of_calls: 1
     plugin_result:
+      content: '14'
       failed: false
-      content: "14"
-  Run command version:
-    number_of_calls: 1
-    expected_args:
-      argv:
-        - C:\Program Files\PostgreSQL\14\bin\postgres.exe
-        - --version
-      cmd: null
-      in_docker: true
-    execute_module_result:
-      failed: false
-      stdout: postgres (PostgreSQL) 14.2
-  Get from child processes cmdline:
+  Read configuration file as dict:
     calls:
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
+    - expected_args:
+        delegate_reading: false
+        file_path: C:\Program Files\PostgreSQL\14\data/postgresql.conf
+        in_docker: true
+        parser: key_value
+        parser_params:
+          separators:
+          - '='
+          - ' '
+      expected_attributes:
+        register: result
+      plugin_result:
+        failed: false
+        parsed:
+          datestyle: iso, mdy
+          default_text_search_config: pg_catalog.english
+          dynamic_shared_memory_type: windows
+          lc_messages: English_United States.1252
+          lc_monetary: English_United States.1252
+          lc_numeric: English_United States.1252
+          lc_time: English_United States.1252
+          listen_addresses: '*'
+          log_destination: stderr
+          log_file_mode: '0640'
+          log_timezone: UTC
+          logging_collector: 'on'
+          max_connections: '100'
+          max_wal_size: 1GB
+          min_wal_size: 80MB
+          port: '5432'
+          shared_buffers: 128MB
+          timezone: UTC
   Read pg_hba file from path:
-    number_of_calls: 1
+    execute_module_result:
+      content: '# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+        # \"local\" is for Unix domain socket connections only
+
+        local   all             all                                     scram-sha-256
+
+        # IPv4 local connections:
+
+        host    all             all             127.0.0.1/32            scram-sha-256
+
+        # IPv6 local connections:
+
+        host    all             all             ::1/128                 scram-sha-256
+
+        # Allow replication connections from localhost, by a user with the
+
+        # replication privilege.
+
+        local   replication     all                                     scram-sha-256
+
+        host    replication     all             127.0.0.1/32            scram-sha-256
+
+        host    replication     all             ::1/128                 scram-sha-256'
+      encoding: plain
+      failed: false
     expected_args:
       delegate_reading: false
       file_path: C:\Program Files\PostgreSQL\14\data/pg_hba.conf
       in_docker: true
       parser: null
       parser_params: null
-    execute_module_result:
-      failed: false
-      encoding: plain
-      content: |-
-        # TYPE  DATABASE        USER            ADDRESS                 METHOD
-        # \"local\" is for Unix domain socket connections only
-        local   all             all                                     scram-sha-256
-        # IPv4 local connections:
-        host    all             all             127.0.0.1/32            scram-sha-256
-        # IPv6 local connections:
-        host    all             all             ::1/128                 scram-sha-256
-        # Allow replication connections from localhost, by a user with the
-        # replication privilege.
-        local   replication     all                                     scram-sha-256
-        host    replication     all             127.0.0.1/32            scram-sha-256
-        host    replication     all             ::1/128                 scram-sha-256
-  Get user if available:
+    number_of_calls: 1
+  Read process environment:
     calls:
-      - expected_exception:
-          message: "'NoneType' object is not iterable"
-  Add users from pg_hba, pg process and 'postgres':
-    calls:
-      - expected_args:
-          _connect_with_users:
-            - username: postgres
-              password: password
-            - username: NT AUTHORITY\NETWORK SERVICE
+    - execute_module_result:
+        failed: true
+      expected_args:
+        pid: '1628'
   Run command to get databases:
     calls:
-      - expected_args:
-          argv: null
-          cmd: >-
-            psql -U postgres -d postgres -w -t -A -c 'select datname from pg_database;' -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            su - postgres -c 'psql -d postgres -w -t -A -c "select datname from pg_database;" -p 5432 -h 127.0.0.1'
-          in_docker: true
-        plugin_result:
-          failed: true
-      - expected_args:
-          argv: null
-          cmd: >-
-            "C:\Program Files\PostgreSQL\14\bin\psql.exe" -U postgres -d  postgres -w -t -A -c
-            "select datname from pg_database;" -p 5432 -h 127.0.0.1
-          in_docker: true
-        plugin_result:
-          failed: false
-          stdout_lines:
-            - postgres
-            - template1
-            - template0
-
-
-expected_result:
-  - bindings:
-      - address: '::'
-        class: service
-        port: 5432
-        protocol: tcp
-      - address: 0.0.0.0
-        class: service
-        port: 5432
-        protocol: tcp
-    configuration:
-      datestyle: iso, mdy
-      default_text_search_config: pg_catalog.english
-      dynamic_shared_memory_type: windows
-      lc_messages: English_United States.1252
-      lc_monetary: English_United States.1252
-      lc_numeric: English_United States.1252
-      lc_time: English_United States.1252
-      listen_addresses: '*'
-      log_destination: stderr
-      log_file_mode: '0640'
-      log_timezone: UTC
-      logging_collector: 'on'
-      max_connections: '100'
-      max_wal_size: 1GB
-      min_wal_size: 80MB
-      port: '5432'
-      shared_buffers: 128MB
-      timezone: UTC
-    discovery_time: '2023-01-13T12:27:22+02:00'
-    extra_data:
-      active_databases: [ ]
-      databases: [ ]
-    files:
-      - path: C:\Program Files\PostgreSQL\14\bin\postgres.exe
-        subtype: generic
-        type: binary
-      - name: postgresql.conf
-        path: C:\Program Files\PostgreSQL\14\data
-        subtype: generic
-        type: conf
-      - path: C:\Program Files\PostgreSQL\14\data
-        subtype: generic
-        type: data
-    listening_ports:
-      - 5432
-    packages: [ ]
-    process:
-      children:
-        - children: [ ]
-          cmdline: \??\C:\windows\system32\conhost.exe 0x4
-          pid: '1640'
-          ppid: '1628'
-          user: NT AUTHORITY\NETWORK SERVICE
-        - children: [ ]
-          cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forklog" "5308" "5312" "0"'
-          pid: '1908'
-          ppid: '1628'
-          user: NT AUTHORITY\NETWORK SERVICE
-        - children: [ ]
-          cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5212" "-x5"'
-          pid: '1028'
-          ppid: '1628'
-          user: NT AUTHORITY\NETWORK SERVICE
-        - children: [ ]
-          cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5224" "-x3"'
-          pid: '72'
-          ppid: '1628'
-          user: NT AUTHORITY\NETWORK SERVICE
-        - children: [ ]
-          cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5204" "-x6"'
-          pid: '224'
-          ppid: '1628'
-          user: NT AUTHORITY\NETWORK SERVICE
-        - children: [ ]
-          cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkavlauncher" "5196"'
-          pid: '1312'
-          ppid: '1628'
-          user: NT AUTHORITY\NETWORK SERVICE
-        - children: [ ]
-          cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkcol" "5188"'
-          pid: '1336'
-          ppid: '1628'
-          user: NT AUTHORITY\NETWORK SERVICE
-        - children: [ ]
-          cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkbgworker=0" "5180"'
-          pid: '1468'
-          ppid: '1628'
-          user: NT AUTHORITY\NETWORK SERVICE
-      cmdline: '"C:\Program Files\PostgreSQL\14\bin\postgres.exe" -D "C:\Program Files\PostgreSQL\14\data" '
-      listening_ports:
-        - 5432
-      pid: '1628'
-      ppid: '1432'
-      user: NT AUTHORITY\NETWORK SERVICE
-    type: PostgreSQL Database
-    version:
-      - number: '14'
-        type: file
-      - number: '14.2'
-        type: active
+    - expected_args:
+        argv: null
+        cmd: psql -U postgres -d postgres -w -t -A -c 'select datname from pg_database;'
+          -p 5432 -h 127.0.0.1
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: su - postgres -c 'psql -d postgres -w -t -A -c "select datname from pg_database;"
+          -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: true
+    - expected_args:
+        argv: null
+        cmd: '"C:\Program Files\PostgreSQL\14\bin\psql.exe" -U postgres -d  postgres
+          -w -t -A -c "select datname from pg_database;" -p 5432 -h 127.0.0.1'
+        in_docker: true
+      plugin_result:
+        failed: false
+        stdout_lines:
+        - postgres
+        - template1
+        - template0
+  Run command version:
+    execute_module_result:
+      failed: false
+      stdout: postgres (PostgreSQL) 14.2
+    expected_args:
+      argv:
+      - C:\Program Files\PostgreSQL\14\bin\postgres.exe
+      - --version
+      cmd: null
+      in_docker: true
+    number_of_calls: 1
 packages:
   Azure Data Studio:
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 543259
-      help_link: https://github.com/Microsoft/azuredatastudio
-      help_telephone: null
-      install_date: '20220530'
-      install_location: C:\Program Files\Azure Data Studio\
-      install_source: null
-      language: null
-      modify_path: null
-      name: Azure Data Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\Azure Data Studio\unins000.exe"'
-      url_info_about: https://github.com/Microsoft/azuredatastudio
-      url_update_info: https://github.com/Microsoft/azuredatastudio
-      vendor: null
-      version: 1.35.0
-      version_major: 1
-      version_minor: 35
-      windows_installer: null
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 543259
+    help_link: https://github.com/Microsoft/azuredatastudio
+    help_telephone: null
+    install_date: '20220530'
+    install_location: C:\Program Files\Azure Data Studio\
+    install_source: null
+    language: null
+    modify_path: null
+    name: Azure Data Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\Azure Data Studio\unins000.exe"'
+    url_info_about: https://github.com/Microsoft/azuredatastudio
+    url_update_info: https://github.com/Microsoft/azuredatastudio
+    vendor: null
+    version: 1.35.0
+    version_major: 1
+    version_minor: 35
+    windows_installer: null
   Browser for SQL Server 2017:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11312
-      help_link: https://go.microsoft.com/fwlink/?LinkId=90959
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
-      name: Browser for SQL Server 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11312
+    help_link: https://go.microsoft.com/fwlink/?LinkId=90959
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
+    name: Browser for SQL Server 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   Cloudbase-Init 0.9.11:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 121670
-      help_link: ''
-      help_telephone: ''
-      install_date: '20170320'
-      install_location: ''
-      install_source: C:\UnattendResources\
-      language: 1033
-      modify_path: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
-      name: Cloudbase-Init 0.9.11
-      no_repair: null
-      publisher: Cloudbase Solutions Srl
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 0.9.11.0
-      version_major: 0
-      version_minor: 9
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 121670
+    help_link: ''
+    help_telephone: ''
+    install_date: '20170320'
+    install_location: ''
+    install_source: C:\UnattendResources\
+    language: 1033
+    modify_path: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
+    name: Cloudbase-Init 0.9.11
+    no_repair: null
+    publisher: Cloudbase Solutions Srl
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 0.9.11.0
+    version_major: 0
+    version_minor: 9
+    windows_installer: 1
   Integration Services:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 91264
-      help_link: https://support.microsoft.com
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{4938A647-7EA4-4496-A843-5E338B91C07E}v15.0.2000.168\x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
-      name: Integration Services
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.168
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 91264
+    help_link: https://support.microsoft.com
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{4938A647-7EA4-4496-A843-5E338B91C07E}v15.0.2000.168\x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
+    name: Integration Services
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.168
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
   Microsoft Analysis Services OLE DB Provider:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 243952
-      help_link: https://go.microsoft.com/fwlink/?LinkId=52159
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}v15.0.2000.832\x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
-      name: Microsoft Analysis Services OLE DB Provider
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.832
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 499504
-      help_link: https://go.microsoft.com/fwlink/?LinkId=52159
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}v15.0.2000.832\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
-      name: Microsoft Analysis Services OLE DB Provider
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.832
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 243952
+    help_link: https://go.microsoft.com/fwlink/?LinkId=52159
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}v15.0.2000.832\x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
+    name: Microsoft Analysis Services OLE DB Provider
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.832
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 499504
+    help_link: https://go.microsoft.com/fwlink/?LinkId=52159
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}v15.0.2000.832\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
+    name: Microsoft Analysis Services OLE DB Provider
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.832
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
   Microsoft Help Viewer 2.3:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 12438
-      help_link: https://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: null
-      install_date: null
-      install_location: C:\Program Files (x86)\Microsoft Help Viewer\v2.3\
-      install_source: null
-      language: null
-      modify_path: msiexec.exe /I{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      name: Microsoft Help Viewer 2.3
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: msiexec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      url_info_about: null
-      url_update_info: https://go.microsoft.com/fwlink/?LinkId=133408
-      vendor: null
-      version: 2.3.28307
-      version_major: '2'
-      version_minor: '0'
-      windows_installer: null
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 13260
-      help_link: https://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}v2.3.28307\redist\
-      language: 1033
-      modify_path: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      name: Microsoft Help Viewer 2.3
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 2.3.28307
-      version_major: 2
-      version_minor: 3
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 12438
+    help_link: https://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: null
+    install_date: null
+    install_location: C:\Program Files (x86)\Microsoft Help Viewer\v2.3\
+    install_source: null
+    language: null
+    modify_path: msiexec.exe /I{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    name: Microsoft Help Viewer 2.3
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: msiexec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    url_info_about: null
+    url_update_info: https://go.microsoft.com/fwlink/?LinkId=133408
+    vendor: null
+    version: 2.3.28307
+    version_major: '2'
+    version_minor: '0'
+    windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 13260
+    help_link: https://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}v2.3.28307\redist\
+    language: 1033
+    modify_path: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    name: Microsoft Help Viewer 2.3
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 2.3.28307
+    version_major: 2
+    version_minor: 3
+    windows_installer: 1
   Microsoft ODBC Driver 13 for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 5124
-      help_link: https://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
-      name: Microsoft ODBC Driver 13 for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 5124
+    help_link: https://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
+    name: Microsoft ODBC Driver 13 for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   Microsoft ODBC Driver 17 for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 7184
-      help_link: https://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{853997DA-6FCB-4FB9-918E-E0FF881FAF65}v17.7.2.1\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
-      name: Microsoft ODBC Driver 17 for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 17.7.2.1
-      version_major: 17
-      version_minor: 7
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 7184
+    help_link: https://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{853997DA-6FCB-4FB9-918E-E0FF881FAF65}v17.7.2.1\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
+    name: Microsoft ODBC Driver 17 for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 17.7.2.1
+    version_major: 17
+    version_minor: 7
+    windows_installer: 1
   Microsoft OLE DB Driver for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8480
-      help_link: https://go.microsoft.com/fwlink/?linkid=870127
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{9D6F8754-28E9-4940-B319-3FC8588CF18F}v18.5.0.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
-      name: Microsoft OLE DB Driver for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 18.5.0.0
-      version_major: 18
-      version_minor: 5
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8480
+    help_link: https://go.microsoft.com/fwlink/?linkid=870127
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{9D6F8754-28E9-4940-B319-3FC8588CF18F}v18.5.0.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
+    name: Microsoft OLE DB Driver for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 18.5.0.0
+    version_major: 18
+    version_minor: 5
+    windows_installer: 1
   'Microsoft SQL Server 2012 Native Client ':
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8160
-      help_link: http://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{9D93D367-A2CC-4378-BD63-79EF3FE76C78}v11.4.7462.6\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
-      name: 'Microsoft SQL Server 2012 Native Client '
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 11.4.7462.6
-      version_major: 11
-      version_minor: 4
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8160
+    help_link: http://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{9D93D367-A2CC-4378-BD63-79EF3FE76C78}v11.4.7462.6\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
+    name: 'Microsoft SQL Server 2012 Native Client '
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 11.4.7462.6
+    version_major: 11
+    version_minor: 4
+    windows_installer: 1
   Microsoft SQL Server 2017 (64-bit):
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: null
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server 2017 (64-bit)
-      no_repair: null
-      publisher: null
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: 1
-      uninstall_string: null
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: null
-      version_major: null
-      version_minor: null
-      windows_installer: null
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: null
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server 2017 (64-bit)
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\Microsoft SQL Server\140\Setup Bootstrap\SQL2017\x64\SetupARP.exe"'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: null
-      version_major: null
-      version_minor: null
-      windows_installer: null
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: null
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server 2017 (64-bit)
+    no_repair: null
+    publisher: null
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: 1
+    uninstall_string: null
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: null
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: null
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server 2017 (64-bit)
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\Microsoft SQL Server\140\Setup Bootstrap\SQL2017\x64\SetupARP.exe"'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: null
+    version_major: null
+    version_minor: null
+    windows_installer: null
   Microsoft SQL Server 2017 RsFx Driver:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 344
-      help_link: https://go.microsoft.com/fwlink/?LinkId=101173
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
-      name: Microsoft SQL Server 2017 RsFx Driver
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 344
+    help_link: https://go.microsoft.com/fwlink/?LinkId=101173
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
+    name: Microsoft SQL Server 2017 RsFx Driver
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   Microsoft SQL Server 2017 Setup (English):
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 39588
-      help_link: https://go.microsoft.com/fwlink/?LinkId=101173
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
-      name: Microsoft SQL Server 2017 Setup (English)
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 39588
+    help_link: https://go.microsoft.com/fwlink/?LinkId=101173
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
+    name: Microsoft SQL Server 2017 Setup (English)
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   'Microsoft SQL Server 2017 T-SQL Language Service ':
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8116
-      help_link: https://go.microsoft.com/fwlink/?LinkID=150605
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
-      name: 'Microsoft SQL Server 2017 T-SQL Language Service '
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8116
+    help_link: https://go.microsoft.com/fwlink/?LinkID=150605
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
+    name: 'Microsoft SQL Server 2017 T-SQL Language Service '
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   Microsoft SQL Server Management Studio - 18.11.1:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 2881605
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server Management Studio - 18.11.1
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{88f77b67-7f88-4b59-b93b-c9f2546b649c}\SSMS-Setup-ENU.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 15.0.18410.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 2881605
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server Management Studio - 18.11.1
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{88f77b67-7f88-4b59-b93b-c9f2546b649c}\SSMS-Setup-ENU.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 15.0.18410.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
   Microsoft VSS Writer for SQL Server 2017:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 3256
-      help_link: https://go.microsoft.com/fwlink/?LinkId=90958
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
-      name: Microsoft VSS Writer for SQL Server 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 3256
+    help_link: https://go.microsoft.com/fwlink/?LinkId=90958
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
+    name: Microsoft VSS Writer for SQL Server 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 21062
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe" /modify'
-      name: Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 12.0.40664.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 21062
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"
+      /modify'
+    name: Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 12.0.40664.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
   Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 17602
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe" /modify'
-      name: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 12.0.40664.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 17602
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"
+      /modify'
+    name: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 12.0.40664.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
   Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 11784
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{010792BA-551A-3AC0-A7EF-0FAB4156C382}v12.0.40664\packages\vcRuntimeAdditional_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
-      name: Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 11784
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{010792BA-551A-3AC0-A7EF-0FAB4156C382}v12.0.40664\packages\vcRuntimeAdditional_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
+    name: Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
   Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 2524
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{53CF6934-A98D-3D84-9146-FC4EDF3D5641}v12.0.40664\packages\vcRuntimeMinimum_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
-      name: Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 2524
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{53CF6934-A98D-3D84-9146-FC4EDF3D5641}v12.0.40664\packages\vcRuntimeMinimum_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
+    name: Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
   Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 9456
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{D401961D-3A20-3AC7-943B-6139D5BD490A}v12.0.40664\packages\vcRuntimeAdditional_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
-      name: Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 9456
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{D401961D-3A20-3AC7-943B-6139D5BD490A}v12.0.40664\packages\vcRuntimeAdditional_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
+    name: Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
   Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 2076
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{8122DAB1-ED4D-3676-BB0A-CA368196543E}v12.0.40664\packages\vcRuntimeMinimum_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
-      name: Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 2076
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{8122DAB1-ED4D-3676-BB0A-CA368196543E}v12.0.40664\packages\vcRuntimeMinimum_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
+    name: Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
   Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 22598
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe" /modify'
-      name: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.30.30704.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 22598
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"
+      /modify'
+    name: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.30.30704.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
   Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 19969
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe" /modify'
-      name: Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.30.30704.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 19969
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"
+      /modify'
+    name: Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.30.30704.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
   Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11724
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}v14.30.30704\packages\vcRuntimeAdditional_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
-      name: Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11724
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}v14.30.30704\packages\vcRuntimeAdditional_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
+    name: Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
   Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 2168
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{662A0088-6FCD-45DD-9EA7-68674058AED5}v14.30.30704\packages\vcRuntimeMinimum_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
-      name: Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 2168
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{662A0088-6FCD-45DD-9EA7-68674058AED5}v14.30.30704\packages\vcRuntimeMinimum_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
+    name: Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
   Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 10164
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{BF08E976-B92E-4336-B56F-2171179476C4}v14.30.30704\packages\vcRuntimeAdditional_x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
-      name: Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 10164
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{BF08E976-B92E-4336-B56F-2171179476C4}v14.30.30704\packages\vcRuntimeAdditional_x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
+    name: Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
   Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 1744
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}v14.30.30704\packages\vcRuntimeMinimum_x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
-      name: Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 1744
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}v14.30.30704\packages\vcRuntimeMinimum_x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
+    name: Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
   Microsoft Visual Studio Tools for Applications 2017:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 19606
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe" /modify'
-      name: Microsoft Visual Studio Tools for Applications 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 15.0.26717
-      version_major: null
-      version_minor: null
-      windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 19606
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"
+      /modify'
+    name: Microsoft Visual Studio Tools for Applications 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 15.0.26717
+    version_major: null
+    version_minor: null
+    windows_installer: null
   Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 2844
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{10AB056B-1B8C-3E9E-95CC-43C33EB88513}v15.0.26717\packages\vsta_hostingcore_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
-      name: Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.26717
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 2844
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{10AB056B-1B8C-3E9E-95CC-43C33EB88513}v15.0.26717\packages\vsta_hostingcore_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
+    name: Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.26717
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
   Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 3828
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}v15.0.26717\packages\vsta_hostingcore_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
-      name: Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.26717
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 3828
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}v15.0.26717\packages\vsta_hostingcore_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
+    name: Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.26717
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
   PgBouncer 1.16.1:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: 'PgBouncer: Connection pooler for PostgreSQL, packaged by EnterpriseDB'
-      contact: ''
-      estimated_size: 25101
-      help_link: ''
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files (x86)\PgBouncer
-      install_source: null
-      language: null
-      modify_path: null
-      name: PgBouncer 1.16.1
-      no_repair: '1'
-      publisher: EnterpriseDB
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files (x86)\PgBouncer\uninstall-pgbouncer.exe"'
-      url_info_about: ''
-      url_update_info: null
-      vendor: null
-      version: 1.16.1-1
-      version_major: 1
-      version_minor: 16
-      windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: 'PgBouncer: Connection pooler for PostgreSQL, packaged by EnterpriseDB'
+    contact: ''
+    estimated_size: 25101
+    help_link: ''
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files (x86)\PgBouncer
+    install_source: null
+    language: null
+    modify_path: null
+    name: PgBouncer 1.16.1
+    no_repair: '1'
+    publisher: EnterpriseDB
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files (x86)\PgBouncer\uninstall-pgbouncer.exe"'
+    url_info_about: ''
+    url_update_info: null
+    vendor: null
+    version: 1.16.1-1
+    version_major: 1
+    version_minor: 16
+    windows_installer: null
   'PostgreSQL 14 ':
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: The PostgreSQL RDBMS, version 14, packaged by EnterpriseDB
-      contact: ''
-      estimated_size: 829400
-      help_link: http://www.postgresql.org/docs
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files\PostgreSQL\14
-      install_source: null
-      language: null
-      modify_path: null
-      name: 'PostgreSQL 14 '
-      no_repair: '1'
-      publisher: PostgreSQL Global Development Group
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\PostgreSQL\14\uninstall-postgresql.exe"'
-      url_info_about: http://www.postgresql.org/
-      url_update_info: null
-      vendor: null
-      version: '14'
-      version_major: 14
-      version_minor: 0
-      windows_installer: null
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: The PostgreSQL RDBMS, version 14, packaged by EnterpriseDB
+    contact: ''
+    estimated_size: 829400
+    help_link: http://www.postgresql.org/docs
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files\PostgreSQL\14
+    install_source: null
+    language: null
+    modify_path: null
+    name: 'PostgreSQL 14 '
+    no_repair: '1'
+    publisher: PostgreSQL Global Development Group
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\PostgreSQL\14\uninstall-postgresql.exe"'
+    url_info_about: http://www.postgresql.org/
+    url_update_info: null
+    vendor: null
+    version: '14'
+    version_major: 14
+    version_minor: 0
+    windows_installer: null
   SQL Server 2017 Batch Parser:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 744
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
-      name: SQL Server 2017 Batch Parser
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 744
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
+    name: SQL Server 2017 Batch Parser
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server 2017 Common Files:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 21464
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
-      name: SQL Server 2017 Common Files
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 760
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
-      name: SQL Server 2017 Common Files
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 21464
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
+    name: SQL Server 2017 Common Files
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 760
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
+    name: SQL Server 2017 Common Files
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server 2017 Connection Info:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 264
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
-      name: SQL Server 2017 Connection Info
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 884
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
-      name: SQL Server 2017 Connection Info
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 264
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
+    name: SQL Server 2017 Connection Info
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 884
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
+    name: SQL Server 2017 Connection Info
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server 2017 DMF:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 1376
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
-      name: SQL Server 2017 DMF
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 408
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
-      name: SQL Server 2017 DMF
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 1376
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
+    name: SQL Server 2017 DMF
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 408
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
+    name: SQL Server 2017 DMF
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server 2017 Database Engine Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 72372
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
-      name: SQL Server 2017 Database Engine Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 285556
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
-      name: SQL Server 2017 Database Engine Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 72372
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
+    name: SQL Server 2017 Database Engine Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 285556
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
+    name: SQL Server 2017 Database Engine Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server 2017 Database Engine Shared:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 87436
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
-      name: SQL Server 2017 Database Engine Shared
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11884
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
-      name: SQL Server 2017 Database Engine Shared
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 87436
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
+    name: SQL Server 2017 Database Engine Shared
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11884
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
+    name: SQL Server 2017 Database Engine Shared
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server 2017 SQL Diagnostics:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 516
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
-      name: SQL Server 2017 SQL Diagnostics
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 516
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
+    name: SQL Server 2017 SQL Diagnostics
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server 2017 Shared Management Objects:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 5908
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
-      name: SQL Server 2017 Shared Management Objects
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 12528
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
-      name: SQL Server 2017 Shared Management Objects
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 5908
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
+    name: SQL Server 2017 Shared Management Objects
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 12528
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
+    name: SQL Server 2017 Shared Management Objects
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server 2017 Shared Management Objects Extensions:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 4952
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
-      name: SQL Server 2017 Shared Management Objects Extensions
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 532
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
-      name: SQL Server 2017 Shared Management Objects Extensions
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 4952
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
+    name: SQL Server 2017 Shared Management Objects Extensions
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 532
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
+    name: SQL Server 2017 Shared Management Objects Extensions
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server 2017 XEvent:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 84
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
-      name: SQL Server 2017 XEvent
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 732
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
-      name: SQL Server 2017 XEvent
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 84
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
+    name: SQL Server 2017 XEvent
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 732
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
+    name: SQL Server 2017 XEvent
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
   SQL Server Management Studio:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 4796
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{3A6E604C-766B-46F2-8E2D-4371B4CDF858}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
-      name: SQL Server Management Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 215640
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
-      name: SQL Server Management Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 4796
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{3A6E604C-766B-46F2-8E2D-4371B4CDF858}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
+    name: SQL Server Management Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 215640
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
+    name: SQL Server Management Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
   SQL Server Management Studio for Analysis Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 358312
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
-      name: SQL Server Management Studio for Analysis Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 358312
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
+    name: SQL Server Management Studio for Analysis Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
   SQL Server Management Studio for Reporting Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 26840
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{D91AA5D8-1080-487B-83B6-622061902012}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
-      name: SQL Server Management Studio for Reporting Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 26840
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{D91AA5D8-1080-487B-83B6-622061902012}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
+    name: SQL Server Management Studio for Reporting Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
   SSMS Post Install Tasks:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 296
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{7AEA9B43-10CD-4D33-B116-621B81A45490}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
-      name: SSMS Post Install Tasks
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 296
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{7AEA9B43-10CD-4D33-B116-621B81A45490}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
+    name: SSMS Post Install Tasks
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
   Visual Studio 2017 Isolated Shell for SSMS:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 412588
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{AAA9F15B-AF45-4562-9991-93A848D3A902}v15.0.28307.421\redist\
-      language: 1033
-      modify_path: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
-      name: Visual Studio 2017 Isolated Shell for SSMS
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.28307.421
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 412588
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{AAA9F15B-AF45-4562-9991-93A848D3A902}v15.0.28307.421\redist\
+    language: 1033
+    modify_path: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
+    name: Visual Studio 2017 Isolated Shell for SSMS
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.28307.421
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
   psqlODBC 13.00.0000:
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: ODBC drivers for PostgreSQL, packaged by EnterpriseDB
-      contact: ''
-      estimated_size: 13676
-      help_link: ''
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files\PostgreSQL\psqlODBC
-      install_source: null
-      language: null
-      modify_path: null
-      name: psqlODBC 13.00.0000
-      no_repair: '1'
-      publisher: EnterpriseDB
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\PostgreSQL\psqlODBC\uninstall-psqlodbc.exe"'
-      url_info_about: ''
-      url_update_info: null
-      vendor: null
-      version: 13.00.0000-2
-      version_major: 13
-      version_minor: 0
-      windows_installer: null
-processes:
-  - cmdline: null
-    pid: '0'
-    ppid: '0'
-    user: null
-  - cmdline: null
-    pid: '4'
-    ppid: '0'
-    user: null
-  - cmdline: null
-    pid: '192'
-    ppid: '4'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '280'
-    ppid: '272'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '332'
-    ppid: '324'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: wininit.exe
-    pid: '340'
-    ppid: '272'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: winlogon.exe
-    pid: '368'
-    ppid: '324'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '428'
-    ppid: '340'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\lsass.exe
-    pid: '436'
-    ppid: '340'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\svchost.exe -k DcomLaunch
-    pid: '492'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\svchost.exe -k RPCSS
-    pid: '520'
-    ppid: '428'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"dwm.exe"'
-    pid: '628'
-    ppid: '368'
-    user: Window Manager\DWM-1
-  - cmdline: C:\windows\System32\svchost.exe -k LocalServiceNetworkRestricted
-    pid: '648'
-    ppid: '428'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: C:\windows\system32\svchost.exe -k netsvcs
-    pid: '696'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\svchost.exe -k LocalService
-    pid: '740'
-    ppid: '428'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: C:\windows\system32\svchost.exe -k NetworkService
-    pid: '836'
-    ppid: '428'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: C:\windows\system32\svchost.exe -k LocalServiceNoNetwork
-    pid: '984'
-    ppid: '428'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: C:\windows\System32\spoolsv.exe
-    pid: '516'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\svchost.exe -k apphost
-    pid: '756'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\System32\svchost.exe -k utcsvc
-    pid: '912'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\mqsvc.exe
-    pid: '236'
-    ppid: '428'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe" -sSQLEXPRESS'
-    pid: '1144'
-    ppid: '428'
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - cmdline: C:\windows\Microsoft.NET\Framework64\v4.0.30319\SMSvcHost.exe
-    pid: '1216'
-    ppid: '428'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: '"C:\Program Files (x86)\PgBouncer\bin\pgbouncer.exe" --service "C:\Program Files (x86)\PgBouncer\share\pgbouncer.ini"'
-    pid: '1324'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"C:\Program Files\PostgreSQL\14\bin\pg_ctl.exe" runservice -N "postgresql-x64-14" -D "C:\Program Files\PostgreSQL\14\data" -w'
-    pid: '1432'
-    ppid: '428'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlceip.exe" -Service SQLEXPRESS'
-    pid: '1492'
-    ppid: '428'
-    user: NT SERVICE\SQLTELEMETRY$SQLEXPRESS
-  - cmdline: '"C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe"'
-    pid: '1544'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\System32\svchost.exe -k LocalSystemNetworkRestricted
-    pid: '1560'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\svchost.exe -k iissvcs
-    pid: '1580'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"C:\Program Files\PostgreSQL\14\bin\postgres.exe" -D "C:\Program Files\PostgreSQL\14\data" '
-    pid: '1628'
-    ppid: '1432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: \??\C:\windows\system32\conhost.exe 0x4
-    pid: '1640'
-    ppid: '1628'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:\windows\Microsoft.NET\Framework64\v4.0.30319\SMSvcHost.exe" -NetMsmqActivator'
-    pid: '1816'
-    ppid: '428'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forklog" "5308" "5312" "0"'
-    pid: '1908'
-    ppid: '1628'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5212" "-x5"'
-    pid: '1028'
-    ppid: '1628'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5224" "-x3"'
-    pid: '72'
-    ppid: '1628'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5204" "-x6"'
-    pid: '224'
-    ppid: '1628'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkavlauncher" "5196"'
-    pid: '1312'
-    ppid: '1628'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkcol" "5188"'
-    pid: '1336'
-    ppid: '1628'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkbgworker=0" "5180"'
-    pid: '1468'
-    ppid: '1628'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: C:\windows\System32\svchost.exe -k termsvcs
-    pid: '1644'
-    ppid: '428'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: C:\windows\system32\svchost.exe -k NetworkServiceNetworkRestricted
-    pid: '1748'
-    ppid: '428'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: 'taskhostex.exe '
-    pid: '2852'
-    ppid: '696'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\Explorer.EXE
-    pid: '2980'
-    ppid: '2968'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\windows\system32\ServerManager.exe" '
-    pid: '2600'
-    ppid: '2860'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\Program Files\Internet Explorer\iexplore.exe" '
-    pid: '656'
-    ppid: '2980'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\Program Files (x86)\Internet Explorer\IEXPLORE.EXE" SCODEF:656 CREDAT:209921 /prefetch:2'
-    pid: '1960'
-    ppid: '656'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\Program Files (x86)\Internet Explorer\IEXPLORE.EXE" SCODEF:656 CREDAT:3879945 /prefetch:2'
-    pid: '2912'
-    ppid: '656'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\System32\msdtc.exe
-    pid: '3004'
-    ppid: '428'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: C:/telegraf/telegraf.exe -config C:/telegraf/telegraf.conf -config-directory C:/telegraf/telegraf.d/
-    pid: '3088'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"C:\winlogbeat\winlogbeat.exe" -c "C:\winlogbeat\winlogbeat.yml" -path.home "C:\winlogbeat" -path.data "C:\ProgramData\winlogbeat" -path.logs "C:\ProgramData\winlogbeat\logs"'
-    pid: '2712'
-    ppid: '428'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '4032'
-    ppid: '2764'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: winlogon.exe
-    pid: '2108'
-    ppid: '2764'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"dwm.exe"'
-    pid: '2636'
-    ppid: '2108'
-    user: Window Manager\DWM-2
-  - cmdline: 'taskhostex.exe '
-    pid: '3696'
-    ppid: '696'
-    user: TEST-NORM-WIN01\iometrics
-  - cmdline: rdpclip
-    pid: '2584'
-    ppid: '1644'
-    user: TEST-NORM-WIN01\iometrics
-  - cmdline: C:\windows\Explorer.EXE
-    pid: '144'
-    ppid: '3588'
-    user: TEST-NORM-WIN01\iometrics
-  - cmdline: '"C:\windows\system32\ServerManager.exe" '
-    pid: '1304'
-    ppid: '548'
-    user: TEST-NORM-WIN01\iometrics
-  - cmdline: null
-    pid: '612'
-    ppid: '1716'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: winlogon.exe
-    pid: '2484'
-    ppid: '1716'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"LogonUI.exe" /flags:0x0'
-    pid: '3144'
-    ppid: '2484'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"dwm.exe"'
-    pid: '3356'
-    ppid: '2484'
-    user: Window Manager\DWM-4
-  - cmdline: rdpclip
-    pid: '3820'
-    ppid: '1644'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\system32\wbem\wmiprvse.exe
-    pid: '5552'
-    ppid: '492'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: C:\windows\system32\WinrsHost.exe -Embedding
-    pid: '5184'
-    ppid: '492'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: \??\C:\windows\system32\conhost.exe 0x4
-    pid: '9024'
-    ppid: '5184'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\system32\WinrsHost.exe -Embedding
-    pid: '7264'
-    ppid: '492'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: \??\C:\windows\system32\conhost.exe 0x4
-    pid: '5048'
-    ppid: '7264'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\system32\wbem\wmiprvse.exe
-    pid: '4468'
-    ppid: '492'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: C:\windows\system32\WinrsHost.exe -Embedding
-    pid: '7944'
-    ppid: '492'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: \??\C:\windows\system32\conhost.exe 0x4
-    pid: '6472'
-    ppid: '7944'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: C:\windows\system32\cmd.exe /C PowerShell -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
-    pid: '8252'
-    ppid: '7944'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: PowerShell  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
-    pid: '2696'
-    ppid: '8252'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe"  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand JgBjAGgAYwBwAC4AYwBvAG0AIAA2ADUAMAAwADEAIAA+ACAAJABuAHUAbABsAAoAaQBmACAAKAAkAFAAUwBWAGUAcgBzAGkAbwBuAFQAYQBiAGwAZQAuAFAAUwBWAGUAcgBzAGkAbwBuACAALQBsAHQAIABbAFYAZQByAHMAaQBvAG4AXQAiADMALgAwACIAKQAgAHsACgAnAHsAIgBmAGEAaQBsAGUAZAAiADoAdAByAHUAZQAsACIAbQBzAGcAIgA6ACIAQQBuAHMAaQBiAGwAZQAgAHIAZQBxAHUAaQByAGUAcwAgAFAAbwB3AGUAcgBTAGgAZQBsAGwAIAB2ADMALgAwACAAbwByACAAbgBlAHcAZQByACIAfQAnAAoAZQB4AGkAdAAgADEACgB9AAoAJABlAHgAZQBjAF8AdwByAGEAcABwAGUAcgBfAHMAdAByACAAPQAgACQAaQBuAHAAdQB0ACAAfAAgAE8AdQB0AC0AUwB0AHIAaQBuAGcACgAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAgAD0AIAAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAF8AcwB0AHIALgBTAHAAbABpAHQAKABAACgAIgBgADAAYAAwAGAAMABgADAAIgApACwAIAAyACwAIABbAFMAdAByAGkAbgBnAFMAcABsAGkAdABPAHAAdABpAG8AbgBzAF0AOgA6AFIAZQBtAG8AdgBlAEUAbQBwAHQAeQBFAG4AdAByAGkAZQBzACkACgBJAGYAIAAoAC0AbgBvAHQAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAuAEwAZQBuAGcAdABoACAALQBlAHEAIAAyACkAIAB7ACAAdABoAHIAbwB3ACAAIgBpAG4AdgBhAGwAaQBkACAAcABhAHkAbABvAGEAZAAiACAAfQAKAFMAZQB0AC0AVgBhAHIAaQBhAGIAbABlACAALQBOAGEAbQBlACAAagBzAG8AbgBfAHIAYQB3ACAALQBWAGEAbAB1AGUAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADEAXQAKACQAZQB4AGUAYwBfAHcAcgBhAHAAcABlAHIAIAA9ACAAWwBTAGMAcgBpAHAAdABCAGwAbwBjAGsAXQA6ADoAQwByAGUAYQB0AGUAKAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADAAXQApAAoAJgAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAA=='
-    pid: '2124'
-    ppid: '2696'
-    user: TEST-NORM-WIN01\Administrator
-dockers: { }
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: ODBC drivers for PostgreSQL, packaged by EnterpriseDB
+    contact: ''
+    estimated_size: 13676
+    help_link: ''
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files\PostgreSQL\psqlODBC
+    install_source: null
+    language: null
+    modify_path: null
+    name: psqlODBC 13.00.0000
+    no_repair: '1'
+    publisher: EnterpriseDB
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\PostgreSQL\psqlODBC\uninstall-psqlodbc.exe"'
+    url_info_about: ''
+    url_update_info: null
+    vendor: null
+    version: 13.00.0000-2
+    version_major: 13
+    version_minor: 0
+    windows_installer: null
+"processes": [
+        {
+            "cmdline": null,
+            "cwd": "",
+            "pid": "0",
+            "ppid": "0",
+            "user": null
+        },
+        {
+            "cmdline": null,
+            "cwd": "",
+            "pid": "4",
+            "ppid": "0",
+            "user": null
+        },
+        {
+            "cmdline": null,
+            "cwd": "",
+            "pid": "192",
+            "ppid": "4",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": null,
+            "cwd": "",
+            "pid": "280",
+            "ppid": "272",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": null,
+            "cwd": "",
+            "pid": "332",
+            "ppid": "324",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "wininit.exe",
+            "cwd": "",
+            "pid": "340",
+            "ppid": "272",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "winlogon.exe",
+            "cwd": "",
+            "pid": "368",
+            "ppid": "324",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": null,
+            "cwd": "",
+            "pid": "428",
+            "ppid": "340",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\lsass.exe",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "436",
+            "ppid": "340",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\svchost.exe -k DcomLaunch",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "492",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\svchost.exe -k RPCSS",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "520",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "dwm.exe",
+            "cwd": "",
+            "pid": "628",
+            "ppid": "368",
+            "user": "Window Manager\\DWM-1"
+        },
+        {
+            "cmdline": "C:\\windows\\System32\\svchost.exe -k LocalServiceNetworkRestricted",
+            "cwd": "C:\\windows\\System32\\",
+            "pid": "648",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\LOCAL SERVICE"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\svchost.exe -k netsvcs",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "696",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\svchost.exe -k LocalService",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "740",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\LOCAL SERVICE"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\svchost.exe -k NetworkService",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "836",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\svchost.exe -k LocalServiceNoNetwork",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "984",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\LOCAL SERVICE"
+        },
+        {
+            "cmdline": "C:\\windows\\System32\\spoolsv.exe",
+            "cwd": "C:\\windows\\System32\\",
+            "pid": "516",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\svchost.exe -k apphost",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "756",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\System32\\svchost.exe -k utcsvc",
+            "cwd": "C:\\windows\\System32\\",
+            "pid": "912",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\mqsvc.exe",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "236",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:\\Program Files\\Microsoft SQL Server\\MSSQL14.SQLEXPRESS\\MSSQL\\Binn\\sqlservr.exe\" -sSQLEXPRESS",
+            "cwd": "C:\\",
+            "pid": "1144",
+            "ppid": "428",
+            "user": "NT SERVICE\\MSSQL$SQLEXPRESS"
+        },
+        {
+            "cmdline": "C:\\windows\\Microsoft.NET\\Framework64\\v4.0.30319\\SMSvcHost.exe",
+            "cwd": "C:\\windows\\Microsoft.NET\\Framework64\\v4.0.30319\\",
+            "pid": "1216",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\LOCAL SERVICE"
+        },
+        {
+            "cmdline": "C:\\Program Files (x86)\\PgBouncer\\bin\\pgbouncer.exe\" --service \"C:\\Program Files (x86)\\PgBouncer\\share\\pgbouncer.ini",
+            "cwd": "C:\\",
+            "pid": "1324",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\Program Files\\PostgreSQL\\14\\bin\\pg_ctl.exe\" runservice -N \"postgresql-x64-14\" -D \"C:\\Program Files\\PostgreSQL\\14\\data\" -w",
+            "cwd": "C:\\Program Files\\PostgreSQL\\14\\bin\\",
+            "pid": "1432",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:\\Program Files\\Microsoft SQL Server\\MSSQL14.SQLEXPRESS\\MSSQL\\Binn\\sqlceip.exe\" -Service SQLEXPRESS",
+            "cwd": "C:\\",
+            "pid": "1492",
+            "ppid": "428",
+            "user": "NT SERVICE\\SQLTELEMETRY$SQLEXPRESS"
+        },
+        {
+            "cmdline": "C:\\Program Files\\Microsoft SQL Server\\90\\Shared\\sqlwriter.exe",
+            "cwd": "C:\\",
+            "pid": "1544",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\System32\\svchost.exe -k LocalSystemNetworkRestricted",
+            "cwd": "C:\\windows\\System32\\",
+            "pid": "1560",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\svchost.exe -k iissvcs",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "1580",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\Program Files\\PostgreSQL\\14\\bin\\postgres.exe -D C:\\Program Files\\PostgreSQL\\14\\data",
+            "cwd": "C:\\Program Files\\PostgreSQL\\14\\bin\\",
+            "pid": "1628",
+            "ppid": "1432",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\conhost.exe 0x4",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "1640",
+            "ppid": "1628",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:\\windows\\Microsoft.NET\\Framework64\\v4.0.30319\\SMSvcHost.exe\" -NetMsmqActivator",
+            "cwd": "C:\\windows\\Microsoft.NET\\Framework64\\v4.0.30319\\",
+            "pid": "1816",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:/Program Files/PostgreSQL/14/bin/postgres.exe --forklog 5308 5312 0",
+            "cwd": "C:/Program Files/PostgreSQL/14/bin/",
+            "pid": "1908",
+            "ppid": "1628",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkboot 5212 -x5",
+            "cwd": "C:/Program Files/PostgreSQL/14/bin/",
+            "pid": "1028",
+            "ppid": "1628",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkboot 5224 -x3",
+            "cwd": "C:/Program Files/PostgreSQL/14/bin/",
+            "pid": "72",
+            "ppid": "1628",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkboot 5204 -x6",
+            "cwd": "C:/Program Files/PostgreSQL/14/bin/",
+            "pid": "224",
+            "ppid": "1628",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkavlauncher 5196",
+            "cwd": "C:/Program Files/PostgreSQL/14/bin/",
+            "pid": "1312",
+            "ppid": "1628",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkcol 5188",
+            "cwd": "C:/Program Files/PostgreSQL/14/bin/",
+            "pid": "1336",
+            "ppid": "1628",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:/Program Files/PostgreSQL/14/bin/postgres.exe --forkbgworker=0 5180",
+            "cwd": "C:/Program Files/PostgreSQL/14/bin/",
+            "pid": "1468",
+            "ppid": "1628",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:\\windows\\System32\\svchost.exe -k termsvcs",
+            "cwd": "C:\\windows\\System32\\",
+            "pid": "1644",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\svchost.exe -k NetworkServiceNetworkRestricted",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "1748",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "taskhostex.exe ",
+            "cwd": "",
+            "pid": "2852",
+            "ppid": "696",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\windows\\Explorer.EXE",
+            "cwd": "C:\\windows\\",
+            "pid": "2980",
+            "ppid": "2968",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\ServerManager.exe\" ",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "2600",
+            "ppid": "2860",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\Program Files\\Internet Explorer\\iexplore.exe\" ",
+            "cwd": "C:\\",
+            "pid": "656",
+            "ppid": "2980",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\Program Files (x86)\\Internet Explorer\\IEXPLORE.EXE\" SCODEF:656 CREDAT:209921 /prefetch:2",
+            "cwd": "C:\\",
+            "pid": "1960",
+            "ppid": "656",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\Program Files (x86)\\Internet Explorer\\IEXPLORE.EXE\" SCODEF:656 CREDAT:3879945 /prefetch:2",
+            "cwd": "C:\\",
+            "pid": "2912",
+            "ppid": "656",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\windows\\System32\\msdtc.exe",
+            "cwd": "C:\\windows\\System32\\",
+            "pid": "3004",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:/telegraf/telegraf.exe -config C:/telegraf/telegraf.conf -config-directory C:/telegraf/telegraf.d/",
+            "cwd": "",
+            "pid": "3088",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\winlogbeat\\winlogbeat.exe\" -c \"C:\\winlogbeat\\winlogbeat.yml\" -path.home \"C:\\winlogbeat\" -path.data \"C:\\ProgramData\\winlogbeat\" -path.logs \"C:\\ProgramData\\winlogbeat\\logs",
+            "cwd": "C:\\winlogbeat\\",
+            "pid": "2712",
+            "ppid": "428",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": null,
+            "cwd": "",
+            "pid": "4032",
+            "ppid": "2764",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "winlogon.exe",
+            "cwd": "",
+            "pid": "2108",
+            "ppid": "2764",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "dwm.exe",
+            "cwd": "",
+            "pid": "2636",
+            "ppid": "2108",
+            "user": "Window Manager\\DWM-2"
+        },
+        {
+            "cmdline": "taskhostex.exe ",
+            "cwd": "",
+            "pid": "3696",
+            "ppid": "696",
+            "user": "TEST-NORM-WIN01\\iometrics"
+        },
+        {
+            "cmdline": "rdpclip",
+            "cwd": "",
+            "pid": "2584",
+            "ppid": "1644",
+            "user": "TEST-NORM-WIN01\\iometrics"
+        },
+        {
+            "cmdline": "C:\\windows\\Explorer.EXE",
+            "cwd": "C:\\windows\\",
+            "pid": "144",
+            "ppid": "3588",
+            "user": "TEST-NORM-WIN01\\iometrics"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\ServerManager.exe\" ",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "1304",
+            "ppid": "548",
+            "user": "TEST-NORM-WIN01\\iometrics"
+        },
+        {
+            "cmdline": null,
+            "cwd": "",
+            "pid": "612",
+            "ppid": "1716",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "winlogon.exe",
+            "cwd": "",
+            "pid": "2484",
+            "ppid": "1716",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "LogonUI.exe\" /flags:0x0",
+            "cwd": "",
+            "pid": "3144",
+            "ppid": "2484",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "dwm.exe",
+            "cwd": "",
+            "pid": "3356",
+            "ppid": "2484",
+            "user": "Window Manager\\DWM-4"
+        },
+        {
+            "cmdline": "rdpclip",
+            "cwd": "",
+            "pid": "3820",
+            "ppid": "1644",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\wbem\\wmiprvse.exe",
+            "cwd": "C:\\windows\\system32\\wbem\\",
+            "pid": "5552",
+            "ppid": "492",
+            "user": "NT AUTHORITY\\NETWORK SERVICE"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\WinrsHost.exe -Embedding",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "5184",
+            "ppid": "492",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "\\??\\C:\\windows\\system32\\conhost.exe 0x4",
+            "cwd": "\\??\\C:\\windows\\system32\\",
+            "pid": "9024",
+            "ppid": "5184",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\WinrsHost.exe -Embedding",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "7264",
+            "ppid": "492",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "\\??\\C:\\windows\\system32\\conhost.exe 0x4",
+            "cwd": "\\??\\C:\\windows\\system32\\",
+            "pid": "5048",
+            "ppid": "7264",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\wbem\\wmiprvse.exe",
+            "cwd": "C:\\windows\\system32\\wbem\\",
+            "pid": "4468",
+            "ppid": "492",
+            "user": "NT AUTHORITY\\SYSTEM"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\WinrsHost.exe -Embedding",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "7944",
+            "ppid": "492",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "\\??\\C:\\windows\\system32\\conhost.exe 0x4",
+            "cwd": "\\??\\C:\\windows\\system32\\",
+            "pid": "6472",
+            "ppid": "7944",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\windows\\system32\\cmd.exe /C PowerShell -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A",
+            "cwd": "C:\\windows\\system32\\",
+            "pid": "8252",
+            "ppid": "7944",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "PowerShell  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A",
+            "cwd": "",
+            "pid": "2696",
+            "ppid": "8252",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        },
+        {
+            "cmdline": "C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\"  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand JgBjAGgAYwBwAC4AYwBvAG0AIAA2ADUAMAAwADEAIAA+ACAAJABuAHUAbABsAAoAaQBmACAAKAAkAFAAUwBWAGUAcgBzAGkAbwBuAFQAYQBiAGwAZQAuAFAAUwBWAGUAcgBzAGkAbwBuACAALQBsAHQAIABbAFYAZQByAHMAaQBvAG4AXQAiADMALgAwACIAKQAgAHsACgAnAHsAIgBmAGEAaQBsAGUAZAAiADoAdAByAHUAZQAsACIAbQBzAGcAIgA6ACIAQQBuAHMAaQBiAGwAZQAgAHIAZQBxAHUAaQByAGUAcwAgAFAAbwB3AGUAcgBTAGgAZQBsAGwAIAB2ADMALgAwACAAbwByACAAbgBlAHcAZQByACIAfQAnAAoAZQB4AGkAdAAgADEACgB9AAoAJABlAHgAZQBjAF8AdwByAGEAcABwAGUAcgBfAHMAdAByACAAPQAgACQAaQBuAHAAdQB0ACAAfAAgAE8AdQB0AC0AUwB0AHIAaQBuAGcACgAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAgAD0AIAAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAF8AcwB0AHIALgBTAHAAbABpAHQAKABAACgAIgBgADAAYAAwAGAAMABgADAAIgApACwAIAAyACwAIABbAFMAdAByAGkAbgBnAFMAcABsAGkAdABPAHAAdABpAG8AbgBzAF0AOgA6AFIAZQBtAG8AdgBlAEUAbQBwAHQAeQBFAG4AdAByAGkAZQBzACkACgBJAGYAIAAoAC0AbgBvAHQAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAuAEwAZQBuAGcAdABoACAALQBlAHEAIAAyACkAIAB7ACAAdABoAHIAbwB3ACAAIgBpAG4AdgBhAGwAaQBkACAAcABhAHkAbABvAGEAZAAiACAAfQAKAFMAZQB0AC0AVgBhAHIAaQBhAGIAbABlACAALQBOAGEAbQBlACAAagBzAG8AbgBfAHIAYQB3ACAALQBWAGEAbAB1AGUAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADEAXQAKACQAZQB4AGUAYwBfAHcAcgBhAHAAcABlAHIAIAA9ACAAWwBTAGMAcgBpAHAAdABCAGwAbwBjAGsAXQA6ADoAQwByAGUAYQB0AGUAKAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADAAXQApAAoAJgAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAA==",
+            "cwd": "C:\\windows\\System32\\WindowsPowerShell\\v1.0\\",
+            "pid": "2124",
+            "ppid": "2696",
+            "user": "TEST-NORM-WIN01\\Administrator"
+        }
+    ]
 software_list:
-  - cmd_regexp: postgres:|postgres\.exe.*?--fork
-    custom_tasks:
-      - include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/postgresql.yaml"
-        name: Include postgres specific plugins
-    name: PostgreSQL Database
-    pkg_regexp: postgresql.*-server|postgresql-\d
-    process_type: child
-    return_children: true
-    return_packages: true
-    vars:
-      connect_with_users:
-        - password: password
-          username: postgres
-      ignore_databases:
-        - postgres
-        - template0
-        - template1
-      sql_connection_extra_params: -h 127.0.0.1
+- cmd_regexp: postgres:|postgres\.exe.*?--fork
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/postgresql.yaml'
+    name: Include postgres specific plugins
+  name: PostgreSQL Database
+  pkg_regexp: postgresql.*-server|postgresql-\d
+  process_type: child
+  return_children: true
+  return_packages: true
+  vars:
+    connect_with_users:
+    - password: password
+      username: postgres
+    ignore_databases:
+    - postgres
+    - template0
+    - template1
+    sql_connection_extra_params: -h 127.0.0.1
 tcp_listen:
-  - address: '::'
-    name: sqlservr.exe
-    pid: 1144
-    port: 49350
-    protocol: tcp
-    stime: Wed Dec 21 12:02:28 2022
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - address: '::'
-    name: services.exe
-    pid: 428
-    port: 49160
-    protocol: tcp
-    stime: Wed Dec 21 12:02:23 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: lsass.exe
-    pid: 436
-    port: 49159
-    protocol: tcp
-    stime: Wed Dec 21 12:02:23 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: mqsvc.exe
-    pid: 236
-    port: 49156
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: spoolsv.exe
-    pid: 516
-    port: 49155
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: svchost.exe
-    pid: 696
-    port: 49154
-    protocol: tcp
-    stime: Wed Dec 21 12:02:25 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: svchost.exe
-    pid: 648
-    port: 49153
-    protocol: tcp
-    stime: Wed Dec 21 12:02:25 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: '::'
-    name: wininit.exe
-    pid: 340
-    port: 49152
-    protocol: tcp
-    stime: Wed Dec 21 12:02:22 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: System
-    pid: 4
-    port: 47001
-    protocol: tcp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: ::1
-    name: pgbouncer.exe
-    pid: 1324
-    port: 6432
-    protocol: tcp
-    stime: Wed Dec 21 12:02:30 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: System
-    pid: 4
-    port: 5986
-    protocol: tcp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: System
-    pid: 4
-    port: 5985
-    protocol: tcp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: postgres.exe
-    pid: 1628
-    port: 5432
-    protocol: tcp
-    stime: Wed Dec 21 12:02:34 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: svchost.exe
-    pid: 1644
-    port: 3389
-    protocol: tcp
-    stime: Wed Dec 21 12:02:35 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: mqsvc.exe
-    pid: 236
-    port: 2107
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: mqsvc.exe
-    pid: 236
-    port: 2105
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: mqsvc.exe
-    pid: 236
-    port: 2103
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: mqsvc.exe
-    pid: 236
-    port: 1801
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: SMSvcHost.exe
-    pid: 1216
-    port: 808
-    protocol: tcp
-    stime: Wed Dec 21 12:02:29 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: '::'
-    name: System
-    pid: 4
-    port: 800
-    protocol: tcp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: System
-    pid: 4
-    port: 445
-    protocol: tcp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: System
-    pid: 4
-    port: 443
-    protocol: tcp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: svchost.exe
-    pid: 520
-    port: 135
-    protocol: tcp
-    stime: Wed Dec 21 12:02:24 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: System
-    pid: 4
-    port: 80
-    protocol: tcp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: 0.0.0.0
-    name: sqlservr.exe
-    pid: 1144
-    port: 49350
-    protocol: tcp
-    stime: Wed Dec 21 12:02:28 2022
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - address: 0.0.0.0
-    name: services.exe
-    pid: 428
-    port: 49160
-    protocol: tcp
-    stime: Wed Dec 21 12:02:23 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: lsass.exe
-    pid: 436
-    port: 49159
-    protocol: tcp
-    stime: Wed Dec 21 12:02:23 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: mqsvc.exe
-    pid: 236
-    port: 49156
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: spoolsv.exe
-    pid: 516
-    port: 49155
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 696
-    port: 49154
-    protocol: tcp
-    stime: Wed Dec 21 12:02:25 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 648
-    port: 49153
-    protocol: tcp
-    stime: Wed Dec 21 12:02:25 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: 0.0.0.0
-    name: wininit.exe
-    pid: 340
-    port: 49152
-    protocol: tcp
-    stime: Wed Dec 21 12:02:22 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 127.0.0.1
-    name: pgbouncer.exe
-    pid: 1324
-    port: 6432
-    protocol: tcp
-    stime: Wed Dec 21 12:02:30 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: postgres.exe
-    pid: 1628
-    port: 5432
-    protocol: tcp
-    stime: Wed Dec 21 12:02:34 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 1644
-    port: 3389
-    protocol: tcp
-    stime: Wed Dec 21 12:02:35 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: mqsvc.exe
-    pid: 236
-    port: 2107
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: mqsvc.exe
-    pid: 236
-    port: 2105
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: mqsvc.exe
-    pid: 236
-    port: 2103
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: mqsvc.exe
-    pid: 236
-    port: 1801
-    protocol: tcp
-    stime: Wed Dec 21 12:02:27 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: SMSvcHost.exe
-    pid: 1216
-    port: 808
-    protocol: tcp
-    stime: Wed Dec 21 12:02:29 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: 172.16.0.94
-    name: System
-    pid: 4
-    port: 139
-    protocol: tcp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 520
-    port: 135
-    protocol: tcp
-    stime: Wed Dec 21 12:02:24 2022
-    user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: sqlservr.exe
+  pid: 1144
+  port: 49350
+  protocol: tcp
+  stime: Wed Dec 21 12:02:28 2022
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- address: '::'
+  name: services.exe
+  pid: 428
+  port: 49160
+  protocol: tcp
+  stime: Wed Dec 21 12:02:23 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: lsass.exe
+  pid: 436
+  port: 49159
+  protocol: tcp
+  stime: Wed Dec 21 12:02:23 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: mqsvc.exe
+  pid: 236
+  port: 49156
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: spoolsv.exe
+  pid: 516
+  port: 49155
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: svchost.exe
+  pid: 696
+  port: 49154
+  protocol: tcp
+  stime: Wed Dec 21 12:02:25 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: svchost.exe
+  pid: 648
+  port: 49153
+  protocol: tcp
+  stime: Wed Dec 21 12:02:25 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: '::'
+  name: wininit.exe
+  pid: 340
+  port: 49152
+  protocol: tcp
+  stime: Wed Dec 21 12:02:22 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: System
+  pid: 4
+  port: 47001
+  protocol: tcp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: ::1
+  name: pgbouncer.exe
+  pid: 1324
+  port: 6432
+  protocol: tcp
+  stime: Wed Dec 21 12:02:30 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: System
+  pid: 4
+  port: 5986
+  protocol: tcp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: System
+  pid: 4
+  port: 5985
+  protocol: tcp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: postgres.exe
+  pid: 1628
+  port: 5432
+  protocol: tcp
+  stime: Wed Dec 21 12:02:34 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: svchost.exe
+  pid: 1644
+  port: 3389
+  protocol: tcp
+  stime: Wed Dec 21 12:02:35 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: mqsvc.exe
+  pid: 236
+  port: 2107
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: mqsvc.exe
+  pid: 236
+  port: 2105
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: mqsvc.exe
+  pid: 236
+  port: 2103
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: mqsvc.exe
+  pid: 236
+  port: 1801
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: SMSvcHost.exe
+  pid: 1216
+  port: 808
+  protocol: tcp
+  stime: Wed Dec 21 12:02:29 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: '::'
+  name: System
+  pid: 4
+  port: 800
+  protocol: tcp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: System
+  pid: 4
+  port: 445
+  protocol: tcp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: System
+  pid: 4
+  port: 443
+  protocol: tcp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: svchost.exe
+  pid: 520
+  port: 135
+  protocol: tcp
+  stime: Wed Dec 21 12:02:24 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: System
+  pid: 4
+  port: 80
+  protocol: tcp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: 0.0.0.0
+  name: sqlservr.exe
+  pid: 1144
+  port: 49350
+  protocol: tcp
+  stime: Wed Dec 21 12:02:28 2022
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- address: 0.0.0.0
+  name: services.exe
+  pid: 428
+  port: 49160
+  protocol: tcp
+  stime: Wed Dec 21 12:02:23 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: lsass.exe
+  pid: 436
+  port: 49159
+  protocol: tcp
+  stime: Wed Dec 21 12:02:23 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: mqsvc.exe
+  pid: 236
+  port: 49156
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: spoolsv.exe
+  pid: 516
+  port: 49155
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 696
+  port: 49154
+  protocol: tcp
+  stime: Wed Dec 21 12:02:25 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 648
+  port: 49153
+  protocol: tcp
+  stime: Wed Dec 21 12:02:25 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: 0.0.0.0
+  name: wininit.exe
+  pid: 340
+  port: 49152
+  protocol: tcp
+  stime: Wed Dec 21 12:02:22 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 127.0.0.1
+  name: pgbouncer.exe
+  pid: 1324
+  port: 6432
+  protocol: tcp
+  stime: Wed Dec 21 12:02:30 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: postgres.exe
+  pid: 1628
+  port: 5432
+  protocol: tcp
+  stime: Wed Dec 21 12:02:34 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 1644
+  port: 3389
+  protocol: tcp
+  stime: Wed Dec 21 12:02:35 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: mqsvc.exe
+  pid: 236
+  port: 2107
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: mqsvc.exe
+  pid: 236
+  port: 2105
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: mqsvc.exe
+  pid: 236
+  port: 2103
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: mqsvc.exe
+  pid: 236
+  port: 1801
+  protocol: tcp
+  stime: Wed Dec 21 12:02:27 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: SMSvcHost.exe
+  pid: 1216
+  port: 808
+  protocol: tcp
+  stime: Wed Dec 21 12:02:29 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: 172.16.0.94
+  name: System
+  pid: 4
+  port: 139
+  protocol: tcp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 520
+  port: 135
+  protocol: tcp
+  stime: Wed Dec 21 12:02:24 2022
+  user: NT AUTHORITY\NETWORK SERVICE
 udp_listen:
-  - address: fe80::1002:b306:e05b:c850%12
-    name: System Idle Process
-    pid: null
-    port: 546
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: ::1
-    name: System Idle Process
-    pid: null
-    port: 57908
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 5355
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 4500
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 3389
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 500
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 123
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 5355
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 4500
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 3389
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 500
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: 172.16.0.94
-    name: System Idle Process
-    pid: null
-    port: 138
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: 172.16.0.94
-    name: System Idle Process
-    pid: null
-    port: 137
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 123
-    protocol: udp
-    stime: Wed Dec 21 12:02:20 2022
-    user: null
+- address: fe80::1002:b306:e05b:c850%12
+  name: System Idle Process
+  pid: null
+  port: 546
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: ::1
+  name: System Idle Process
+  pid: null
+  port: 57908
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 5355
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 4500
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 3389
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 500
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 123
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 5355
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 4500
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 3389
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 500
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: 172.16.0.94
+  name: System Idle Process
+  pid: null
+  port: 138
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: 172.16.0.94
+  name: System Idle Process
+  pid: null
+  port: 137
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 123
+  protocol: udp
+  stime: Wed Dec 21 12:02:20 2022
+  user: null

--- a/tests/unit/plugins/action/auto/resources/redis/redis6_centos7.6_docker.yaml
+++ b/tests/unit/plugins/action/auto/resources/redis/redis6_centos7.6_docker.yaml
@@ -1,4133 +1,4180 @@
-mocked_plugin_tasks:
-  Get environment:
-    execute_module_result:
-      failed: false
-      encoding: plain
-      content: ""
-    expected_result:
-      failed: false
-      content: any
-      parsed: {
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "GOSU_VERSION": "1.12",
-        "REDIS_VERSION": "6.0.1",
-        "REDIS_DOWNLOAD_URL": "http://download.redis.io/releases/redis-6.0.1.tar.gz",
-        "REDIS_DOWNLOAD_SHA": "b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273"
-      }
-
-  Run which:
-    calls:
-      - expected_args:
-          hidden: false
-          in_docker: true
-          name: redis-server
-          paths:
-            - /usr/local/sbin
-            - /usr/local/bin
-            - /usr/sbin
-            - /usr/bin
-            - /sbin
-            - /bin
-          windows_valid_extensions: null
-        execute_module_result:
-          failed: false
-          matched: 1
-          files:
-            - path: /proc/7054/root/usr/local/bin/redis-server
-              isdir: false
-              xusr: true
-              xgrp: true
-              xoth: true
-
-  Run version command:
-    calls:
-      - expected_args:
-          argv: null
-          cmd: '/usr/local/bin/redis-server --version'
-          in_docker: true
-        execute_module_result:
-          failed: false
-          stdout: 'Redis server v=6.0.1 sha=00000000:0 malloc=jemalloc-5.1.0 bits=64 build=0'
-
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 6378
-        protocol: 'tcp'
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 6379
-        protocol: 'tcp'
-    discovery_time: '2022-06-07T13:11:16+02:00'
-    files:
-      - path: '/usr/local/bin'
-        name: 'redis-server'
-        subtype: 'generic'
-        type: 'binary'
-    docker:
-      exposed_ports:
-        6379/tcp: { }
-      id: 9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
-      image: 'redis:6.0.1'
-      name: /redis
-      network_mode: 'host'
-      port_bindings: { }
-    listening_ports:
-      - 6378
-      - 6379
-    type: Redis
-    packages: [ ]
-    process:
-      cmdline: 'redis-server 0.0.0.0:6379'
-      listening_ports:
-        - 6378
-        - 6379
-      pid: '7054'
-      ppid: '6905'
-      user: polkitd
-    version:
-      - number: 6.0.1
-        type: command
-      - number: 6.0.1
-        type: docker
-
-software_list:
-  - name: Redis
-    cmd_regexp: redis-serve
-    pkg_regexp: ^redis
-    process_type: parent
-    return_children: false
-    return_packages: true
-    vars: { }
-    custom_tasks:
-      - name: Include redis specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/redis.yaml"
-
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - python ./listener.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - python ./listener.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
-        Hostname: indexer01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.1.0-c165633
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /config: { }
-        WorkingDir: ''
-      Created: '2022-06-01T16:32:15.591995742Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521-init/diff:/var/lib/docker/overlay2/48af681efdc26a18db1f454929c8a9008b0c59035b43be3a8ad58e211a309a85/diff:/var/lib/docker/overlay2/c703bb1c40fe2d0178aae8f123e88241c3c6928e189d7ef47a9aaad609439655/diff:/var/lib/docker/overlay2/f0b32c9349991844490375e72f6a025c9d162a7edac7a4e585d295a66f01e782/diff:/var/lib/docker/overlay2/1ed8f7cae0ab8d14f1db25dc40bdc50d71a5ef5555cd05970f9b7ba08b7d7c61/diff:/var/lib/docker/overlay2/5cf6c028fe2b081fdcbda31e8e9133b89a79eccf663de59530b61a61692e97c6/diff:/var/lib/docker/overlay2/8311c64009b57db6fb231a3ca4ca41218abdc03e6b771602908e1a3bff032b13/diff:/var/lib/docker/overlay2/1009cd354b76d65ca194ab211a8ee1209c930aba645d667f0f2de93e7777fef8/diff:/var/lib/docker/overlay2/c7eb8b0108c5013dca78bf4a9eebf3ea41552d7f047664c842ef3f9ec0930f46/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/redis-cleaner:/config:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hosts
-      Id: 17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
-      Image: 'sha256:f4b8014dcf496e8a2dbc8786835825926dbd8db6a8ab8be9d012139a3e59e851'
-      LogPath: >-
-        /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /config
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis-cleaner
-          Type: bind
-      Name: /iometrics-cmdb-redis-cleaner
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 42a46173b8a6a29b240d5e11e26f5142d483daac2b3a9ff7d463656952f656c4
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
-        Ports: { }
-        SandboxID: 35eeca78d95001ee58384d24c44d5c7cb0774fa1d3ccf65135245c3e115b8c64
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 28025
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-01T16:32:15.934702372Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /usr/local/bin/docker-entrypoint
-        Env:
-          - LOGSTASH_KEYSTORE_PASS=the_password
-          - >-
-            PATH=/usr/share/logstash/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - ELASTIC_CONTAINER=true
-          - LANG=en_US.UTF-8
-          - LC_ALL=en_US.UTF-8
-        ExposedPorts:
-          5044/tcp: { }
-          9600/tcp: { }
-        Hostname: indexer01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/logstash:7.4.2_iometrics-1'
-        Labels:
-          license: Elastic License
-          org.label-schema.build-date: '20190801'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: logstash
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.url: 'https://www.elastic.co/products/logstash'
-          org.label-schema.vcs-url: 'https://github.com/elastic/logstash'
-          org.label-schema.vendor: Elastic
-          org.label-schema.version: 7.4.2
-          os_container_type: logstash
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: logstash
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /usr/share/logstash/config/jvm.options: { }
-          /usr/share/logstash/config/logstash.keystore: { }
-          /usr/share/logstash/config/logstash.yml: { }
-          /usr/share/logstash/config/pipelines.yml: { }
-          /usr/share/logstash/config/ssl: { }
-          /usr/share/logstash/libs: { }
-          /usr/share/logstash/pipelines: { }
-          /usr/share/logstash/scripts: { }
-          /var/lib/logstash/spool: { }
-        WorkingDir: /usr/share/logstash
-      Created: '2021-09-08T15:34:37.283512426Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23-init/diff:/var/lib/docker/overlay2/c0b64f0d978f9438dfbff80ce43ea262a8c3fada60512ae10e10cedf6155f2e5/diff:/var/lib/docker/overlay2/cecec1371061521c9c470de506604b84f0c7115e8afc98364cda87b4dee22fde/diff:/var/lib/docker/overlay2/34ed4ad551160a52e601b1d18bf370daad0f239bc6e77227b16b4c782a0eca06/diff:/var/lib/docker/overlay2/6df2c0f7c377aa12d60990c8c699892ab1b13be249c0c6fb6fbb98fe05480dc6/diff:/var/lib/docker/overlay2/85645c13b8a4234107187513bda39ca87750c745d01739d812905125684a5376/diff:/var/lib/docker/overlay2/571aeec40700310388bbeb8bd6167ff0a4e2e2df9e6c6e0288c409d334f54ca1/diff:/var/lib/docker/overlay2/de0534dca03a3dedda930c1ad97d22dd942c75b9616ab879972f07665838f08c/diff:/var/lib/docker/overlay2/7e8ced8ae7353db588e6473b42bfdc1d316dc47ac5f494dcc3e6d4f7e57da3e3/diff:/var/lib/docker/overlay2/001f9147b6ab66d62b1fbceaf77a9793a753a60559353c6327c50a0e49bc1231/diff:/var/lib/docker/overlay2/5516c130cfbb3f233c5b214316cdd11908b3bda15770c25496f2aa59b8849253/diff:/var/lib/docker/overlay2/68d49fb7cd2f845a36bf22bba766c721fe67274d7f5d0e6e1091071fc01f4fff/diff:/var/lib/docker/overlay2/e1d95b6fcae995ab60f12b75f6fcbeabecc2b02d02bb8ab225e5a55485adc03c/diff:/var/lib/docker/overlay2/09e21e4e8434de7e2800bfdc86f4dbbe999bc89186b7c099e58a58f13b083672/diff:/var/lib/docker/overlay2/7f3df92947c65debb3de8c0ecd1d556e90b355bc3af0163bc8a9862e8f869dac/diff:/var/lib/docker/overlay2/46b9ba93c62b5e0bd35145b2327e060712a85cf1cdd263188c010d5e2554670b/diff:/var/lib/docker/overlay2/f2454d9a3b25399047feb41486803d43fcbb45a81dc710601d5950da79ac8030/diff:/var/lib/docker/overlay2/b27d3ae7aff2ac9754f1c56378012380a1e5c17896c0c71b4759bfcb10a7c40a/diff:/var/lib/docker/overlay2/75d6bdb58f70a62e6ea684d6d3b37652c8b72d9d4f86551e553c6cf6bb7326ab/diff:/var/lib/docker/overlay2/54689b9f778d0fb8970c658303b1f70fd60328cd888dc5b74326b29c57ef8105/diff:/var/lib/docker/overlay2/e6ac2cd447117ff53d3fa9439b80162af5eeb91d20567780a58fa542b04e2a38/diff:/var/lib/docker/overlay2/78435691d0b8543fbe89e1d88f9a7b5fa681432b9a271a097a1fdcae9cb5a9e5/diff:/var/lib/docker/overlay2/229ee1b3a56196e119210269fce872d0fe3fb56b6f87f86a770837a5fa5b1ac7/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/logstash/ssl:/usr/share/logstash/config/ssl:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - >-
-            /etc/logstash/logstash.yml:/usr/share/logstash/config/logstash.yml:rw
-          - '/usr/share/logstash/libs:/usr/share/logstash/libs:rw'
-          - '/etc/logstash/scripts:/usr/share/logstash/scripts:rw'
-          - '/etc/logstash/pipelines:/usr/share/logstash/pipelines:rw'
-          - '/etc/logstash/jvm.options:/usr/share/logstash/config/jvm.options:rw'
-          - '/etc/hosts:/etc/hosts:rw'
-          - >-
-            /etc/logstash/pipelines.yml:/usr/share/logstash/config/pipelines.yml:rw
-          - >-
-            /etc/logstash/logstash.keystore:/usr/share/logstash/config/logstash.keystore:rw
-          - '/var/lib/logstash/spool:/var/lib/logstash/spool:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/hostname
-      HostsPath: /etc/hosts
-      Id: 1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
-      Image: 'sha256:6dea016b06dec9bd6649861e6ff6f37fa4cc33f4af5a908d42756f1ff07e1e3a'
-      LogPath: >-
-        /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/share/logstash/libs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /usr/share/logstash/libs
-          Type: bind
-        - Destination: /usr/share/logstash/pipelines
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/pipelines
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /usr/share/logstash/config/jvm.options
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/jvm.options
-          Type: bind
-        - Destination: /usr/share/logstash/config/logstash.keystore
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/logstash.keystore
-          Type: bind
-        - Destination: /usr/share/logstash/config/pipelines.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/pipelines.yml
-          Type: bind
-        - Destination: /usr/share/logstash/config/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/ssl
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /usr/share/logstash/config/logstash.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/logstash.yml
-          Type: bind
-        - Destination: /usr/share/logstash/scripts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/scripts
-          Type: bind
-        - Destination: /var/lib/logstash/spool
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/logstash/spool
-          Type: bind
-      Name: /logstash
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: a05e3bedd671d506ea7c75121f96d6f15b58fb25d99f0a761d85522c4cb31c13
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
-        Ports: { }
-        SandboxID: b70e6ce41402ab5de2b13827be954a106a7d738478fee9bd07a2ca753971613b
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/local/bin/docker-entrypoint
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:40.665430732Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 7056
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:55:51.256169421Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '--port'
-        - '6379'
-        - '--tls-port'
-        - '6378'
-        - '--appendonly'
-        - 'no'
-        - '--maxmemory'
-        - '0'
-        - '--maxclients'
-        - '10000'
-        - '--bind'
-        - 0.0.0.0
-        - '--tls-auth-clients'
-        - 'no'
-        - '--tls-cert-file'
-        - /data/ssl/redis.crt
-        - '--tls-key-file'
-        - /data/ssl/redis.pem
-        - '--tls-ca-cert-file'
-        - /data/ssl/redis_ca.crt
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '--port'
-          - '6379'
-          - '--tls-port'
-          - '6378'
-          - '--appendonly'
-          - 'no'
-          - '--maxmemory'
-          - '0'
-          - '--maxclients'
-          - '10000'
-          - '--bind'
-          - 0.0.0.0
-          - '--tls-auth-clients'
-          - 'no'
-          - '--tls-cert-file'
-          - /data/ssl/redis.crt
-          - '--tls-key-file'
-          - /data/ssl/redis.pem
-          - '--tls-ca-cert-file'
-          - /data/ssl/redis_ca.crt
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.0.1
-          - >-
-            REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
-          - >-
-            REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
-        ExposedPorts:
-          6379/tcp: { }
-        Hostname: indexer01.novalocal
-        Image: 'redis:6.0.1'
-        Labels:
-          os_contianer_type: redis
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: { }
-          /data/ssl/: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-        WorkingDir: /data
-      Created: '2021-09-08T15:21:08.364900148Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671-init/diff:/var/lib/docker/overlay2/d729bad126881ac666c1ce86fd53b9fbb89dd31a32982fbe52d7b0348d00a7a5/diff:/var/lib/docker/overlay2/6147c7e4ffcac3df8515c47b85fb28fa9cb14e2eda1ae99024a0ad2d4d2f2564/diff:/var/lib/docker/overlay2/e65a456f02dd73ccbf8fcf90ad6c9cd2d090f59a8419916c39c5e3d2f1f4633e/diff:/var/lib/docker/overlay2/0d37d43d45e3912548e3578ac61ec6ae557a5b096629ca286fc5b07999ccae31/diff:/var/lib/docker/overlay2/2c5d5d7ffd6855efcf3a7788c2a72f12de032ac3d00ffa437e32113ae5706b4d/diff:/var/lib/docker/overlay2/ef4edd4aa9d123bae52ac92f708fb15264ac3036df51240db0e17b7ae280a06d/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/redis:/data:rw'
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/redis/ssl/:/data/ssl/:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/hostname
-      HostsPath: /etc/hosts
-      Id: 9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
-      Image: 'sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c'
-      LogPath: >-
-        /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/redis
-          Type: bind
-        - Destination: /data/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis/ssl
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-      Name: /redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: c124f14eba8e33d8dfbf7244d810451b50469d02c40f191ac28d6309b4c2fb20
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
-        Ports: { }
-        SandboxID: 12fa0db070f4558f5c022bb880897adb0e4a11662b3ec5143027e742a036611d
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:40.681971343Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 7054
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:55:50.844646575Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  keepalived:
-    - arch: x86_64
-      epoch: null
-      name: keepalived
-      release: 16.el7
-      source: rpm
-      version: 1.3.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-devel:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-devel
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsepol-devel:
-    - arch: x86_64
-      epoch: null
-      name: libsepol-devel
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mariadb-server:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-server
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 48.el7_8.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 48.el7_8.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcre-devel:
-    - arch: x86_64
-      epoch: null
-      name: pcre-devel
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
-  perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
-  perl-DBD-MySQL:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBD-MySQL
-      release: 6.el7
-      source: rpm
-      version: '4.023'
-  perl-DBI:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBI
-      release: 4.el7
-      source: rpm
-      version: '1.627'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
-  perl-Net-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-Daemon
-      release: 5.el7
-      source: rpm
-      version: '0.48'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-PlRPC:
-    - arch: noarch
-      epoch: null
-      name: perl-PlRPC
-      release: 14.el7
-      source: rpm
-      version: '0.2020'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  socat:
-    - arch: x86_64
-      epoch: null
-      name: socat
-      release: 2.el7
-      source: rpm
-      version: 1.7.3.2
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '40'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '93'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '301'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '306'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '377'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '393'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '477'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '541'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '673'
-    ppid: '1'
-    user: polkitd
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '704'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '720'
-    ppid: '1'
-    user: rpc
-  - cmdline: ''
-    pid: '721'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '724'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '731'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '743'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '747'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H indexer01 eth0
-    pid: '976'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '1037'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1038'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1042'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1128'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1136'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1140'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1151'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1152'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1153'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '1290'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '1291'
-    ppid: '1290'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '1292'
-    ppid: '1290'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1346'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1348'
-    ppid: '1346'
-    user: postfix
-  - cmdline: ''
-    pid: '4947'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '6905'
-    ppid: '1042'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '6923'
-    ppid: '1042'
-    user: root
-  - cmdline: 'redis-server 0.0.0.0:6379'
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - python ./listener.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - python ./listener.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
+      Hostname: indexer01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.1.0-c165633
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /config: {}
+      WorkingDir: ''
+    Created: '2022-06-01T16:32:15.591995742Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521-init/diff:/var/lib/docker/overlay2/48af681efdc26a18db1f454929c8a9008b0c59035b43be3a8ad58e211a309a85/diff:/var/lib/docker/overlay2/c703bb1c40fe2d0178aae8f123e88241c3c6928e189d7ef47a9aaad609439655/diff:/var/lib/docker/overlay2/f0b32c9349991844490375e72f6a025c9d162a7edac7a4e585d295a66f01e782/diff:/var/lib/docker/overlay2/1ed8f7cae0ab8d14f1db25dc40bdc50d71a5ef5555cd05970f9b7ba08b7d7c61/diff:/var/lib/docker/overlay2/5cf6c028fe2b081fdcbda31e8e9133b89a79eccf663de59530b61a61692e97c6/diff:/var/lib/docker/overlay2/8311c64009b57db6fb231a3ca4ca41218abdc03e6b771602908e1a3bff032b13/diff:/var/lib/docker/overlay2/1009cd354b76d65ca194ab211a8ee1209c930aba645d667f0f2de93e7777fef8/diff:/var/lib/docker/overlay2/c7eb8b0108c5013dca78bf4a9eebf3ea41552d7f047664c842ef3f9ec0930f46/diff
+        MergedDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/merged
+        UpperDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/diff
+        WorkDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/redis-cleaner:/config:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hostname
+    HostsPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hosts
+    Id: 17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
+    Image: sha256:f4b8014dcf496e8a2dbc8786835825926dbd8db6a8ab8be9d012139a3e59e851
+    LogPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /config
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis-cleaner
+      Type: bind
+    Name: /iometrics-cmdb-redis-cleaner
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 42a46173b8a6a29b240d5e11e26f5142d483daac2b3a9ff7d463656952f656c4
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
+      Ports: {}
+      SandboxID: 35eeca78d95001ee58384d24c44d5c7cb0774fa1d3ccf65135245c3e115b8c64
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 28025
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-01T16:32:15.934702372Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /usr/local/bin/docker-entrypoint
+      Env:
+      - LOGSTASH_KEYSTORE_PASS=the_password
+      - PATH=/usr/share/logstash/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - ELASTIC_CONTAINER=true
+      - LANG=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+      ExposedPorts:
+        5044/tcp: {}
+        9600/tcp: {}
+      Hostname: indexer01.novalocal
+      Image: nexusregistry.opensolutions.cloud/logstash:7.4.2_iometrics-1
+      Labels:
+        license: Elastic License
+        org.label-schema.build-date: '20190801'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: logstash
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.url: https://www.elastic.co/products/logstash
+        org.label-schema.vcs-url: https://github.com/elastic/logstash
+        org.label-schema.vendor: Elastic
+        org.label-schema.version: 7.4.2
+        os_container_type: logstash
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: logstash
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /usr/share/logstash/config/jvm.options: {}
+        /usr/share/logstash/config/logstash.keystore: {}
+        /usr/share/logstash/config/logstash.yml: {}
+        /usr/share/logstash/config/pipelines.yml: {}
+        /usr/share/logstash/config/ssl: {}
+        /usr/share/logstash/libs: {}
+        /usr/share/logstash/pipelines: {}
+        /usr/share/logstash/scripts: {}
+        /var/lib/logstash/spool: {}
+      WorkingDir: /usr/share/logstash
+    Created: '2021-09-08T15:34:37.283512426Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23-init/diff:/var/lib/docker/overlay2/c0b64f0d978f9438dfbff80ce43ea262a8c3fada60512ae10e10cedf6155f2e5/diff:/var/lib/docker/overlay2/cecec1371061521c9c470de506604b84f0c7115e8afc98364cda87b4dee22fde/diff:/var/lib/docker/overlay2/34ed4ad551160a52e601b1d18bf370daad0f239bc6e77227b16b4c782a0eca06/diff:/var/lib/docker/overlay2/6df2c0f7c377aa12d60990c8c699892ab1b13be249c0c6fb6fbb98fe05480dc6/diff:/var/lib/docker/overlay2/85645c13b8a4234107187513bda39ca87750c745d01739d812905125684a5376/diff:/var/lib/docker/overlay2/571aeec40700310388bbeb8bd6167ff0a4e2e2df9e6c6e0288c409d334f54ca1/diff:/var/lib/docker/overlay2/de0534dca03a3dedda930c1ad97d22dd942c75b9616ab879972f07665838f08c/diff:/var/lib/docker/overlay2/7e8ced8ae7353db588e6473b42bfdc1d316dc47ac5f494dcc3e6d4f7e57da3e3/diff:/var/lib/docker/overlay2/001f9147b6ab66d62b1fbceaf77a9793a753a60559353c6327c50a0e49bc1231/diff:/var/lib/docker/overlay2/5516c130cfbb3f233c5b214316cdd11908b3bda15770c25496f2aa59b8849253/diff:/var/lib/docker/overlay2/68d49fb7cd2f845a36bf22bba766c721fe67274d7f5d0e6e1091071fc01f4fff/diff:/var/lib/docker/overlay2/e1d95b6fcae995ab60f12b75f6fcbeabecc2b02d02bb8ab225e5a55485adc03c/diff:/var/lib/docker/overlay2/09e21e4e8434de7e2800bfdc86f4dbbe999bc89186b7c099e58a58f13b083672/diff:/var/lib/docker/overlay2/7f3df92947c65debb3de8c0ecd1d556e90b355bc3af0163bc8a9862e8f869dac/diff:/var/lib/docker/overlay2/46b9ba93c62b5e0bd35145b2327e060712a85cf1cdd263188c010d5e2554670b/diff:/var/lib/docker/overlay2/f2454d9a3b25399047feb41486803d43fcbb45a81dc710601d5950da79ac8030/diff:/var/lib/docker/overlay2/b27d3ae7aff2ac9754f1c56378012380a1e5c17896c0c71b4759bfcb10a7c40a/diff:/var/lib/docker/overlay2/75d6bdb58f70a62e6ea684d6d3b37652c8b72d9d4f86551e553c6cf6bb7326ab/diff:/var/lib/docker/overlay2/54689b9f778d0fb8970c658303b1f70fd60328cd888dc5b74326b29c57ef8105/diff:/var/lib/docker/overlay2/e6ac2cd447117ff53d3fa9439b80162af5eeb91d20567780a58fa542b04e2a38/diff:/var/lib/docker/overlay2/78435691d0b8543fbe89e1d88f9a7b5fa681432b9a271a097a1fdcae9cb5a9e5/diff:/var/lib/docker/overlay2/229ee1b3a56196e119210269fce872d0fe3fb56b6f87f86a770837a5fa5b1ac7/diff
+        MergedDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/merged
+        UpperDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/diff
+        WorkDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/logstash/ssl:/usr/share/logstash/config/ssl:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/logstash/logstash.yml:/usr/share/logstash/config/logstash.yml:rw
+      - /usr/share/logstash/libs:/usr/share/logstash/libs:rw
+      - /etc/logstash/scripts:/usr/share/logstash/scripts:rw
+      - /etc/logstash/pipelines:/usr/share/logstash/pipelines:rw
+      - /etc/logstash/jvm.options:/usr/share/logstash/config/jvm.options:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/logstash/pipelines.yml:/usr/share/logstash/config/pipelines.yml:rw
+      - /etc/logstash/logstash.keystore:/usr/share/logstash/config/logstash.keystore:rw
+      - /var/lib/logstash/spool:/var/lib/logstash/spool:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/hostname
+    HostsPath: /etc/hosts
+    Id: 1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
+    Image: sha256:6dea016b06dec9bd6649861e6ff6f37fa4cc33f4af5a908d42756f1ff07e1e3a
+    LogPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/share/logstash/libs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /usr/share/logstash/libs
+      Type: bind
+    - Destination: /usr/share/logstash/pipelines
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/pipelines
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /usr/share/logstash/config/jvm.options
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/jvm.options
+      Type: bind
+    - Destination: /usr/share/logstash/config/logstash.keystore
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/logstash.keystore
+      Type: bind
+    - Destination: /usr/share/logstash/config/pipelines.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/pipelines.yml
+      Type: bind
+    - Destination: /usr/share/logstash/config/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/ssl
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /usr/share/logstash/config/logstash.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/logstash.yml
+      Type: bind
+    - Destination: /usr/share/logstash/scripts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/scripts
+      Type: bind
+    - Destination: /var/lib/logstash/spool
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/logstash/spool
+      Type: bind
+    Name: /logstash
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: a05e3bedd671d506ea7c75121f96d6f15b58fb25d99f0a761d85522c4cb31c13
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
+      Ports: {}
+      SandboxID: b70e6ce41402ab5de2b13827be954a106a7d738478fee9bd07a2ca753971613b
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/local/bin/docker-entrypoint
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:40.665430732Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 7056
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:55:51.256169421Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --port
+    - '6379'
+    - --tls-port
+    - '6378'
+    - --appendonly
+    - 'no'
+    - --maxmemory
+    - '0'
+    - --maxclients
+    - '10000'
+    - --bind
+    - 0.0.0.0
+    - --tls-auth-clients
+    - 'no'
+    - --tls-cert-file
+    - /data/ssl/redis.crt
+    - --tls-key-file
+    - /data/ssl/redis.pem
+    - --tls-ca-cert-file
+    - /data/ssl/redis_ca.crt
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - --port
+      - '6379'
+      - --tls-port
+      - '6378'
+      - --appendonly
+      - 'no'
+      - --maxmemory
+      - '0'
+      - --maxclients
+      - '10000'
+      - --bind
+      - 0.0.0.0
+      - --tls-auth-clients
+      - 'no'
+      - --tls-cert-file
+      - /data/ssl/redis.crt
+      - --tls-key-file
+      - /data/ssl/redis.pem
+      - --tls-ca-cert-file
+      - /data/ssl/redis_ca.crt
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.0.1
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
+      - REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: indexer01.novalocal
+      Image: redis:6.0.1
+      Labels:
+        os_contianer_type: redis
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+        /data/ssl/: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+      WorkingDir: /data
+    Created: '2021-09-08T15:21:08.364900148Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671-init/diff:/var/lib/docker/overlay2/d729bad126881ac666c1ce86fd53b9fbb89dd31a32982fbe52d7b0348d00a7a5/diff:/var/lib/docker/overlay2/6147c7e4ffcac3df8515c47b85fb28fa9cb14e2eda1ae99024a0ad2d4d2f2564/diff:/var/lib/docker/overlay2/e65a456f02dd73ccbf8fcf90ad6c9cd2d090f59a8419916c39c5e3d2f1f4633e/diff:/var/lib/docker/overlay2/0d37d43d45e3912548e3578ac61ec6ae557a5b096629ca286fc5b07999ccae31/diff:/var/lib/docker/overlay2/2c5d5d7ffd6855efcf3a7788c2a72f12de032ac3d00ffa437e32113ae5706b4d/diff:/var/lib/docker/overlay2/ef4edd4aa9d123bae52ac92f708fb15264ac3036df51240db0e17b7ae280a06d/diff
+        MergedDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/merged
+        UpperDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/diff
+        WorkDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/redis:/data:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/redis/ssl/:/data/ssl/:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/hostname
+    HostsPath: /etc/hosts
+    Id: 9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
+    Image: sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c
+    LogPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/redis
+      Type: bind
+    - Destination: /data/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis/ssl
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    Name: /redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: c124f14eba8e33d8dfbf7244d810451b50469d02c40f191ac28d6309b4c2fb20
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
+      Ports: {}
+      SandboxID: 12fa0db070f4558f5c022bb880897adb0e4a11662b3ec5143027e742a036611d
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:40.681971343Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 7054
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:55:50.844646575Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 6378
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 6379
+    protocol: tcp
+  discovery_time: '2022-06-07T13:11:16+02:00'
+  docker:
+    exposed_ports:
+      6379/tcp: {}
+    id: 9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
+    image: redis:6.0.1
+    name: /redis
+    network_mode: host
+    port_bindings: {}
+  files:
+  - name: redis-server
+    path: /usr/local/bin
+    subtype: generic
+    type: binary
+  listening_ports:
+  - 6378
+  - 6379
+  packages: []
+  process:
+    cmdline: redis-server 0.0.0.0:6379
+    cwd: /
+    listening_ports:
+    - 6378
+    - 6379
     pid: '7054'
     ppid: '6905'
     user: polkitd
-  - cmdline: >-
-      /bin/java -Xms2048m -Xmx2048m -XX:+UseConcMarkSweepGC
-      -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly
-      -Djava.awt.headless=true -Dfile.encoding=UTF-8
-      -Djruby.compile.invokedynamic=true -Djruby.jit.threshold=0
-      -Djruby.regexp.interruptible=true -Djava.security.egd=file:/dev/urandom
-      -Dlog4j2.isThreadContextMapInheritable=true
-      -Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ -cp
-      /usr/share/logstash/logstash-core/lib/jars/animal-sniffer-annotations-1.14.jar:/usr/share/logstash/logstash-core/lib/jars/commons-codec-1.11.jar:/usr/share/logstash/logstash-core/lib/jars/commons-compiler-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/error_prone_annotations-2.0.18.jar:/usr/share/logstash/logstash-core/lib/jars/google-java-format-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/gradle-license-report-0.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/guava-22.0.jar:/usr/share/logstash/logstash-core/lib/jars/j2objc-annotations-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-annotations-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-core-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-databind-2.9.9.3.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-dataformat-cbor-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/janino-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/javassist-3.24.0-GA.jar:/usr/share/logstash/logstash-core/lib/jars/jruby-complete-9.2.8.0.jar:/usr/share/logstash/logstash-core/lib/jars/jsr305-1.3.9.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-api-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-core-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-slf4j-impl-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/logstash-core.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.commands-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.contenttype-3.4.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.expressions-3.4.300.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.filesystem-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.jobs-3.5.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.resources-3.7.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.runtime-3.7.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.app-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.common-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.preferences-3.4.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.registry-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.jdt.core-3.10.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.osgi-3.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.text-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/reflections-0.9.11.jar:/usr/share/logstash/logstash-core/lib/jars/slf4j-api-1.7.25.jar
-      org.logstash.Logstash
-    pid: '7056'
-    ppid: '6923'
-    user: centos
-  - cmdline: /usr/bin/docker start -a redis
-    pid: '7301'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a logstash
-    pid: '7302'
-    ppid: '1'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '12810'
-    ppid: '1346'
-    user: postfix
-  - cmdline: 'sshd: centos [priv]'
-    pid: '13667'
-    ppid: '1140'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '13669'
-    ppid: '13667'
-    user: centos
-  - cmdline: '-bash'
-    pid: '13670'
-    ppid: '13669'
-    user: centos
-  - cmdline: sudo su -
-    pid: '13719'
-    ppid: '13670'
-    user: root
-  - cmdline: su -
-    pid: '13720'
-    ppid: '13719'
-    user: root
-  - cmdline: '-bash'
-    pid: '13721'
-    ppid: '13720'
-    user: root
-  - cmdline: ''
-    pid: '13912'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14107'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15270'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654600223
-    pid: '15308'
-    ppid: '1037'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '15309'
-    ppid: '1140'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '15311'
-    ppid: '15309'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-pbgqltdtfflntwnjnegyiqbekgkonwvs ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654600263.029511-77332-190726768087580/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '15496'
-    ppid: '15311'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-pbgqltdtfflntwnjnegyiqbekgkonwvs ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654600263.029511-77332-190726768087580/AnsiballZ_process_facts.py
-    pid: '15511'
-    ppid: '15496'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-pbgqltdtfflntwnjnegyiqbekgkonwvs ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654600263.029511-77332-190726768087580/AnsiballZ_process_facts.py
-    pid: '15512'
-    ppid: '15511'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1654600263.029511-77332-190726768087580/AnsiballZ_process_facts.py
-    pid: '15513'
-    ppid: '15512'
-    user: root
-  - cmdline: ''
-    pid: '15576'
-    ppid: '2'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '28010'
-    ppid: '1042'
-    user: root
-  - cmdline: /bin/sh -c python ./listener.py
-    pid: '28025'
-    ppid: '28010'
-    user: root
-  - cmdline: python ./listener.py
-    pid: '28039'
-    ppid: '28025'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1346
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:56 2022'
-    user: root
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 7054
-    port: 6378
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:48 2022'
-    user: polkitd
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 7054
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:48 2022'
-    user: polkitd
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:05 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1140
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:48 2022'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1346
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:56 2022'
-    user: root
-  - address: '::'
-    name: java
-    pid: 7056
-    port: 5055
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:48 2022'
-    user: centos
-  - address: '::'
-    name: java
-    pid: 7056
-    port: 9600
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:48 2022'
-    user: centos
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:05 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1140
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:48 2022'
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: Redis
+  version:
+  - number: 6.0.1
+    type: command
+  - number: 6.0.1
+    type: docker
+mocked_plugin_tasks:
+  Get environment:
+    execute_module_result:
+      content: ''
+      encoding: plain
+      failed: false
+    expected_result:
+      content: any
+      failed: false
+      parsed:
+        GOSU_VERSION: '1.12'
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        REDIS_DOWNLOAD_SHA: b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
+        REDIS_DOWNLOAD_URL: http://download.redis.io/releases/redis-6.0.1.tar.gz
+        REDIS_VERSION: 6.0.1
+  Run version command:
+    calls:
+    - execute_module_result:
+        failed: false
+        stdout: Redis server v=6.0.1 sha=00000000:0 malloc=jemalloc-5.1.0 bits=64
+          build=0
+      expected_args:
+        argv: null
+        cmd: /usr/local/bin/redis-server --version
+        in_docker: true
+  Run which:
+    calls:
+    - execute_module_result:
+        failed: false
+        files:
+        - isdir: false
+          path: /proc/7054/root/usr/local/bin/redis-server
+          xgrp: true
+          xoth: true
+          xusr: true
+        matched: 1
+      expected_args:
+        hidden: false
+        in_docker: true
+        name: redis-server
+        paths:
+        - /usr/local/sbin
+        - /usr/local/bin
+        - /usr/sbin
+        - /usr/bin
+        - /sbin
+        - /bin
+        windows_valid_extensions: null
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 976
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:43 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:05 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 743
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:30 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  keepalived:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 16.el7
+    source: rpm
+    version: 1.3.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-devel:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-devel
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsepol-devel:
+  - arch: x86_64
+    epoch: null
+    name: libsepol-devel
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mariadb-server:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-server
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 48.el7_8.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 48.el7_8.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcre-devel:
+  - arch: x86_64
+    epoch: null
+    name: pcre-devel
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Compress-Raw-Bzip2:
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
+  perl-Compress-Raw-Zlib:
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
+  perl-DBD-MySQL:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBD-MySQL
+    release: 6.el7
+    source: rpm
+    version: '4.023'
+  perl-DBI:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBI
+    release: 4.el7
+    source: rpm
+    version: '1.627'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-IO-Compress:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
+  perl-Net-Daemon:
+  - arch: noarch
+    epoch: null
+    name: perl-Net-Daemon
+    release: 5.el7
+    source: rpm
+    version: '0.48'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-PlRPC:
+  - arch: noarch
+    epoch: null
+    name: perl-PlRPC
+    release: 14.el7
+    source: rpm
+    version: '0.2020'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 720
-    port: 837
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  socat:
+  - arch: x86_64
+    epoch: null
+    name: socat
+    release: 2.el7
+    source: rpm
+    version: 1.7.3.2
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:05 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 743
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:30 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 720
-    port: 837
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '40'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '93'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '301'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '306'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '377'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '393'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '477'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '541'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '673'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '704'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '720'
+  ppid: '1'
+  user: rpc
+- cmdline: ''
+  cwd: /
+  pid: '721'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '724'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '731'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '743'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '747'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H indexer01 eth0
+  cwd: /sbin/
+  pid: '976'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1037'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1038'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1042'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1128'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1136'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1140'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1152'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1153'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '1290'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '1291'
+  ppid: '1290'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '1292'
+  ppid: '1290'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1346'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1348'
+  ppid: '1346'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '4947'
+  ppid: '2'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '6905'
+  ppid: '1042'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '6923'
+  ppid: '1042'
+  user: root
+- cmdline: redis-server 0.0.0.0:6379
+  cwd: /
+  pid: '7054'
+  ppid: '6905'
+  user: polkitd
+- cmdline: /bin/java -Xms2048m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75
+    -XX:+UseCMSInitiatingOccupancyOnly -Djava.awt.headless=true -Dfile.encoding=UTF-8
+    -Djruby.compile.invokedynamic=true -Djruby.jit.threshold=0 -Djruby.regexp.interruptible=true
+    -Djava.security.egd=file:/dev/urandom -Dlog4j2.isThreadContextMapInheritable=true
+    -Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ -cp /usr/share/logstash/logstash-core/lib/jars/animal-sniffer-annotations-1.14.jar:/usr/share/logstash/logstash-core/lib/jars/commons-codec-1.11.jar:/usr/share/logstash/logstash-core/lib/jars/commons-compiler-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/error_prone_annotations-2.0.18.jar:/usr/share/logstash/logstash-core/lib/jars/google-java-format-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/gradle-license-report-0.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/guava-22.0.jar:/usr/share/logstash/logstash-core/lib/jars/j2objc-annotations-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-annotations-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-core-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-databind-2.9.9.3.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-dataformat-cbor-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/janino-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/javassist-3.24.0-GA.jar:/usr/share/logstash/logstash-core/lib/jars/jruby-complete-9.2.8.0.jar:/usr/share/logstash/logstash-core/lib/jars/jsr305-1.3.9.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-api-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-core-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-slf4j-impl-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/logstash-core.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.commands-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.contenttype-3.4.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.expressions-3.4.300.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.filesystem-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.jobs-3.5.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.resources-3.7.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.runtime-3.7.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.app-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.common-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.preferences-3.4.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.registry-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.jdt.core-3.10.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.osgi-3.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.text-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/reflections-0.9.11.jar:/usr/share/logstash/logstash-core/lib/jars/slf4j-api-1.7.25.jar
+    org.logstash.Logstash
+  cwd: /bin/
+  pid: '7056'
+  ppid: '6923'
+  user: centos
+- cmdline: /usr/bin/docker start -a redis
+  cwd: /usr/bin/
+  pid: '7301'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a logstash
+  cwd: /usr/bin/
+  pid: '7302'
+  ppid: '1'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '12810'
+  ppid: '1346'
+  user: postfix
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '13667'
+  ppid: '1140'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '13669'
+  ppid: '13667'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '13670'
+  ppid: '13669'
+  user: centos
+- cmdline: sudo su -
+  cwd: /
+  pid: '13719'
+  ppid: '13670'
+  user: root
+- cmdline: su -
+  cwd: /
+  pid: '13720'
+  ppid: '13719'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '13721'
+  ppid: '13720'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13912'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14107'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15270'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1654600223
+  cwd: /usr/lib64/sa/
+  pid: '15308'
+  ppid: '1037'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '15309'
+  ppid: '1140'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '15311'
+  ppid: '15309'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-pbgqltdtfflntwnjnegyiqbekgkonwvs
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654600263.029511-77332-190726768087580/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '15496'
+  ppid: '15311'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-pbgqltdtfflntwnjnegyiqbekgkonwvs
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654600263.029511-77332-190726768087580/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '15511'
+  ppid: '15496'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-pbgqltdtfflntwnjnegyiqbekgkonwvs ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1654600263.029511-77332-190726768087580/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '15512'
+  ppid: '15511'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1654600263.029511-77332-190726768087580/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '15513'
+  ppid: '15512'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15576'
+  ppid: '2'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '28010'
+  ppid: '1042'
+  user: root
+- cmdline: /bin/sh -c python ./listener.py
+  cwd: /bin/
+  pid: '28025'
+  ppid: '28010'
+  user: root
+- cmdline: python ./listener.py
+  cwd: /
+  pid: '28039'
+  ppid: '28025'
+  user: root
+software_list:
+- cmd_regexp: redis-serve
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/redis.yaml'
+    name: Include redis specific plugins
+  name: Redis
+  pkg_regexp: ^redis
+  process_type: parent
+  return_children: false
+  return_packages: true
+  vars: {}
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1346
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:54:56 2022
+  user: root
+- address: 0.0.0.0
+  name: redis-server
+  pid: 7054
+  port: 6378
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: polkitd
+- address: 0.0.0.0
+  name: redis-server
+  pid: 7054
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: polkitd
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1140
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:54:48 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1346
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:54:56 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 7056
+  port: 5055
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: centos
+- address: '::'
+  name: java
+  pid: 7056
+  port: 9600
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: centos
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1140
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:54:48 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 976
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:54:43 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 743
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:30 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 720
+  port: 837
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 743
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:30 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 720
+  port: 837
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/sap_ccms/sap_ccms_tests.yaml
+++ b/tests/unit/plugins/action/auto/resources/sap_ccms/sap_ccms_tests.yaml
@@ -1,3768 +1,3760 @@
-mocked_plugin_tasks:
-  Check http or https:
-    calls:
-      - expected_args:
-          check_connection:
-            address: "127.0.0.1"
-            port: "4000"
-        plugin_result: {
-          "failed": false,
-          "skipped": false,
-          "msg": "",
-          "invocation": {
-            "module_args": {
-              "port": 4000,
-              "timeout": 1,
-              "address": "127.0.0.1"
-            }
-          },
-          "task": "Check http or https",
-          "available": false,
-          "identified_as": true,
-          "changed": false,
-          "_ansible_parsed": true,
-          "ansible_facts": {
-            "discovered_interpreter_python": "/usr/bin/python"
-          }
-        }
-      - expected_args:
-          check_connection:
-            address: "127.0.0.1"
-            port: "5000"
-        plugin_result: {
-            "failed": false,
-            "skipped": false,
-            "msg": "",
-            "invocation": {
-              "module_args": {
-                "port": 5000,
-                "timeout": 1,
-                "address": "127.0.0.1"
-              }
-            },
-            "task": "Check http or https",
-            "available": false,
-            "identified_as": false,
-            "changed": false,
-            "_ansible_parsed": true,
-            "ansible_facts": {
-              "discovered_interpreter_python": "/usr/bin/python"
-            }
-          }
-      - expected_args:
-          check_connection:
-            address: "127.0.0.1"
-            port: "6000"
-        plugin_result: {
-          "failed": false,
-          "skipped": false,
-          "msg": "",
-          "invocation": {
-            "module_args": {
-              "port": 6000,
-              "timeout": 1,
-              "address": "127.0.0.1"
-            }
-          },
-          "task": "Check http or https",
-          "available": false,
-          "identified_as": null,
-          "changed": false,
-          "_ansible_parsed": null,
-          "ansible_facts": {
-            "discovered_interpreter_python": "/usr/bin/python"
-          }
-        }
-
-expected_result:
-  - discovery_time: '2022-06-30T16:34:51+02:00'
-    endpoints:
-      - uri: 0.0.0.0:4000
-        type: icman
-        extra_data:
-          tls: True
-      - uri: 0.0.0.0:5000
-        type: msg_server
-        extra_data:
-          tls: False
-    bindings:
-      - address: 0.0.0.0
-        class: service
-        extra_data:
-          sysnr: '87'
-        port: 3387
-        protocol: tcp
-      - address: 127.0.0.1
-        class: service
-        extra_data:
-          sysnr: '88'
-        port: 3388
-        protocol: tcp
-      - address: 192.168.1.35
-        class: service
-        extra_data:
-          sysnr: '89'
-        port: 3389
-        protocol: tcp
-    listening_ports:
-      - 3387
-      - 3388
-      - 3389
-    process:
-      listening_ports:
-        - 3387
-        - 3388
-        - 3389
-      cmdline: /usr/bin/gwrd -b config.yaml
-      pid: '123'
-      ppid: '0'
-      user: root
-    type: SAP CCMS
-    version: [ ]
-software_list:
-  - cmd_regexp: gwrd
-    name: SAP CCMS
-    custom_tasks:
-      - include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/sap_ccms.yaml"
-        name: Include sap ccms specific plugins
-    process_type: parent
-    return_children: false
 dockers:
-  containers: [ ]
-packages:
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
-  apache-commons-collections:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-collections
-      release: 22.el7_2
-      source: rpm
-      version: 3.2.1
-  apache-commons-daemon:
-    - arch: x86_64
-      epoch: null
-      name: apache-commons-daemon
-      release: 7.el7
-      source: rpm
-      version: 1.0.13
-  apache-commons-dbcp:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-dbcp
-      release: 17.el7
-      source: rpm
-      version: '1.4'
-  apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
-  apache-commons-pool:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-pool
-      release: 9.el7
-      source: rpm
-      version: '1.6'
-  apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
-  apr-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-devel
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
-  apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
-  apr-util-devel:
-    - arch: x86_64
-      epoch: null
-      name: apr-util-devel
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
-  atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autoconf:
-    - arch: noarch
-      epoch: null
-      name: autoconf
-      release: 11.el7
-      source: rpm
-      version: '2.69'
-  automake:
-    - arch: noarch
-      epoch: null
-      name: automake
-      release: 3.el7
-      source: rpm
-      version: 1.13.4
-  avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
-  avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
-  avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 16.P2.el7_8.2
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 43.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 76.el7_7
-      source: rpm
-      version: 2019.2.32
-  cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
-  centos-indexhtml:
-    - arch: noarch
-      epoch: null
-      name: centos-indexhtml
-      release: 9.el7.centos
-      source: rpm
-      version: '7'
-  centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 8.2003.0.el7.centos
-      source: rpm
-      version: '7'
-  centos-release-scl-rh:
-    - arch: noarch
-      epoch: null
-      name: centos-release-scl-rh
-      release: 3.el7.centos
-      source: rpm
-      version: '2'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 6.el7.centos
-      source: rpm
-      version: '18.5'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
-  copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
-  cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  cyrus-sasl-devel:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-devel
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 7.el7_8.1
-      source: rpm
-      version: 1.02.164
-  devtoolset-7-binutils:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-binutils
-      release: 11.el7
-      source: rpm
-      version: '2.28'
-  devtoolset-7-gcc:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
-  devtoolset-7-gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-gcc-c++
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
-  devtoolset-7-libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-libstdc++-devel
-      release: 5.16.el7
-      source: rpm
-      version: 7.3.1
-  devtoolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: devtoolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: '7.1'
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 79.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 3.el7
-      source: rpm
-      version: '3.2'
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 568.el7
-      source: rpm
-      version: '033'
-  dwz:
-    - arch: x86_64
-      epoch: null
-      name: dwz
-      release: 3.el7
-      source: rpm
-      version: '0.11'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  ecj:
-    - arch: x86_64
-      epoch: 1
-      name: ecj
-      release: 3.el7
-      source: rpm
-      version: 4.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 4.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  expat-devel:
-    - arch: x86_64
-      epoch: null
-      name: expat-devel
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 36.el7
-      source: rpm
-      version: '5.11'
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  geronimo-jta:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jta
-      release: 17.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 5.el7
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gperftools-libs:
-    - arch: x86_64
-      epoch: null
-      name: gperftools-libs
-      release: 1.el7
-      source: rpm
-      version: 2.6.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 608c8351
-      source: rpm
-      version: 442df0f8
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 560cfc0a
-      source: rpm
-      version: f2ee9d55
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.81.el7.centos
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 28.el7
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  haproxy:
-    - arch: x86_64
-      epoch: null
-      name: haproxy
-      release: 9.el7_9.1
-      source: rpm
-      version: 1.5.18
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  httpd:
-    - arch: x86_64
-      epoch: null
-      name: httpd
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-devel:
-    - arch: x86_64
-      epoch: null
-      name: httpd-devel
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  httpd-tools:
-    - arch: x86_64
-      epoch: null
-      name: httpd-tools
-      release: 97.el7.centos
-      source: rpm
-      version: 2.4.6
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.5.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.49
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 25.el7_7.2
-      source: rpm
-      version: 4.11.0
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 34.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-taglibs-standard:
-    - arch: noarch
-      epoch: 0
-      name: jakarta-taglibs-standard
-      release: 14.el7_1
-      source: rpm
-      version: 1.1.2
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 0.el7_9
-      source: rpm
-      version: 1.8.0.302.b08
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  keepalived:
-    - arch: x86_64
-      epoch: null
-      name: keepalived
-      release: 19.el7
-      source: rpm
-      version: 1.3.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.42.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 43.el7
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 131.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 46.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 57.el7
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-devel:
-    - arch: x86_64
-      epoch: null
-      name: libdb-devel
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libedit-devel:
-    - arch: x86_64
-      epoch: null
-      name: libedit-devel
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libicu-devel:
-    - arch: x86_64
-      epoch: null
-      name: libicu-devel
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 17.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 3.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libtool:
-    - arch: x86_64
-      epoch: null
-      name: libtool
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7.4
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  llvm-toolset-7-clang:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-clang-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-clang-libs
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-compiler-rt:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-compiler-rt
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-libomp:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-libomp
-      release: 2.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-llvm-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-llvm-libs
-      release: 8.el7
-      source: rpm
-      version: 5.0.1
-  llvm-toolset-7-runtime:
-    - arch: x86_64
-      epoch: null
-      name: llvm-toolset-7-runtime
-      release: 4.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-devel:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-devel
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  llvm5.0-libs:
-    - arch: x86_64
-      epoch: null
-      name: llvm5.0-libs
-      release: 7.el7
-      source: rpm
-      version: 5.0.1
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 16.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 14.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 3.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
-  mailcap:
-    - arch: noarch
-      epoch: null
-      name: mailcap
-      release: 2.el7
-      source: rpm
-      version: 2.1.41
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.65
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 61.el7
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-devel:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-devel
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 49.el7_9.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.66.el7
-      source: rpm
-      version: 1.3.0
-  nginx:
-    - arch: x86_64
-      epoch: 1
-      name: nginx
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: nginx-filesystem
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nginx-mod-stream:
-    - arch: x86_64
-      epoch: 1
-      name: nginx-mod-stream
-      release: 2.el7
-      source: rpm
-      version: 1.20.1
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7
-      source: rpm
-      version: 4.21.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 8.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.el7_7
-      source: rpm
-      version: 3.44.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 4.el7_7
-      source: rpm
-      version: 3.44.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openldap-devel:
-    - arch: x86_64
-      epoch: null
-      name: openldap-devel
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 19.el7
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Thread-Queue:
-    - arch: noarch
-      epoch: null
-      name: perl-Thread-Queue
-      release: 2.el7
-      source: rpm
-      version: '3.02'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: perl-srpm-macros
-      release: 8.el7
-      source: rpm
-      version: '1'
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pgdg-redhat-repo:
-    - arch: noarch
-      epoch: null
-      name: pgdg-redhat-repo
-      release: '24'
-      source: rpm
-      version: '42.0'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql11:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-contrib
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-devel:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-devel
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-libs
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  postgresql11-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql11-server
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '11.15'
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 27.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-devel:
-    - arch: x86_64
-      epoch: null
-      name: python-devel
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 9.el7_8
-      source: rpm
-      version: 2.6.0
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python2-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python2-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-devel:
-    - arch: x86_64
-      epoch: null
-      name: python3-devel
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-rpm-generators:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-generators
-      release: 2.el7
-      source: rpm
-      version: '6'
-  python3-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redhat-rpm-config:
-    - arch: noarch
-      epoch: null
-      name: redhat-rpm-config
-      release: 88.el7.centos
-      source: rpm
-      version: 9.1.0
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 43.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 52.el7
-      source: rpm
-      version: 8.24.0
-  scl-utils:
-    - arch: x86_64
-      epoch: null
-      name: scl-utils
-      release: 19.el7
-      source: rpm
-      version: '20130529'
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 6.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 266.el7
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 9.el7
-      source: rpm
-      version: 1.8.23
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 73.el7_8.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 1.el7
-      source: rpm
-      version: '1.29'
-  tomcat:
-    - arch: noarch
-      epoch: 0
-      name: tomcat
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-admin-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-admin-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-el-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-el-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-jsp-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-jsp-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-lib:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-lib
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 8.el7
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019c
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021a
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 63.el7
-      source: rpm
-      version: 2.23.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 20.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 167.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 53.el7
-      source: rpm
-      version: 1.1.31
-  zip:
-    - arch: x86_64
-      epoch: null
-      name: zip
-      release: 11.el7
-      source: rpm
-      version: '3.0'
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/bin/gwrd -b config.yaml
+  containers: []
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    extra_data:
+      sysnr: '87'
+    port: 3387
+    protocol: tcp
+  - address: 127.0.0.1
+    class: service
+    extra_data:
+      sysnr: '88'
+    port: 3388
+    protocol: tcp
+  - address: 192.168.1.35
+    class: service
+    extra_data:
+      sysnr: '89'
+    port: 3389
+    protocol: tcp
+  discovery_time: '2022-06-30T16:34:51+02:00'
+  endpoints:
+  - extra_data:
+      tls: true
+    type: icman
+    uri: 0.0.0.0:4000
+  - extra_data:
+      tls: false
+    type: msg_server
+    uri: 0.0.0.0:5000
+  listening_ports:
+  - 3387
+  - 3388
+  - 3389
+  process:
+    cmdline: /usr/bin/gwrd -b config.yaml
+    cwd: /usr/bin/
+    listening_ports:
+    - 3387
+    - 3388
+    - 3389
     pid: '123'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '126'
-    ppid: '0'
-    user: root
+  type: SAP CCMS
+  version: []
+mocked_plugin_tasks:
+  Check http or https:
+    calls:
+    - expected_args:
+        check_connection:
+          address: 127.0.0.1
+          port: '4000'
+      plugin_result:
+        _ansible_parsed: true
+        ansible_facts:
+          discovered_interpreter_python: /usr/bin/python
+        available: false
+        changed: false
+        failed: false
+        identified_as: true
+        invocation:
+          module_args:
+            address: 127.0.0.1
+            port: 4000
+            timeout: 1
+        msg: ''
+        skipped: false
+        task: Check http or https
+    - expected_args:
+        check_connection:
+          address: 127.0.0.1
+          port: '5000'
+      plugin_result:
+        _ansible_parsed: true
+        ansible_facts:
+          discovered_interpreter_python: /usr/bin/python
+        available: false
+        changed: false
+        failed: false
+        identified_as: false
+        invocation:
+          module_args:
+            address: 127.0.0.1
+            port: 5000
+            timeout: 1
+        msg: ''
+        skipped: false
+        task: Check http or https
+    - expected_args:
+        check_connection:
+          address: 127.0.0.1
+          port: '6000'
+      plugin_result:
+        _ansible_parsed: null
+        ansible_facts:
+          discovered_interpreter_python: /usr/bin/python
+        available: false
+        changed: false
+        failed: false
+        identified_as: null
+        invocation:
+          module_args:
+            address: 127.0.0.1
+            port: 6000
+            timeout: 1
+        msg: ''
+        skipped: false
+        task: Check http or https
+packages:
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  alsa-lib:
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
+  apache-commons-collections:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
+  apache-commons-daemon:
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
+  apache-commons-dbcp:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
+  apache-commons-logging:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
+  apache-commons-pool:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
+  apr:
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
+  apr-devel:
+  - arch: x86_64
+    epoch: null
+    name: apr-devel
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
+  apr-util:
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
+  apr-util-devel:
+  - arch: x86_64
+    epoch: null
+    name: apr-util-devel
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
+  atk:
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autoconf:
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
+  automake:
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
+  avahi-libs:
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  avalon-framework:
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
+  avalon-logkit:
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 16.P2.el7_8.2
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 43.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 76.el7_7
+    source: rpm
+    version: 2019.2.32
+  cairo:
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
+  centos-indexhtml:
+  - arch: noarch
+    epoch: null
+    name: centos-indexhtml
+    release: 9.el7.centos
+    source: rpm
+    version: '7'
+  centos-logos:
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 8.2003.0.el7.centos
+    source: rpm
+    version: '7'
+  centos-release-scl-rh:
+  - arch: noarch
+    epoch: null
+    name: centos-release-scl-rh
+    release: 3.el7.centos
+    source: rpm
+    version: '2'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 6.el7.centos
+    source: rpm
+    version: '18.5'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
+  copy-jdk-configs:
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
+  cups-libs:
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-devel:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-devel
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  dejavu-fonts-common:
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  dejavu-sans-fonts:
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
+  devtoolset-7-binutils:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-binutils
+    release: 11.el7
+    source: rpm
+    version: '2.28'
+  devtoolset-7-gcc:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
+  devtoolset-7-gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc-c++
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
+  devtoolset-7-libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-libstdc++-devel
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
+  devtoolset-7-runtime:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: '7.1'
+  dhclient:
+  - arch: x86_64
+    epoch: 12
+    name: dhclient
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 3.el7
+    source: rpm
+    version: '3.2'
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dwz:
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  expat-devel:
+  - arch: x86_64
+    epoch: null
+    name: expat-devel
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 5.el7
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gperftools-libs:
+  - arch: x86_64
+    epoch: null
+    name: gperftools-libs
+    release: 1.el7
+    source: rpm
+    version: 2.6.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 560cfc0a
+    source: rpm
+    version: f2ee9d55
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 28.el7
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  haproxy:
+  - arch: x86_64
+    epoch: null
+    name: haproxy
+    release: 9.el7_9.1
+    source: rpm
+    version: 1.5.18
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  httpd:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-devel:
+  - arch: x86_64
+    epoch: null
+    name: httpd-devel
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-tools:
+  - arch: x86_64
+    epoch: null
+    name: httpd-tools
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.5.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.49
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 25.el7_7.2
+    source: rpm
+    version: 4.11.0
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 34.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  keepalived:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 19.el7
+    source: rpm
+    version: 1.3.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.42.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 43.el7
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 131.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-devel:
+  - arch: x86_64
+    epoch: null
+    name: libdb-devel
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libedit-devel:
+  - arch: x86_64
+    epoch: null
+    name: libedit-devel
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libicu-devel:
+  - arch: x86_64
+    epoch: null
+    name: libicu-devel
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 3.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libtool:
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  llvm-toolset-7-clang:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-clang-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang-libs
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-compiler-rt:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-compiler-rt
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-libomp:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-libomp
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-llvm-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-llvm-libs
+    release: 8.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-runtime:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-devel:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-devel
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-libs
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 16.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 14.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.65
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 61.el7
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-devel:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-devel
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.66.el7
+    source: rpm
+    version: 1.3.0
+  nginx:
+  - arch: x86_64
+    epoch: 1
+    name: nginx
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: nginx-filesystem
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-mod-stream:
+  - arch: x86_64
+    epoch: 1
+    name: nginx-mod-stream
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7
+    source: rpm
+    version: 4.21.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 4.el7_7
+    source: rpm
+    version: 3.44.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openldap-devel:
+  - arch: x86_64
+    epoch: null
+    name: openldap-devel
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Thread-Queue:
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pgdg-redhat-repo:
+  - arch: noarch
+    epoch: null
+    name: pgdg-redhat-repo
+    release: '24'
+    source: rpm
+    version: '42.0'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql11:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-devel:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-devel
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 27.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-devel:
+  - arch: x86_64
+    epoch: null
+    name: python-devel
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 9.el7_8
+    source: rpm
+    version: 2.6.0
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python2-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python2-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
+    name: rpcbind
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 52.el7
+    source: rpm
+    version: 8.24.0
+  scl-utils:
+  - arch: x86_64
+    epoch: null
+    name: scl-utils
+    release: 19.el7
+    source: rpm
+    version: '20130529'
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 6.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 9.el7
+    source: rpm
+    version: 1.8.23
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 8.el7
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019c
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 20.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 167.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/bin/gwrd -b config.yaml
+  cwd: /usr/bin/
+  pid: '123'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '126'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: gwrd
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/sap_ccms.yaml'
+    name: Include sap ccms specific plugins
+  name: SAP CCMS
+  process_type: parent
+  return_children: false
 tcp_listen:
-  - address: 0.0.0.0
-    name: sapport1
-    pid: 123
-    port: 3387
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: sapport2
-    pid: 123
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: sapport3
-    pid: 123
-    port: 3389
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sapport4
-    pid: 124
-    port: 4000
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sapport5
-    pid: 125
-    port: 5000
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sapport5
-    pid: 126
-    port: 6000
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-udp_listen: [ ]
+- address: 0.0.0.0
+  name: sapport1
+  pid: 123
+  port: 3387
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: sapport2
+  pid: 123
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: sapport3
+  pid: 123
+  port: 3389
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: sapport4
+  pid: 124
+  port: 4000
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: sapport5
+  pid: 125
+  port: 5000
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: sapport5
+  pid: 126
+  port: 6000
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+udp_listen: []

--- a/tests/unit/plugins/action/auto/resources/sap_control/sap_control_tests.yaml
+++ b/tests/unit/plugins/action/auto/resources/sap_control/sap_control_tests.yaml
@@ -1,3823 +1,3779 @@
----
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 53314
-        protocol: 'tcp'
-    discovery_time: '2022-07-04T10:11:21+02:00'
-    endpoints:
-      - uri: https://127.0.0.1:53314
-        type: generic
-    listening_ports:
-      - 53314
-    process:
-      cmdline: /usr/bin/sapstartsrv -b config.yaml
-      listening_ports:
-        - 53314
-      pid: '121'
-      ppid: '0'
-      user: root
-    type: SAPcontrol
-    version: []
-software_list:
-  - cmd_regexp: sapstartsrv
-    name: SAPcontrol
-    custom_tasks:
-      - include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/sap_control.yaml"
-        name: Include sap control specific plugins
-    process_type: parent
-    return_children: false
-    return_packages: false
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: {}
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: 'sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25'
-      LogPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: []
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: {}
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /var/lib/grafana: {}
-          /var/log/grafana: {}
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: {}
-          /var/lib/postgresql/data: {}
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: {}
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: {}
-          /etc/localtime: {}
-          /etc/nginx: {}
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: {}
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 9c1d011c0c819c6d8164e9555eb7f0fe0c56570d5b1a552be87c52c6cf07d6f9
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: {}
-        SandboxID: aec58358e90aa03c618912b9de2c668c71dcf79b422103ed2f65187aa27a45bb
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-04T08:11:18.644919286Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 24380
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-04T08:11:19.273928516Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.9
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.3.1p1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 3.el7
-      source: rpm
-      version: '1.217'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 22.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 6.el7
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/bin/sapstartsrv -b config.yaml
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 9c1d011c0c819c6d8164e9555eb7f0fe0c56570d5b1a552be87c52c6cf07d6f9
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: aec58358e90aa03c618912b9de2c668c71dcf79b422103ed2f65187aa27a45bb
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-04T08:11:18.644919286Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 24380
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-04T08:11:19.273928516Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 53314
+    protocol: tcp
+  discovery_time: '2022-07-04T10:11:21+02:00'
+  endpoints:
+  - type: generic
+    uri: https://127.0.0.1:53314
+  listening_ports:
+  - 53314
+  process:
+    cmdline: /usr/bin/sapstartsrv -b config.yaml
+    cwd: /usr/bin/
+    listening_ports:
+    - 53314
     pid: '121'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
-tcp_listen:
-  - address: 0.0.0.0
-    name: sapport1
-    pid: 121
-    port: 53314
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: sapport2
-    pid: 122
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: sapport3
-    pid: 123
-    port: 52914
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sapport4
-    pid: 124
-    port: 53213
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sapport5
-    pid: 125
-    port: 52614
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: SAPcontrol
+  version: []
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.9
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.3.1p1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 3.el7
+    source: rpm
+    version: '1.217'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 22.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/bin/sapstartsrv -b config.yaml
+  cwd: /usr/bin/
+  pid: '121'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: sapstartsrv
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/sap_control.yaml'
+    name: Include sap control specific plugins
+  name: SAPcontrol
+  process_type: parent
+  return_children: false
+  return_packages: false
+tcp_listen:
+- address: 0.0.0.0
+  name: sapport1
+  pid: 121
+  port: 53314
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: sapport2
+  pid: 122
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: sapport3
+  pid: 123
+  port: 52914
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: sapport4
+  pid: 124
+  port: 53213
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: sapport5
+  pid: 125
+  port: 52614
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/sap_hana/saphana_test.yaml
+++ b/tests/unit/plugins/action/auto/resources/sap_hana/saphana_test.yaml
@@ -1,169 +1,173 @@
----
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 8082
-        protocol: 'tcp'
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 111
-        protocol: 'udp'
-      - class: service
-        address: 127.0.0.1
-        port: 34515
-    discovery_time: '2022-06-24T13:24:09+02:00'
-    listening_ports:
-      - 111
-      - 8082
-    packages: []
-    process:
-      cmdline: /usr/lib/systemd/hdbindexserver
-      listening_ports:
-        - 111
-        - 8082
-      pid: '1'
-      ppid: '0'
-      user: root
-    type: SAP HANA DatabaseServer
-    version:
-      []
-software_list:
-  - name: SAP HANA DatabaseServer
-    cmd_regexp: hdbindexserver
-    process_type: parent
-    return_children: false
-    return_packages: true
-    custom_tasks:
-      - name: Include skydive specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/sap_hana.yaml"
 dockers:
-  containers: [ ]
-
-processes:
-  - cmdline: /usr/lib/systemd/hdbindexserver
+  containers: []
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 8082
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 111
+    protocol: udp
+  - address: 127.0.0.1
+    class: service
+    port: 34515
+  discovery_time: '2022-06-24T13:24:09+02:00'
+  listening_ports:
+  - 111
+  - 8082
+  packages: []
+  process:
+    cmdline: /usr/lib/systemd/hdbindexserver
+    cwd: /usr/lib/systemd/
+    listening_ports:
+    - 111
+    - 8082
     pid: '1'
     ppid: '0'
     user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
+  type: SAP HANA DatabaseServer
+  version: []
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+processes:
+- cmdline: /usr/lib/systemd/hdbindexserver
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: hdbindexserver
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/sap_hana.yaml'
+    name: Include skydive specific plugins
+  name: SAP HANA DatabaseServer
+  process_type: parent
+  return_children: false
+  return_packages: true
 tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1055
-    port: 8080
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:02 2022'
-    user: root
-  - address: 127.0.0.1
-    name: sap hana
-    pid: 5410
-    port: 4000
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: 127.0.0.1
-    name: sap hana
-    pid: 5410
-    port: 12379
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 8082
-    protocol: tcp
-    stime: 'Tue Apr 26 15:53:41 2022'
-    user: root
+- address: 127.0.0.1
+  name: master
+  pid: 1055
+  port: 8080
+  protocol: tcp
+  stime: Tue Apr 26 15:54:02 2022
+  user: root
+- address: 127.0.0.1
+  name: sap hana
+  pid: 5410
+  port: 4000
+  protocol: tcp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: 127.0.0.1
+  name: sap hana
+  pid: 5410
+  port: 12379
+  protocol: tcp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 8082
+  protocol: tcp
+  stime: Tue Apr 26 15:53:41 2022
+  user: root
 udp_listen:
-  - address: 127.0.0.1
-    name: dhclient
-    pid: 865
-    port: 34515
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:59 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:41 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 626
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:48 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 618
-    port: 781
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:47 2022'
-    user: rpc
+- address: 127.0.0.1
+  name: dhclient
+  pid: 865
+  port: 34515
+  protocol: udp
+  stime: Tue Apr 26 15:53:59 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:53:41 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 626
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:53:48 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 618
+  port: 781
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/skydive/skydive0.28.0_centos.yaml
+++ b/tests/unit/plugins/action/auto/resources/skydive/skydive0.28.0_centos.yaml
@@ -1,3494 +1,3589 @@
-mocked_plugin_tasks:
-  Check socket from a port:
-    calls:
-      - plugin_result:
-          failed: false
-      - plugin_result:
-          failed: false
-      - plugin_result:
-          failed: false
-      - plugin_result:
-          failed: false
-      - plugin_result:
-          failed: false
-  Request information from api port:
-    calls:
-      - plugin_result:
-          failed: true
-          status: 406
-      - plugin_result:
-          failed: false
-          status: 200
-          content: "<!DOCTYPE html>\n<html>\n<head>\n\t<meta charset=utf-8/>\n\t<meta name=\"viewport\" content=\"user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui\">\n\t<link rel=\"shortcut icon\" href=\"https://graphcool-playground.netlify.com/favicon.png\">\n\t<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/static/css/index.css\"\n\t\tintegrity=\"sha256-dKnNLEFwKSVFpkpjRWe&#43;o/jQDM6n/JsvQ0J3l5Dk3fc=\" crossorigin=\"anonymous\"/>\n\t<link rel=\"shortcut icon\" href=\"https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/favicon.png\"\n\t\tintegrity=\"sha256-GhTyE&#43;McTU79R4&#43;pRO6ih&#43;4TfsTOrpPwD8ReKFzb3PM=\" crossorigin=\"anonymous\"/>\n\t<script src=\"https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/static/js/middleware.js\"\n\t\tintegrity=\"sha256-SG9YAy4eywTcLckwij7V4oSCG3hOdV1m&#43;2e1XuNxIgk=\" crossorigin=\"anonymous\"></script>\n\t<title>GraphQL playground</title>\n</head>\n<body>\n<style type=\"text/css\">\n\thtml { font-family: \"Open Sans\", sans-serif; overflow: hidden; }\n\tbody { margin: 0; background: #172a3a; }\n</style>\n<div id=\"root\"/>\n<script type=\"text/javascript\">\n\twindow.addEventListener('load', function (event) {\n\t\tconst root = document.getElementById('root');\n\t\troot.classList.add('playgroundIn');\n\t\tconst wsProto = location.protocol == 'https:' ? 'wss:' : 'ws:'\n\t\tGraphQLPlayground.init(root, {\n\t\t\tendpoint: location.protocol + '//' + location.host + '\\/query',\n\t\t\tsubscriptionsEndpoint: wsProto + '//' + location.host + '\\/query',\n           shareEnabled: true,\n\t\t\tsettings: {\n\t\t\t\t'request.credentials': 'same-origin'\n\t\t\t}\n\t\t})\n\t})\n</script>\n</body>\n</html>\n"
-      - plugin_result:
-          failed: false
-          status: 200
-          json: {
-            "Host": "skydive01.novalocal",
-            "Version": "0.28.0_-16",
-            "Service": "analyzer"
-          }
-      - plugin_result:
-          failed: true
-          status: 404
-      - plugin_result:
-          failed: true
-          status: 404
-
-
-expected_result:
-  - bindings:
-      - address: '127.0.0.1'
-        class: 'service'
-        port: 12379
-        protocol: 'tcp'
-      - address: '127.0.0.1'
-        class: 'service'
-        port: 12380
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 4000
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 8080
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 8082
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 8082
-        protocol: 'udp'
-      - class: proccon_port
-        port: 4000
-      - class: graphql_port
-        port: 8080
-      - class: api_port
-        port: 8082
-    discovery_time: '2022-06-24T13:24:09+02:00'
-    docker:
-      exposed_ports:
-        8082/tcp: { }
-      id: 20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606
-      image: 'nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-16'
-      name: /skydive-analyzer
-      network_mode: 'host'
-      port_bindings: { }
-    listening_ports:
-      - 4000
-      - 8080
-      - 8082
-      - 12379
-      - 12380
-    packages: [ ]
-    process:
-      cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
-      listening_ports:
-        - 4000
-        - 8080
-        - 8082
-        - 12379
-        - 12380
-      pid: '5410'
-      ppid: '5304'
-      user: root
-    type: Skydive Analyzer
-    version:
-      - number: 0.28.0_-16
-        type: request
-      - number: v0.28.0_datadope-16
-        type: docker
-software_list:
-  - name: Skydive Analyzer
-    cmd_regexp: skydive analyzer
-    process_type: parent
-    return_children: false
-    return_packages: true
-    custom_tasks:
-      - name: Include skydive specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/skydive.yaml"
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - analyzer
-        - '-c'
-        - /etc/iometrics/skydive/skydive.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - analyzer
-          - '-c'
-          - /etc/iometrics/skydive/skydive.yml
-        Domainname: ''
-        Entrypoint:
-          - /usr/local/bin/skydive
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-        ExposedPorts:
-          8082/tcp: { }
-        Hostname: skydive01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-16'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/iometrics/skydive/skydive.yml: { }
-          /var/lib/skydive: { }
-        WorkingDir: ''
-      Created: '2022-02-21T11:57:10.201558481Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/0921fa45079d79f5ecb9ef8670e0997212894aabcc19fed496d6d5321f0a5932-init/diff:/var/lib/docker/overlay2/c3341d451baed12e57e850b43b2c6205849a00e3697aa31c62872c74318c84c6/diff:/var/lib/docker/overlay2/7a056e9d541e437c2baecb9469f65e25a5434cc1f6195c743ec27a0ce729f458/diff:/var/lib/docker/overlay2/73c276c089c4c664867fac16d2b79904449b9928bf8f2fdadb08743f4dcb0570/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/0921fa45079d79f5ecb9ef8670e0997212894aabcc19fed496d6d5321f0a5932/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/0921fa45079d79f5ecb9ef8670e0997212894aabcc19fed496d6d5321f0a5932/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/0921fa45079d79f5ecb9ef8670e0997212894aabcc19fed496d6d5321f0a5932/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/iometrics/skydive/:/var/lib/skydive:rw'
-          - >-
-            /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606/hosts
-      Id: 20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606
-      Image: 'sha256:b369c109fc2634db304c113cd9ae5386dcfdbee12a37abed3b0544a2a3e83d38'
-      LogPath: >-
-        /var/lib/docker/containers/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/iometrics/skydive/skydive.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics/skydive/skydive.yml
-          Type: bind
-        - Destination: /var/lib/skydive
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/iometrics/skydive
-          Type: bind
-      Name: /skydive-analyzer
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ba283edb832a5cee669fc1fcfcee56331ff46dea1cce4ad680fadb1434300039
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: efe5541c0d38ec7e32ddd9e836e96497f0dfddce03630245bb96032dadc1c5fe
-        Ports: { }
-        SandboxID: e4dcc47facee23c3ebc096c0f8113bfe13a1b7458afeb7bca9377f756cd52d2a
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/local/bin/skydive
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:54:39.214694889Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 5410
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:54:45.981734261Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.9
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.3.7
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.13
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.13
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.3.1p1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 3.el7
-      source: rpm
-      version: '1.217'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.26.20120314git3c2946.el7
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 6.el7
-      source: rpm
-      version: '4.24'
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  tcpreplay:
-    - arch: x86_64
-      epoch: null
-      name: tcpreplay
-      release: 1.el7
-      source: rpm
-      version: 4.3.4
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '102'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '179'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '180'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '318'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '319'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '424'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '463'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '562'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '569'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '577'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '602'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '608'
-    ppid: '1'
-    user: polkitd
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '611'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '618'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '620'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '621'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '626'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '643'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H skydive01 eth0
-    pid: '865'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '926'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '928'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '931'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1055'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1063'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1066'
-    ppid: '1055'
-    user: postfix
-  - cmdline: >-
-      /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml
-      -path.home /usr/share/filebeat -path.config /etc/filebeat -path.data
-      /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '1067'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1071'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1073'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1074'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1075'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '2272'
-    ppid: '2'
-    user: root
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '2427'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '5304'
-    ppid: '931'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '5404'
-    ppid: '1055'
-    user: postfix
-  - cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
+  - AppArmorProfile: ''
+    Args:
+    - analyzer
+    - -c
+    - /etc/iometrics/skydive/skydive.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - analyzer
+      - -c
+      - /etc/iometrics/skydive/skydive.yml
+      Domainname: ''
+      Entrypoint:
+      - /usr/local/bin/skydive
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      ExposedPorts:
+        8082/tcp: {}
+      Hostname: skydive01.novalocal
+      Image: nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-16
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/iometrics/skydive/skydive.yml: {}
+        /var/lib/skydive: {}
+      WorkingDir: ''
+    Created: '2022-02-21T11:57:10.201558481Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/0921fa45079d79f5ecb9ef8670e0997212894aabcc19fed496d6d5321f0a5932-init/diff:/var/lib/docker/overlay2/c3341d451baed12e57e850b43b2c6205849a00e3697aa31c62872c74318c84c6/diff:/var/lib/docker/overlay2/7a056e9d541e437c2baecb9469f65e25a5434cc1f6195c743ec27a0ce729f458/diff:/var/lib/docker/overlay2/73c276c089c4c664867fac16d2b79904449b9928bf8f2fdadb08743f4dcb0570/diff
+        MergedDir: /var/lib/docker/overlay2/0921fa45079d79f5ecb9ef8670e0997212894aabcc19fed496d6d5321f0a5932/merged
+        UpperDir: /var/lib/docker/overlay2/0921fa45079d79f5ecb9ef8670e0997212894aabcc19fed496d6d5321f0a5932/diff
+        WorkDir: /var/lib/docker/overlay2/0921fa45079d79f5ecb9ef8670e0997212894aabcc19fed496d6d5321f0a5932/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/iometrics/skydive/:/var/lib/skydive:rw
+      - /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606/hostname
+    HostsPath: /var/lib/docker/containers/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606/hosts
+    Id: 20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606
+    Image: sha256:b369c109fc2634db304c113cd9ae5386dcfdbee12a37abed3b0544a2a3e83d38
+    LogPath: /var/lib/docker/containers/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/iometrics/skydive/skydive.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics/skydive/skydive.yml
+      Type: bind
+    - Destination: /var/lib/skydive
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/iometrics/skydive
+      Type: bind
+    Name: /skydive-analyzer
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ba283edb832a5cee669fc1fcfcee56331ff46dea1cce4ad680fadb1434300039
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: efe5541c0d38ec7e32ddd9e836e96497f0dfddce03630245bb96032dadc1c5fe
+      Ports: {}
+      SandboxID: e4dcc47facee23c3ebc096c0f8113bfe13a1b7458afeb7bca9377f756cd52d2a
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/local/bin/skydive
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:54:39.214694889Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 5410
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:54:45.981734261Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 127.0.0.1
+    class: service
+    port: 12379
+    protocol: tcp
+  - address: 127.0.0.1
+    class: service
+    port: 12380
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 4000
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8080
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8082
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8082
+    protocol: udp
+  - class: proccon_port
+    port: 4000
+  - class: graphql_port
+    port: 8080
+  - class: api_port
+    port: 8082
+  discovery_time: '2022-06-24T13:24:09+02:00'
+  docker:
+    exposed_ports:
+      8082/tcp: {}
+    id: 20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606
+    image: nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-16
+    name: /skydive-analyzer
+    network_mode: host
+    port_bindings: {}
+  listening_ports:
+  - 4000
+  - 8080
+  - 8082
+  - 12379
+  - 12380
+  packages: []
+  process:
+    cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
+    cwd: /usr/local/bin/
+    listening_ports:
+    - 4000
+    - 8080
+    - 8082
+    - 12379
+    - 12380
     pid: '5410'
     ppid: '5304'
     user: root
-  - cmdline: /usr/bin/docker start -a skydive-analyzer
-    pid: '5612'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '6912'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8448'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9381'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9550'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9724'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1656069809
-    pid: '9743'
-    ppid: '928'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '9758'
-    ppid: '1071'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '9760'
-    ppid: '9758'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-ncgkmrjiubaoauxfakkvzkbesqldties ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656069828.2882864-24750-175345019413662/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '9947'
-    ppid: '9760'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-ncgkmrjiubaoauxfakkvzkbesqldties ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656069828.2882864-24750-175345019413662/AnsiballZ_process_facts.py
-    pid: '9962'
-    ppid: '9947'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-ncgkmrjiubaoauxfakkvzkbesqldties ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656069828.2882864-24750-175345019413662/AnsiballZ_process_facts.py
-    pid: '9963'
-    ppid: '9962'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1656069828.2882864-24750-175345019413662/AnsiballZ_process_facts.py
-    pid: '9964'
-    ppid: '9963'
-    user: root
-  - cmdline: ''
-    pid: '16560'
-    ppid: '2'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1055
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:02 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 5410
-    port: 12379
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 5410
-    port: 12380
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:53:41 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1071
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:02 2022'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1055
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:02 2022'
-    user: root
-  - address: '::'
-    name: skydive
-    pid: 5410
-    port: 4000
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:53:41 2022'
-    user: root
-  - address: '::'
-    name: skydive
-    pid: 5410
-    port: 8080
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: '::'
-    name: skydive
-    pid: 5410
-    port: 8082
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1071
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:02 2022'
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: Skydive Analyzer
+  version:
+  - number: 0.28.0_-16
+    type: request
+  - number: v0.28.0_datadope-16
+    type: docker
+mocked_plugin_tasks:
+  Check socket from a port:
+    calls:
+    - plugin_result:
+        failed: false
+    - plugin_result:
+        failed: false
+    - plugin_result:
+        failed: false
+    - plugin_result:
+        failed: false
+    - plugin_result:
+        failed: false
+  Request information from api port:
+    calls:
+    - plugin_result:
+        failed: true
+        status: 406
+    - plugin_result:
+        content: "<!DOCTYPE html>\n<html>\n<head>\n\t<meta charset=utf-8/>\n\t<meta\
+          \ name=\"viewport\" content=\"user-scalable=no, initial-scale=1.0, minimum-scale=1.0,\
+          \ maximum-scale=1.0, minimal-ui\">\n\t<link rel=\"shortcut icon\" href=\"\
+          https://graphcool-playground.netlify.com/favicon.png\">\n\t<link rel=\"\
+          stylesheet\" href=\"https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/static/css/index.css\"\
+          \n\t\tintegrity=\"sha256-dKnNLEFwKSVFpkpjRWe&#43;o/jQDM6n/JsvQ0J3l5Dk3fc=\"\
+          \ crossorigin=\"anonymous\"/>\n\t<link rel=\"shortcut icon\" href=\"https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/favicon.png\"\
+          \n\t\tintegrity=\"sha256-GhTyE&#43;McTU79R4&#43;pRO6ih&#43;4TfsTOrpPwD8ReKFzb3PM=\"\
+          \ crossorigin=\"anonymous\"/>\n\t<script src=\"https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.26/build/static/js/middleware.js\"\
+          \n\t\tintegrity=\"sha256-SG9YAy4eywTcLckwij7V4oSCG3hOdV1m&#43;2e1XuNxIgk=\"\
+          \ crossorigin=\"anonymous\"></script>\n\t<title>GraphQL playground</title>\n\
+          </head>\n<body>\n<style type=\"text/css\">\n\thtml { font-family: \"Open\
+          \ Sans\", sans-serif; overflow: hidden; }\n\tbody { margin: 0; background:\
+          \ #172a3a; }\n</style>\n<div id=\"root\"/>\n<script type=\"text/javascript\"\
+          >\n\twindow.addEventListener('load', function (event) {\n\t\tconst root\
+          \ = document.getElementById('root');\n\t\troot.classList.add('playgroundIn');\n\
+          \t\tconst wsProto = location.protocol == 'https:' ? 'wss:' : 'ws:'\n\t\t\
+          GraphQLPlayground.init(root, {\n\t\t\tendpoint: location.protocol + '//'\
+          \ + location.host + '\\/query',\n\t\t\tsubscriptionsEndpoint: wsProto +\
+          \ '//' + location.host + '\\/query',\n           shareEnabled: true,\n\t\
+          \t\tsettings: {\n\t\t\t\t'request.credentials': 'same-origin'\n\t\t\t}\n\
+          \t\t})\n\t})\n</script>\n</body>\n</html>\n"
+        failed: false
+        status: 200
+    - plugin_result:
+        failed: false
+        json:
+          Host: skydive01.novalocal
+          Service: analyzer
+          Version: 0.28.0_-16
+        status: 200
+    - plugin_result:
+        failed: true
+        status: 404
+    - plugin_result:
+        failed: true
+        status: 404
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.9
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.3.7
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 865
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:59 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:41 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 626
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:48 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.13
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.13
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.3.1p1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 3.el7
+    source: rpm
+    version: '1.217'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 618
-    port: 781
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:47 2022'
-    user: rpc
-  - address: '::'
-    name: skydive
-    pid: 5410
-    port: 8082
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:44 2022'
-    user: root
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.26.20120314git3c2946.el7
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 6.el7
+    source: rpm
+    version: '4.24'
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:41 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 626
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:48 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 618
-    port: 781
-    protocol: udp
-    stime: 'Tue Apr 26 15:53:47 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  tcpreplay:
+  - arch: x86_64
+    epoch: null
+    name: tcpreplay
+    release: 1.el7
+    source: rpm
+    version: 4.3.4
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '102'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '179'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '180'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '424'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '463'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '562'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '569'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '577'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '602'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '608'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '611'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '618'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '620'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '621'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '626'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '643'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H skydive01 eth0
+  cwd: /sbin/
+  pid: '865'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '926'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '928'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '931'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1055'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1063'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1066'
+  ppid: '1055'
+  user: postfix
+- cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '1067'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1071'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1073'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1074'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1075'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2272'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '2427'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/20aec879332b18e43681ae2e601706a6450f77baf8ed25e9eaccb6773bbb4606
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '5304'
+  ppid: '931'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '5404'
+  ppid: '1055'
+  user: postfix
+- cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
+  cwd: /usr/local/bin/
+  pid: '5410'
+  ppid: '5304'
+  user: root
+- cmdline: /usr/bin/docker start -a skydive-analyzer
+  cwd: /usr/bin/
+  pid: '5612'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6912'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8448'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9381'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9550'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9724'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1656069809
+  cwd: /usr/lib64/sa/
+  pid: '9743'
+  ppid: '928'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '9758'
+  ppid: '1071'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '9760'
+  ppid: '9758'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-ncgkmrjiubaoauxfakkvzkbesqldties
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656069828.2882864-24750-175345019413662/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '9947'
+  ppid: '9760'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-ncgkmrjiubaoauxfakkvzkbesqldties
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656069828.2882864-24750-175345019413662/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '9962'
+  ppid: '9947'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-ncgkmrjiubaoauxfakkvzkbesqldties ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656069828.2882864-24750-175345019413662/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '9963'
+  ppid: '9962'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656069828.2882864-24750-175345019413662/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '9964'
+  ppid: '9963'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16560'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: skydive analyzer
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/skydive.yaml'
+    name: Include skydive specific plugins
+  name: Skydive Analyzer
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1055
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:54:02 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 5410
+  port: 12379
+  protocol: tcp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 5410
+  port: 12380
+  protocol: tcp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:53:41 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1071
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:54:02 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1055
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:54:02 2022
+  user: root
+- address: '::'
+  name: skydive
+  pid: 5410
+  port: 4000
+  protocol: tcp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:53:41 2022
+  user: root
+- address: '::'
+  name: skydive
+  pid: 5410
+  port: 8080
+  protocol: tcp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: '::'
+  name: skydive
+  pid: 5410
+  port: 8082
+  protocol: tcp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1071
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:54:02 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 865
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:53:59 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:53:41 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 626
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:53:48 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 618
+  port: 781
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: rpc
+- address: '::'
+  name: skydive
+  pid: 5410
+  port: 8082
+  protocol: udp
+  stime: Tue Apr 26 15:54:44 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:53:41 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 626
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:53:48 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 618
+  port: 781
+  protocol: udp
+  stime: Tue Apr 26 15:53:47 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/sql_server/windows_server_2012_r2_sql_server_express_14.yaml
+++ b/tests/unit/plugins/action/auto/resources/sql_server/windows_server_2012_r2_sql_server_express_14.yaml
@@ -1,2344 +1,2384 @@
-mocked_plugin_tasks:
-  "Get hostname":
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      stdout_lines:
-        - test-norm-win01
-  "Get installed instances":
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      stdout_lines:
-        - MSSQLSERVER
-  "Get databases of instance":
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      stdout_lines:
-        - master
-        - model
-        - msdb
-        - tempdb
-  Add databases if needed:
-    calls:
-      - expected_args:
-          databases_per_instance:
-            MSSQLSERVER:
-              - master
-              - model
-              - msdb
-
-expected_tasks_calls_mode_strict: false
-expected_tasks_calls:
-  Get hostname: 1
-  Get installed instances: 1
-  Get databases of instance: 1
-
-expected_result:
-  - bindings:
-      - address: '::'
-        class: 'service'
-        port: 49350
-        protocol: 'tcp'
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 49350
-        protocol: 'tcp'
-    discovery_time: '2022-05-31T13:49:37+02:00'
-    extra_data:
-      databases_per_instance:
-        MSSQLSERVER:
-          - master
-          - model
-          - msdb
-      instances:
-        - MSSQLSERVER
-    listening_ports:
-      - 49350
-    type: Microsoft SQL Server
-    process:
-      cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe" -sSQLEXPRESS'
-      listening_ports:
-        - 49350
-      pid: "1904"
-      ppid: "432"
-      user: NT SERVICE\MSSQL$SQLEXPRESS
-    version:
-      - 'number': '14.0.1000.169'
-        'type': 'package'
-
-software_list:
-  - cmd_regexp: Microsoft.SQL.Server.*sqlservr\.exe
-    name: Microsoft SQL Server
-    pkg_regexp: '^SQL.Server.\d{4}.Database.Engine'
-    process_type: single
-    return_children: false
-    return_packages: false
-    vars:
-      ignore_databases:
-        - tempdb
-    custom_tasks:
-      - name: Include SQL Server specific plugins
-        include_tasks:
-          file: "<< software_discovery__custom_tasks_definition_files_path >>/sql_server.yaml"
-
 dockers:
-  containers: [ ]
-packages:
-  Azure Data Studio:
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 543259
-      help_link: https://github.com/Microsoft/azuredatastudio
-      help_telephone: null
-      install_date: '20220530'
-      install_location: C:\Program Files\Azure Data Studio\
-      install_source: null
-      language: null
-      modify_path: null
-      name: Azure Data Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\Azure Data Studio\unins000.exe"'
-      url_info_about: https://github.com/Microsoft/azuredatastudio
-      url_update_info: https://github.com/Microsoft/azuredatastudio
-      vendor: null
-      version: 1.35.0
-      version_major: 1
-      version_minor: 35
-      windows_installer: null
-  Browser for SQL Server 2017:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11312
-      help_link: https://go.microsoft.com/fwlink/?LinkId=90959
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
-      name: Browser for SQL Server 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Cloudbase-Init 0.9.11:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 121670
-      help_link: ''
-      help_telephone: ''
-      install_date: '20170320'
-      install_location: ''
-      install_source: C:\UnattendResources\
-      language: 1033
-      modify_path: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
-      name: Cloudbase-Init 0.9.11
-      no_repair: null
-      publisher: Cloudbase Solutions Srl
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 0.9.11.0
-      version_major: 0
-      version_minor: 9
-      windows_installer: 1
-  Integration Services:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 91264
-      help_link: https://support.microsoft.com
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{4938A647-7EA4-4496-A843-5E338B91C07E}v15.0.2000.168\x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
-      name: Integration Services
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.168
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Analysis Services OLE DB Provider:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 243952
-      help_link: https://go.microsoft.com/fwlink/?LinkId=52159
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}v15.0.2000.832\x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
-      name: Microsoft Analysis Services OLE DB Provider
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.832
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 499504
-      help_link: https://go.microsoft.com/fwlink/?LinkId=52159
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}v15.0.2000.832\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
-      name: Microsoft Analysis Services OLE DB Provider
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.2000.832
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Help Viewer 2.3:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 12438
-      help_link: https://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: null
-      install_date: null
-      install_location: C:\Program Files (x86)\Microsoft Help Viewer\v2.3\
-      install_source: null
-      language: null
-      modify_path: msiexec.exe /I{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      name: Microsoft Help Viewer 2.3
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: msiexec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      url_info_about: null
-      url_update_info: https://go.microsoft.com/fwlink/?LinkId=133408
-      vendor: null
-      version: 2.3.28307
-      version_major: '2'
-      version_minor: '0'
-      windows_installer: null
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 13260
-      help_link: https://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}v2.3.28307\redist\
-      language: 1033
-      modify_path: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      name: Microsoft Help Viewer 2.3
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 2.3.28307
-      version_major: 2
-      version_minor: 3
-      windows_installer: 1
-  Microsoft ODBC Driver 13 for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 5124
-      help_link: https://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
-      name: Microsoft ODBC Driver 13 for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft ODBC Driver 17 for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 7184
-      help_link: https://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{853997DA-6FCB-4FB9-918E-E0FF881FAF65}v17.7.2.1\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
-      name: Microsoft ODBC Driver 17 for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 17.7.2.1
-      version_major: 17
-      version_minor: 7
-      windows_installer: 1
-  Microsoft OLE DB Driver for SQL Server:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8480
-      help_link: https://go.microsoft.com/fwlink/?linkid=870127
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{9D6F8754-28E9-4940-B319-3FC8588CF18F}v18.5.0.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
-      name: Microsoft OLE DB Driver for SQL Server
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 18.5.0.0
-      version_major: 18
-      version_minor: 5
-      windows_installer: 1
-  'Microsoft SQL Server 2012 Native Client ':
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8160
-      help_link: http://go.microsoft.com/fwlink/?LinkId=191752
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{9D93D367-A2CC-4378-BD63-79EF3FE76C78}v11.4.7462.6\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
-      name: 'Microsoft SQL Server 2012 Native Client '
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 11.4.7462.6
-      version_major: 11
-      version_minor: 4
-      windows_installer: 1
-  Microsoft SQL Server 2017 (64-bit):
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: null
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server 2017 (64-bit)
-      no_repair: null
-      publisher: null
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: 1
-      uninstall_string: null
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: null
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: null
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server 2017 (64-bit)
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\Microsoft SQL Server\140\Setup Bootstrap\SQL2017\x64\SetupARP.exe"'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: null
-  Microsoft SQL Server 2017 RsFx Driver:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 344
-      help_link: https://go.microsoft.com/fwlink/?LinkId=101173
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
-      name: Microsoft SQL Server 2017 RsFx Driver
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft SQL Server 2017 Setup (English):
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 39588
-      help_link: https://go.microsoft.com/fwlink/?LinkId=101173
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
-      name: Microsoft SQL Server 2017 Setup (English)
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  'Microsoft SQL Server 2017 T-SQL Language Service ':
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 8116
-      help_link: https://go.microsoft.com/fwlink/?LinkID=150605
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
-      name: 'Microsoft SQL Server 2017 T-SQL Language Service '
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft SQL Server Management Studio - 18.11.1:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 2881605
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: null
-      name: Microsoft SQL Server Management Studio - 18.11.1
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{88f77b67-7f88-4b59-b93b-c9f2546b649c}\SSMS-Setup-ENU.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 15.0.18410.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft VSS Writer for SQL Server 2017:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 3256
-      help_link: https://go.microsoft.com/fwlink/?LinkId=90958
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
-      name: Microsoft VSS Writer for SQL Server 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: null
-      uninstall_string: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 21062
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe" /modify'
-      name: Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 12.0.40664.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 17602
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe" /modify'
-      name: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 12.0.40664.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 11784
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{010792BA-551A-3AC0-A7EF-0FAB4156C382}v12.0.40664\packages\vcRuntimeAdditional_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
-      name: Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 2524
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{53CF6934-A98D-3D84-9146-FC4EDF3D5641}v12.0.40664\packages\vcRuntimeMinimum_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
-      name: Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 9456
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{D401961D-3A20-3AC7-943B-6139D5BD490A}v12.0.40664\packages\vcRuntimeAdditional_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
-      name: Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: Caution. Removing this product might prevent some applications from running.
-      contact: ''
-      estimated_size: 2076
-      help_link: http://go.microsoft.com/fwlink/?LinkId=133405
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{8122DAB1-ED4D-3676-BB0A-CA368196543E}v12.0.40664\packages\vcRuntimeMinimum_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
-      name: Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 12.0.40664
-      version_major: 12
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 22598
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe" /modify'
-      name: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.30.30704.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 19969
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe" /modify'
-      name: Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 14.30.30704.0
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11724
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}v14.30.30704\packages\vcRuntimeAdditional_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
-      name: Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 2168
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{662A0088-6FCD-45DD-9EA7-68674058AED5}v14.30.30704\packages\vcRuntimeMinimum_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
-      name: Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 10164
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{BF08E976-B92E-4336-B56F-2171179476C4}v14.30.30704\packages\vcRuntimeAdditional_x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
-      name: Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 1744
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220215'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}v14.30.30704\packages\vcRuntimeMinimum_x86\
-      language: 1033
-      modify_path: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
-      name: Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.30.30704
-      version_major: 14
-      version_minor: 30
-      windows_installer: 1
-  Microsoft Visual Studio Tools for Applications 2017:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: null
-      contact: null
-      estimated_size: 19606
-      help_link: null
-      help_telephone: null
-      install_date: null
-      install_location: null
-      install_source: null
-      language: null
-      modify_path: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe" /modify'
-      name: Microsoft Visual Studio Tools for Applications 2017
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"  /uninstall'
-      url_info_about: null
-      url_update_info: null
-      vendor: null
-      version: 15.0.26717
-      version_major: null
-      version_minor: null
-      windows_installer: null
-  Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 2844
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{10AB056B-1B8C-3E9E-95CC-43C33EB88513}v15.0.26717\packages\vsta_hostingcore_amd64\
-      language: 1033
-      modify_path: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
-      name: Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.26717
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 3828
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}v15.0.26717\packages\vsta_hostingcore_x86\
-      language: 1033
-      modify_path: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
-      name: Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.26717
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  PgBouncer 1.16.1:
-    - arch: x86
-      authorized_cdf_prefix: null
-      comments: 'PgBouncer: Connection pooler for PostgreSQL, packaged by EnterpriseDB'
-      contact: ''
-      estimated_size: 25101
-      help_link: ''
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files (x86)\PgBouncer
-      install_source: null
-      language: null
-      modify_path: null
-      name: PgBouncer 1.16.1
-      no_repair: '1'
-      publisher: EnterpriseDB
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files (x86)\PgBouncer\uninstall-pgbouncer.exe"'
-      url_info_about: ''
-      url_update_info: null
-      vendor: null
-      version: 1.16.1-1
-      version_major: 1
-      version_minor: 16
-      windows_installer: null
-  'PostgreSQL 14 ':
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: The PostgreSQL RDBMS, version 14, packaged by EnterpriseDB
-      contact: ''
-      estimated_size: 829400
-      help_link: http://www.postgresql.org/docs
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files\PostgreSQL\14
-      install_source: null
-      language: null
-      modify_path: null
-      name: 'PostgreSQL 14 '
-      no_repair: '1'
-      publisher: PostgreSQL Global Development Group
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\PostgreSQL\14\uninstall-postgresql.exe"'
-      url_info_about: http://www.postgresql.org/
-      url_update_info: null
-      vendor: null
-      version: '14'
-      version_major: 14
-      version_minor: 0
-      windows_installer: null
-  SQL Server 2017 Batch Parser:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 744
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
-      name: SQL Server 2017 Batch Parser
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Common Files:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 21464
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
-      name: SQL Server 2017 Common Files
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 760
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
-      name: SQL Server 2017 Common Files
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Connection Info:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 264
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
-      name: SQL Server 2017 Connection Info
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 884
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
-      name: SQL Server 2017 Connection Info
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 DMF:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 1376
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
-      name: SQL Server 2017 DMF
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 408
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
-      name: SQL Server 2017 DMF
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Database Engine Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 72372
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
-      name: SQL Server 2017 Database Engine Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 285556
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
-      name: SQL Server 2017 Database Engine Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Database Engine Shared:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 87436
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
-      name: SQL Server 2017 Database Engine Shared
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 11884
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
-      name: SQL Server 2017 Database Engine Shared
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 SQL Diagnostics:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 516
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
-      name: SQL Server 2017 SQL Diagnostics
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Shared Management Objects:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 5908
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
-      name: SQL Server 2017 Shared Management Objects
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 12528
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
-      name: SQL Server 2017 Shared Management Objects
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 Shared Management Objects Extensions:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 4952
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
-      name: SQL Server 2017 Shared Management Objects Extensions
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 532
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
-      name: SQL Server 2017 Shared Management Objects Extensions
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server 2017 XEvent:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 84
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
-      name: SQL Server 2017 XEvent
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 732
-      help_link: https://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220224'
-      install_location: ''
-      install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
-      language: 1033
-      modify_path: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
-      name: SQL Server 2017 XEvent
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 14.0.1000.169
-      version_major: 14
-      version_minor: 0
-      windows_installer: 1
-  SQL Server Management Studio:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 4796
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{3A6E604C-766B-46F2-8E2D-4371B4CDF858}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
-      name: SQL Server Management Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 215640
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
-      name: SQL Server Management Studio
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  SQL Server Management Studio for Analysis Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 358312
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
-      name: SQL Server Management Studio for Analysis Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  SQL Server Management Studio for Reporting Services:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 26840
-      help_link: http://go.microsoft.com/fwlink/?LinkId=154582
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{D91AA5D8-1080-487B-83B6-622061902012}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
-      name: SQL Server Management Studio for Reporting Services
-      no_repair: 1
-      publisher: Microsoft Corporation
-      readme: Placeholder for ARP readme in case of no UI
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  SSMS Post Install Tasks:
-    - arch: AMD64
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 296
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{7AEA9B43-10CD-4D33-B116-621B81A45490}v15.0.18410.0\x64\
-      language: 1033
-      modify_path: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
-      name: SSMS Post Install Tasks
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.18410.0
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  Visual Studio 2017 Isolated Shell for SSMS:
-    - arch: x86
-      authorized_cdf_prefix: ''
-      comments: ''
-      contact: ''
-      estimated_size: 412588
-      help_link: ''
-      help_telephone: ''
-      install_date: '20220530'
-      install_location: ''
-      install_source: C:\ProgramData\Package Cache\{AAA9F15B-AF45-4562-9991-93A848D3A902}v15.0.28307.421\redist\
-      language: 1033
-      modify_path: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
-      name: Visual Studio 2017 Isolated Shell for SSMS
-      no_repair: null
-      publisher: Microsoft Corporation
-      readme: ''
-      size: ''
-      source: windows_registry
-      system_component: 1
-      uninstall_string: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
-      url_info_about: ''
-      url_update_info: ''
-      vendor: null
-      version: 15.0.28307.421
-      version_major: 15
-      version_minor: 0
-      windows_installer: 1
-  psqlODBC 13.00.0000:
-    - arch: AMD64
-      authorized_cdf_prefix: null
-      comments: ODBC drivers for PostgreSQL, packaged by EnterpriseDB
-      contact: ''
-      estimated_size: 13676
-      help_link: ''
-      help_telephone: null
-      install_date: '20220215'
-      install_location: C:\Program Files\PostgreSQL\psqlODBC
-      install_source: null
-      language: null
-      modify_path: null
-      name: psqlODBC 13.00.0000
-      no_repair: '1'
-      publisher: EnterpriseDB
-      readme: null
-      size: null
-      source: windows_registry
-      system_component: null
-      uninstall_string: '"C:\Program Files\PostgreSQL\psqlODBC\uninstall-psqlodbc.exe"'
-      url_info_about: ''
-      url_update_info: null
-      vendor: null
-      version: 13.00.0000-2
-      version_major: 13
-      version_minor: 0
-      windows_installer: null
-processes:
-  - cmdline: null
-    pid: '0'
-    ppid: '0'
-    user: null
-  - cmdline: null
-    pid: '4'
-    ppid: '0'
-    user: null
-  - cmdline: null
-    pid: '192'
-    ppid: '4'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '284'
-    ppid: '276'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '336'
-    ppid: '328'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: wininit.exe
-    pid: '344'
-    ppid: '276'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: winlogon.exe
-    pid: '372'
-    ppid: '328'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: null
-    pid: '432'
-    ppid: '344'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\lsass.exe'
-    pid: '440'
-    ppid: '344'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\svchost.exe -k DcomLaunch'
-    pid: '496'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\svchost.exe -k RPCSS'
-    pid: '524'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"LogonUI.exe" /flags:0x0'
-    pid: '624'
-    ppid: '372'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"dwm.exe"'
-    pid: '632'
-    ppid: '372'
-    user: Window Manager\DWM-1
-  - cmdline: 'C:\windows\System32\svchost.exe -k LocalServiceNetworkRestricted'
-    pid: '652'
-    ppid: '432'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: 'C:\windows\system32\svchost.exe -k netsvcs'
-    pid: '708'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\svchost.exe -k LocalService'
-    pid: '800'
-    ppid: '432'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: 'C:\windows\system32\svchost.exe -k NetworkService'
-    pid: '888'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: 'C:\windows\system32\svchost.exe -k LocalServiceNoNetwork'
-    pid: '292'
-    ppid: '432'
-    user: NT AUTHORITY\LOCAL SERVICE
-  - cmdline: 'C:\windows\System32\spoolsv.exe'
-    pid: '444'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\System32\svchost.exe -k utcsvc'
-    pid: '1040'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: >-
-      "C:\Program Files (x86)\PgBouncer\bin\pgbouncer.exe" --service "C:\Program
-      Files (x86)\PgBouncer\share\pgbouncer.ini"
-    pid: '1076'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: >-
-      "C:\Program Files\PostgreSQL\14\bin\pg_ctl.exe" runservice -N
-      "postgresql-x64-14" -D "C:\Program Files\PostgreSQL\14\data" -w
-    pid: '1176'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:\Program Files\Microsoft SQL
-      Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlceip.exe" -Service SQLEXPRESS
-    pid: '1240'
-    ppid: '432'
-    user: NT SERVICE\SQLTELEMETRY$SQLEXPRESS
-  - cmdline: >-
-      "C:\Program Files\PostgreSQL\14\bin\postgres.exe" -D "C:\Program
-      Files\PostgreSQL\14\data"
-    pid: '1248'
-    ppid: '1176'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '\??\C:\windows\system32\conhost.exe 0x4'
-    pid: '1256'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forklog" "5308"
-      "5312" "0"
-    pid: '1304'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5212"
-      "-x5"
-    pid: '1336'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5224"
-      "-x3"
-    pid: '1344'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5204"
-      "-x6"
-    pid: '1352'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkavlauncher"
-      "5196"
-    pid: '1360'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkcol" "5188"'
-    pid: '1368'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      "C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkbgworker=0"
-      "5180"
-    pid: '1376'
-    ppid: '1248'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: '"C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe"'
-    pid: '1420'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\System32\svchost.exe -k LocalSystemNetworkRestricted'
-    pid: '1444'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: >-
-      "C:\winlogbeat\winlogbeat.exe" -c "C:\winlogbeat\winlogbeat.yml"
-      -path.home "C:\winlogbeat" -path.data "C:\ProgramData\winlogbeat"
-      -path.logs "C:\ProgramData\winlogbeat\logs"
-    pid: '1484'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\System32\svchost.exe -k termsvcs'
-    pid: '2028'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: 'C:\windows\system32\svchost.exe -k NetworkServiceNetworkRestricted'
-    pid: '1052'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: null
-    pid: '2772'
-    ppid: '2764'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: winlogon.exe
-    pid: '2800'
-    ppid: '2764'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: '"dwm.exe"'
-    pid: '2856'
-    ppid: '2800'
-    user: Window Manager\DWM-2
-  - cmdline: 'taskhostex.exe '
-    pid: '3008'
-    ppid: '708'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: rdpclip
-    pid: '880'
-    ppid: '2028'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: 'C:\windows\Explorer.EXE'
-    pid: '2144'
-    ppid: '2176'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: 'C:\windows\system32\wbem\wmiprvse.exe'
-    pid: '2084'
-    ppid: '496'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: 'C:\windows\System32\msdtc.exe'
-    pid: '1836'
-    ppid: '432'
-    user: NT AUTHORITY\NETWORK SERVICE
-  - cmdline: >-
-      C:/telegraf/telegraf.exe -config C:/telegraf/telegraf.conf
-      -config-directory C:/telegraf/telegraf.d/
-    pid: '3272'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: >-
-      "C:\Program Files\Microsoft SQL
-      Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe" -sSQLEXPRESS
+  containers: []
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 49350
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 49350
+    protocol: tcp
+  discovery_time: '2022-05-31T13:49:37+02:00'
+  extra_data:
+    databases_per_instance:
+      MSSQLSERVER:
+      - master
+      - model
+      - msdb
+    instances:
+    - MSSQLSERVER
+  listening_ports:
+  - 49350
+  process:
+    cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe"
+      -sSQLEXPRESS'
+    cwd: /
+    listening_ports:
+    - 49350
     pid: '1904'
     ppid: '432'
     user: NT SERVICE\MSSQL$SQLEXPRESS
-  - cmdline: >-
-      "C:\Program Files (x86)\Microsoft SQL Server Management Studio
-      18\Common7\IDE\Ssms.exe"
-    pid: '3236'
-    ppid: '2144'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
-    pid: '3316'
-    ppid: '2144'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '\??\C:\windows\system32\conhost.exe 0x4'
-    pid: '1908'
-    ppid: '3316'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
-    pid: '2384'
-    ppid: '2144'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '\??\C:\windows\system32\conhost.exe 0x4'
-    pid: '3208'
-    ppid: '2384'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: 'C:\windows\system32\msiexec.exe /V'
-    pid: '1600'
-    ppid: '432'
-    user: NT AUTHORITY\SYSTEM
-  - cmdline: 'C:\windows\system32\WinrsHost.exe -Embedding'
-    pid: '4552'
-    ppid: '496'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: '\??\C:\windows\system32\conhost.exe 0x4'
-    pid: '5352'
-    ppid: '4552'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: >-
-      C:\windows\system32\cmd.exe /C PowerShell -NoProfile -NonInteractive
-      -ExecutionPolicy Unrestricted -EncodedCommand
-      UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
-    pid: '6104'
-    ppid: '4552'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: >-
-      PowerShell  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted
-      -EncodedCommand
-      UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
-    pid: '6056'
-    ppid: '6104'
-    user: TEST-NORM-WIN01\Administrator
-  - cmdline: >-
-      "C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe"  -NoProfile
-      -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand
-      JgBjAGgAYwBwAC4AYwBvAG0AIAA2ADUAMAAwADEAIAA+ACAAJABuAHUAbABsAAoAaQBmACAAKAAkAFAAUwBWAGUAcgBzAGkAbwBuAFQAYQBiAGwAZQAuAFAAUwBWAGUAcgBzAGkAbwBuACAALQBsAHQAIABbAFYAZQByAHMAaQBvAG4AXQAiADMALgAwACIAKQAgAHsACgAnAHsAIgBmAGEAaQBsAGUAZAAiADoAdAByAHUAZQAsACIAbQBzAGcAIgA6ACIAQQBuAHMAaQBiAGwAZQAgAHIAZQBxAHUAaQByAGUAcwAgAFAAbwB3AGUAcgBTAGgAZQBsAGwAIAB2ADMALgAwACAAbwByACAAbgBlAHcAZQByACIAfQAnAAoAZQB4AGkAdAAgADEACgB9AAoAJABlAHgAZQBjAF8AdwByAGEAcABwAGUAcgBfAHMAdAByACAAPQAgACQAaQBuAHAAdQB0ACAAfAAgAE8AdQB0AC0AUwB0AHIAaQBuAGcACgAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAgAD0AIAAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAF8AcwB0AHIALgBTAHAAbABpAHQAKABAACgAIgBgADAAYAAwAGAAMABgADAAIgApACwAIAAyACwAIABbAFMAdAByAGkAbgBnAFMAcABsAGkAdABPAHAAdABpAG8AbgBzAF0AOgA6AFIAZQBtAG8AdgBlAEUAbQBwAHQAeQBFAG4AdAByAGkAZQBzACkACgBJAGYAIAAoAC0AbgBvAHQAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAuAEwAZQBuAGcAdABoACAALQBlAHEAIAAyACkAIAB7ACAAdABoAHIAbwB3ACAAIgBpAG4AdgBhAGwAaQBkACAAcABhAHkAbABvAGEAZAAiACAAfQAKAFMAZQB0AC0AVgBhAHIAaQBhAGIAbABlACAALQBOAGEAbQBlACAAagBzAG8AbgBfAHIAYQB3ACAALQBWAGEAbAB1AGUAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADEAXQAKACQAZQB4AGUAYwBfAHcAcgBhAHAAcABlAHIAIAA9ACAAWwBTAGMAcgBpAHAAdABCAGwAbwBjAGsAXQA6ADoAQwByAGUAYQB0AGUAKAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADAAXQApAAoAJgAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAA==
-    pid: '4416'
-    ppid: '6056'
-    user: TEST-NORM-WIN01\Administrator
+  type: Microsoft SQL Server
+  version:
+  - number: 14.0.1000.169
+    type: package
+expected_tasks_calls:
+  Get databases of instance: 1
+  Get hostname: 1
+  Get installed instances: 1
+expected_tasks_calls_mode_strict: false
+mocked_plugin_tasks:
+  Add databases if needed:
+    calls:
+    - expected_args:
+        databases_per_instance:
+          MSSQLSERVER:
+          - master
+          - model
+          - msdb
+  Get databases of instance:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      stdout_lines:
+      - master
+      - model
+      - msdb
+      - tempdb
+  Get hostname:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      stdout_lines:
+      - test-norm-win01
+  Get installed instances:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      stdout_lines:
+      - MSSQLSERVER
+packages:
+  Azure Data Studio:
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 543259
+    help_link: https://github.com/Microsoft/azuredatastudio
+    help_telephone: null
+    install_date: '20220530'
+    install_location: C:\Program Files\Azure Data Studio\
+    install_source: null
+    language: null
+    modify_path: null
+    name: Azure Data Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\Azure Data Studio\unins000.exe"'
+    url_info_about: https://github.com/Microsoft/azuredatastudio
+    url_update_info: https://github.com/Microsoft/azuredatastudio
+    vendor: null
+    version: 1.35.0
+    version_major: 1
+    version_minor: 35
+    windows_installer: null
+  Browser for SQL Server 2017:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11312
+    help_link: https://go.microsoft.com/fwlink/?LinkId=90959
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
+    name: Browser for SQL Server 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /X{CF8EEB96-E7E7-4EF7-A0A1-559F09953156}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Cloudbase-Init 0.9.11:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 121670
+    help_link: ''
+    help_telephone: ''
+    install_date: '20170320'
+    install_location: ''
+    install_source: C:\UnattendResources\
+    language: 1033
+    modify_path: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
+    name: Cloudbase-Init 0.9.11
+    no_repair: null
+    publisher: Cloudbase Solutions Srl
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{ED85F19F-057A-4EE6-BC8D-F576DEACE78D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 0.9.11.0
+    version_major: 0
+    version_minor: 9
+    windows_installer: 1
+  Integration Services:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 91264
+    help_link: https://support.microsoft.com
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{4938A647-7EA4-4496-A843-5E338B91C07E}v15.0.2000.168\x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
+    name: Integration Services
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{4938A647-7EA4-4496-A843-5E338B91C07E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.168
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Analysis Services OLE DB Provider:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 243952
+    help_link: https://go.microsoft.com/fwlink/?LinkId=52159
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}v15.0.2000.832\x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
+    name: Microsoft Analysis Services OLE DB Provider
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{8CE89D3D-FBC5-4964-B6AD-2F52060304C3}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.832
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 499504
+    help_link: https://go.microsoft.com/fwlink/?LinkId=52159
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}v15.0.2000.832\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
+    name: Microsoft Analysis Services OLE DB Provider
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7EA2A3F7-A6D2-4D28-B3C4-4C32BCF4A0A2}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.2000.832
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Help Viewer 2.3:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 12438
+    help_link: https://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: null
+    install_date: null
+    install_location: C:\Program Files (x86)\Microsoft Help Viewer\v2.3\
+    install_source: null
+    language: null
+    modify_path: msiexec.exe /I{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    name: Microsoft Help Viewer 2.3
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: msiexec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    url_info_about: null
+    url_update_info: https://go.microsoft.com/fwlink/?LinkId=133408
+    vendor: null
+    version: 2.3.28307
+    version_major: '2'
+    version_minor: '0'
+    windows_installer: null
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 13260
+    help_link: https://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}v2.3.28307\redist\
+    language: 1033
+    modify_path: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    name: Microsoft Help Viewer 2.3
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{99DC6816-30B2-32EB-9E12-AF8944C4FA4E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 2.3.28307
+    version_major: 2
+    version_minor: 3
+    windows_installer: 1
+  Microsoft ODBC Driver 13 for SQL Server:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 5124
+    help_link: https://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
+    name: Microsoft ODBC Driver 13 for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{76CF9EF4-ABA0-484E-8042-12B99499AF5F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft ODBC Driver 17 for SQL Server:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 7184
+    help_link: https://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{853997DA-6FCB-4FB9-918E-E0FF881FAF65}v17.7.2.1\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
+    name: Microsoft ODBC Driver 17 for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{853997DA-6FCB-4FB9-918E-E0FF881FAF65}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 17.7.2.1
+    version_major: 17
+    version_minor: 7
+    windows_installer: 1
+  Microsoft OLE DB Driver for SQL Server:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8480
+    help_link: https://go.microsoft.com/fwlink/?linkid=870127
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{9D6F8754-28E9-4940-B319-3FC8588CF18F}v18.5.0.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
+    name: Microsoft OLE DB Driver for SQL Server
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{9D6F8754-28E9-4940-B319-3FC8588CF18F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 18.5.0.0
+    version_major: 18
+    version_minor: 5
+    windows_installer: 1
+  'Microsoft SQL Server 2012 Native Client ':
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8160
+    help_link: http://go.microsoft.com/fwlink/?LinkId=191752
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{9D93D367-A2CC-4378-BD63-79EF3FE76C78}v11.4.7462.6\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
+    name: 'Microsoft SQL Server 2012 Native Client '
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{9D93D367-A2CC-4378-BD63-79EF3FE76C78}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 11.4.7462.6
+    version_major: 11
+    version_minor: 4
+    windows_installer: 1
+  Microsoft SQL Server 2017 (64-bit):
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: null
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server 2017 (64-bit)
+    no_repair: null
+    publisher: null
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: 1
+    uninstall_string: null
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: null
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: null
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server 2017 (64-bit)
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\Microsoft SQL Server\140\Setup Bootstrap\SQL2017\x64\SetupARP.exe"'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: null
+  Microsoft SQL Server 2017 RsFx Driver:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 344
+    help_link: https://go.microsoft.com/fwlink/?LinkId=101173
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
+    name: Microsoft SQL Server 2017 RsFx Driver
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7123D29F-9197-4686-A619-C7E8EA289718}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft SQL Server 2017 Setup (English):
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 39588
+    help_link: https://go.microsoft.com/fwlink/?LinkId=101173
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
+    name: Microsoft SQL Server 2017 Setup (English)
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /X{405252DC-ADF7-4BC8-95F5-F89DE513DD62}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  'Microsoft SQL Server 2017 T-SQL Language Service ':
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 8116
+    help_link: https://go.microsoft.com/fwlink/?LinkID=150605
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
+    name: 'Microsoft SQL Server 2017 T-SQL Language Service '
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{C8A51693-98B9-4AB1-91B8-9A1B86729D5F}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft SQL Server Management Studio - 18.11.1:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 2881605
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: null
+    name: Microsoft SQL Server Management Studio - 18.11.1
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{88f77b67-7f88-4b59-b93b-c9f2546b649c}\SSMS-Setup-ENU.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 15.0.18410.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft VSS Writer for SQL Server 2017:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 3256
+    help_link: https://go.microsoft.com/fwlink/?LinkId=90958
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
+    name: Microsoft VSS Writer for SQL Server 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: null
+    uninstall_string: MsiExec.exe /I{20B328C9-C6BB-434A-928A-00F05CD820B8}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 21062
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"
+      /modify'
+    name: Microsoft Visual C++ 2013 Redistributable (x64) - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}\vcredist_x64.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 12.0.40664.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 17602
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"
+      /modify'
+    name: Microsoft Visual C++ 2013 Redistributable (x86) - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 12.0.40664.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 11784
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{010792BA-551A-3AC0-A7EF-0FAB4156C382}v12.0.40664\packages\vcRuntimeAdditional_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
+    name: Microsoft Visual C++ 2013 x64 Additional Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{010792BA-551A-3AC0-A7EF-0FAB4156C382}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 2524
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{53CF6934-A98D-3D84-9146-FC4EDF3D5641}v12.0.40664\packages\vcRuntimeMinimum_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
+    name: Microsoft Visual C++ 2013 x64 Minimum Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{53CF6934-A98D-3D84-9146-FC4EDF3D5641}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 9456
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{D401961D-3A20-3AC7-943B-6139D5BD490A}v12.0.40664\packages\vcRuntimeAdditional_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
+    name: Microsoft Visual C++ 2013 x86 Additional Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{D401961D-3A20-3AC7-943B-6139D5BD490A}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: Caution. Removing this product might prevent some applications from
+      running.
+    contact: ''
+    estimated_size: 2076
+    help_link: http://go.microsoft.com/fwlink/?LinkId=133405
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{8122DAB1-ED4D-3676-BB0A-CA368196543E}v12.0.40664\packages\vcRuntimeMinimum_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
+    name: Microsoft Visual C++ 2013 x86 Minimum Runtime - 12.0.40664
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{8122DAB1-ED4D-3676-BB0A-CA368196543E}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 12.0.40664
+    version_major: 12
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 22598
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"
+      /modify'
+    name: Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}\VC_redist.x64.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.30.30704.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 19969
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"
+      /modify'
+    name: Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{4d8dcf8c-a72a-43e1-9833-c12724db736e}\VC_redist.x86.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 14.30.30704.0
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11724
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}v14.30.30704\packages\vcRuntimeAdditional_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
+    name: Microsoft Visual C++ 2022 X64 Additional Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{6DB765A8-05AF-49A1-A71D-6F645EE3CE41}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 2168
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{662A0088-6FCD-45DD-9EA7-68674058AED5}v14.30.30704\packages\vcRuntimeMinimum_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
+    name: Microsoft Visual C++ 2022 X64 Minimum Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{662A0088-6FCD-45DD-9EA7-68674058AED5}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 10164
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{BF08E976-B92E-4336-B56F-2171179476C4}v14.30.30704\packages\vcRuntimeAdditional_x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
+    name: Microsoft Visual C++ 2022 X86 Additional Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{BF08E976-B92E-4336-B56F-2171179476C4}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 1744
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220215'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}v14.30.30704\packages\vcRuntimeMinimum_x86\
+    language: 1033
+    modify_path: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
+    name: Microsoft Visual C++ 2022 X86 Minimum Runtime - 14.30.30704
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F6080405-9FA8-4CAA-9982-14E95D1A3DAC}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.30.30704
+    version_major: 14
+    version_minor: 30
+    windows_installer: 1
+  Microsoft Visual Studio Tools for Applications 2017:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: null
+    contact: null
+    estimated_size: 19606
+    help_link: null
+    help_telephone: null
+    install_date: null
+    install_location: null
+    install_source: null
+    language: null
+    modify_path: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"
+      /modify'
+    name: Microsoft Visual Studio Tools for Applications 2017
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\ProgramData\Package Cache\{5a7dc0ad-cdb2-43b5-8b82-f81065fe6092}\vsta_setup.exe"  /uninstall'
+    url_info_about: null
+    url_update_info: null
+    vendor: null
+    version: 15.0.26717
+    version_major: null
+    version_minor: null
+    windows_installer: null
+  Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 2844
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{10AB056B-1B8C-3E9E-95CC-43C33EB88513}v15.0.26717\packages\vsta_hostingcore_amd64\
+    language: 1033
+    modify_path: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
+    name: Microsoft Visual Studio Tools for Applications 2017 x64 Hosting Support
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{10AB056B-1B8C-3E9E-95CC-43C33EB88513}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.26717
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 3828
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}v15.0.26717\packages\vsta_hostingcore_x86\
+    language: 1033
+    modify_path: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
+    name: Microsoft Visual Studio Tools for Applications 2017 x86 Hosting Support
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /X{AB46A6EF-12D2-3146-A38D-1D6FF1AFFF69}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.26717
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  PgBouncer 1.16.1:
+  - arch: x86
+    authorized_cdf_prefix: null
+    comments: 'PgBouncer: Connection pooler for PostgreSQL, packaged by EnterpriseDB'
+    contact: ''
+    estimated_size: 25101
+    help_link: ''
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files (x86)\PgBouncer
+    install_source: null
+    language: null
+    modify_path: null
+    name: PgBouncer 1.16.1
+    no_repair: '1'
+    publisher: EnterpriseDB
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files (x86)\PgBouncer\uninstall-pgbouncer.exe"'
+    url_info_about: ''
+    url_update_info: null
+    vendor: null
+    version: 1.16.1-1
+    version_major: 1
+    version_minor: 16
+    windows_installer: null
+  'PostgreSQL 14 ':
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: The PostgreSQL RDBMS, version 14, packaged by EnterpriseDB
+    contact: ''
+    estimated_size: 829400
+    help_link: http://www.postgresql.org/docs
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files\PostgreSQL\14
+    install_source: null
+    language: null
+    modify_path: null
+    name: 'PostgreSQL 14 '
+    no_repair: '1'
+    publisher: PostgreSQL Global Development Group
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\PostgreSQL\14\uninstall-postgresql.exe"'
+    url_info_about: http://www.postgresql.org/
+    url_update_info: null
+    vendor: null
+    version: '14'
+    version_major: 14
+    version_minor: 0
+    windows_installer: null
+  SQL Server 2017 Batch Parser:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 744
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
+    name: SQL Server 2017 Batch Parser
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{2C6E8311-28BD-4615-9545-6E39E8E83A4B}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Common Files:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 21464
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
+    name: SQL Server 2017 Common Files
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{9D1C0509-D490-4E9E-ACF5-A73E5C53742D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 760
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
+    name: SQL Server 2017 Common Files
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{B777C4C0-A1CD-4AB9-99B1-AD5FBED6F8E5}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Connection Info:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 264
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
+    name: SQL Server 2017 Connection Info
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{89A7644F-E056-4EC1-BFDE-9D1A531D6855}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 884
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
+    name: SQL Server 2017 Connection Info
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{A9A443F5-56E1-4FC6-937C-5F481345A843}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 DMF:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 1376
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
+    name: SQL Server 2017 DMF
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{B9998A13-5563-496C-B95E-597FFC70B670}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 408
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
+    name: SQL Server 2017 DMF
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{D7D28BBF-3B0E-43F0-A457-331F1CD9E9EB}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Database Engine Services:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 72372
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
+    name: SQL Server 2017 Database Engine Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{28EEF6BA-A23A-42D2-86BA-A6BEE723B969}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 285556
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
+    name: SQL Server 2017 Database Engine Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{DED314CA-0EFE-4593-9D66-EF75E5289A4C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Database Engine Shared:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 87436
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
+    name: SQL Server 2017 Database Engine Shared
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{0E22DBB4-691B-400C-B52D-8DFE8EC421AA}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 11884
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
+    name: SQL Server 2017 Database Engine Shared
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{793F1C1E-5C83-4E33-A29B-6EAA7C1E791C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 SQL Diagnostics:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 516
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
+    name: SQL Server 2017 SQL Diagnostics
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{DFA6A906-3024-49DE-87AD-750EAED2FA49}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Shared Management Objects:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 5908
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
+    name: SQL Server 2017 Shared Management Objects
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{10855B1A-F7F2-4D8A-A725-9287C73BED5A}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 12528
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
+    name: SQL Server 2017 Shared Management Objects
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{6CBBF624-696C-499E-948D-ADBAFFA2F548}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 Shared Management Objects Extensions:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 4952
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
+    name: SQL Server 2017 Shared Management Objects Extensions
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{8C515C22-BE07-4908-985C-0AA9349E1ED4}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 532
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
+    name: SQL Server 2017 Shared Management Objects Extensions
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{C6D92730-3EC0-47B1-8F6C-6F5635D1EFAC}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server 2017 XEvent:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 84
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\1033_ENU_LP\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
+    name: SQL Server 2017 XEvent
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{12D2DB8D-80FF-4152-8F51-EDB3BD3C6976}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 732
+    help_link: https://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220224'
+    install_location: ''
+    install_source: C:\SQLServer2017Media\Express_ENU\x64\setup\
+    language: 1033
+    modify_path: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
+    name: SQL Server 2017 XEvent
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{AA2A015C-C210-413B-95F6-BF9D3CDD6E0D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 14.0.1000.169
+    version_major: 14
+    version_minor: 0
+    windows_installer: 1
+  SQL Server Management Studio:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 4796
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{3A6E604C-766B-46F2-8E2D-4371B4CDF858}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
+    name: SQL Server Management Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{3A6E604C-766B-46F2-8E2D-4371B4CDF858}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 215640
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
+    name: SQL Server Management Studio
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F36F0BAF-ADF8-4865-83C5-6E947A1A579C}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  SQL Server Management Studio for Analysis Services:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 358312
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
+    name: SQL Server Management Studio for Analysis Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{F6FCF9DB-1242-45FB-A1D5-CFDDA82FA70D}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  SQL Server Management Studio for Reporting Services:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 26840
+    help_link: http://go.microsoft.com/fwlink/?LinkId=154582
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{D91AA5D8-1080-487B-83B6-622061902012}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
+    name: SQL Server Management Studio for Reporting Services
+    no_repair: 1
+    publisher: Microsoft Corporation
+    readme: Placeholder for ARP readme in case of no UI
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{D91AA5D8-1080-487B-83B6-622061902012}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  SSMS Post Install Tasks:
+  - arch: AMD64
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 296
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{7AEA9B43-10CD-4D33-B116-621B81A45490}v15.0.18410.0\x64\
+    language: 1033
+    modify_path: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
+    name: SSMS Post Install Tasks
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{7AEA9B43-10CD-4D33-B116-621B81A45490}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.18410.0
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  Visual Studio 2017 Isolated Shell for SSMS:
+  - arch: x86
+    authorized_cdf_prefix: ''
+    comments: ''
+    contact: ''
+    estimated_size: 412588
+    help_link: ''
+    help_telephone: ''
+    install_date: '20220530'
+    install_location: ''
+    install_source: C:\ProgramData\Package Cache\{AAA9F15B-AF45-4562-9991-93A848D3A902}v15.0.28307.421\redist\
+    language: 1033
+    modify_path: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
+    name: Visual Studio 2017 Isolated Shell for SSMS
+    no_repair: null
+    publisher: Microsoft Corporation
+    readme: ''
+    size: ''
+    source: windows_registry
+    system_component: 1
+    uninstall_string: MsiExec.exe /I{AAA9F15B-AF45-4562-9991-93A848D3A902}
+    url_info_about: ''
+    url_update_info: ''
+    vendor: null
+    version: 15.0.28307.421
+    version_major: 15
+    version_minor: 0
+    windows_installer: 1
+  psqlODBC 13.00.0000:
+  - arch: AMD64
+    authorized_cdf_prefix: null
+    comments: ODBC drivers for PostgreSQL, packaged by EnterpriseDB
+    contact: ''
+    estimated_size: 13676
+    help_link: ''
+    help_telephone: null
+    install_date: '20220215'
+    install_location: C:\Program Files\PostgreSQL\psqlODBC
+    install_source: null
+    language: null
+    modify_path: null
+    name: psqlODBC 13.00.0000
+    no_repair: '1'
+    publisher: EnterpriseDB
+    readme: null
+    size: null
+    source: windows_registry
+    system_component: null
+    uninstall_string: '"C:\Program Files\PostgreSQL\psqlODBC\uninstall-psqlodbc.exe"'
+    url_info_about: ''
+    url_update_info: null
+    vendor: null
+    version: 13.00.0000-2
+    version_major: 13
+    version_minor: 0
+    windows_installer: null
+processes:
+- cmdline: null
+  cwd: /
+  pid: '0'
+  ppid: '0'
+  user: null
+- cmdline: null
+  cwd: /
+  pid: '4'
+  ppid: '0'
+  user: null
+- cmdline: null
+  cwd: /
+  pid: '192'
+  ppid: '4'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: null
+  cwd: /
+  pid: '284'
+  ppid: '276'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: null
+  cwd: /
+  pid: '336'
+  ppid: '328'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: wininit.exe
+  cwd: /
+  pid: '344'
+  ppid: '276'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: winlogon.exe
+  cwd: /
+  pid: '372'
+  ppid: '328'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: null
+  cwd: /
+  pid: '432'
+  ppid: '344'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\lsass.exe
+  cwd: /
+  pid: '440'
+  ppid: '344'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k DcomLaunch
+  cwd: /
+  pid: '496'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k RPCSS
+  cwd: /
+  pid: '524'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"LogonUI.exe" /flags:0x0'
+  cwd: /
+  pid: '624'
+  ppid: '372'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"dwm.exe"'
+  cwd: /
+  pid: '632'
+  ppid: '372'
+  user: Window Manager\DWM-1
+- cmdline: C:\windows\System32\svchost.exe -k LocalServiceNetworkRestricted
+  cwd: /
+  pid: '652'
+  ppid: '432'
+  user: NT AUTHORITY\LOCAL SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k netsvcs
+  cwd: /
+  pid: '708'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\svchost.exe -k LocalService
+  cwd: /
+  pid: '800'
+  ppid: '432'
+  user: NT AUTHORITY\LOCAL SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k NetworkService
+  cwd: /
+  pid: '888'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k LocalServiceNoNetwork
+  cwd: /
+  pid: '292'
+  ppid: '432'
+  user: NT AUTHORITY\LOCAL SERVICE
+- cmdline: C:\windows\System32\spoolsv.exe
+  cwd: /
+  pid: '444'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\System32\svchost.exe -k utcsvc
+  cwd: /
+  pid: '1040'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\Program Files (x86)\PgBouncer\bin\pgbouncer.exe" --service "C:\Program
+    Files (x86)\PgBouncer\share\pgbouncer.ini"'
+  cwd: /
+  pid: '1076'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\Program Files\PostgreSQL\14\bin\pg_ctl.exe" runservice -N "postgresql-x64-14"
+    -D "C:\Program Files\PostgreSQL\14\data" -w'
+  cwd: /
+  pid: '1176'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlceip.exe"
+    -Service SQLEXPRESS'
+  cwd: /
+  pid: '1240'
+  ppid: '432'
+  user: NT SERVICE\SQLTELEMETRY$SQLEXPRESS
+- cmdline: '"C:\Program Files\PostgreSQL\14\bin\postgres.exe" -D "C:\Program Files\PostgreSQL\14\data"'
+  cwd: /
+  pid: '1248'
+  ppid: '1176'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: '1256'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forklog" "5308" "5312"
+    "0"'
+  cwd: '"C:/'
+  pid: '1304'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5212"
+    "-x5"'
+  cwd: '"C:/'
+  pid: '1336'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5224"
+    "-x3"'
+  cwd: '"C:/'
+  pid: '1344'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkboot" "5204"
+    "-x6"'
+  cwd: '"C:/'
+  pid: '1352'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkavlauncher" "5196"'
+  cwd: '"C:/'
+  pid: '1360'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkcol" "5188"'
+  cwd: '"C:/'
+  pid: '1368'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:/Program Files/PostgreSQL/14/bin/postgres.exe" "--forkbgworker=0" "5180"'
+  cwd: '"C:/'
+  pid: '1376'
+  ppid: '1248'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: '"C:\Program Files\Microsoft SQL Server\90\Shared\sqlwriter.exe"'
+  cwd: /
+  pid: '1420'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\System32\svchost.exe -k LocalSystemNetworkRestricted
+  cwd: /
+  pid: '1444'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\winlogbeat\winlogbeat.exe" -c "C:\winlogbeat\winlogbeat.yml" -path.home
+    "C:\winlogbeat" -path.data "C:\ProgramData\winlogbeat" -path.logs "C:\ProgramData\winlogbeat\logs"'
+  cwd: /
+  pid: '1484'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\System32\svchost.exe -k termsvcs
+  cwd: /
+  pid: '2028'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:\windows\system32\svchost.exe -k NetworkServiceNetworkRestricted
+  cwd: /
+  pid: '1052'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: null
+  cwd: /
+  pid: '2772'
+  ppid: '2764'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: winlogon.exe
+  cwd: /
+  pid: '2800'
+  ppid: '2764'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"dwm.exe"'
+  cwd: /
+  pid: '2856'
+  ppid: '2800'
+  user: Window Manager\DWM-2
+- cmdline: 'taskhostex.exe '
+  cwd: /
+  pid: '3008'
+  ppid: '708'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: rdpclip
+  cwd: /
+  pid: '880'
+  ppid: '2028'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\Explorer.EXE
+  cwd: /
+  pid: '2144'
+  ppid: '2176'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\system32\wbem\wmiprvse.exe
+  cwd: /
+  pid: '2084'
+  ppid: '496'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:\windows\System32\msdtc.exe
+  cwd: /
+  pid: '1836'
+  ppid: '432'
+  user: NT AUTHORITY\NETWORK SERVICE
+- cmdline: C:/telegraf/telegraf.exe -config C:/telegraf/telegraf.conf -config-directory
+    C:/telegraf/telegraf.d/
+  cwd: C:/telegraf/
+  pid: '3272'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: '"C:\Program Files\Microsoft SQL Server\MSSQL14.SQLEXPRESS\MSSQL\Binn\sqlservr.exe"
+    -sSQLEXPRESS'
+  cwd: /
+  pid: '1904'
+  ppid: '432'
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- cmdline: '"C:\Program Files (x86)\Microsoft SQL Server Management Studio 18\Common7\IDE\Ssms.exe"'
+  cwd: /
+  pid: '3236'
+  ppid: '2144'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
+  cwd: /
+  pid: '3316'
+  ppid: '2144'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: '1908'
+  ppid: '3316'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" '
+  cwd: /
+  pid: '2384'
+  ppid: '2144'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: '3208'
+  ppid: '2384'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\system32\msiexec.exe /V
+  cwd: /
+  pid: '1600'
+  ppid: '432'
+  user: NT AUTHORITY\SYSTEM
+- cmdline: C:\windows\system32\WinrsHost.exe -Embedding
+  cwd: /
+  pid: '4552'
+  ppid: '496'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: \??\C:\windows\system32\conhost.exe 0x4
+  cwd: /
+  pid: '5352'
+  ppid: '4552'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: C:\windows\system32\cmd.exe /C PowerShell -NoProfile -NonInteractive -ExecutionPolicy
+    Unrestricted -EncodedCommand UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
+  cwd: /
+  pid: '6104'
+  ppid: '4552'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: PowerShell  -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand
+    UABvAHcAZQByAFMAaABlAGwAbAAgAC0ATgBvAFAAcgBvAGYAaQBsAGUAIAAtAE4AbwBuAEkAbgB0AGUAcgBhAGMAdABpAHYAZQAgAC0ARQB4AGUAYwB1AHQAaQBvAG4AUABvAGwAaQBjAHkAIABVAG4AcgBlAHMAdAByAGkAYwB0AGUAZAAgAC0ARQBuAGMAbwBkAGUAZABDAG8AbQBtAGEAbgBkACAASgBnAEIAagBBAEcAZwBBAFkAdwBCAHcAQQBDADQAQQBZAHcAQgB2AEEARwAwAEEASQBBAEEAMgBBAEQAVQBBAE0AQQBBAHcAQQBEAEUAQQBJAEEAQQArAEEAQwBBAEEASgBBAEIAdQBBAEgAVQBBAGIAQQBCAHMAQQBBAG8AQQBhAFEAQgBtAEEAQwBBAEEASwBBAEEAawBBAEYAQQBBAFUAdwBCAFcAQQBHAFUAQQBjAGcAQgB6AEEARwBrAEEAYgB3AEIAdQBBAEYAUQBBAFkAUQBCAGkAQQBHAHcAQQBaAFEAQQB1AEEARgBBAEEAVQB3AEIAVwBBAEcAVQBBAGMAZwBCAHoAQQBHAGsAQQBiAHcAQgB1AEEAQwBBAEEATABRAEIAcwBBAEgAUQBBAEkAQQBCAGIAQQBGAFkAQQBaAFEAQgB5AEEASABNAEEAYQBRAEIAdgBBAEcANABBAFgAUQBBAGkAQQBEAE0AQQBMAGcAQQB3AEEAQwBJAEEASwBRAEEAZwBBAEgAcwBBAEMAZwBBAG4AQQBIAHMAQQBJAGcAQgBtAEEARwBFAEEAYQBRAEIAcwBBAEcAVQBBAFoAQQBBAGkAQQBEAG8AQQBkAEEAQgB5AEEASABVAEEAWgBRAEEAcwBBAEMASQBBAGIAUQBCAHoAQQBHAGMAQQBJAGcAQQA2AEEAQwBJAEEAUQBRAEIAdQBBAEgATQBBAGEAUQBCAGkAQQBHAHcAQQBaAFEAQQBnAEEASABJAEEAWgBRAEIAeABBAEgAVQBBAGEAUQBCAHkAQQBHAFUAQQBjAHcAQQBnAEEARgBBAEEAYgB3AEIAMwBBAEcAVQBBAGMAZwBCAFQAQQBHAGcAQQBaAFEAQgBzAEEARwB3AEEASQBBAEIAMgBBAEQATQBBAEwAZwBBAHcAQQBDAEEAQQBiAHcAQgB5AEEAQwBBAEEAYgBnAEIAbABBAEgAYwBBAFoAUQBCAHkAQQBDAEkAQQBmAFEAQQBuAEEAQQBvAEEAWgBRAEIANABBAEcAawBBAGQAQQBBAGcAQQBEAEUAQQBDAGcAQgA5AEEAQQBvAEEASgBBAEIAbABBAEgAZwBBAFoAUQBCAGoAQQBGADgAQQBkAHcAQgB5AEEARwBFAEEAYwBBAEIAdwBBAEcAVQBBAGMAZwBCAGYAQQBIAE0AQQBkAEEAQgB5AEEAQwBBAEEAUABRAEEAZwBBAEMAUQBBAGEAUQBCAHUAQQBIAEEAQQBkAFEAQgAwAEEAQwBBAEEAZgBBAEEAZwBBAEUAOABBAGQAUQBCADAAQQBDADAAQQBVAHcAQgAwAEEASABJAEEAYQBRAEIAdQBBAEcAYwBBAEMAZwBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQBnAEEARAAwAEEASQBBAEEAawBBAEcAVQBBAGUAQQBCAGwAQQBHAE0AQQBYAHcAQgAzAEEASABJAEEAWQBRAEIAdwBBAEgAQQBBAFoAUQBCAHkAQQBGADgAQQBjAHcAQgAwAEEASABJAEEATABnAEIAVABBAEgAQQBBAGIAQQBCAHAAQQBIAFEAQQBLAEEAQgBBAEEAQwBnAEEASQBnAEIAZwBBAEQAQQBBAFkAQQBBAHcAQQBHAEEAQQBNAEEAQgBnAEEARABBAEEASQBnAEEAcABBAEMAdwBBAEkAQQBBAHkAQQBDAHcAQQBJAEEAQgBiAEEARgBNAEEAZABBAEIAeQBBAEcAawBBAGIAZwBCAG4AQQBGAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAUABBAEgAQQBBAGQAQQBCAHAAQQBHADgAQQBiAGcAQgB6AEEARgAwAEEATwBnAEEANgBBAEYASQBBAFoAUQBCAHQAQQBHADgAQQBkAGcAQgBsAEEARQBVAEEAYgBRAEIAdwBBAEgAUQBBAGUAUQBCAEYAQQBHADQAQQBkAEEAQgB5AEEARwBrAEEAWgBRAEIAegBBAEMAawBBAEMAZwBCAEoAQQBHAFkAQQBJAEEAQQBvAEEAQwAwAEEAYgBnAEIAdgBBAEgAUQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQQB1AEEARQB3AEEAWgBRAEIAdQBBAEcAYwBBAGQAQQBCAG8AQQBDAEEAQQBMAFEAQgBsAEEASABFAEEASQBBAEEAeQBBAEMAawBBAEkAQQBCADcAQQBDAEEAQQBkAEEAQgBvAEEASABJAEEAYgB3AEIAMwBBAEMAQQBBAEkAZwBCAHAAQQBHADQAQQBkAGcAQgBoAEEARwB3AEEAYQBRAEIAawBBAEMAQQBBAGMAQQBCAGgAQQBIAGsAQQBiAEEAQgB2AEEARwBFAEEAWgBBAEEAaQBBAEMAQQBBAGYAUQBBAEsAQQBGAE0AQQBaAFEAQgAwAEEAQwAwAEEAVgBnAEIAaABBAEgASQBBAGEAUQBCAGgAQQBHAEkAQQBiAEEAQgBsAEEAQwBBAEEATABRAEIATwBBAEcARQBBAGIAUQBCAGwAQQBDAEEAQQBhAGcAQgB6AEEARwA4AEEAYgBnAEIAZgBBAEgASQBBAFkAUQBCADMAQQBDAEEAQQBMAFEAQgBXAEEARwBFAEEAYgBBAEIAMQBBAEcAVQBBAEkAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABFAEEAWABRAEEASwBBAEMAUQBBAFoAUQBCADQAQQBHAFUAQQBZAHcAQgBmAEEASABjAEEAYwBnAEIAaABBAEgAQQBBAGMAQQBCAGwAQQBIAEkAQQBJAEEAQQA5AEEAQwBBAEEAVwB3AEIAVABBAEcATQBBAGMAZwBCAHAAQQBIAEEAQQBkAEEAQgBDAEEARwB3AEEAYgB3AEIAagBBAEcAcwBBAFgAUQBBADYAQQBEAG8AQQBRAHcAQgB5AEEARwBVAEEAWQBRAEIAMABBAEcAVQBBAEsAQQBBAGsAQQBIAE0AQQBjAEEAQgBzAEEARwBrAEEAZABBAEIAZgBBAEgAQQBBAFkAUQBCAHkAQQBIAFEAQQBjAHcAQgBiAEEARABBAEEAWABRAEEAcABBAEEAbwBBAEoAZwBBAGsAQQBHAFUAQQBlAEEAQgBsAEEARwBNAEEAWAB3AEIAMwBBAEgASQBBAFkAUQBCAHcAQQBIAEEAQQBaAFEAQgB5AEEAQQA9AD0A
+  cwd: /
+  pid: '6056'
+  ppid: '6104'
+  user: TEST-NORM-WIN01\Administrator
+- cmdline: '"C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe"  -NoProfile
+    -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand JgBjAGgAYwBwAC4AYwBvAG0AIAA2ADUAMAAwADEAIAA+ACAAJABuAHUAbABsAAoAaQBmACAAKAAkAFAAUwBWAGUAcgBzAGkAbwBuAFQAYQBiAGwAZQAuAFAAUwBWAGUAcgBzAGkAbwBuACAALQBsAHQAIABbAFYAZQByAHMAaQBvAG4AXQAiADMALgAwACIAKQAgAHsACgAnAHsAIgBmAGEAaQBsAGUAZAAiADoAdAByAHUAZQAsACIAbQBzAGcAIgA6ACIAQQBuAHMAaQBiAGwAZQAgAHIAZQBxAHUAaQByAGUAcwAgAFAAbwB3AGUAcgBTAGgAZQBsAGwAIAB2ADMALgAwACAAbwByACAAbgBlAHcAZQByACIAfQAnAAoAZQB4AGkAdAAgADEACgB9AAoAJABlAHgAZQBjAF8AdwByAGEAcABwAGUAcgBfAHMAdAByACAAPQAgACQAaQBuAHAAdQB0ACAAfAAgAE8AdQB0AC0AUwB0AHIAaQBuAGcACgAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAgAD0AIAAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAF8AcwB0AHIALgBTAHAAbABpAHQAKABAACgAIgBgADAAYAAwAGAAMABgADAAIgApACwAIAAyACwAIABbAFMAdAByAGkAbgBnAFMAcABsAGkAdABPAHAAdABpAG8AbgBzAF0AOgA6AFIAZQBtAG8AdgBlAEUAbQBwAHQAeQBFAG4AdAByAGkAZQBzACkACgBJAGYAIAAoAC0AbgBvAHQAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwAuAEwAZQBuAGcAdABoACAALQBlAHEAIAAyACkAIAB7ACAAdABoAHIAbwB3ACAAIgBpAG4AdgBhAGwAaQBkACAAcABhAHkAbABvAGEAZAAiACAAfQAKAFMAZQB0AC0AVgBhAHIAaQBhAGIAbABlACAALQBOAGEAbQBlACAAagBzAG8AbgBfAHIAYQB3ACAALQBWAGEAbAB1AGUAIAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADEAXQAKACQAZQB4AGUAYwBfAHcAcgBhAHAAcABlAHIAIAA9ACAAWwBTAGMAcgBpAHAAdABCAGwAbwBjAGsAXQA6ADoAQwByAGUAYQB0AGUAKAAkAHMAcABsAGkAdABfAHAAYQByAHQAcwBbADAAXQApAAoAJgAkAGUAeABlAGMAXwB3AHIAYQBwAHAAZQByAA=='
+  cwd: /
+  pid: '4416'
+  ppid: '6056'
+  user: TEST-NORM-WIN01\Administrator
+software_list:
+- cmd_regexp: Microsoft.SQL.Server.*sqlservr\.exe
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/sql_server.yaml
+    name: Include SQL Server specific plugins
+  name: Microsoft SQL Server
+  pkg_regexp: ^SQL.Server.\d{4}.Database.Engine
+  process_type: single
+  return_children: false
+  return_packages: false
+  vars:
+    ignore_databases:
+    - tempdb
 tcp_listen:
-  - address: '::'
-    name: sqlservr.exe
-    pid: 1904
-    port: 49350
-    protocol: tcp
-    stime: Mon May 30 17:47:16 2022
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - address: '::'
-    name: services.exe
-    pid: 432
-    port: 49169
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: lsass.exe
-    pid: 440
-    port: 49167
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: spoolsv.exe
-    pid: 444
-    port: 49155
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: svchost.exe
-    pid: 708
-    port: 49154
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: svchost.exe
-    pid: 652
-    port: 49153
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: '::'
-    name: wininit.exe
-    pid: 344
-    port: 49152
-    protocol: tcp
-    stime: Mon May 30 17:21:40 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: System
-    pid: 4
-    port: 47001
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: ::1
-    name: pgbouncer.exe
-    pid: 1076
-    port: 6432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: '::'
-    name: System
-    pid: 4
-    port: 5986
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System
-    pid: 4
-    port: 5985
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: postgres.exe
-    pid: 1248
-    port: 5432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: svchost.exe
-    pid: 2028
-    port: 3389
-    protocol: tcp
-    stime: Mon May 30 17:21:53 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: '::'
-    name: System
-    pid: 4
-    port: 445
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: svchost.exe
-    pid: 524
-    port: 135
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: sqlservr.exe
-    pid: 1904
-    port: 49350
-    protocol: tcp
-    stime: Mon May 30 17:47:16 2022
-    user: NT SERVICE\MSSQL$SQLEXPRESS
-  - address: 0.0.0.0
-    name: services.exe
-    pid: 432
-    port: 49169
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: lsass.exe
-    pid: 440
-    port: 49167
-    protocol: tcp
-    stime: Mon May 30 17:21:41 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: spoolsv.exe
-    pid: 444
-    port: 49155
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 708
-    port: 49154
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 652
-    port: 49153
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\LOCAL SERVICE
-  - address: 0.0.0.0
-    name: wininit.exe
-    pid: 344
-    port: 49152
-    protocol: tcp
-    stime: Mon May 30 17:21:40 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 127.0.0.1
-    name: pgbouncer.exe
-    pid: 1076
-    port: 6432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\SYSTEM
-  - address: 0.0.0.0
-    name: postgres.exe
-    pid: 1248
-    port: 5432
-    protocol: tcp
-    stime: Mon May 30 17:21:44 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 2028
-    port: 3389
-    protocol: tcp
-    stime: Mon May 30 17:21:53 2022
-    user: NT AUTHORITY\NETWORK SERVICE
-  - address: 192.168.0.94
-    name: System
-    pid: 4
-    port: 139
-    protocol: tcp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: svchost.exe
-    pid: 524
-    port: 135
-    protocol: tcp
-    stime: Mon May 30 17:21:42 2022
-    user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: sqlservr.exe
+  pid: 1904
+  port: 49350
+  protocol: tcp
+  stime: Mon May 30 17:47:16 2022
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- address: '::'
+  name: services.exe
+  pid: 432
+  port: 49169
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: lsass.exe
+  pid: 440
+  port: 49167
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: spoolsv.exe
+  pid: 444
+  port: 49155
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: svchost.exe
+  pid: 708
+  port: 49154
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: svchost.exe
+  pid: 652
+  port: 49153
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: '::'
+  name: wininit.exe
+  pid: 344
+  port: 49152
+  protocol: tcp
+  stime: Mon May 30 17:21:40 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: System
+  pid: 4
+  port: 47001
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: ::1
+  name: pgbouncer.exe
+  pid: 1076
+  port: 6432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: '::'
+  name: System
+  pid: 4
+  port: 5986
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System
+  pid: 4
+  port: 5985
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: postgres.exe
+  pid: 1248
+  port: 5432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: svchost.exe
+  pid: 2028
+  port: 3389
+  protocol: tcp
+  stime: Mon May 30 17:21:53 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: '::'
+  name: System
+  pid: 4
+  port: 445
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: svchost.exe
+  pid: 524
+  port: 135
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: sqlservr.exe
+  pid: 1904
+  port: 49350
+  protocol: tcp
+  stime: Mon May 30 17:47:16 2022
+  user: NT SERVICE\MSSQL$SQLEXPRESS
+- address: 0.0.0.0
+  name: services.exe
+  pid: 432
+  port: 49169
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: lsass.exe
+  pid: 440
+  port: 49167
+  protocol: tcp
+  stime: Mon May 30 17:21:41 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: spoolsv.exe
+  pid: 444
+  port: 49155
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 708
+  port: 49154
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 652
+  port: 49153
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\LOCAL SERVICE
+- address: 0.0.0.0
+  name: wininit.exe
+  pid: 344
+  port: 49152
+  protocol: tcp
+  stime: Mon May 30 17:21:40 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 127.0.0.1
+  name: pgbouncer.exe
+  pid: 1076
+  port: 6432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\SYSTEM
+- address: 0.0.0.0
+  name: postgres.exe
+  pid: 1248
+  port: 5432
+  protocol: tcp
+  stime: Mon May 30 17:21:44 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 2028
+  port: 3389
+  protocol: tcp
+  stime: Mon May 30 17:21:53 2022
+  user: NT AUTHORITY\NETWORK SERVICE
+- address: 192.168.0.94
+  name: System
+  pid: 4
+  port: 139
+  protocol: tcp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: svchost.exe
+  pid: 524
+  port: 135
+  protocol: tcp
+  stime: Mon May 30 17:21:42 2022
+  user: NT AUTHORITY\NETWORK SERVICE
 udp_listen:
-  - address: fe80::1002:b306:e05b:c850%12
-    name: System Idle Process
-    pid: null
-    port: 546
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: ::1
-    name: System Idle Process
-    pid: null
-    port: 59132
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 5355
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 4500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 3389
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: '::'
-    name: System Idle Process
-    pid: null
-    port: 123
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 5355
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 4500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 3389
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 500
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 192.168.0.94
-    name: System Idle Process
-    pid: null
-    port: 138
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 192.168.0.94
-    name: System Idle Process
-    pid: null
-    port: 137
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
-  - address: 0.0.0.0
-    name: System Idle Process
-    pid: null
-    port: 123
-    protocol: udp
-    stime: Mon May 30 17:21:38 2022
-    user: null
+- address: fe80::1002:b306:e05b:c850%12
+  name: System Idle Process
+  pid: null
+  port: 546
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: ::1
+  name: System Idle Process
+  pid: null
+  port: 59132
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 5355
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 4500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 3389
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: '::'
+  name: System Idle Process
+  pid: null
+  port: 123
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 5355
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 4500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 3389
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 500
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 192.168.0.94
+  name: System Idle Process
+  pid: null
+  port: 138
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 192.168.0.94
+  name: System Idle Process
+  pid: null
+  port: 137
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null
+- address: 0.0.0.0
+  name: System Idle Process
+  pid: null
+  port: 123
+  protocol: udp
+  stime: Mon May 30 17:21:38 2022
+  user: null

--- a/tests/unit/plugins/action/auto/resources/sybase_ase/sunos_5.10_sybase_ase.yaml
+++ b/tests/unit/plugins/action/auto/resources/sybase_ase/sunos_5.10_sybase_ase.yaml
@@ -1,1614 +1,1729 @@
+dockers: {}
 expected_result:
-  - type: Sybase ASE
-    process:
-      cmdline: "/opt2/sybase125/ASE-12_5/bin/dataserver -d/dev/vx/rdsk/dwdg/dwdes_master
-        -e/opt"
-      ppid: '1'
-      pid: '12288'
-      user: sybase
-      listening_ports:
-        - 10006
+- bindings:
+  - address: 127.0.0.1
+    class: service
+    port: 10006
+    protocol: tcp
+  - address: 192.168.3.26
+    class: service
+    port: 10006
+    protocol: tcp
+  discovery_time: '2022-09-29T19:51:34+02:00'
+  listening_ports:
+  - 10006
+  process:
+    cmdline: /opt2/sybase125/ASE-12_5/bin/dataserver -d/dev/vx/rdsk/dwdg/dwdes_master
+      -e/opt
+    cwd: /opt2/sybase125/ASE-12_5/bin/
     listening_ports:
-      - 10006
-    bindings:
-      - address: 127.0.0.1
-        port: 10006
-        protocol: tcp
-        class: service
-      - address: 192.168.3.26
-        port: 10006
-        protocol: tcp
-        class: service
-    discovery_time: '2022-09-29T19:51:34+02:00'
-  - type: Sybase ASE
-    process:
-      cmdline: "/opt2/sybase155/ASE-15_0/bin/dataserver -sASEDW_DES -d/dev/vx/rdsk/dwdg/asedwde"
-      ppid: '1'
-      pid: '12612'
-      user: sybase
-      listening_ports:
-        - 10000
-    listening_ports:
-      - 10000
-    bindings:
-      - address: 192.168.3.26
-        port: 10000
-        protocol: tcp
-        class: service
-    discovery_time: '2022-09-29T19:51:34+02:00'
-
-software_list:
-  - name: Sybase ASE
-    cmd_regexp: "dataserver"
-    process_type: parent
-    return_children: false
-    return_packages: false
-
-processes:
-  - cmdline: sched
-    ppid: '0'
-    pid: '0'
-    user: root
-  - cmdline: "/sbin/init"
-    ppid: '0'
-    pid: '1'
-    user: root
-  - cmdline: pageout
-    ppid: '0'
-    pid: '2'
-    user: root
-  - cmdline: fsflush
-    ppid: '0'
-    pid: '3'
-    user: root
-  - cmdline: "/usr/lib/nfs/mountd"
-    ppid: '1'
-    pid: '2215'
-    user: root
-  - cmdline: "/lib/svc/bin/svc.startd"
-    ppid: '1'
-    pid: '7'
-    user: root
-  - cmdline: "/lib/svc/bin/svc.configd"
-    ppid: '1'
-    pid: '9'
-    user: root
-  - cmdline: "/usr/sbin/cron"
-    ppid: '1'
-    pid: '2014'
-    user: root
-  - cmdline: "/usr/bin/python2.6 ~iometrics/.ansible/tmp/ansible-tmp-1664473849.839634-797351"
-    ppid: '19411'
-    pid: '19412'
-    user: root
-  - cmdline: "/usr/lib/sysevent/syseventd"
-    ppid: '1'
-    pid: '410'
-    user: root
-  - cmdline: "/usr/sbin/ipmon -Ds"
-    ppid: '1'
-    pid: '381'
-    user: root
-  - cmdline: "/lib/svc/method/iscsi-initiator"
-    ppid: '1'
-    pid: '530'
-    user: root
-  - cmdline: "/usr/lib/efcode/sparcv9/efdaemon"
-    ppid: '1'
-    pid: '1564'
-    user: root
-  - cmdline: "/usr/lib/crypto/kcfd"
-    ppid: '1'
-    pid: '432'
-    user: daemon
-  - cmdline: devfsadmd
-    ppid: '1'
-    pid: '433'
-    user: root
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '14720'
-    user: root
-  - cmdline: "/sbin/vxesd"
-    ppid: '1'
-    pid: '664'
-    user: root
-  - cmdline: "/usr/lib/dmi/snmpXdmid -s eud1dw"
-    ppid: '1'
-    pid: '2236'
-    user: root
-  - cmdline: "/usr/lib/nfs/statd"
-    ppid: '1'
-    pid: '2057'
-    user: daemon
-  - cmdline: "/usr/lib/nfs/nfs4cbd"
-    ppid: '1'
-    pid: '2056'
-    user: daemon
-  - cmdline: "/usr/sbin/nscd"
-    ppid: '1'
-    pid: '424'
-    user: root
-  - cmdline: "/opt/OV/lbin/perf/coda"
-    ppid: '4983'
-    pid: '5529'
-    user: root
-  - cmdline: "/usr/platform/sun4u/lib/sckmd"
-    ppid: '1'
-    pid: '2013'
-    user: root
-  - cmdline: "/usr/lib/sendmail -Ac -q15m"
-    ppid: '1'
-    pid: '2253'
-    user: smmsp
-  - cmdline: "/usr/lib/picl/picld"
-    ppid: '1'
-    pid: '465'
-    user: root
-  - cmdline: "/usr/lib/inet/in.mpathd -a"
-    ppid: '1'
-    pid: '493'
-    user: root
-  - cmdline: "/usr/sfw/sbin/snmpd"
-    ppid: '1'
-    pid: '2234'
-    user: root
-  - cmdline: "/usr/platform/SUNW,SPARC-Enterprise/lib/sparcv9/oplhpd"
-    ppid: '1'
-    pid: '460'
-    user: root
-  - cmdline: "/usr/bin/pppd /dev/dm2s0 unit 0 file /usr/platform/SUNW,SPARC-Enterprise/lib/ds"
-    ppid: '1'
-    pid: '2042'
-    user: root
-  - cmdline: "/opt/perf/bin/midaemon"
-    ppid: '1'
-    pid: '4785'
-    user: root
-  - cmdline: "/usr/sbin/rpcbind"
-    ppid: '1'
-    pid: '2047'
-    user: daemon
-  - cmdline: "/usr/sbin/vold -f /etc/vold.conf"
-    ppid: '1'
-    pid: '2251'
-    user: root
-  - cmdline: "/usr/lib/hotplugd"
-    ppid: '1'
-    pid: '2027'
-    user: root
-  - cmdline: "/usr/sadm/lib/smc/bin/smcboot"
-    ppid: '2160'
-    pid: '2162'
-    user: root
-  - cmdline: "/usr/lib/saf/ttymon"
-    ppid: '2068'
-    pid: '2097'
-    user: root
-  - cmdline: "/usr/lib/utmpd"
-    ppid: '1'
-    pid: '2075'
-    user: root
-  - cmdline: "/usr/lib/nfs/nfsmapid"
-    ppid: '1'
-    pid: '2060'
-    user: daemon
-  - cmdline: "/usr/sbin/syslogd"
-    ppid: '1'
-    pid: '2153'
-    user: root
-  - cmdline: "/usr/sadm/lib/smc/bin/smcboot"
-    ppid: '1'
-    pid: '2160'
-    user: root
-  - cmdline: "/usr/lib/dmi/dmispd"
-    ppid: '1'
-    pid: '2235'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcacta"
-    ppid: '4983'
-    pid: '5545'
-    user: root
-  - cmdline: "/usr/sadm/lib/smc/bin/smcboot"
-    ppid: '2160'
-    pid: '2161'
-    user: root
-  - cmdline: "/usr/lib/saf/sac -t 300"
-    ppid: '7'
-    pid: '2068'
-    user: root
-  - cmdline: "/usr/lib/saf/ttymon -g -d /dev/console -l console -T vt100 -m ldterm,ttcompat
-    -"
-    ppid: '7'
-    pid: '1316'
-    user: root
-  - cmdline: "/usr/lib/fm/fmd/fmd"
-    ppid: '1'
-    pid: '2274'
-    user: root
-  - cmdline: "/usr/lib/nfs/lockd"
-    ppid: '1'
-    pid: '2088'
-    user: daemon
-  - cmdline: "/usr/lib/saf/ttymon"
-    ppid: '2068'
-    pid: '2099'
-    user: root
-  - cmdline: "/usr/lib/inet/inetd start"
-    ppid: '1'
-    pid: '2100'
-    user: root
-  - cmdline: "/usr/local/sbin/prngd /var/spool/prngd/pool"
-    ppid: '1'
-    pid: '2656'
-    user: root
-  - cmdline: "/usr/lib/snmp/snmpdx -y -c /etc/snmp/conf"
-    ppid: '1'
-    pid: '2226'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcmona"
-    ppid: '4983'
-    pid: '5552'
-    user: root
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '19826'
-    user: root
-  - cmdline: "/usr/lib/sendmail -bl -q15m"
-    ppid: '1'
-    pid: '2252'
-    user: root
-  - cmdline: "/usr/lib/dcs -l"
-    ppid: '1'
-    pid: '2271'
-    user: root
-  - cmdline: "/usr/lib/inet/xntpd"
-    ppid: '1'
-    pid: '2276'
-    user: root
-  - cmdline: "/usr/lib/nfs/nfsd"
-    ppid: '1'
-    pid: '2220'
-    user: daemon
-  - cmdline: "/opt/OV/bin/ovcd"
-    ppid: '1'
-    pid: '4983'
-    user: root
-  - cmdline: "/usr/java/bin/java -server -Xmx128m -XX:+UseParallelGC -XX:ParallelGCThreads=4"
-    ppid: '1'
-    pid: '2588'
-    user: noaccess
-  - cmdline: "/Infa95/telecable/java/bin/java -ea -Djava.awt.headless=true -Duser.dir=/Infa95"
-    ppid: '1'
-    pid: '22465'
-    user: telecable
-  - cmdline: "//opt/VRTSob/bin/vxsvc -r //opt/VRTSob/config/Registry -e"
-    ppid: '1'
-    pid: '4190'
-    user: root
-  - cmdline: "/opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqdw_des/iqdw_des.cfg /iq/iqdw_des/iqdw_des"
-    ppid: '1'
-    pid: '319'
-    user: iq
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '1'
-    pid: '3028'
-    user: root
-  - cmdline: "/opt/perf/bin/perfalarm"
-    ppid: '1'
-    pid: '16096'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcmsgi"
-    ppid: '4983'
-    pid: '5548'
-    user: root
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '24808'
-    user: root
-  - cmdline: "/usr/dt/bin/dtlogin -daemon"
-    ppid: '1'
-    pid: '3273'
-    user: root
-  - cmdline: "-sh"
-    ppid: '14720'
-    pid: '14725'
-    user: iq
-  - cmdline: "/var/app/oracle/agent13c/agent_13.1.0.0.0/perl/bin/perl /var/app/oracle/agent13"
-    ppid: '1'
-    pid: '5079'
-    user: em13c
-  - cmdline: "/opt/perf/bin/ttd"
-    ppid: '1'
-    pid: '4299'
-    user: root
-  - cmdline: "-sh"
-    ppid: '24808'
-    pid: '24811'
-    user: sybase
-  - cmdline: "/var/app/oracle/agent13c/agent_13.1.0.0.0/oracle_common/jdk/bin/sparcv9/java
-    -X"
-    ppid: '5079'
-    pid: '17162'
-    user: em13c
-  - cmdline: "/opt/VRTSsfmh/bin/xprtld -X 1 /etc/opt/VRTSsfmh/xprtld.conf"
-    ppid: '1'
-    pid: '4257'
-    user: root
-  - cmdline: veaintf
-    ppid: '4257'
-    pid: '4470'
-    user: root
-  - cmdline: "/opt/OV/lbin/conf/ovconfd"
-    ppid: '4983'
-    pid: '4985'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcle -std"
-    ppid: '4983'
-    pid: '5550'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcmsga"
-    ppid: '4983'
-    pid: '5527'
-    user: root
-  - cmdline: "/opt/OV/lbin/xpl/trc/ovtrcd"
-    ppid: '1'
-    pid: '4840'
-    user: root
-  - cmdline: "/Infa95/cdi/java/bin/java -ea -Djava.awt.headless=true -Duser.dir=/Infa95/cdi/t"
-    ppid: '1'
-    pid: '21514'
-    user: cdi
-  - cmdline: "/opt2/sybase155/ASE-15_0/bin/backupserver -e/opt2/sybase155/ASE-15_0/install/AS"
-    ppid: '14299'
-    pid: '14300'
-    user: sybase
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '19292'
-    user: root
-  - cmdline: "/opt/OV/bin/ovbbccb -nodaemon"
-    ppid: '4983'
-    pid: '4984'
-    user: root
-  - cmdline: "/opt2/sybase155/ASE-15_0/bin/dataserver -sASEDW_DES -d/dev/vx/rdsk/dwdg/asedwde"
-    ppid: '1'
-    pid: '12612'
-    user: sybase
-  - cmdline: "/Infa95/cdi/java/bin/java -XX:GCTimeRatio=9 -XX:MaxPermSize=128m -Xmx512M
-    -Dsun"
-    ppid: '21514'
-    pid: '21889'
-    user: cdi
-  - cmdline: ps -e -o pid= -o ppid= -o user= -o args=
-    ppid: '19413'
-    pid: '19414'
-    user: root
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-gbxazylhooudvvuedbenbqozzk
-    ppid: '19409'
-    pid: '19410'
-    user: root
-  - cmdline: "/usr/lib/sysevent/syseventconfd"
-    ppid: '1'
-    pid: '28492'
-    user: root
-  - cmdline: "/opt2/sybase125/ASE-12_5/bin/dataserver -d/dev/vx/rdsk/dwdg/dwdes_master
-    -e/opt"
-    ppid: '1'
+    - 10006
     pid: '12288'
+    ppid: '1'
     user: sybase
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '25618'
-    user: root
-  - cmdline: "/bin/sh /opt2/sybase125/ASE-12_5/install/RUN_DW_DES_BACKUP"
-    ppid: '1'
-    pid: '21529'
-    user: sybase
-  - cmdline: "-sh"
-    ppid: '25618'
-    pid: '25630'
-    user: sybase
-  - cmdline: "/bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-gbxazylhooudv"
-    ppid: '19408'
-    pid: '19409'
-    user: iometrics
-  - cmdline: "/bin/sh /opt2/sybase155/ASE-15_0/install/RUN_ASEDW_DES_BACKUP"
-    ppid: '1'
-    pid: '14299'
-    user: sybase
-  - cmdline: "/usr/openv/netbackup/bin/bpcd -standalone"
-    ppid: '1'
-    pid: '7257'
-    user: root
-  - cmdline: bash
-    ppid: '19839'
-    pid: '20873'
-    user: root
-  - cmdline: "/opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqtele_des/iqtele_des.cfg /iq/iqtele_des/iq"
-    ppid: '1'
-    pid: '18022'
-    user: iq
-  - cmdline: "/bin/sh -c echo BECOME-SUCCESS-gbxazylhooudvvuedbenbqozzknlqodl ; /usr/bin/pyth"
-    ppid: '19410'
-    pid: '19411'
-    user: root
-  - cmdline: sh
-    ppid: '19838'
-    pid: '19839'
-    user: root
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '25674'
-    user: root
-  - cmdline: "/Infa95/cdi/server/bin/pmserver RE9NX0RFU0E= UE1fU0VSVkVS bm9kZTAxX2V1ZDFkd19jZ"
-    ppid: '21514'
-    pid: '21899'
-    user: cdi
-  - cmdline: vxconfigd
-    ppid: '1'
-    pid: '5596'
-    user: root
-  - cmdline: sh -c /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-gb
-    ppid: '19292'
-    pid: '19408'
-    user: iometrics
-  - cmdline: "/bin/sh -c ps -e -o pid= -o ppid= -o user= -o args="
-    ppid: '19412'
-    pid: '19413'
-    user: root
-  - cmdline: sudo su
-    ppid: '19829'
-    pid: '19838'
-    user: root
-  - cmdline: "-sh"
-    ppid: '19826'
-    pid: '19829'
-    user: iometrics
-  - cmdline: "/Infa95/telecable/server/bin/pmserver RE9NX0RFU0E= VExfU0VSVkVS bm9kZTAxX2V1ZDF"
-    ppid: '22465'
-    pid: '22527'
-    user: telecable
-  - cmdline: "/opt/perf/bin/scopeux"
-    ppid: '1'
-    pid: '16080'
-    user: root
-  - cmdline: "/opt/VRTSpbx/bin/pbx_exchange"
-    ppid: '1'
-    pid: '27629'
-    user: root
-  - cmdline: "/opt/perf/bin/perf64"
-    ppid: '16080'
-    pid: '16101'
-    user: root
-  - cmdline: "/Infa95/cdi/server/bin/pmserver RE9NX0RFU0E= UE1fU0VSVkVSX0NEUlM= bm9kZTAxX2V1Z"
-    ppid: '21514'
-    pid: '21969'
-    user: cdi
-  - cmdline: "-sh"
-    ppid: '25674'
-    pid: '25688'
-    user: iq
-  - cmdline: "/Infa95/cdi/server/bin/pmrepagent - RE9NX0RFU0E= UFdfREVTQTk= bm9kZTAxX2V1ZDFkd"
-    ppid: '21514'
-    pid: '21898'
-    user: cdi
-  - cmdline: "/opt2/sybase125/ASE-12_5/bin/backupserver -e/opt2/sybase125/ASE-12_5/install/DW"
-    ppid: '21529'
-    pid: '21530'
-    user: sybase
-  - cmdline: "/opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqcdi_des/iqcdi_des.cfg /iq/iqcdi_des/iqcdi"
-    ppid: '1'
-    pid: '17806'
-    user: iq
-  - cmdline: "/usr/openv/netbackup/bin/vnetd -standalone"
-    ppid: '1'
-    pid: '7254'
-    user: root
-  - cmdline: python
-    ppid: '20873'
-    pid: '14858'
-    user: root
-packages: { }
-tcp_listen:
-  - protocol: tcp
-    name: sshd
-    pid: '14720'
-    user: root
-    address: 192.168.3.26
-    port: 22
-    stime: Mon Sep 19 11:31:23  2022
-  - protocol: tcp
-    name: coda
-    pid: '5529'
-    user: root
-    address: 127.0.0.1
-    port: 59998
-    stime: Thu Nov 15 12:25:38  2018
-  - protocol: tcp
-    name: in.mpath
-    pid: '493'
-    user: root
-    address: 127.0.0.1
-    port: 5999
-    stime: Thu Nov 15 12:24:59  2018
-  - protocol: tcp
-    name: in.mpath
-    pid: '493'
-    user: root
-    address: 192.168.3.120
-    port: 0
-    stime: Thu Nov 15 12:24:59  2018
-  - protocol: tcp
-    name: in.mpath
-    pid: '493'
-    user: root
-    address: 192.168.3.119
-    port: 0
-    stime: Thu Nov 15 12:24:59  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2162'
-    user: root
-    address: 127.0.0.1
-    port: 32774
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2160'
-    user: root
-    address: 127.0.0.1
-    port: 5987
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2160'
-    user: root
-    address: 127.0.0.1
-    port: 898
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2160'
-    user: root
-    address: 127.0.0.1
-    port: 5988
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: opcacta
-    pid: '5545'
-    user: root
-    address: 127.0.0.1
-    port: 32881
-    stime: Thu Nov 15 12:25:38  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2161'
-    user: root
-    address: 127.0.0.1
-    port: 32773
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: fmd
-    pid: '2274'
-    user: root
-    address: 192.168.224.4
-    port: 12
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: tcp
-    name: fmd
-    pid: '2274'
-    user: root
-    address: 192.168.224.4
-    port: 24
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: tcp
-    name: inetd
-    pid: '2100'
-    user: root
-    address: "::"
-    port: 21
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: sendmail
-    pid: '2252'
-    user: root
-    address: 127.0.0.1
-    port: 25
-    stime: Thu Nov 15 12:25:11  2018
-  - protocol: tcp
-    name: dcs
-    pid: '2271'
-    user: root
-    address: 192.168.224.4
-    port: 665
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: tcp
-    name: ovcd
-    pid: '4983'
-    user: root
-    address: 127.0.0.1
-    port: 32840
-    stime: Thu Nov 15 12:25:29  2018
-  - protocol: tcp
-    name: ovcd
-    pid: '4983'
-    user: root
-    address: 127.0.0.1
-    port: 32848
-    stime: Thu Nov 15 12:25:29  2018
-  - protocol: tcp
-    name: java
-    pid: '2588'
-    user: noaccess
-    address: 127.0.0.1
-    port: 6788
-    stime: Thu Nov 15 12:25:16  2018
-  - protocol: tcp
-    name: java
-    pid: '2588'
-    user: noaccess
-    address: 0.0.0.0
-    port: 32799
-    stime: Thu Nov 15 12:25:16  2018
-  - protocol: tcp
-    name: java
-    pid: '2588'
-    user: noaccess
-    address: 127.0.0.1
-    port: 6789
-    stime: Thu Nov 15 12:25:16  2018
-  - protocol: tcp
-    name: java
-    pid: '2588'
-    user: noaccess
-    address: 127.0.0.1
-    port: 32787
-    stime: Thu Nov 15 12:25:16  2018
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 0.0.0.0
-    port: 7005
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 0.0.0.0
-    port: 61300
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 38070
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 7005
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 38260
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 38276
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61463
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 127.0.0.1
-    port: 7007
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61526
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61530
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61529
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61532
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 0.0.0.0
-    port: 7006
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: "::"
-    port: 2148
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: tcp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: "::ffff:127.0.0.1"
-    port: 2148
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: tcp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: 192.168.3.26
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: 0.0.0.0
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: "::"
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: tcp
-    name: sshd
-    pid: '3028'
-    user: root
-    address: "::"
-    port: 22
-    stime: Thu Nov 15 12:25:22  2018
-  - protocol: tcp
-    name: sshd
-    pid: '3028'
-    user: root
-    address: 0.0.0.0
-    port: 22
-    stime: Thu Nov 15 12:25:22  2018
-  - protocol: tcp
-    name: dtlogin
-    pid: '3273'
-    user: root
-    address: 0.0.0.0
-    port: 32804
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: tcp
-    name: java
-    pid: '17162'
-    user: em13c
-    address: 0.0.0.0
-    port: 3872
-    stime: Fri Jul 15 01:31:24  2022
-  - protocol: tcp
-    name: xprtld
-    pid: '4257'
-    user: root
-    address: 0.0.0.0
-    port: 5634
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: xprtld
-    pid: '4257'
-    user: root
-    address: 127.0.0.1
-    port: 32813
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: veaintf
-    pid: '4470'
-    user: root
-    address: 127.0.0.1
-    port: 32812
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: veaintf
-    pid: '4470'
-    user: root
-    address: 127.0.0.1
-    port: 32000
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: veaintf
-    pid: '4470'
-    user: root
-    address: 127.0.0.1
-    port: 32929
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: ovconfd
-    pid: '4985'
-    user: root
-    address: 127.0.0.1
-    port: 32856
-    stime: Thu Nov 15 12:25:31  2018
-  - protocol: tcp
-    name: ovconfd
-    pid: '4985'
-    user: root
-    address: 127.0.0.1
-    port: 46812
-    stime: Thu Nov 15 12:25:31  2018
-  - protocol: tcp
-    name: opcmsga
-    pid: '5527'
-    user: root
-    address: 127.0.0.1
-    port: 32879
-    stime: Thu Nov 15 12:25:37  2018
-  - protocol: tcp
-    name: ovtrcd
-    pid: '4840'
-    user: root
-    address: 0.0.0.0
-    port: 5053
-    stime: Thu Nov 15 12:25:25  2018
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 0.0.0.0
-    port: 6005
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 0.0.0.0
-    port: 59995
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60210
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 6006
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 37100
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60159
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 35363
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 6005
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 127.0.0.1
-    port: 6007
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60287
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 0.0.0.0
-    port: 60291
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60305
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60372
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 0.0.0.0
-    port: 6006
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: backupse
-    pid: '14300'
-    user: sybase
-    address: 192.168.3.26
-    port: 10001
-    stime: Fri Jun 28 13:55:35  2019
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: "::"
-    port: 383
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: 127.0.0.1
-    port: 53114
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: 127.0.0.1
-    port: 53116
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: 127.0.0.1
-    port: 53118
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: "::ffff:127.0.0.1"
-    port: 383
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: dataserv
-    pid: '12612'
-    user: sybase
-    address: 192.168.3.26
+  type: Sybase ASE
+- bindings:
+  - address: 192.168.3.26
+    class: service
     port: 10000
-    stime: Tue Jun 25 11:02:18  2019
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 0.0.0.0
-    port: 6008
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 0.0.0.0
-    port: 60316
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60339
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60340
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60345
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 127.0.0.1
-    port: 6009
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60402
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60403
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60404
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60437
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60438
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60439
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: dataserv
-    pid: '12288'
+    protocol: tcp
+  discovery_time: '2022-09-29T19:51:34+02:00'
+  listening_ports:
+  - 10000
+  process:
+    cmdline: /opt2/sybase155/ASE-15_0/bin/dataserver -sASEDW_DES -d/dev/vx/rdsk/dwdg/asedwde
+    cwd: /opt2/sybase155/ASE-15_0/bin/
+    listening_ports:
+    - 10000
+    pid: '12612'
+    ppid: '1'
     user: sybase
-    address: 127.0.0.1
-    port: 10006
-    stime: Tue Jun 25 11:01:07  2019
-  - protocol: tcp
-    name: dataserv
-    pid: '12288'
-    user: sybase
-    address: 192.168.3.26
-    port: 10006
-    stime: Tue Jun 25 11:01:07  2019
-  - protocol: tcp
-    name: bpcd
-    pid: '7257'
-    user: root
-    address: 0.0.0.0
-    port: 13782
-    stime: Mon Feb 14 12:54:52  2022
-  - protocol: tcp
-    name: bpcd
-    pid: '7257'
-    user: root
-    address: 127.0.0.1
-    port: 54011
-    stime: Mon Feb 14 12:54:52  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '18022'
-    user: iq
-    address: 0.0.0.0
-    port: 2641
-    stime: Thu Mar 10 15:10:27  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '18022'
-    user: iq
-    address: "::"
-    port: 2641
-    stime: Thu Mar 10 15:10:27  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 192.168.3.26
-    port: 60419
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 192.168.3.26
-    port: 36935
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 0.0.0.0
-    port: 6014
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 192.168.3.26
-    port: 60412
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 192.168.3.26
-    port: 60417
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 61633
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 37992
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 0.0.0.0
-    port: 7013
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 61624
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 61631
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 61635
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pbx_exch
-    pid: '27629'
-    user: root
-    address: "::"
-    port: 1556
-    stime: Tue Feb  8 13:35:58  2022
-  - protocol: tcp
-    name: pbx_exch
-    pid: '27629'
-    user: root
-    address: 0.0.0.0
-    port: 1556
-    stime: Tue Feb  8 13:35:58  2022
-  - protocol: tcp
-    name: pbx_exch
-    pid: '27629'
-    user: root
-    address: 127.0.0.1
-    port: 1557
-    stime: Tue Feb  8 13:35:58  2022
-  - protocol: tcp
-    name: pbx_exch
-    pid: '27629'
-    user: root
-    address: 127.0.0.1
-    port: 65036
-    stime: Tue Feb  8 13:35:58  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 192.168.3.26
-    port: 60507
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 192.168.3.26
-    port: 36955
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 0.0.0.0
-    port: 6015
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 192.168.3.26
-    port: 60493
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 192.168.3.26
-    port: 60497
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 36916
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 44075
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 0.0.0.0
-    port: 6013
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 60363
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 0.0.0.0
-    port: 0
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 6013
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 60379
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: backupse
-    pid: '21530'
-    user: sybase
-    address: 127.0.0.1
-    port: 10007
-    stime: Thu Jun 27 13:57:15  2019
-  - protocol: tcp
-    name: backupse
-    pid: '21530'
-    user: sybase
-    address: 192.168.3.26
-    port: 10007
-    stime: Thu Jun 27 13:57:15  2019
-  - protocol: tcp
-    name: iqsrv15
-    pid: '17806'
-    user: iq
-    address: 0.0.0.0
-    port: 2637
-    stime: Thu Mar 10 15:10:02  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '17806'
-    user: iq
-    address: "::"
-    port: 2637
-    stime: Thu Mar 10 15:10:02  2022
-  - protocol: tcp
-    name: vnetd
-    pid: '7254'
-    user: root
-    address: 0.0.0.0
-    port: 13724
-    stime: Mon Feb 14 12:54:52  2022
-  - protocol: tcp
-    name: vnetd
-    pid: '7254'
-    user: root
-    address: 127.0.0.1
-    port: 54008
-    stime: Mon Feb 14 12:54:52  2022
+  type: Sybase ASE
+packages: {}
+processes:
+- cmdline: sched
+  cwd: /
+  pid: '0'
+  ppid: '0'
+  user: root
+- cmdline: /sbin/init
+  cwd: /sbin/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: pageout
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: fsflush
+  cwd: /
+  pid: '3'
+  ppid: '0'
+  user: root
+- cmdline: /usr/lib/nfs/mountd
+  cwd: /usr/lib/nfs/
+  pid: '2215'
+  ppid: '1'
+  user: root
+- cmdline: /lib/svc/bin/svc.startd
+  cwd: /lib/svc/bin/
+  pid: '7'
+  ppid: '1'
+  user: root
+- cmdline: /lib/svc/bin/svc.configd
+  cwd: /lib/svc/bin/
+  pid: '9'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/cron
+  cwd: /usr/sbin/
+  pid: '2014'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2.6 ~iometrics/.ansible/tmp/ansible-tmp-1664473849.839634-797351
+  cwd: /usr/bin/
+  pid: '19412'
+  ppid: '19411'
+  user: root
+- cmdline: /usr/lib/sysevent/syseventd
+  cwd: /usr/lib/sysevent/
+  pid: '410'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/ipmon -Ds
+  cwd: /usr/sbin/
+  pid: '381'
+  ppid: '1'
+  user: root
+- cmdline: /lib/svc/method/iscsi-initiator
+  cwd: /lib/svc/method/
+  pid: '530'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/efcode/sparcv9/efdaemon
+  cwd: /usr/lib/efcode/sparcv9/
+  pid: '1564'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/crypto/kcfd
+  cwd: /usr/lib/crypto/
+  pid: '432'
+  ppid: '1'
+  user: daemon
+- cmdline: devfsadmd
+  cwd: /
+  pid: '433'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '14720'
+  ppid: '3028'
+  user: root
+- cmdline: /sbin/vxesd
+  cwd: /sbin/
+  pid: '664'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/dmi/snmpXdmid -s eud1dw
+  cwd: /usr/lib/dmi/
+  pid: '2236'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/nfs/statd
+  cwd: /usr/lib/nfs/
+  pid: '2057'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/lib/nfs/nfs4cbd
+  cwd: /usr/lib/nfs/
+  pid: '2056'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/sbin/nscd
+  cwd: /usr/sbin/
+  pid: '424'
+  ppid: '1'
+  user: root
+- cmdline: /opt/OV/lbin/perf/coda
+  cwd: /opt/OV/lbin/perf/
+  pid: '5529'
+  ppid: '4983'
+  user: root
+- cmdline: /usr/platform/sun4u/lib/sckmd
+  cwd: /usr/platform/sun4u/lib/
+  pid: '2013'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/sendmail -Ac -q15m
+  cwd: /usr/lib/
+  pid: '2253'
+  ppid: '1'
+  user: smmsp
+- cmdline: /usr/lib/picl/picld
+  cwd: /usr/lib/picl/
+  pid: '465'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/inet/in.mpathd -a
+  cwd: /usr/lib/inet/
+  pid: '493'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sfw/sbin/snmpd
+  cwd: /usr/sfw/sbin/
+  pid: '2234'
+  ppid: '1'
+  user: root
+- cmdline: /usr/platform/SUNW,SPARC-Enterprise/lib/sparcv9/oplhpd
+  cwd: /usr/platform/SUNW,SPARC-Enterprise/lib/sparcv9/
+  pid: '460'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/pppd /dev/dm2s0 unit 0 file /usr/platform/SUNW,SPARC-Enterprise/lib/ds
+  cwd: /usr/bin/
+  pid: '2042'
+  ppid: '1'
+  user: root
+- cmdline: /opt/perf/bin/midaemon
+  cwd: /opt/perf/bin/
+  pid: '4785'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rpcbind
+  cwd: /usr/sbin/
+  pid: '2047'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/sbin/vold -f /etc/vold.conf
+  cwd: /usr/sbin/
+  pid: '2251'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/hotplugd
+  cwd: /usr/lib/
+  pid: '2027'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sadm/lib/smc/bin/smcboot
+  cwd: /usr/sadm/lib/smc/bin/
+  pid: '2162'
+  ppid: '2160'
+  user: root
+- cmdline: /usr/lib/saf/ttymon
+  cwd: /usr/lib/saf/
+  pid: '2097'
+  ppid: '2068'
+  user: root
+- cmdline: /usr/lib/utmpd
+  cwd: /usr/lib/
+  pid: '2075'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/nfs/nfsmapid
+  cwd: /usr/lib/nfs/
+  pid: '2060'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/sbin/syslogd
+  cwd: /usr/sbin/
+  pid: '2153'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sadm/lib/smc/bin/smcboot
+  cwd: /usr/sadm/lib/smc/bin/
+  pid: '2160'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/dmi/dmispd
+  cwd: /usr/lib/dmi/
+  pid: '2235'
+  ppid: '1'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcacta
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5545'
+  ppid: '4983'
+  user: root
+- cmdline: /usr/sadm/lib/smc/bin/smcboot
+  cwd: /usr/sadm/lib/smc/bin/
+  pid: '2161'
+  ppid: '2160'
+  user: root
+- cmdline: /usr/lib/saf/sac -t 300
+  cwd: /usr/lib/saf/
+  pid: '2068'
+  ppid: '7'
+  user: root
+- cmdline: /usr/lib/saf/ttymon -g -d /dev/console -l console -T vt100 -m ldterm,ttcompat
+    -
+  cwd: /usr/lib/saf/
+  pid: '1316'
+  ppid: '7'
+  user: root
+- cmdline: /usr/lib/fm/fmd/fmd
+  cwd: /usr/lib/fm/fmd/
+  pid: '2274'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/nfs/lockd
+  cwd: /usr/lib/nfs/
+  pid: '2088'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/lib/saf/ttymon
+  cwd: /usr/lib/saf/
+  pid: '2099'
+  ppid: '2068'
+  user: root
+- cmdline: /usr/lib/inet/inetd start
+  cwd: /usr/lib/inet/
+  pid: '2100'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/sbin/prngd /var/spool/prngd/pool
+  cwd: /usr/local/sbin/
+  pid: '2656'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/snmp/snmpdx -y -c /etc/snmp/conf
+  cwd: /usr/lib/snmp/
+  pid: '2226'
+  ppid: '1'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcmona
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5552'
+  ppid: '4983'
+  user: root
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '19826'
+  ppid: '3028'
+  user: root
+- cmdline: /usr/lib/sendmail -bl -q15m
+  cwd: /usr/lib/
+  pid: '2252'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/dcs -l
+  cwd: /usr/lib/
+  pid: '2271'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/inet/xntpd
+  cwd: /usr/lib/inet/
+  pid: '2276'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/nfs/nfsd
+  cwd: /usr/lib/nfs/
+  pid: '2220'
+  ppid: '1'
+  user: daemon
+- cmdline: /opt/OV/bin/ovcd
+  cwd: /opt/OV/bin/
+  pid: '4983'
+  ppid: '1'
+  user: root
+- cmdline: /usr/java/bin/java -server -Xmx128m -XX:+UseParallelGC -XX:ParallelGCThreads=4
+  cwd: /usr/java/bin/
+  pid: '2588'
+  ppid: '1'
+  user: noaccess
+- cmdline: /Infa95/telecable/java/bin/java -ea -Djava.awt.headless=true -Duser.dir=/Infa95
+  cwd: /Infa95/telecable/java/bin/
+  pid: '22465'
+  ppid: '1'
+  user: telecable
+- cmdline: //opt/VRTSob/bin/vxsvc -r //opt/VRTSob/config/Registry -e
+  cwd: //opt/VRTSob/bin/
+  pid: '4190'
+  ppid: '1'
+  user: root
+- cmdline: /opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqdw_des/iqdw_des.cfg /iq/iqdw_des/iqdw_des
+  cwd: /opt2/iq/IQ-15_4/bin64/
+  pid: '319'
+  ppid: '1'
+  user: iq
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '3028'
+  ppid: '1'
+  user: root
+- cmdline: /opt/perf/bin/perfalarm
+  cwd: /opt/perf/bin/
+  pid: '16096'
+  ppid: '1'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcmsgi
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5548'
+  ppid: '4983'
+  user: root
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '24808'
+  ppid: '3028'
+  user: root
+- cmdline: /usr/dt/bin/dtlogin -daemon
+  cwd: /usr/dt/bin/
+  pid: '3273'
+  ppid: '1'
+  user: root
+- cmdline: -sh
+  cwd: /
+  pid: '14725'
+  ppid: '14720'
+  user: iq
+- cmdline: /var/app/oracle/agent13c/agent_13.1.0.0.0/perl/bin/perl /var/app/oracle/agent13
+  cwd: /var/app/oracle/agent13c/agent_13.1.0.0.0/perl/bin/
+  pid: '5079'
+  ppid: '1'
+  user: em13c
+- cmdline: /opt/perf/bin/ttd
+  cwd: /opt/perf/bin/
+  pid: '4299'
+  ppid: '1'
+  user: root
+- cmdline: -sh
+  cwd: /
+  pid: '24811'
+  ppid: '24808'
+  user: sybase
+- cmdline: /var/app/oracle/agent13c/agent_13.1.0.0.0/oracle_common/jdk/bin/sparcv9/java
+    -X
+  cwd: /var/app/oracle/agent13c/agent_13.1.0.0.0/oracle_common/jdk/bin/sparcv9/
+  pid: '17162'
+  ppid: '5079'
+  user: em13c
+- cmdline: /opt/VRTSsfmh/bin/xprtld -X 1 /etc/opt/VRTSsfmh/xprtld.conf
+  cwd: /opt/VRTSsfmh/bin/
+  pid: '4257'
+  ppid: '1'
+  user: root
+- cmdline: veaintf
+  cwd: /
+  pid: '4470'
+  ppid: '4257'
+  user: root
+- cmdline: /opt/OV/lbin/conf/ovconfd
+  cwd: /opt/OV/lbin/conf/
+  pid: '4985'
+  ppid: '4983'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcle -std
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5550'
+  ppid: '4983'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcmsga
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5527'
+  ppid: '4983'
+  user: root
+- cmdline: /opt/OV/lbin/xpl/trc/ovtrcd
+  cwd: /opt/OV/lbin/xpl/trc/
+  pid: '4840'
+  ppid: '1'
+  user: root
+- cmdline: /Infa95/cdi/java/bin/java -ea -Djava.awt.headless=true -Duser.dir=/Infa95/cdi/t
+  cwd: /Infa95/cdi/java/bin/
+  pid: '21514'
+  ppid: '1'
+  user: cdi
+- cmdline: /opt2/sybase155/ASE-15_0/bin/backupserver -e/opt2/sybase155/ASE-15_0/install/AS
+  cwd: /opt2/sybase155/ASE-15_0/bin/
+  pid: '14300'
+  ppid: '14299'
+  user: sybase
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '19292'
+  ppid: '3028'
+  user: root
+- cmdline: /opt/OV/bin/ovbbccb -nodaemon
+  cwd: /opt/OV/bin/
+  pid: '4984'
+  ppid: '4983'
+  user: root
+- cmdline: /opt2/sybase155/ASE-15_0/bin/dataserver -sASEDW_DES -d/dev/vx/rdsk/dwdg/asedwde
+  cwd: /opt2/sybase155/ASE-15_0/bin/
+  pid: '12612'
+  ppid: '1'
+  user: sybase
+- cmdline: /Infa95/cdi/java/bin/java -XX:GCTimeRatio=9 -XX:MaxPermSize=128m -Xmx512M
+    -Dsun
+  cwd: /Infa95/cdi/java/bin/
+  pid: '21889'
+  ppid: '21514'
+  user: cdi
+- cmdline: ps -e -o pid= -o ppid= -o user= -o args=
+  cwd: /
+  pid: '19414'
+  ppid: '19413'
+  user: root
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-gbxazylhooudvvuedbenbqozzk
+  cwd: /
+  pid: '19410'
+  ppid: '19409'
+  user: root
+- cmdline: /usr/lib/sysevent/syseventconfd
+  cwd: /usr/lib/sysevent/
+  pid: '28492'
+  ppid: '1'
+  user: root
+- cmdline: /opt2/sybase125/ASE-12_5/bin/dataserver -d/dev/vx/rdsk/dwdg/dwdes_master
+    -e/opt
+  cwd: /opt2/sybase125/ASE-12_5/bin/
+  pid: '12288'
+  ppid: '1'
+  user: sybase
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '25618'
+  ppid: '3028'
+  user: root
+- cmdline: /bin/sh /opt2/sybase125/ASE-12_5/install/RUN_DW_DES_BACKUP
+  cwd: /bin/
+  pid: '21529'
+  ppid: '1'
+  user: sybase
+- cmdline: -sh
+  cwd: /
+  pid: '25630'
+  ppid: '25618'
+  user: sybase
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-gbxazylhooudv
+  cwd: /bin/
+  pid: '19409'
+  ppid: '19408'
+  user: iometrics
+- cmdline: /bin/sh /opt2/sybase155/ASE-15_0/install/RUN_ASEDW_DES_BACKUP
+  cwd: /bin/
+  pid: '14299'
+  ppid: '1'
+  user: sybase
+- cmdline: /usr/openv/netbackup/bin/bpcd -standalone
+  cwd: /usr/openv/netbackup/bin/
+  pid: '7257'
+  ppid: '1'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '20873'
+  ppid: '19839'
+  user: root
+- cmdline: /opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqtele_des/iqtele_des.cfg /iq/iqtele_des/iq
+  cwd: /opt2/iq/IQ-15_4/bin64/
+  pid: '18022'
+  ppid: '1'
+  user: iq
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-gbxazylhooudvvuedbenbqozzknlqodl ; /usr/bin/pyth
+  cwd: /bin/
+  pid: '19411'
+  ppid: '19410'
+  user: root
+- cmdline: sh
+  cwd: /
+  pid: '19839'
+  ppid: '19838'
+  user: root
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '25674'
+  ppid: '3028'
+  user: root
+- cmdline: /Infa95/cdi/server/bin/pmserver RE9NX0RFU0E= UE1fU0VSVkVS bm9kZTAxX2V1ZDFkd19jZ
+  cwd: /Infa95/cdi/server/bin/
+  pid: '21899'
+  ppid: '21514'
+  user: cdi
+- cmdline: vxconfigd
+  cwd: /
+  pid: '5596'
+  ppid: '1'
+  user: root
+- cmdline: sh -c /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-gb
+  cwd: /
+  pid: '19408'
+  ppid: '19292'
+  user: iometrics
+- cmdline: /bin/sh -c ps -e -o pid= -o ppid= -o user= -o args=
+  cwd: /bin/
+  pid: '19413'
+  ppid: '19412'
+  user: root
+- cmdline: sudo su
+  cwd: /
+  pid: '19838'
+  ppid: '19829'
+  user: root
+- cmdline: -sh
+  cwd: /
+  pid: '19829'
+  ppid: '19826'
+  user: iometrics
+- cmdline: /Infa95/telecable/server/bin/pmserver RE9NX0RFU0E= VExfU0VSVkVS bm9kZTAxX2V1ZDF
+  cwd: /Infa95/telecable/server/bin/
+  pid: '22527'
+  ppid: '22465'
+  user: telecable
+- cmdline: /opt/perf/bin/scopeux
+  cwd: /opt/perf/bin/
+  pid: '16080'
+  ppid: '1'
+  user: root
+- cmdline: /opt/VRTSpbx/bin/pbx_exchange
+  cwd: /opt/VRTSpbx/bin/
+  pid: '27629'
+  ppid: '1'
+  user: root
+- cmdline: /opt/perf/bin/perf64
+  cwd: /opt/perf/bin/
+  pid: '16101'
+  ppid: '16080'
+  user: root
+- cmdline: /Infa95/cdi/server/bin/pmserver RE9NX0RFU0E= UE1fU0VSVkVSX0NEUlM= bm9kZTAxX2V1Z
+  cwd: /Infa95/cdi/server/bin/
+  pid: '21969'
+  ppid: '21514'
+  user: cdi
+- cmdline: -sh
+  cwd: /
+  pid: '25688'
+  ppid: '25674'
+  user: iq
+- cmdline: /Infa95/cdi/server/bin/pmrepagent - RE9NX0RFU0E= UFdfREVTQTk= bm9kZTAxX2V1ZDFkd
+  cwd: /Infa95/cdi/server/bin/
+  pid: '21898'
+  ppid: '21514'
+  user: cdi
+- cmdline: /opt2/sybase125/ASE-12_5/bin/backupserver -e/opt2/sybase125/ASE-12_5/install/DW
+  cwd: /opt2/sybase125/ASE-12_5/bin/
+  pid: '21530'
+  ppid: '21529'
+  user: sybase
+- cmdline: /opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqcdi_des/iqcdi_des.cfg /iq/iqcdi_des/iqcdi
+  cwd: /opt2/iq/IQ-15_4/bin64/
+  pid: '17806'
+  ppid: '1'
+  user: iq
+- cmdline: /usr/openv/netbackup/bin/vnetd -standalone
+  cwd: /usr/openv/netbackup/bin/
+  pid: '7254'
+  ppid: '1'
+  user: root
+- cmdline: python
+  cwd: /
+  pid: '14858'
+  ppid: '20873'
+  user: root
+software_list:
+- cmd_regexp: dataserver
+  name: Sybase ASE
+  process_type: parent
+  return_children: false
+  return_packages: false
+tcp_listen:
+- address: 192.168.3.26
+  name: sshd
+  pid: '14720'
+  port: 22
+  protocol: tcp
+  stime: Mon Sep 19 11:31:23  2022
+  user: root
+- address: 127.0.0.1
+  name: coda
+  pid: '5529'
+  port: 59998
+  protocol: tcp
+  stime: Thu Nov 15 12:25:38  2018
+  user: root
+- address: 127.0.0.1
+  name: in.mpath
+  pid: '493'
+  port: 5999
+  protocol: tcp
+  stime: Thu Nov 15 12:24:59  2018
+  user: root
+- address: 192.168.3.120
+  name: in.mpath
+  pid: '493'
+  port: 0
+  protocol: tcp
+  stime: Thu Nov 15 12:24:59  2018
+  user: root
+- address: 192.168.3.119
+  name: in.mpath
+  pid: '493'
+  port: 0
+  protocol: tcp
+  stime: Thu Nov 15 12:24:59  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2162'
+  port: 32774
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2160'
+  port: 5987
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2160'
+  port: 898
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2160'
+  port: 5988
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: opcacta
+  pid: '5545'
+  port: 32881
+  protocol: tcp
+  stime: Thu Nov 15 12:25:38  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2161'
+  port: 32773
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 192.168.224.4
+  name: fmd
+  pid: '2274'
+  port: 12
+  protocol: tcp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.224.4
+  name: fmd
+  pid: '2274'
+  port: 24
+  protocol: tcp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: '::'
+  name: inetd
+  pid: '2100'
+  port: 21
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: sendmail
+  pid: '2252'
+  port: 25
+  protocol: tcp
+  stime: Thu Nov 15 12:25:11  2018
+  user: root
+- address: 192.168.224.4
+  name: dcs
+  pid: '2271'
+  port: 665
+  protocol: tcp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 127.0.0.1
+  name: ovcd
+  pid: '4983'
+  port: 32840
+  protocol: tcp
+  stime: Thu Nov 15 12:25:29  2018
+  user: root
+- address: 127.0.0.1
+  name: ovcd
+  pid: '4983'
+  port: 32848
+  protocol: tcp
+  stime: Thu Nov 15 12:25:29  2018
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: '2588'
+  port: 6788
+  protocol: tcp
+  stime: Thu Nov 15 12:25:16  2018
+  user: noaccess
+- address: 0.0.0.0
+  name: java
+  pid: '2588'
+  port: 32799
+  protocol: tcp
+  stime: Thu Nov 15 12:25:16  2018
+  user: noaccess
+- address: 127.0.0.1
+  name: java
+  pid: '2588'
+  port: 6789
+  protocol: tcp
+  stime: Thu Nov 15 12:25:16  2018
+  user: noaccess
+- address: 127.0.0.1
+  name: java
+  pid: '2588'
+  port: 32787
+  protocol: tcp
+  stime: Thu Nov 15 12:25:16  2018
+  user: noaccess
+- address: 0.0.0.0
+  name: java
+  pid: '22465'
+  port: 7005
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 0.0.0.0
+  name: java
+  pid: '22465'
+  port: 61300
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 38070
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 7005
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 38260
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 38276
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61463
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 127.0.0.1
+  name: java
+  pid: '22465'
+  port: 7007
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61526
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61530
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61529
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61532
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 0.0.0.0
+  name: java
+  pid: '22465'
+  port: 7006
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: '::'
+  name: vxsvc
+  pid: '4190'
+  port: 2148
+  protocol: tcp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: ::ffff:127.0.0.1
+  name: vxsvc
+  pid: '4190'
+  port: 2148
+  protocol: tcp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 192.168.3.26
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: tcp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: tcp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: tcp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: sshd
+  pid: '3028'
+  port: 22
+  protocol: tcp
+  stime: Thu Nov 15 12:25:22  2018
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: '3028'
+  port: 22
+  protocol: tcp
+  stime: Thu Nov 15 12:25:22  2018
+  user: root
+- address: 0.0.0.0
+  name: dtlogin
+  pid: '3273'
+  port: 32804
+  protocol: tcp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: '17162'
+  port: 3872
+  protocol: tcp
+  stime: Fri Jul 15 01:31:24  2022
+  user: em13c
+- address: 0.0.0.0
+  name: xprtld
+  pid: '4257'
+  port: 5634
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: xprtld
+  pid: '4257'
+  port: 32813
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: veaintf
+  pid: '4470'
+  port: 32812
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: veaintf
+  pid: '4470'
+  port: 32000
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: veaintf
+  pid: '4470'
+  port: 32929
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: ovconfd
+  pid: '4985'
+  port: 32856
+  protocol: tcp
+  stime: Thu Nov 15 12:25:31  2018
+  user: root
+- address: 127.0.0.1
+  name: ovconfd
+  pid: '4985'
+  port: 46812
+  protocol: tcp
+  stime: Thu Nov 15 12:25:31  2018
+  user: root
+- address: 127.0.0.1
+  name: opcmsga
+  pid: '5527'
+  port: 32879
+  protocol: tcp
+  stime: Thu Nov 15 12:25:37  2018
+  user: root
+- address: 0.0.0.0
+  name: ovtrcd
+  pid: '4840'
+  port: 5053
+  protocol: tcp
+  stime: Thu Nov 15 12:25:25  2018
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: '21514'
+  port: 6005
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 0.0.0.0
+  name: java
+  pid: '21514'
+  port: 59995
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60210
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 6006
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 37100
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60159
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 35363
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 6005
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 127.0.0.1
+  name: java
+  pid: '21514'
+  port: 6007
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60287
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 0.0.0.0
+  name: java
+  pid: '21514'
+  port: 60291
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60305
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60372
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 0.0.0.0
+  name: java
+  pid: '21514'
+  port: 6006
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: backupse
+  pid: '14300'
+  port: 10001
+  protocol: tcp
+  stime: Fri Jun 28 13:55:35  2019
+  user: sybase
+- address: '::'
+  name: ovbbccb
+  pid: '4984'
+  port: 383
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: 127.0.0.1
+  name: ovbbccb
+  pid: '4984'
+  port: 53114
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: 127.0.0.1
+  name: ovbbccb
+  pid: '4984'
+  port: 53116
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: 127.0.0.1
+  name: ovbbccb
+  pid: '4984'
+  port: 53118
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: ::ffff:127.0.0.1
+  name: ovbbccb
+  pid: '4984'
+  port: 383
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: 192.168.3.26
+  name: dataserv
+  pid: '12612'
+  port: 10000
+  protocol: tcp
+  stime: Tue Jun 25 11:02:18  2019
+  user: sybase
+- address: 0.0.0.0
+  name: java
+  pid: '21889'
+  port: 6008
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 0.0.0.0
+  name: java
+  pid: '21889'
+  port: 60316
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60339
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60340
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60345
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 127.0.0.1
+  name: java
+  pid: '21889'
+  port: 6009
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60402
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60403
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60404
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60437
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60438
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60439
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 127.0.0.1
+  name: dataserv
+  pid: '12288'
+  port: 10006
+  protocol: tcp
+  stime: Tue Jun 25 11:01:07  2019
+  user: sybase
+- address: 192.168.3.26
+  name: dataserv
+  pid: '12288'
+  port: 10006
+  protocol: tcp
+  stime: Tue Jun 25 11:01:07  2019
+  user: sybase
+- address: 0.0.0.0
+  name: bpcd
+  pid: '7257'
+  port: 13782
+  protocol: tcp
+  stime: Mon Feb 14 12:54:52  2022
+  user: root
+- address: 127.0.0.1
+  name: bpcd
+  pid: '7257'
+  port: 54011
+  protocol: tcp
+  stime: Mon Feb 14 12:54:52  2022
+  user: root
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '18022'
+  port: 2641
+  protocol: tcp
+  stime: Thu Mar 10 15:10:27  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '18022'
+  port: 2641
+  protocol: tcp
+  stime: Thu Mar 10 15:10:27  2022
+  user: iq
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21899'
+  port: 60419
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21899'
+  port: 36935
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 0.0.0.0
+  name: pmserver
+  pid: '21899'
+  port: 6014
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21899'
+  port: 60412
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21899'
+  port: 60417
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 61633
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 37992
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 0.0.0.0
+  name: pmserver
+  pid: '22527'
+  port: 7013
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 61624
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 61631
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 61635
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: '::'
+  name: pbx_exch
+  pid: '27629'
+  port: 1556
+  protocol: tcp
+  stime: Tue Feb  8 13:35:58  2022
+  user: root
+- address: 0.0.0.0
+  name: pbx_exch
+  pid: '27629'
+  port: 1556
+  protocol: tcp
+  stime: Tue Feb  8 13:35:58  2022
+  user: root
+- address: 127.0.0.1
+  name: pbx_exch
+  pid: '27629'
+  port: 1557
+  protocol: tcp
+  stime: Tue Feb  8 13:35:58  2022
+  user: root
+- address: 127.0.0.1
+  name: pbx_exch
+  pid: '27629'
+  port: 65036
+  protocol: tcp
+  stime: Tue Feb  8 13:35:58  2022
+  user: root
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21969'
+  port: 60507
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21969'
+  port: 36955
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 0.0.0.0
+  name: pmserver
+  pid: '21969'
+  port: 6015
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21969'
+  port: 60493
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21969'
+  port: 60497
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 36916
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 44075
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 0.0.0.0
+  name: pmrepage
+  pid: '21898'
+  port: 6013
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 60363
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 0.0.0.0
+  name: pmrepage
+  pid: '21898'
+  port: 0
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 6013
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 60379
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 127.0.0.1
+  name: backupse
+  pid: '21530'
+  port: 10007
+  protocol: tcp
+  stime: Thu Jun 27 13:57:15  2019
+  user: sybase
+- address: 192.168.3.26
+  name: backupse
+  pid: '21530'
+  port: 10007
+  protocol: tcp
+  stime: Thu Jun 27 13:57:15  2019
+  user: sybase
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '17806'
+  port: 2637
+  protocol: tcp
+  stime: Thu Mar 10 15:10:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '17806'
+  port: 2637
+  protocol: tcp
+  stime: Thu Mar 10 15:10:02  2022
+  user: iq
+- address: 0.0.0.0
+  name: vnetd
+  pid: '7254'
+  port: 13724
+  protocol: tcp
+  stime: Mon Feb 14 12:54:52  2022
+  user: root
+- address: 127.0.0.1
+  name: vnetd
+  pid: '7254'
+  port: 54008
+  protocol: tcp
+  stime: Mon Feb 14 12:54:52  2022
+  user: root
 udp_listen:
-  - protocol: udp
-    name: snmpXdmi
-    pid: '2236'
-    user: root
-    address: 0.0.0.0
-    port: 32831
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: statd
-    pid: '2057'
-    user: daemon
-    address: 0.0.0.0
-    port: 0
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: in.mpath
-    pid: '493'
-    user: root
-    address: "::"
-    port: 0
-    stime: Thu Nov 15 12:24:59  2018
-  - protocol: udp
-    name: snmpd
-    pid: '2234'
-    user: root
-    address: 0.0.0.0
-    port: 161
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpd
-    pid: '2234'
-    user: root
-    address: 0.0.0.0
-    port: 32782
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpd
-    pid: '2234'
-    user: root
-    address: 0.0.0.0
-    port: 32827
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpdx
-    pid: '2226'
-    user: root
-    address: 0.0.0.0
-    port: 16161
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpdx
-    pid: '2226'
-    user: root
-    address: 0.0.0.0
-    port: 32774
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpdx
-    pid: '2226'
-    user: root
-    address: 0.0.0.0
-    port: 32775
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 0.0.0.0
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 127.0.0.1
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.3.119
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.3.26
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.3.120
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.7.123
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.224.4
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: "::"
-    port: 2148
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: udp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: 127.0.0.1
-    port: 32806
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: udp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: 127.0.0.1
-    port: 32808
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: udp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: 0.0.0.0
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: "::"
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: 0.0.0.0
-    port: 2638
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: "::"
-    port: 2638
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: udp
-    name: dtlogin
-    pid: '3273'
-    user: root
-    address: "::"
-    port: 177
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: udp
-    name: java
-    pid: '17162'
-    user: em13c
-    address: 0.0.0.0
-    port: 3872
-    stime: Fri Jul 15 01:31:24  2022
-  - protocol: udp
-    name: opcmsga
-    pid: '5527'
-    user: root
-    address: 0.0.0.0
-    port: 32784
-    stime: Thu Nov 15 12:25:37  2018
-  - protocol: udp
-    name: iqsrv15
-    pid: '18022'
-    user: iq
-    address: 0.0.0.0
-    port: 2641
-    stime: Thu Mar 10 15:10:27  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '18022'
-    user: iq
-    address: "::"
-    port: 2641
-    stime: Thu Mar 10 15:10:27  2022
-  - protocol: udp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 127.0.0.1
-    port: 41841
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: udp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 127.0.0.1
-    port: 41842
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '17806'
-    user: iq
-    address: 0.0.0.0
-    port: 2637
-    stime: Thu Mar 10 15:10:02  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '17806'
-    user: iq
-    address: "::"
-    port: 2637
-    stime: Thu Mar 10 15:10:02  2022
-dockers: { }
+- address: 0.0.0.0
+  name: snmpXdmi
+  pid: '2236'
+  port: 32831
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: statd
+  pid: '2057'
+  port: 0
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: daemon
+- address: '::'
+  name: in.mpath
+  pid: '493'
+  port: 0
+  protocol: udp
+  stime: Thu Nov 15 12:24:59  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpd
+  pid: '2234'
+  port: 161
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpd
+  pid: '2234'
+  port: 32782
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpd
+  pid: '2234'
+  port: 32827
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpdx
+  pid: '2226'
+  port: 16161
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpdx
+  pid: '2226'
+  port: 32774
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpdx
+  pid: '2226'
+  port: 32775
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 127.0.0.1
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.3.119
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.3.26
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.3.120
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.7.123
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.224.4
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: '::'
+  name: vxsvc
+  pid: '4190'
+  port: 2148
+  protocol: udp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 127.0.0.1
+  name: vxsvc
+  pid: '4190'
+  port: 32806
+  protocol: udp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 127.0.0.1
+  name: vxsvc
+  pid: '4190'
+  port: 32808
+  protocol: udp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: udp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: udp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '319'
+  port: 2638
+  protocol: udp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '319'
+  port: 2638
+  protocol: udp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: dtlogin
+  pid: '3273'
+  port: 177
+  protocol: udp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: '17162'
+  port: 3872
+  protocol: udp
+  stime: Fri Jul 15 01:31:24  2022
+  user: em13c
+- address: 0.0.0.0
+  name: opcmsga
+  pid: '5527'
+  port: 32784
+  protocol: udp
+  stime: Thu Nov 15 12:25:37  2018
+  user: root
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '18022'
+  port: 2641
+  protocol: udp
+  stime: Thu Mar 10 15:10:27  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '18022'
+  port: 2641
+  protocol: udp
+  stime: Thu Mar 10 15:10:27  2022
+  user: iq
+- address: 127.0.0.1
+  name: pmrepage
+  pid: '21898'
+  port: 41841
+  protocol: udp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 127.0.0.1
+  name: pmrepage
+  pid: '21898'
+  port: 41842
+  protocol: udp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '17806'
+  port: 2637
+  protocol: udp
+  stime: Thu Mar 10 15:10:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '17806'
+  port: 2637
+  protocol: udp
+  stime: Thu Mar 10 15:10:02  2022
+  user: iq

--- a/tests/unit/plugins/action/auto/resources/sybase_iq/sunos_5.10_sybase_iq.yaml
+++ b/tests/unit/plugins/action/auto/resources/sybase_iq/sunos_5.10_sybase_iq.yaml
@@ -1,1675 +1,1791 @@
+dockers: {}
 expected_result:
-  - type: Sybase IQ
-    process:
-      cmdline: "/opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqdw_des/iqdw_des.cfg /iq/iqdw_des/iqdw_des"
-      ppid: '1'
-      pid: '319'
-      user: iq
-      listening_ports:
-        - 2638
-        - 2639
+- bindings:
+  - address: 192.168.3.26
+    class: service
+    port: 2639
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 2639
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 2639
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 2639
+    protocol: udp
+  - address: '::'
+    class: service
+    port: 2639
+    protocol: udp
+  - address: 0.0.0.0
+    class: service
+    port: 2638
+    protocol: udp
+  - address: '::'
+    class: service
+    port: 2638
+    protocol: udp
+  discovery_time: '2022-09-29T19:51:34+02:00'
+  listening_ports:
+  - 2638
+  - 2639
+  process:
+    cmdline: /opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqdw_des/iqdw_des.cfg /iq/iqdw_des/iqdw_des
+    cwd: /opt2/iq/IQ-15_4/bin64/
     listening_ports:
-      - 2638
-      - 2639
-    bindings:
-      - address: 192.168.3.26
-        port: 2639
-        protocol: tcp
-        class: service
-      - address: 0.0.0.0
-        port: 2639
-        protocol: tcp
-        class: service
-      - address: "::"
-        port: 2639
-        protocol: tcp
-        class: service
-      - address: 0.0.0.0
-        port: 2639
-        protocol: udp
-        class: service
-      - address: "::"
-        port: 2639
-        protocol: udp
-        class: service
-      - address: 0.0.0.0
-        port: 2638
-        protocol: udp
-        class: service
-      - address: "::"
-        port: 2638
-        protocol: udp
-        class: service
-    discovery_time: '2022-09-29T19:51:34+02:00'
-  - type: Sybase IQ
-    process:
-      cmdline: "/opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqcdi_des/iqcdi_des.cfg /iq/iqcdi_des/iqcdi"
-      ppid: '1'
-      pid: '17806'
-      user: iq
-      listening_ports:
-        - 2637
+    - 2638
+    - 2639
+    pid: '319'
+    ppid: '1'
+    user: iq
+  type: Sybase IQ
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 2637
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 2637
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 2637
+    protocol: udp
+  - address: '::'
+    class: service
+    port: 2637
+    protocol: udp
+  discovery_time: '2022-09-29T19:51:34+02:00'
+  listening_ports:
+  - 2637
+  process:
+    cmdline: /opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqcdi_des/iqcdi_des.cfg /iq/iqcdi_des/iqcdi
+    cwd: /opt2/iq/IQ-15_4/bin64/
     listening_ports:
-      - 2637
-    bindings:
-      - address: 0.0.0.0
-        port: 2637
-        protocol: tcp
-        class: service
-      - address: "::"
-        port: 2637
-        protocol: tcp
-        class: service
-      - address: 0.0.0.0
-        port: 2637
-        protocol: udp
-        class: service
-      - address: "::"
-        port: 2637
-        protocol: udp
-        class: service
-    discovery_time: '2022-09-29T19:51:34+02:00'
-  - type: Sybase IQ
-    process:
-      cmdline: "/opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqtele_des/iqtele_des.cfg /iq/iqtele_des/iq"
-      ppid: '1'
-      pid: '18022'
-      user: iq
-      listening_ports:
-        - 2641
+    - 2637
+    pid: '17806'
+    ppid: '1'
+    user: iq
+  type: Sybase IQ
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 2641
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 2641
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 2641
+    protocol: udp
+  - address: '::'
+    class: service
+    port: 2641
+    protocol: udp
+  discovery_time: '2022-09-29T19:51:34+02:00'
+  listening_ports:
+  - 2641
+  process:
+    cmdline: /opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqtele_des/iqtele_des.cfg /iq/iqtele_des/iq
+    cwd: /opt2/iq/IQ-15_4/bin64/
     listening_ports:
-      - 2641
-    bindings:
-      - address: 0.0.0.0
-        port: 2641
-        protocol: tcp
-        class: service
-      - address: "::"
-        port: 2641
-        protocol: tcp
-        class: service
-      - address: 0.0.0.0
-        port: 2641
-        protocol: udp
-        class: service
-      - address: "::"
-        port: 2641
-        protocol: udp
-        class: service
-    discovery_time: '2022-09-29T19:51:34+02:00'
-
-software_list:
-  - name: Sybase IQ
-    cmd_regexp: "iqsrv"
-    process_type: parent
-    return_children: false
-    return_packages: false
-
+    - 2641
+    pid: '18022'
+    ppid: '1'
+    user: iq
+  type: Sybase IQ
+packages: {}
 processes:
-  - cmdline: sched
-    ppid: '0'
-    pid: '0'
-    user: root
-  - cmdline: "/sbin/init"
-    ppid: '0'
-    pid: '1'
-    user: root
-  - cmdline: pageout
-    ppid: '0'
-    pid: '2'
-    user: root
-  - cmdline: fsflush
-    ppid: '0'
-    pid: '3'
-    user: root
-  - cmdline: "/usr/lib/nfs/mountd"
-    ppid: '1'
-    pid: '2215'
-    user: root
-  - cmdline: "/lib/svc/bin/svc.startd"
-    ppid: '1'
-    pid: '7'
-    user: root
-  - cmdline: "/lib/svc/bin/svc.configd"
-    ppid: '1'
-    pid: '9'
-    user: root
-  - cmdline: "/usr/sbin/cron"
-    ppid: '1'
-    pid: '2014'
-    user: root
-  - cmdline: "/usr/bin/python2.6 ~iometrics/.ansible/tmp/ansible-tmp-1664473849.839634-797351"
-    ppid: '19411'
-    pid: '19412'
-    user: root
-  - cmdline: "/usr/lib/sysevent/syseventd"
-    ppid: '1'
-    pid: '410'
-    user: root
-  - cmdline: "/usr/sbin/ipmon -Ds"
-    ppid: '1'
-    pid: '381'
-    user: root
-  - cmdline: "/lib/svc/method/iscsi-initiator"
-    ppid: '1'
-    pid: '530'
-    user: root
-  - cmdline: "/usr/lib/efcode/sparcv9/efdaemon"
-    ppid: '1'
-    pid: '1564'
-    user: root
-  - cmdline: "/usr/lib/crypto/kcfd"
-    ppid: '1'
-    pid: '432'
-    user: daemon
-  - cmdline: devfsadmd
-    ppid: '1'
-    pid: '433'
-    user: root
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '14720'
-    user: root
-  - cmdline: "/sbin/vxesd"
-    ppid: '1'
-    pid: '664'
-    user: root
-  - cmdline: "/usr/lib/dmi/snmpXdmid -s eud1dw"
-    ppid: '1'
-    pid: '2236'
-    user: root
-  - cmdline: "/usr/lib/nfs/statd"
-    ppid: '1'
-    pid: '2057'
-    user: daemon
-  - cmdline: "/usr/lib/nfs/nfs4cbd"
-    ppid: '1'
-    pid: '2056'
-    user: daemon
-  - cmdline: "/usr/sbin/nscd"
-    ppid: '1'
-    pid: '424'
-    user: root
-  - cmdline: "/opt/OV/lbin/perf/coda"
-    ppid: '4983'
-    pid: '5529'
-    user: root
-  - cmdline: "/usr/platform/sun4u/lib/sckmd"
-    ppid: '1'
-    pid: '2013'
-    user: root
-  - cmdline: "/usr/lib/sendmail -Ac -q15m"
-    ppid: '1'
-    pid: '2253'
-    user: smmsp
-  - cmdline: "/usr/lib/picl/picld"
-    ppid: '1'
-    pid: '465'
-    user: root
-  - cmdline: "/usr/lib/inet/in.mpathd -a"
-    ppid: '1'
-    pid: '493'
-    user: root
-  - cmdline: "/usr/sfw/sbin/snmpd"
-    ppid: '1'
-    pid: '2234'
-    user: root
-  - cmdline: "/usr/platform/SUNW,SPARC-Enterprise/lib/sparcv9/oplhpd"
-    ppid: '1'
-    pid: '460'
-    user: root
-  - cmdline: "/usr/bin/pppd /dev/dm2s0 unit 0 file /usr/platform/SUNW,SPARC-Enterprise/lib/ds"
-    ppid: '1'
-    pid: '2042'
-    user: root
-  - cmdline: "/opt/perf/bin/midaemon"
-    ppid: '1'
-    pid: '4785'
-    user: root
-  - cmdline: "/usr/sbin/rpcbind"
-    ppid: '1'
-    pid: '2047'
-    user: daemon
-  - cmdline: "/usr/sbin/vold -f /etc/vold.conf"
-    ppid: '1'
-    pid: '2251'
-    user: root
-  - cmdline: "/usr/lib/hotplugd"
-    ppid: '1'
-    pid: '2027'
-    user: root
-  - cmdline: "/usr/sadm/lib/smc/bin/smcboot"
-    ppid: '2160'
-    pid: '2162'
-    user: root
-  - cmdline: "/usr/lib/saf/ttymon"
-    ppid: '2068'
-    pid: '2097'
-    user: root
-  - cmdline: "/usr/lib/utmpd"
-    ppid: '1'
-    pid: '2075'
-    user: root
-  - cmdline: "/usr/lib/nfs/nfsmapid"
-    ppid: '1'
-    pid: '2060'
-    user: daemon
-  - cmdline: "/usr/sbin/syslogd"
-    ppid: '1'
-    pid: '2153'
-    user: root
-  - cmdline: "/usr/sadm/lib/smc/bin/smcboot"
-    ppid: '1'
-    pid: '2160'
-    user: root
-  - cmdline: "/usr/lib/dmi/dmispd"
-    ppid: '1'
-    pid: '2235'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcacta"
-    ppid: '4983'
-    pid: '5545'
-    user: root
-  - cmdline: "/usr/sadm/lib/smc/bin/smcboot"
-    ppid: '2160'
-    pid: '2161'
-    user: root
-  - cmdline: "/usr/lib/saf/sac -t 300"
-    ppid: '7'
-    pid: '2068'
-    user: root
-  - cmdline: "/usr/lib/saf/ttymon -g -d /dev/console -l console -T vt100 -m ldterm,ttcompat
-    -"
-    ppid: '7'
-    pid: '1316'
-    user: root
-  - cmdline: "/usr/lib/fm/fmd/fmd"
-    ppid: '1'
-    pid: '2274'
-    user: root
-  - cmdline: "/usr/lib/nfs/lockd"
-    ppid: '1'
-    pid: '2088'
-    user: daemon
-  - cmdline: "/usr/lib/saf/ttymon"
-    ppid: '2068'
-    pid: '2099'
-    user: root
-  - cmdline: "/usr/lib/inet/inetd start"
-    ppid: '1'
-    pid: '2100'
-    user: root
-  - cmdline: "/usr/local/sbin/prngd /var/spool/prngd/pool"
-    ppid: '1'
-    pid: '2656'
-    user: root
-  - cmdline: "/usr/lib/snmp/snmpdx -y -c /etc/snmp/conf"
-    ppid: '1'
-    pid: '2226'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcmona"
-    ppid: '4983'
-    pid: '5552'
-    user: root
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '19826'
-    user: root
-  - cmdline: "/usr/lib/sendmail -bl -q15m"
-    ppid: '1'
-    pid: '2252'
-    user: root
-  - cmdline: "/usr/lib/dcs -l"
-    ppid: '1'
-    pid: '2271'
-    user: root
-  - cmdline: "/usr/lib/inet/xntpd"
-    ppid: '1'
-    pid: '2276'
-    user: root
-  - cmdline: "/usr/lib/nfs/nfsd"
-    ppid: '1'
-    pid: '2220'
-    user: daemon
-  - cmdline: "/opt/OV/bin/ovcd"
-    ppid: '1'
-    pid: '4983'
-    user: root
-  - cmdline: "/usr/java/bin/java -server -Xmx128m -XX:+UseParallelGC -XX:ParallelGCThreads=4"
-    ppid: '1'
-    pid: '2588'
-    user: noaccess
-  - cmdline: "/Infa95/telecable/java/bin/java -ea -Djava.awt.headless=true -Duser.dir=/Infa95"
-    ppid: '1'
-    pid: '22465'
-    user: telecable
-  - cmdline: "//opt/VRTSob/bin/vxsvc -r //opt/VRTSob/config/Registry -e"
-    ppid: '1'
-    pid: '4190'
-    user: root
-  - cmdline: "/opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqdw_des/iqdw_des.cfg /iq/iqdw_des/iqdw_des"
-    ppid: '1'
-    pid: '319'
-    user: iq
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '1'
-    pid: '3028'
-    user: root
-  - cmdline: "/opt/perf/bin/perfalarm"
-    ppid: '1'
-    pid: '16096'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcmsgi"
-    ppid: '4983'
-    pid: '5548'
-    user: root
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '24808'
-    user: root
-  - cmdline: "/usr/dt/bin/dtlogin -daemon"
-    ppid: '1'
-    pid: '3273'
-    user: root
-  - cmdline: "-sh"
-    ppid: '14720'
-    pid: '14725'
-    user: iq
-  - cmdline: "/var/app/oracle/agent13c/agent_13.1.0.0.0/perl/bin/perl /var/app/oracle/agent13"
-    ppid: '1'
-    pid: '5079'
-    user: em13c
-  - cmdline: "/opt/perf/bin/ttd"
-    ppid: '1'
-    pid: '4299'
-    user: root
-  - cmdline: "-sh"
-    ppid: '24808'
-    pid: '24811'
-    user: sybase
-  - cmdline: "/var/app/oracle/agent13c/agent_13.1.0.0.0/oracle_common/jdk/bin/sparcv9/java
-    -X"
-    ppid: '5079'
-    pid: '17162'
-    user: em13c
-  - cmdline: "/opt/VRTSsfmh/bin/xprtld -X 1 /etc/opt/VRTSsfmh/xprtld.conf"
-    ppid: '1'
-    pid: '4257'
-    user: root
-  - cmdline: veaintf
-    ppid: '4257'
-    pid: '4470'
-    user: root
-  - cmdline: "/opt/OV/lbin/conf/ovconfd"
-    ppid: '4983'
-    pid: '4985'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcle -std"
-    ppid: '4983'
-    pid: '5550'
-    user: root
-  - cmdline: "/opt/OV/lbin/eaagt/opcmsga"
-    ppid: '4983'
-    pid: '5527'
-    user: root
-  - cmdline: "/opt/OV/lbin/xpl/trc/ovtrcd"
-    ppid: '1'
-    pid: '4840'
-    user: root
-  - cmdline: "/Infa95/cdi/java/bin/java -ea -Djava.awt.headless=true -Duser.dir=/Infa95/cdi/t"
-    ppid: '1'
-    pid: '21514'
-    user: cdi
-  - cmdline: "/opt2/sybase155/ASE-15_0/bin/backupserver -e/opt2/sybase155/ASE-15_0/install/AS"
-    ppid: '14299'
-    pid: '14300'
-    user: sybase
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '19292'
-    user: root
-  - cmdline: "/opt/OV/bin/ovbbccb -nodaemon"
-    ppid: '4983'
-    pid: '4984'
-    user: root
-  - cmdline: "/opt2/sybase155/ASE-15_0/bin/dataserver -sASEDW_DES -d/dev/vx/rdsk/dwdg/asedwde"
-    ppid: '1'
-    pid: '12612'
-    user: sybase
-  - cmdline: "/Infa95/cdi/java/bin/java -XX:GCTimeRatio=9 -XX:MaxPermSize=128m -Xmx512M
-    -Dsun"
-    ppid: '21514'
-    pid: '21889'
-    user: cdi
-  - cmdline: ps -e -o pid= -o ppid= -o user= -o args=
-    ppid: '19413'
-    pid: '19414'
-    user: root
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-gbxazylhooudvvuedbenbqozzk
-    ppid: '19409'
-    pid: '19410'
-    user: root
-  - cmdline: "/usr/lib/sysevent/syseventconfd"
-    ppid: '1'
-    pid: '28492'
-    user: root
-  - cmdline: "/opt2/sybase125/ASE-12_5/bin/dataserver -d/dev/vx/rdsk/dwdg/dwdes_master
-    -e/opt"
-    ppid: '1'
-    pid: '12288'
-    user: sybase
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '25618'
-    user: root
-  - cmdline: "/bin/sh /opt2/sybase125/ASE-12_5/install/RUN_DW_DES_BACKUP"
-    ppid: '1'
-    pid: '21529'
-    user: sybase
-  - cmdline: "-sh"
-    ppid: '25618'
-    pid: '25630'
-    user: sybase
-  - cmdline: "/bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-gbxazylhooudv"
-    ppid: '19408'
-    pid: '19409'
-    user: iometrics
-  - cmdline: "/bin/sh /opt2/sybase155/ASE-15_0/install/RUN_ASEDW_DES_BACKUP"
-    ppid: '1'
-    pid: '14299'
-    user: sybase
-  - cmdline: "/usr/openv/netbackup/bin/bpcd -standalone"
-    ppid: '1'
-    pid: '7257'
-    user: root
-  - cmdline: bash
-    ppid: '19839'
-    pid: '20873'
-    user: root
-  - cmdline: "/opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqtele_des/iqtele_des.cfg /iq/iqtele_des/iq"
-    ppid: '1'
-    pid: '18022'
-    user: iq
-  - cmdline: "/bin/sh -c echo BECOME-SUCCESS-gbxazylhooudvvuedbenbqozzknlqodl ; /usr/bin/pyth"
-    ppid: '19410'
-    pid: '19411'
-    user: root
-  - cmdline: sh
-    ppid: '19838'
-    pid: '19839'
-    user: root
-  - cmdline: "/usr/local/sbin/sshd"
-    ppid: '3028'
-    pid: '25674'
-    user: root
-  - cmdline: "/Infa95/cdi/server/bin/pmserver RE9NX0RFU0E= UE1fU0VSVkVS bm9kZTAxX2V1ZDFkd19jZ"
-    ppid: '21514'
-    pid: '21899'
-    user: cdi
-  - cmdline: vxconfigd
-    ppid: '1'
-    pid: '5596'
-    user: root
-  - cmdline: sh -c /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-gb
-    ppid: '19292'
-    pid: '19408'
-    user: iometrics
-  - cmdline: "/bin/sh -c ps -e -o pid= -o ppid= -o user= -o args="
-    ppid: '19412'
-    pid: '19413'
-    user: root
-  - cmdline: sudo su
-    ppid: '19829'
-    pid: '19838'
-    user: root
-  - cmdline: "-sh"
-    ppid: '19826'
-    pid: '19829'
-    user: iometrics
-  - cmdline: "/Infa95/telecable/server/bin/pmserver RE9NX0RFU0E= VExfU0VSVkVS bm9kZTAxX2V1ZDF"
-    ppid: '22465'
-    pid: '22527'
-    user: telecable
-  - cmdline: "/opt/perf/bin/scopeux"
-    ppid: '1'
-    pid: '16080'
-    user: root
-  - cmdline: "/opt/VRTSpbx/bin/pbx_exchange"
-    ppid: '1'
-    pid: '27629'
-    user: root
-  - cmdline: "/opt/perf/bin/perf64"
-    ppid: '16080'
-    pid: '16101'
-    user: root
-  - cmdline: "/Infa95/cdi/server/bin/pmserver RE9NX0RFU0E= UE1fU0VSVkVSX0NEUlM= bm9kZTAxX2V1Z"
-    ppid: '21514'
-    pid: '21969'
-    user: cdi
-  - cmdline: "-sh"
-    ppid: '25674'
-    pid: '25688'
-    user: iq
-  - cmdline: "/Infa95/cdi/server/bin/pmrepagent - RE9NX0RFU0E= UFdfREVTQTk= bm9kZTAxX2V1ZDFkd"
-    ppid: '21514'
-    pid: '21898'
-    user: cdi
-  - cmdline: "/opt2/sybase125/ASE-12_5/bin/backupserver -e/opt2/sybase125/ASE-12_5/install/DW"
-    ppid: '21529'
-    pid: '21530'
-    user: sybase
-  - cmdline: "/opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqcdi_des/iqcdi_des.cfg /iq/iqcdi_des/iqcdi"
-    ppid: '1'
-    pid: '17806'
-    user: iq
-  - cmdline: "/usr/openv/netbackup/bin/vnetd -standalone"
-    ppid: '1'
-    pid: '7254'
-    user: root
-  - cmdline: python
-    ppid: '20873'
-    pid: '14858'
-    user: root
-packages: { }
+- cmdline: sched
+  cwd: /
+  pid: '0'
+  ppid: '0'
+  user: root
+- cmdline: /sbin/init
+  cwd: /sbin/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: pageout
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: fsflush
+  cwd: /
+  pid: '3'
+  ppid: '0'
+  user: root
+- cmdline: /usr/lib/nfs/mountd
+  cwd: /usr/lib/nfs/
+  pid: '2215'
+  ppid: '1'
+  user: root
+- cmdline: /lib/svc/bin/svc.startd
+  cwd: /lib/svc/bin/
+  pid: '7'
+  ppid: '1'
+  user: root
+- cmdline: /lib/svc/bin/svc.configd
+  cwd: /lib/svc/bin/
+  pid: '9'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/cron
+  cwd: /usr/sbin/
+  pid: '2014'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2.6 ~iometrics/.ansible/tmp/ansible-tmp-1664473849.839634-797351
+  cwd: /usr/bin/
+  pid: '19412'
+  ppid: '19411'
+  user: root
+- cmdline: /usr/lib/sysevent/syseventd
+  cwd: /usr/lib/sysevent/
+  pid: '410'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/ipmon -Ds
+  cwd: /usr/sbin/
+  pid: '381'
+  ppid: '1'
+  user: root
+- cmdline: /lib/svc/method/iscsi-initiator
+  cwd: /lib/svc/method/
+  pid: '530'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/efcode/sparcv9/efdaemon
+  cwd: /usr/lib/efcode/sparcv9/
+  pid: '1564'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/crypto/kcfd
+  cwd: /usr/lib/crypto/
+  pid: '432'
+  ppid: '1'
+  user: daemon
+- cmdline: devfsadmd
+  cwd: /
+  pid: '433'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '14720'
+  ppid: '3028'
+  user: root
+- cmdline: /sbin/vxesd
+  cwd: /sbin/
+  pid: '664'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/dmi/snmpXdmid -s eud1dw
+  cwd: /usr/lib/dmi/
+  pid: '2236'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/nfs/statd
+  cwd: /usr/lib/nfs/
+  pid: '2057'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/lib/nfs/nfs4cbd
+  cwd: /usr/lib/nfs/
+  pid: '2056'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/sbin/nscd
+  cwd: /usr/sbin/
+  pid: '424'
+  ppid: '1'
+  user: root
+- cmdline: /opt/OV/lbin/perf/coda
+  cwd: /opt/OV/lbin/perf/
+  pid: '5529'
+  ppid: '4983'
+  user: root
+- cmdline: /usr/platform/sun4u/lib/sckmd
+  cwd: /usr/platform/sun4u/lib/
+  pid: '2013'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/sendmail -Ac -q15m
+  cwd: /usr/lib/
+  pid: '2253'
+  ppid: '1'
+  user: smmsp
+- cmdline: /usr/lib/picl/picld
+  cwd: /usr/lib/picl/
+  pid: '465'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/inet/in.mpathd -a
+  cwd: /usr/lib/inet/
+  pid: '493'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sfw/sbin/snmpd
+  cwd: /usr/sfw/sbin/
+  pid: '2234'
+  ppid: '1'
+  user: root
+- cmdline: /usr/platform/SUNW,SPARC-Enterprise/lib/sparcv9/oplhpd
+  cwd: /usr/platform/SUNW,SPARC-Enterprise/lib/sparcv9/
+  pid: '460'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/pppd /dev/dm2s0 unit 0 file /usr/platform/SUNW,SPARC-Enterprise/lib/ds
+  cwd: /usr/bin/
+  pid: '2042'
+  ppid: '1'
+  user: root
+- cmdline: /opt/perf/bin/midaemon
+  cwd: /opt/perf/bin/
+  pid: '4785'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rpcbind
+  cwd: /usr/sbin/
+  pid: '2047'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/sbin/vold -f /etc/vold.conf
+  cwd: /usr/sbin/
+  pid: '2251'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/hotplugd
+  cwd: /usr/lib/
+  pid: '2027'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sadm/lib/smc/bin/smcboot
+  cwd: /usr/sadm/lib/smc/bin/
+  pid: '2162'
+  ppid: '2160'
+  user: root
+- cmdline: /usr/lib/saf/ttymon
+  cwd: /usr/lib/saf/
+  pid: '2097'
+  ppid: '2068'
+  user: root
+- cmdline: /usr/lib/utmpd
+  cwd: /usr/lib/
+  pid: '2075'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/nfs/nfsmapid
+  cwd: /usr/lib/nfs/
+  pid: '2060'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/sbin/syslogd
+  cwd: /usr/sbin/
+  pid: '2153'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sadm/lib/smc/bin/smcboot
+  cwd: /usr/sadm/lib/smc/bin/
+  pid: '2160'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/dmi/dmispd
+  cwd: /usr/lib/dmi/
+  pid: '2235'
+  ppid: '1'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcacta
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5545'
+  ppid: '4983'
+  user: root
+- cmdline: /usr/sadm/lib/smc/bin/smcboot
+  cwd: /usr/sadm/lib/smc/bin/
+  pid: '2161'
+  ppid: '2160'
+  user: root
+- cmdline: /usr/lib/saf/sac -t 300
+  cwd: /usr/lib/saf/
+  pid: '2068'
+  ppid: '7'
+  user: root
+- cmdline: /usr/lib/saf/ttymon -g -d /dev/console -l console -T vt100 -m ldterm,ttcompat
+    -
+  cwd: /usr/lib/saf/
+  pid: '1316'
+  ppid: '7'
+  user: root
+- cmdline: /usr/lib/fm/fmd/fmd
+  cwd: /usr/lib/fm/fmd/
+  pid: '2274'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/nfs/lockd
+  cwd: /usr/lib/nfs/
+  pid: '2088'
+  ppid: '1'
+  user: daemon
+- cmdline: /usr/lib/saf/ttymon
+  cwd: /usr/lib/saf/
+  pid: '2099'
+  ppid: '2068'
+  user: root
+- cmdline: /usr/lib/inet/inetd start
+  cwd: /usr/lib/inet/
+  pid: '2100'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/sbin/prngd /var/spool/prngd/pool
+  cwd: /usr/local/sbin/
+  pid: '2656'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/snmp/snmpdx -y -c /etc/snmp/conf
+  cwd: /usr/lib/snmp/
+  pid: '2226'
+  ppid: '1'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcmona
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5552'
+  ppid: '4983'
+  user: root
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '19826'
+  ppid: '3028'
+  user: root
+- cmdline: /usr/lib/sendmail -bl -q15m
+  cwd: /usr/lib/
+  pid: '2252'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/dcs -l
+  cwd: /usr/lib/
+  pid: '2271'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/inet/xntpd
+  cwd: /usr/lib/inet/
+  pid: '2276'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/nfs/nfsd
+  cwd: /usr/lib/nfs/
+  pid: '2220'
+  ppid: '1'
+  user: daemon
+- cmdline: /opt/OV/bin/ovcd
+  cwd: /opt/OV/bin/
+  pid: '4983'
+  ppid: '1'
+  user: root
+- cmdline: /usr/java/bin/java -server -Xmx128m -XX:+UseParallelGC -XX:ParallelGCThreads=4
+  cwd: /usr/java/bin/
+  pid: '2588'
+  ppid: '1'
+  user: noaccess
+- cmdline: /Infa95/telecable/java/bin/java -ea -Djava.awt.headless=true -Duser.dir=/Infa95
+  cwd: /Infa95/telecable/java/bin/
+  pid: '22465'
+  ppid: '1'
+  user: telecable
+- cmdline: //opt/VRTSob/bin/vxsvc -r //opt/VRTSob/config/Registry -e
+  cwd: //opt/VRTSob/bin/
+  pid: '4190'
+  ppid: '1'
+  user: root
+- cmdline: /opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqdw_des/iqdw_des.cfg /iq/iqdw_des/iqdw_des
+  cwd: /opt2/iq/IQ-15_4/bin64/
+  pid: '319'
+  ppid: '1'
+  user: iq
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '3028'
+  ppid: '1'
+  user: root
+- cmdline: /opt/perf/bin/perfalarm
+  cwd: /opt/perf/bin/
+  pid: '16096'
+  ppid: '1'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcmsgi
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5548'
+  ppid: '4983'
+  user: root
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '24808'
+  ppid: '3028'
+  user: root
+- cmdline: /usr/dt/bin/dtlogin -daemon
+  cwd: /usr/dt/bin/
+  pid: '3273'
+  ppid: '1'
+  user: root
+- cmdline: -sh
+  cwd: /
+  pid: '14725'
+  ppid: '14720'
+  user: iq
+- cmdline: /var/app/oracle/agent13c/agent_13.1.0.0.0/perl/bin/perl /var/app/oracle/agent13
+  cwd: /var/app/oracle/agent13c/agent_13.1.0.0.0/perl/bin/
+  pid: '5079'
+  ppid: '1'
+  user: em13c
+- cmdline: /opt/perf/bin/ttd
+  cwd: /opt/perf/bin/
+  pid: '4299'
+  ppid: '1'
+  user: root
+- cmdline: -sh
+  cwd: /
+  pid: '24811'
+  ppid: '24808'
+  user: sybase
+- cmdline: /var/app/oracle/agent13c/agent_13.1.0.0.0/oracle_common/jdk/bin/sparcv9/java
+    -X
+  cwd: /var/app/oracle/agent13c/agent_13.1.0.0.0/oracle_common/jdk/bin/sparcv9/
+  pid: '17162'
+  ppid: '5079'
+  user: em13c
+- cmdline: /opt/VRTSsfmh/bin/xprtld -X 1 /etc/opt/VRTSsfmh/xprtld.conf
+  cwd: /opt/VRTSsfmh/bin/
+  pid: '4257'
+  ppid: '1'
+  user: root
+- cmdline: veaintf
+  cwd: /
+  pid: '4470'
+  ppid: '4257'
+  user: root
+- cmdline: /opt/OV/lbin/conf/ovconfd
+  cwd: /opt/OV/lbin/conf/
+  pid: '4985'
+  ppid: '4983'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcle -std
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5550'
+  ppid: '4983'
+  user: root
+- cmdline: /opt/OV/lbin/eaagt/opcmsga
+  cwd: /opt/OV/lbin/eaagt/
+  pid: '5527'
+  ppid: '4983'
+  user: root
+- cmdline: /opt/OV/lbin/xpl/trc/ovtrcd
+  cwd: /opt/OV/lbin/xpl/trc/
+  pid: '4840'
+  ppid: '1'
+  user: root
+- cmdline: /Infa95/cdi/java/bin/java -ea -Djava.awt.headless=true -Duser.dir=/Infa95/cdi/t
+  cwd: /Infa95/cdi/java/bin/
+  pid: '21514'
+  ppid: '1'
+  user: cdi
+- cmdline: /opt2/sybase155/ASE-15_0/bin/backupserver -e/opt2/sybase155/ASE-15_0/install/AS
+  cwd: /opt2/sybase155/ASE-15_0/bin/
+  pid: '14300'
+  ppid: '14299'
+  user: sybase
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '19292'
+  ppid: '3028'
+  user: root
+- cmdline: /opt/OV/bin/ovbbccb -nodaemon
+  cwd: /opt/OV/bin/
+  pid: '4984'
+  ppid: '4983'
+  user: root
+- cmdline: /opt2/sybase155/ASE-15_0/bin/dataserver -sASEDW_DES -d/dev/vx/rdsk/dwdg/asedwde
+  cwd: /opt2/sybase155/ASE-15_0/bin/
+  pid: '12612'
+  ppid: '1'
+  user: sybase
+- cmdline: /Infa95/cdi/java/bin/java -XX:GCTimeRatio=9 -XX:MaxPermSize=128m -Xmx512M
+    -Dsun
+  cwd: /Infa95/cdi/java/bin/
+  pid: '21889'
+  ppid: '21514'
+  user: cdi
+- cmdline: ps -e -o pid= -o ppid= -o user= -o args=
+  cwd: /
+  pid: '19414'
+  ppid: '19413'
+  user: root
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-gbxazylhooudvvuedbenbqozzk
+  cwd: /
+  pid: '19410'
+  ppid: '19409'
+  user: root
+- cmdline: /usr/lib/sysevent/syseventconfd
+  cwd: /usr/lib/sysevent/
+  pid: '28492'
+  ppid: '1'
+  user: root
+- cmdline: /opt2/sybase125/ASE-12_5/bin/dataserver -d/dev/vx/rdsk/dwdg/dwdes_master
+    -e/opt
+  cwd: /opt2/sybase125/ASE-12_5/bin/
+  pid: '12288'
+  ppid: '1'
+  user: sybase
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '25618'
+  ppid: '3028'
+  user: root
+- cmdline: /bin/sh /opt2/sybase125/ASE-12_5/install/RUN_DW_DES_BACKUP
+  cwd: /bin/
+  pid: '21529'
+  ppid: '1'
+  user: sybase
+- cmdline: -sh
+  cwd: /
+  pid: '25630'
+  ppid: '25618'
+  user: sybase
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-gbxazylhooudv
+  cwd: /bin/
+  pid: '19409'
+  ppid: '19408'
+  user: iometrics
+- cmdline: /bin/sh /opt2/sybase155/ASE-15_0/install/RUN_ASEDW_DES_BACKUP
+  cwd: /bin/
+  pid: '14299'
+  ppid: '1'
+  user: sybase
+- cmdline: /usr/openv/netbackup/bin/bpcd -standalone
+  cwd: /usr/openv/netbackup/bin/
+  pid: '7257'
+  ppid: '1'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '20873'
+  ppid: '19839'
+  user: root
+- cmdline: /opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqtele_des/iqtele_des.cfg /iq/iqtele_des/iq
+  cwd: /opt2/iq/IQ-15_4/bin64/
+  pid: '18022'
+  ppid: '1'
+  user: iq
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-gbxazylhooudvvuedbenbqozzknlqodl ; /usr/bin/pyth
+  cwd: /bin/
+  pid: '19411'
+  ppid: '19410'
+  user: root
+- cmdline: sh
+  cwd: /
+  pid: '19839'
+  ppid: '19838'
+  user: root
+- cmdline: /usr/local/sbin/sshd
+  cwd: /usr/local/sbin/
+  pid: '25674'
+  ppid: '3028'
+  user: root
+- cmdline: /Infa95/cdi/server/bin/pmserver RE9NX0RFU0E= UE1fU0VSVkVS bm9kZTAxX2V1ZDFkd19jZ
+  cwd: /Infa95/cdi/server/bin/
+  pid: '21899'
+  ppid: '21514'
+  user: cdi
+- cmdline: vxconfigd
+  cwd: /
+  pid: '5596'
+  ppid: '1'
+  user: root
+- cmdline: sh -c /bin/sh -c 'sudo -H -S -n  -u root /bin/sh -c '"'"'echo BECOME-SUCCESS-gb
+  cwd: /
+  pid: '19408'
+  ppid: '19292'
+  user: iometrics
+- cmdline: /bin/sh -c ps -e -o pid= -o ppid= -o user= -o args=
+  cwd: /bin/
+  pid: '19413'
+  ppid: '19412'
+  user: root
+- cmdline: sudo su
+  cwd: /
+  pid: '19838'
+  ppid: '19829'
+  user: root
+- cmdline: -sh
+  cwd: /
+  pid: '19829'
+  ppid: '19826'
+  user: iometrics
+- cmdline: /Infa95/telecable/server/bin/pmserver RE9NX0RFU0E= VExfU0VSVkVS bm9kZTAxX2V1ZDF
+  cwd: /Infa95/telecable/server/bin/
+  pid: '22527'
+  ppid: '22465'
+  user: telecable
+- cmdline: /opt/perf/bin/scopeux
+  cwd: /opt/perf/bin/
+  pid: '16080'
+  ppid: '1'
+  user: root
+- cmdline: /opt/VRTSpbx/bin/pbx_exchange
+  cwd: /opt/VRTSpbx/bin/
+  pid: '27629'
+  ppid: '1'
+  user: root
+- cmdline: /opt/perf/bin/perf64
+  cwd: /opt/perf/bin/
+  pid: '16101'
+  ppid: '16080'
+  user: root
+- cmdline: /Infa95/cdi/server/bin/pmserver RE9NX0RFU0E= UE1fU0VSVkVSX0NEUlM= bm9kZTAxX2V1Z
+  cwd: /Infa95/cdi/server/bin/
+  pid: '21969'
+  ppid: '21514'
+  user: cdi
+- cmdline: -sh
+  cwd: /
+  pid: '25688'
+  ppid: '25674'
+  user: iq
+- cmdline: /Infa95/cdi/server/bin/pmrepagent - RE9NX0RFU0E= UFdfREVTQTk= bm9kZTAxX2V1ZDFkd
+  cwd: /Infa95/cdi/server/bin/
+  pid: '21898'
+  ppid: '21514'
+  user: cdi
+- cmdline: /opt2/sybase125/ASE-12_5/bin/backupserver -e/opt2/sybase125/ASE-12_5/install/DW
+  cwd: /opt2/sybase125/ASE-12_5/bin/
+  pid: '21530'
+  ppid: '21529'
+  user: sybase
+- cmdline: /opt2/iq/IQ-15_4/bin64/iqsrv15 @/iq/iqcdi_des/iqcdi_des.cfg /iq/iqcdi_des/iqcdi
+  cwd: /opt2/iq/IQ-15_4/bin64/
+  pid: '17806'
+  ppid: '1'
+  user: iq
+- cmdline: /usr/openv/netbackup/bin/vnetd -standalone
+  cwd: /usr/openv/netbackup/bin/
+  pid: '7254'
+  ppid: '1'
+  user: root
+- cmdline: python
+  cwd: /
+  pid: '14858'
+  ppid: '20873'
+  user: root
+software_list:
+- cmd_regexp: iqsrv
+  name: Sybase IQ
+  process_type: parent
+  return_children: false
+  return_packages: false
 tcp_listen:
-  - protocol: tcp
-    name: sshd
-    pid: '14720'
-    user: root
-    address: 192.168.3.26
-    port: 22
-    stime: Mon Sep 19 11:31:23  2022
-  - protocol: tcp
-    name: coda
-    pid: '5529'
-    user: root
-    address: 127.0.0.1
-    port: 59998
-    stime: Thu Nov 15 12:25:38  2018
-  - protocol: tcp
-    name: in.mpath
-    pid: '493'
-    user: root
-    address: 127.0.0.1
-    port: 5999
-    stime: Thu Nov 15 12:24:59  2018
-  - protocol: tcp
-    name: in.mpath
-    pid: '493'
-    user: root
-    address: 192.168.3.120
-    port: 0
-    stime: Thu Nov 15 12:24:59  2018
-  - protocol: tcp
-    name: in.mpath
-    pid: '493'
-    user: root
-    address: 192.168.3.119
-    port: 0
-    stime: Thu Nov 15 12:24:59  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2162'
-    user: root
-    address: 127.0.0.1
-    port: 32774
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2160'
-    user: root
-    address: 127.0.0.1
-    port: 5987
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2160'
-    user: root
-    address: 127.0.0.1
-    port: 898
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2160'
-    user: root
-    address: 127.0.0.1
-    port: 5988
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: opcacta
-    pid: '5545'
-    user: root
-    address: 127.0.0.1
-    port: 32881
-    stime: Thu Nov 15 12:25:38  2018
-  - protocol: tcp
-    name: smcboot
-    pid: '2161'
-    user: root
-    address: 127.0.0.1
-    port: 32773
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: fmd
-    pid: '2274'
-    user: root
-    address: 192.168.224.4
-    port: 12
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: tcp
-    name: fmd
-    pid: '2274'
-    user: root
-    address: 192.168.224.4
-    port: 24
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: tcp
-    name: inetd
-    pid: '2100'
-    user: root
-    address: "::"
-    port: 21
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: tcp
-    name: sendmail
-    pid: '2252'
-    user: root
-    address: 127.0.0.1
-    port: 25
-    stime: Thu Nov 15 12:25:11  2018
-  - protocol: tcp
-    name: dcs
-    pid: '2271'
-    user: root
-    address: 192.168.224.4
-    port: 665
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: tcp
-    name: ovcd
-    pid: '4983'
-    user: root
-    address: 127.0.0.1
-    port: 32840
-    stime: Thu Nov 15 12:25:29  2018
-  - protocol: tcp
-    name: ovcd
-    pid: '4983'
-    user: root
-    address: 127.0.0.1
-    port: 32848
-    stime: Thu Nov 15 12:25:29  2018
-  - protocol: tcp
-    name: java
-    pid: '2588'
-    user: noaccess
-    address: 127.0.0.1
-    port: 6788
-    stime: Thu Nov 15 12:25:16  2018
-  - protocol: tcp
-    name: java
-    pid: '2588'
-    user: noaccess
-    address: 0.0.0.0
-    port: 32799
-    stime: Thu Nov 15 12:25:16  2018
-  - protocol: tcp
-    name: java
-    pid: '2588'
-    user: noaccess
-    address: 127.0.0.1
-    port: 6789
-    stime: Thu Nov 15 12:25:16  2018
-  - protocol: tcp
-    name: java
-    pid: '2588'
-    user: noaccess
-    address: 127.0.0.1
-    port: 32787
-    stime: Thu Nov 15 12:25:16  2018
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 0.0.0.0
-    port: 7005
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 0.0.0.0
-    port: 61300
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 38070
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 7005
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 38260
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 38276
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61463
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 127.0.0.1
-    port: 7007
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61526
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61530
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61529
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 192.168.3.26
-    port: 61532
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: java
-    pid: '22465'
-    user: telecable
-    address: 0.0.0.0
-    port: 7006
-    stime: Mon Sep 26 06:10:05  2022
-  - protocol: tcp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: "::"
-    port: 2148
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: tcp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: "::ffff:127.0.0.1"
-    port: 2148
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: tcp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: 192.168.3.26
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: 0.0.0.0
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: "::"
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: tcp
-    name: sshd
-    pid: '3028'
-    user: root
-    address: "::"
-    port: 22
-    stime: Thu Nov 15 12:25:22  2018
-  - protocol: tcp
-    name: sshd
-    pid: '3028'
-    user: root
-    address: 0.0.0.0
-    port: 22
-    stime: Thu Nov 15 12:25:22  2018
-  - protocol: tcp
-    name: dtlogin
-    pid: '3273'
-    user: root
-    address: 0.0.0.0
-    port: 32804
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: tcp
-    name: java
-    pid: '17162'
-    user: em13c
-    address: 0.0.0.0
-    port: 3872
-    stime: Fri Jul 15 01:31:24  2022
-  - protocol: tcp
-    name: xprtld
-    pid: '4257'
-    user: root
-    address: 0.0.0.0
-    port: 5634
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: xprtld
-    pid: '4257'
-    user: root
-    address: 127.0.0.1
-    port: 32813
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: veaintf
-    pid: '4470'
-    user: root
-    address: 127.0.0.1
-    port: 32812
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: veaintf
-    pid: '4470'
-    user: root
-    address: 127.0.0.1
-    port: 32000
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: veaintf
-    pid: '4470'
-    user: root
-    address: 127.0.0.1
-    port: 32929
-    stime: Thu Nov 15 12:25:24  2018
-  - protocol: tcp
-    name: ovconfd
-    pid: '4985'
-    user: root
-    address: 127.0.0.1
-    port: 32856
-    stime: Thu Nov 15 12:25:31  2018
-  - protocol: tcp
-    name: ovconfd
-    pid: '4985'
-    user: root
-    address: 127.0.0.1
-    port: 46812
-    stime: Thu Nov 15 12:25:31  2018
-  - protocol: tcp
-    name: opcmsga
-    pid: '5527'
-    user: root
-    address: 127.0.0.1
-    port: 32879
-    stime: Thu Nov 15 12:25:37  2018
-  - protocol: tcp
-    name: ovtrcd
-    pid: '4840'
-    user: root
-    address: 0.0.0.0
-    port: 5053
-    stime: Thu Nov 15 12:25:25  2018
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 0.0.0.0
-    port: 6005
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 0.0.0.0
-    port: 59995
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60210
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 6006
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 37100
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60159
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 35363
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 6005
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 127.0.0.1
-    port: 6007
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60287
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 0.0.0.0
-    port: 60291
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60305
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 192.168.3.26
-    port: 60372
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: java
-    pid: '21514'
-    user: cdi
-    address: 0.0.0.0
-    port: 6006
-    stime: Mon Sep 26 06:00:05  2022
-  - protocol: tcp
-    name: backupse
-    pid: '14300'
-    user: sybase
-    address: 192.168.3.26
-    port: 10001
-    stime: Fri Jun 28 13:55:35  2019
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: "::"
-    port: 383
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: 127.0.0.1
-    port: 53114
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: 127.0.0.1
-    port: 53116
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: 127.0.0.1
-    port: 53118
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: ovbbccb
-    pid: '4984'
-    user: root
-    address: "::ffff:127.0.0.1"
-    port: 383
-    stime: Thu Nov 15 12:25:30  2018
-  - protocol: tcp
-    name: dataserv
-    pid: '12612'
-    user: sybase
-    address: 192.168.3.26
-    port: 10000
-    stime: Tue Jun 25 11:02:18  2019
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 0.0.0.0
-    port: 6008
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 0.0.0.0
-    port: 60316
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60339
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60340
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60345
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 127.0.0.1
-    port: 6009
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60402
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60403
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60404
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60437
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60438
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: java
-    pid: '21889'
-    user: cdi
-    address: 192.168.3.26
-    port: 60439
-    stime: Mon Sep 26 06:02:38  2022
-  - protocol: tcp
-    name: dataserv
-    pid: '12288'
-    user: sybase
-    address: 127.0.0.1
-    port: 10006
-    stime: Tue Jun 25 11:01:07  2019
-  - protocol: tcp
-    name: dataserv
-    pid: '12288'
-    user: sybase
-    address: 192.168.3.26
-    port: 10006
-    stime: Tue Jun 25 11:01:07  2019
-  - protocol: tcp
-    name: bpcd
-    pid: '7257'
-    user: root
-    address: 0.0.0.0
-    port: 13782
-    stime: Mon Feb 14 12:54:52  2022
-  - protocol: tcp
-    name: bpcd
-    pid: '7257'
-    user: root
-    address: 127.0.0.1
-    port: 54011
-    stime: Mon Feb 14 12:54:52  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '18022'
-    user: iq
-    address: 0.0.0.0
-    port: 2641
-    stime: Thu Mar 10 15:10:27  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '18022'
-    user: iq
-    address: "::"
-    port: 2641
-    stime: Thu Mar 10 15:10:27  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 192.168.3.26
-    port: 60419
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 192.168.3.26
-    port: 36935
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 0.0.0.0
-    port: 6014
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 192.168.3.26
-    port: 60412
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21899'
-    user: cdi
-    address: 192.168.3.26
-    port: 60417
-    stime: Mon Sep 26 06:02:57  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 61633
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 37992
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 0.0.0.0
-    port: 7013
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 61624
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 61631
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '22527'
-    user: telecable
-    address: 192.168.3.26
-    port: 61635
-    stime: Mon Sep 26 06:12:03  2022
-  - protocol: tcp
-    name: pbx_exch
-    pid: '27629'
-    user: root
-    address: "::"
-    port: 1556
-    stime: Tue Feb  8 13:35:58  2022
-  - protocol: tcp
-    name: pbx_exch
-    pid: '27629'
-    user: root
-    address: 0.0.0.0
-    port: 1556
-    stime: Tue Feb  8 13:35:58  2022
-  - protocol: tcp
-    name: pbx_exch
-    pid: '27629'
-    user: root
-    address: 127.0.0.1
-    port: 1557
-    stime: Tue Feb  8 13:35:58  2022
-  - protocol: tcp
-    name: pbx_exch
-    pid: '27629'
-    user: root
-    address: 127.0.0.1
-    port: 65036
-    stime: Tue Feb  8 13:35:58  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 192.168.3.26
-    port: 60507
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 192.168.3.26
-    port: 36955
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 0.0.0.0
-    port: 6015
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 192.168.3.26
-    port: 60493
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmserver
-    pid: '21969'
-    user: cdi
-    address: 192.168.3.26
-    port: 60497
-    stime: Mon Sep 26 06:03:09  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 36916
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 44075
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 0.0.0.0
-    port: 6013
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 60363
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 0.0.0.0
-    port: 0
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 6013
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 192.168.3.26
-    port: 60379
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: tcp
-    name: backupse
-    pid: '21530'
-    user: sybase
-    address: 127.0.0.1
-    port: 10007
-    stime: Thu Jun 27 13:57:15  2019
-  - protocol: tcp
-    name: backupse
-    pid: '21530'
-    user: sybase
-    address: 192.168.3.26
-    port: 10007
-    stime: Thu Jun 27 13:57:15  2019
-  - protocol: tcp
-    name: iqsrv15
-    pid: '17806'
-    user: iq
-    address: 0.0.0.0
-    port: 2637
-    stime: Thu Mar 10 15:10:02  2022
-  - protocol: tcp
-    name: iqsrv15
-    pid: '17806'
-    user: iq
-    address: "::"
-    port: 2637
-    stime: Thu Mar 10 15:10:02  2022
-  - protocol: tcp
-    name: vnetd
-    pid: '7254'
-    user: root
-    address: 0.0.0.0
-    port: 13724
-    stime: Mon Feb 14 12:54:52  2022
-  - protocol: tcp
-    name: vnetd
-    pid: '7254'
-    user: root
-    address: 127.0.0.1
-    port: 54008
-    stime: Mon Feb 14 12:54:52  2022
+- address: 192.168.3.26
+  name: sshd
+  pid: '14720'
+  port: 22
+  protocol: tcp
+  stime: Mon Sep 19 11:31:23  2022
+  user: root
+- address: 127.0.0.1
+  name: coda
+  pid: '5529'
+  port: 59998
+  protocol: tcp
+  stime: Thu Nov 15 12:25:38  2018
+  user: root
+- address: 127.0.0.1
+  name: in.mpath
+  pid: '493'
+  port: 5999
+  protocol: tcp
+  stime: Thu Nov 15 12:24:59  2018
+  user: root
+- address: 192.168.3.120
+  name: in.mpath
+  pid: '493'
+  port: 0
+  protocol: tcp
+  stime: Thu Nov 15 12:24:59  2018
+  user: root
+- address: 192.168.3.119
+  name: in.mpath
+  pid: '493'
+  port: 0
+  protocol: tcp
+  stime: Thu Nov 15 12:24:59  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2162'
+  port: 32774
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2160'
+  port: 5987
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2160'
+  port: 898
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2160'
+  port: 5988
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: opcacta
+  pid: '5545'
+  port: 32881
+  protocol: tcp
+  stime: Thu Nov 15 12:25:38  2018
+  user: root
+- address: 127.0.0.1
+  name: smcboot
+  pid: '2161'
+  port: 32773
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 192.168.224.4
+  name: fmd
+  pid: '2274'
+  port: 12
+  protocol: tcp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.224.4
+  name: fmd
+  pid: '2274'
+  port: 24
+  protocol: tcp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: '::'
+  name: inetd
+  pid: '2100'
+  port: 21
+  protocol: tcp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 127.0.0.1
+  name: sendmail
+  pid: '2252'
+  port: 25
+  protocol: tcp
+  stime: Thu Nov 15 12:25:11  2018
+  user: root
+- address: 192.168.224.4
+  name: dcs
+  pid: '2271'
+  port: 665
+  protocol: tcp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 127.0.0.1
+  name: ovcd
+  pid: '4983'
+  port: 32840
+  protocol: tcp
+  stime: Thu Nov 15 12:25:29  2018
+  user: root
+- address: 127.0.0.1
+  name: ovcd
+  pid: '4983'
+  port: 32848
+  protocol: tcp
+  stime: Thu Nov 15 12:25:29  2018
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: '2588'
+  port: 6788
+  protocol: tcp
+  stime: Thu Nov 15 12:25:16  2018
+  user: noaccess
+- address: 0.0.0.0
+  name: java
+  pid: '2588'
+  port: 32799
+  protocol: tcp
+  stime: Thu Nov 15 12:25:16  2018
+  user: noaccess
+- address: 127.0.0.1
+  name: java
+  pid: '2588'
+  port: 6789
+  protocol: tcp
+  stime: Thu Nov 15 12:25:16  2018
+  user: noaccess
+- address: 127.0.0.1
+  name: java
+  pid: '2588'
+  port: 32787
+  protocol: tcp
+  stime: Thu Nov 15 12:25:16  2018
+  user: noaccess
+- address: 0.0.0.0
+  name: java
+  pid: '22465'
+  port: 7005
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 0.0.0.0
+  name: java
+  pid: '22465'
+  port: 61300
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 38070
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 7005
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 38260
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 38276
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61463
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 127.0.0.1
+  name: java
+  pid: '22465'
+  port: 7007
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61526
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61530
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61529
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 192.168.3.26
+  name: java
+  pid: '22465'
+  port: 61532
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: 0.0.0.0
+  name: java
+  pid: '22465'
+  port: 7006
+  protocol: tcp
+  stime: Mon Sep 26 06:10:05  2022
+  user: telecable
+- address: '::'
+  name: vxsvc
+  pid: '4190'
+  port: 2148
+  protocol: tcp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: ::ffff:127.0.0.1
+  name: vxsvc
+  pid: '4190'
+  port: 2148
+  protocol: tcp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 192.168.3.26
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: tcp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: tcp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: tcp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: sshd
+  pid: '3028'
+  port: 22
+  protocol: tcp
+  stime: Thu Nov 15 12:25:22  2018
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: '3028'
+  port: 22
+  protocol: tcp
+  stime: Thu Nov 15 12:25:22  2018
+  user: root
+- address: 0.0.0.0
+  name: dtlogin
+  pid: '3273'
+  port: 32804
+  protocol: tcp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: '17162'
+  port: 3872
+  protocol: tcp
+  stime: Fri Jul 15 01:31:24  2022
+  user: em13c
+- address: 0.0.0.0
+  name: xprtld
+  pid: '4257'
+  port: 5634
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: xprtld
+  pid: '4257'
+  port: 32813
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: veaintf
+  pid: '4470'
+  port: 32812
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: veaintf
+  pid: '4470'
+  port: 32000
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: veaintf
+  pid: '4470'
+  port: 32929
+  protocol: tcp
+  stime: Thu Nov 15 12:25:24  2018
+  user: root
+- address: 127.0.0.1
+  name: ovconfd
+  pid: '4985'
+  port: 32856
+  protocol: tcp
+  stime: Thu Nov 15 12:25:31  2018
+  user: root
+- address: 127.0.0.1
+  name: ovconfd
+  pid: '4985'
+  port: 46812
+  protocol: tcp
+  stime: Thu Nov 15 12:25:31  2018
+  user: root
+- address: 127.0.0.1
+  name: opcmsga
+  pid: '5527'
+  port: 32879
+  protocol: tcp
+  stime: Thu Nov 15 12:25:37  2018
+  user: root
+- address: 0.0.0.0
+  name: ovtrcd
+  pid: '4840'
+  port: 5053
+  protocol: tcp
+  stime: Thu Nov 15 12:25:25  2018
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: '21514'
+  port: 6005
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 0.0.0.0
+  name: java
+  pid: '21514'
+  port: 59995
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60210
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 6006
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 37100
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60159
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 35363
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 6005
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 127.0.0.1
+  name: java
+  pid: '21514'
+  port: 6007
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60287
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 0.0.0.0
+  name: java
+  pid: '21514'
+  port: 60291
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60305
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21514'
+  port: 60372
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 0.0.0.0
+  name: java
+  pid: '21514'
+  port: 6006
+  protocol: tcp
+  stime: Mon Sep 26 06:00:05  2022
+  user: cdi
+- address: 192.168.3.26
+  name: backupse
+  pid: '14300'
+  port: 10001
+  protocol: tcp
+  stime: Fri Jun 28 13:55:35  2019
+  user: sybase
+- address: '::'
+  name: ovbbccb
+  pid: '4984'
+  port: 383
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: 127.0.0.1
+  name: ovbbccb
+  pid: '4984'
+  port: 53114
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: 127.0.0.1
+  name: ovbbccb
+  pid: '4984'
+  port: 53116
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: 127.0.0.1
+  name: ovbbccb
+  pid: '4984'
+  port: 53118
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: ::ffff:127.0.0.1
+  name: ovbbccb
+  pid: '4984'
+  port: 383
+  protocol: tcp
+  stime: Thu Nov 15 12:25:30  2018
+  user: root
+- address: 192.168.3.26
+  name: dataserv
+  pid: '12612'
+  port: 10000
+  protocol: tcp
+  stime: Tue Jun 25 11:02:18  2019
+  user: sybase
+- address: 0.0.0.0
+  name: java
+  pid: '21889'
+  port: 6008
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 0.0.0.0
+  name: java
+  pid: '21889'
+  port: 60316
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60339
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60340
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60345
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 127.0.0.1
+  name: java
+  pid: '21889'
+  port: 6009
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60402
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60403
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60404
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60437
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60438
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 192.168.3.26
+  name: java
+  pid: '21889'
+  port: 60439
+  protocol: tcp
+  stime: Mon Sep 26 06:02:38  2022
+  user: cdi
+- address: 127.0.0.1
+  name: dataserv
+  pid: '12288'
+  port: 10006
+  protocol: tcp
+  stime: Tue Jun 25 11:01:07  2019
+  user: sybase
+- address: 192.168.3.26
+  name: dataserv
+  pid: '12288'
+  port: 10006
+  protocol: tcp
+  stime: Tue Jun 25 11:01:07  2019
+  user: sybase
+- address: 0.0.0.0
+  name: bpcd
+  pid: '7257'
+  port: 13782
+  protocol: tcp
+  stime: Mon Feb 14 12:54:52  2022
+  user: root
+- address: 127.0.0.1
+  name: bpcd
+  pid: '7257'
+  port: 54011
+  protocol: tcp
+  stime: Mon Feb 14 12:54:52  2022
+  user: root
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '18022'
+  port: 2641
+  protocol: tcp
+  stime: Thu Mar 10 15:10:27  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '18022'
+  port: 2641
+  protocol: tcp
+  stime: Thu Mar 10 15:10:27  2022
+  user: iq
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21899'
+  port: 60419
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21899'
+  port: 36935
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 0.0.0.0
+  name: pmserver
+  pid: '21899'
+  port: 6014
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21899'
+  port: 60412
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21899'
+  port: 60417
+  protocol: tcp
+  stime: Mon Sep 26 06:02:57  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 61633
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 37992
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 0.0.0.0
+  name: pmserver
+  pid: '22527'
+  port: 7013
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 61624
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 61631
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: 192.168.3.26
+  name: pmserver
+  pid: '22527'
+  port: 61635
+  protocol: tcp
+  stime: Mon Sep 26 06:12:03  2022
+  user: telecable
+- address: '::'
+  name: pbx_exch
+  pid: '27629'
+  port: 1556
+  protocol: tcp
+  stime: Tue Feb  8 13:35:58  2022
+  user: root
+- address: 0.0.0.0
+  name: pbx_exch
+  pid: '27629'
+  port: 1556
+  protocol: tcp
+  stime: Tue Feb  8 13:35:58  2022
+  user: root
+- address: 127.0.0.1
+  name: pbx_exch
+  pid: '27629'
+  port: 1557
+  protocol: tcp
+  stime: Tue Feb  8 13:35:58  2022
+  user: root
+- address: 127.0.0.1
+  name: pbx_exch
+  pid: '27629'
+  port: 65036
+  protocol: tcp
+  stime: Tue Feb  8 13:35:58  2022
+  user: root
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21969'
+  port: 60507
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21969'
+  port: 36955
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 0.0.0.0
+  name: pmserver
+  pid: '21969'
+  port: 6015
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21969'
+  port: 60493
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmserver
+  pid: '21969'
+  port: 60497
+  protocol: tcp
+  stime: Mon Sep 26 06:03:09  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 36916
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 44075
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 0.0.0.0
+  name: pmrepage
+  pid: '21898'
+  port: 6013
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 60363
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 0.0.0.0
+  name: pmrepage
+  pid: '21898'
+  port: 0
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 6013
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 192.168.3.26
+  name: pmrepage
+  pid: '21898'
+  port: 60379
+  protocol: tcp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 127.0.0.1
+  name: backupse
+  pid: '21530'
+  port: 10007
+  protocol: tcp
+  stime: Thu Jun 27 13:57:15  2019
+  user: sybase
+- address: 192.168.3.26
+  name: backupse
+  pid: '21530'
+  port: 10007
+  protocol: tcp
+  stime: Thu Jun 27 13:57:15  2019
+  user: sybase
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '17806'
+  port: 2637
+  protocol: tcp
+  stime: Thu Mar 10 15:10:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '17806'
+  port: 2637
+  protocol: tcp
+  stime: Thu Mar 10 15:10:02  2022
+  user: iq
+- address: 0.0.0.0
+  name: vnetd
+  pid: '7254'
+  port: 13724
+  protocol: tcp
+  stime: Mon Feb 14 12:54:52  2022
+  user: root
+- address: 127.0.0.1
+  name: vnetd
+  pid: '7254'
+  port: 54008
+  protocol: tcp
+  stime: Mon Feb 14 12:54:52  2022
+  user: root
 udp_listen:
-  - protocol: udp
-    name: snmpXdmi
-    pid: '2236'
-    user: root
-    address: 0.0.0.0
-    port: 32831
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: statd
-    pid: '2057'
-    user: daemon
-    address: 0.0.0.0
-    port: 0
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: in.mpath
-    pid: '493'
-    user: root
-    address: "::"
-    port: 0
-    stime: Thu Nov 15 12:24:59  2018
-  - protocol: udp
-    name: snmpd
-    pid: '2234'
-    user: root
-    address: 0.0.0.0
-    port: 161
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpd
-    pid: '2234'
-    user: root
-    address: 0.0.0.0
-    port: 32782
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpd
-    pid: '2234'
-    user: root
-    address: 0.0.0.0
-    port: 32827
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpdx
-    pid: '2226'
-    user: root
-    address: 0.0.0.0
-    port: 16161
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpdx
-    pid: '2226'
-    user: root
-    address: 0.0.0.0
-    port: 32774
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: snmpdx
-    pid: '2226'
-    user: root
-    address: 0.0.0.0
-    port: 32775
-    stime: Thu Nov 15 12:25:10  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 0.0.0.0
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 127.0.0.1
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.3.119
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.3.26
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.3.120
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.7.123
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: xntpd
-    pid: '2276'
-    user: root
-    address: 192.168.224.4
-    port: 123
-    stime: Thu Nov 15 12:25:15  2018
-  - protocol: udp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: "::"
-    port: 2148
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: udp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: 127.0.0.1
-    port: 32806
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: udp
-    name: vxsvc
-    pid: '4190'
-    user: root
-    address: 127.0.0.1
-    port: 32808
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: udp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: 0.0.0.0
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: "::"
-    port: 2639
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: 0.0.0.0
-    port: 2638
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '319'
-    user: iq
-    address: "::"
-    port: 2638
-    stime: Wed Mar 16 11:11:02  2022
-  - protocol: udp
-    name: dtlogin
-    pid: '3273'
-    user: root
-    address: "::"
-    port: 177
-    stime: Thu Nov 15 12:25:23  2018
-  - protocol: udp
-    name: java
-    pid: '17162'
-    user: em13c
-    address: 0.0.0.0
-    port: 3872
-    stime: Fri Jul 15 01:31:24  2022
-  - protocol: udp
-    name: opcmsga
-    pid: '5527'
-    user: root
-    address: 0.0.0.0
-    port: 32784
-    stime: Thu Nov 15 12:25:37  2018
-  - protocol: udp
-    name: iqsrv15
-    pid: '18022'
-    user: iq
-    address: 0.0.0.0
-    port: 2641
-    stime: Thu Mar 10 15:10:27  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '18022'
-    user: iq
-    address: "::"
-    port: 2641
-    stime: Thu Mar 10 15:10:27  2022
-  - protocol: udp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 127.0.0.1
-    port: 41841
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: udp
-    name: pmrepage
-    pid: '21898'
-    user: cdi
-    address: 127.0.0.1
-    port: 41842
-    stime: Mon Sep 26 06:02:53  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '17806'
-    user: iq
-    address: 0.0.0.0
-    port: 2637
-    stime: Thu Mar 10 15:10:02  2022
-  - protocol: udp
-    name: iqsrv15
-    pid: '17806'
-    user: iq
-    address: "::"
-    port: 2637
-    stime: Thu Mar 10 15:10:02  2022
-dockers: { }
+- address: 0.0.0.0
+  name: snmpXdmi
+  pid: '2236'
+  port: 32831
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: statd
+  pid: '2057'
+  port: 0
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: daemon
+- address: '::'
+  name: in.mpath
+  pid: '493'
+  port: 0
+  protocol: udp
+  stime: Thu Nov 15 12:24:59  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpd
+  pid: '2234'
+  port: 161
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpd
+  pid: '2234'
+  port: 32782
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpd
+  pid: '2234'
+  port: 32827
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpdx
+  pid: '2226'
+  port: 16161
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpdx
+  pid: '2226'
+  port: 32774
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: snmpdx
+  pid: '2226'
+  port: 32775
+  protocol: udp
+  stime: Thu Nov 15 12:25:10  2018
+  user: root
+- address: 0.0.0.0
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 127.0.0.1
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.3.119
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.3.26
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.3.120
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.7.123
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: 192.168.224.4
+  name: xntpd
+  pid: '2276'
+  port: 123
+  protocol: udp
+  stime: Thu Nov 15 12:25:15  2018
+  user: root
+- address: '::'
+  name: vxsvc
+  pid: '4190'
+  port: 2148
+  protocol: udp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 127.0.0.1
+  name: vxsvc
+  pid: '4190'
+  port: 32806
+  protocol: udp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 127.0.0.1
+  name: vxsvc
+  pid: '4190'
+  port: 32808
+  protocol: udp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: udp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '319'
+  port: 2639
+  protocol: udp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '319'
+  port: 2638
+  protocol: udp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '319'
+  port: 2638
+  protocol: udp
+  stime: Wed Mar 16 11:11:02  2022
+  user: iq
+- address: '::'
+  name: dtlogin
+  pid: '3273'
+  port: 177
+  protocol: udp
+  stime: Thu Nov 15 12:25:23  2018
+  user: root
+- address: 0.0.0.0
+  name: java
+  pid: '17162'
+  port: 3872
+  protocol: udp
+  stime: Fri Jul 15 01:31:24  2022
+  user: em13c
+- address: 0.0.0.0
+  name: opcmsga
+  pid: '5527'
+  port: 32784
+  protocol: udp
+  stime: Thu Nov 15 12:25:37  2018
+  user: root
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '18022'
+  port: 2641
+  protocol: udp
+  stime: Thu Mar 10 15:10:27  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '18022'
+  port: 2641
+  protocol: udp
+  stime: Thu Mar 10 15:10:27  2022
+  user: iq
+- address: 127.0.0.1
+  name: pmrepage
+  pid: '21898'
+  port: 41841
+  protocol: udp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 127.0.0.1
+  name: pmrepage
+  pid: '21898'
+  port: 41842
+  protocol: udp
+  stime: Mon Sep 26 06:02:53  2022
+  user: cdi
+- address: 0.0.0.0
+  name: iqsrv15
+  pid: '17806'
+  port: 2637
+  protocol: udp
+  stime: Thu Mar 10 15:10:02  2022
+  user: iq
+- address: '::'
+  name: iqsrv15
+  pid: '17806'
+  port: 2637
+  protocol: udp
+  stime: Thu Mar 10 15:10:02  2022
+  user: iq

--- a/tests/unit/plugins/action/auto/resources/telegraf/telegraf1.11.3_centos7.6.yaml
+++ b/tests/unit/plugins/action/auto/resources/telegraf/telegraf1.11.3_centos7.6.yaml
@@ -1,4008 +1,4137 @@
-expected_result:
-  - bindings: []
-    discovery_time: '2022-07-05T10:42:24+02:00'
-    listening_ports: [ ]
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: iometrics-agent
-        release: '25'
-        source: rpm
-        version: 1.11.3
-    process:
-      cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
-      pid: '1037'
-      ppid: '1'
-      user: root
-    type: Telegraf
-    version:
-      - number: 1.11.3
-        type: package
-
-software_list:
-  - name: Telegraf
-    cmd_regexp: /usr/bin/telegraf
-    pkg_regexp: telegraf|iometrics-agent
-    process_type: parent
-    return_children: false
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - -c
-        - python ./listener.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - -c
-          - python ./listener.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
-          - PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
-        Hostname: indexer01.novalocal
-        Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.1.0-c165633
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /config: { }
-        WorkingDir: ''
-      Created: '2022-06-01T16:32:15.591995742Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521-init/diff:/var/lib/docker/overlay2/48af681efdc26a18db1f454929c8a9008b0c59035b43be3a8ad58e211a309a85/diff:/var/lib/docker/overlay2/c703bb1c40fe2d0178aae8f123e88241c3c6928e189d7ef47a9aaad609439655/diff:/var/lib/docker/overlay2/f0b32c9349991844490375e72f6a025c9d162a7edac7a4e585d295a66f01e782/diff:/var/lib/docker/overlay2/1ed8f7cae0ab8d14f1db25dc40bdc50d71a5ef5555cd05970f9b7ba08b7d7c61/diff:/var/lib/docker/overlay2/5cf6c028fe2b081fdcbda31e8e9133b89a79eccf663de59530b61a61692e97c6/diff:/var/lib/docker/overlay2/8311c64009b57db6fb231a3ca4ca41218abdc03e6b771602908e1a3bff032b13/diff:/var/lib/docker/overlay2/1009cd354b76d65ca194ab211a8ee1209c930aba645d667f0f2de93e7777fef8/diff:/var/lib/docker/overlay2/c7eb8b0108c5013dca78bf4a9eebf3ea41552d7f047664c842ef3f9ec0930f46/diff
-          MergedDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/merged
-          UpperDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/diff
-          WorkDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/redis-cleaner:/config:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hostname
-      HostsPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hosts
-      Id: 17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
-      Image: sha256:f4b8014dcf496e8a2dbc8786835825926dbd8db6a8ab8be9d012139a3e59e851
-      LogPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /config
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis-cleaner
-          Type: bind
-      Name: /iometrics-cmdb-redis-cleaner
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 42a46173b8a6a29b240d5e11e26f5142d483daac2b3a9ff7d463656952f656c4
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
-        Ports: { }
-        SandboxID: 35eeca78d95001ee58384d24c44d5c7cb0774fa1d3ccf65135245c3e115b8c64
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 28025
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-01T16:32:15.934702372Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /usr/local/bin/docker-entrypoint
-        Env:
-          - LOGSTASH_KEYSTORE_PASS=secur3it
-          - PATH=/usr/share/logstash/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - ELASTIC_CONTAINER=true
-          - LANG=en_US.UTF-8
-          - LC_ALL=en_US.UTF-8
-        ExposedPorts:
-          5044/tcp: { }
-          9600/tcp: { }
-        Hostname: indexer01.novalocal
-        Image: nexusregistry.opensolutions.cloud/logstash:7.4.2_iometrics-1
-        Labels:
-          license: Elastic License
-          org.label-schema.build-date: '20190801'
-          org.label-schema.license: GPLv2
-          org.label-schema.name: logstash
-          org.label-schema.schema-version: '1.0'
-          org.label-schema.url: https://www.elastic.co/products/logstash
-          org.label-schema.vcs-url: https://github.com/elastic/logstash
-          org.label-schema.vendor: Elastic
-          org.label-schema.version: 7.4.2
-          os_container_type: logstash
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: logstash
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /usr/share/logstash/config/jvm.options: { }
-          /usr/share/logstash/config/logstash.keystore: { }
-          /usr/share/logstash/config/logstash.yml: { }
-          /usr/share/logstash/config/pipelines.yml: { }
-          /usr/share/logstash/config/ssl: { }
-          /usr/share/logstash/libs: { }
-          /usr/share/logstash/pipelines: { }
-          /usr/share/logstash/scripts: { }
-          /var/lib/logstash/spool: { }
-        WorkingDir: /usr/share/logstash
-      Created: '2021-09-08T15:34:37.283512426Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23-init/diff:/var/lib/docker/overlay2/c0b64f0d978f9438dfbff80ce43ea262a8c3fada60512ae10e10cedf6155f2e5/diff:/var/lib/docker/overlay2/cecec1371061521c9c470de506604b84f0c7115e8afc98364cda87b4dee22fde/diff:/var/lib/docker/overlay2/34ed4ad551160a52e601b1d18bf370daad0f239bc6e77227b16b4c782a0eca06/diff:/var/lib/docker/overlay2/6df2c0f7c377aa12d60990c8c699892ab1b13be249c0c6fb6fbb98fe05480dc6/diff:/var/lib/docker/overlay2/85645c13b8a4234107187513bda39ca87750c745d01739d812905125684a5376/diff:/var/lib/docker/overlay2/571aeec40700310388bbeb8bd6167ff0a4e2e2df9e6c6e0288c409d334f54ca1/diff:/var/lib/docker/overlay2/de0534dca03a3dedda930c1ad97d22dd942c75b9616ab879972f07665838f08c/diff:/var/lib/docker/overlay2/7e8ced8ae7353db588e6473b42bfdc1d316dc47ac5f494dcc3e6d4f7e57da3e3/diff:/var/lib/docker/overlay2/001f9147b6ab66d62b1fbceaf77a9793a753a60559353c6327c50a0e49bc1231/diff:/var/lib/docker/overlay2/5516c130cfbb3f233c5b214316cdd11908b3bda15770c25496f2aa59b8849253/diff:/var/lib/docker/overlay2/68d49fb7cd2f845a36bf22bba766c721fe67274d7f5d0e6e1091071fc01f4fff/diff:/var/lib/docker/overlay2/e1d95b6fcae995ab60f12b75f6fcbeabecc2b02d02bb8ab225e5a55485adc03c/diff:/var/lib/docker/overlay2/09e21e4e8434de7e2800bfdc86f4dbbe999bc89186b7c099e58a58f13b083672/diff:/var/lib/docker/overlay2/7f3df92947c65debb3de8c0ecd1d556e90b355bc3af0163bc8a9862e8f869dac/diff:/var/lib/docker/overlay2/46b9ba93c62b5e0bd35145b2327e060712a85cf1cdd263188c010d5e2554670b/diff:/var/lib/docker/overlay2/f2454d9a3b25399047feb41486803d43fcbb45a81dc710601d5950da79ac8030/diff:/var/lib/docker/overlay2/b27d3ae7aff2ac9754f1c56378012380a1e5c17896c0c71b4759bfcb10a7c40a/diff:/var/lib/docker/overlay2/75d6bdb58f70a62e6ea684d6d3b37652c8b72d9d4f86551e553c6cf6bb7326ab/diff:/var/lib/docker/overlay2/54689b9f778d0fb8970c658303b1f70fd60328cd888dc5b74326b29c57ef8105/diff:/var/lib/docker/overlay2/e6ac2cd447117ff53d3fa9439b80162af5eeb91d20567780a58fa542b04e2a38/diff:/var/lib/docker/overlay2/78435691d0b8543fbe89e1d88f9a7b5fa681432b9a271a097a1fdcae9cb5a9e5/diff:/var/lib/docker/overlay2/229ee1b3a56196e119210269fce872d0fe3fb56b6f87f86a770837a5fa5b1ac7/diff
-          MergedDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/merged
-          UpperDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/diff
-          WorkDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/logstash/ssl:/usr/share/logstash/config/ssl:rw
-          - /etc/localtime:/etc/localtime:rw
-          - /etc/logstash/logstash.yml:/usr/share/logstash/config/logstash.yml:rw
-          - /usr/share/logstash/libs:/usr/share/logstash/libs:rw
-          - /etc/logstash/scripts:/usr/share/logstash/scripts:rw
-          - /etc/logstash/pipelines:/usr/share/logstash/pipelines:rw
-          - /etc/logstash/jvm.options:/usr/share/logstash/config/jvm.options:rw
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/logstash/pipelines.yml:/usr/share/logstash/config/pipelines.yml:rw
-          - /etc/logstash/logstash.keystore:/usr/share/logstash/config/logstash.keystore:rw
-          - /var/lib/logstash/spool:/var/lib/logstash/spool:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/hostname
-      HostsPath: /etc/hosts
-      Id: 1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
-      Image: sha256:6dea016b06dec9bd6649861e6ff6f37fa4cc33f4af5a908d42756f1ff07e1e3a
-      LogPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /usr/share/logstash/config/logstash.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/logstash.yml
-          Type: bind
-        - Destination: /usr/share/logstash/scripts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/scripts
-          Type: bind
-        - Destination: /var/lib/logstash/spool
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/logstash/spool
-          Type: bind
-        - Destination: /usr/share/logstash/pipelines
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/pipelines
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /usr/share/logstash/config/jvm.options
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/jvm.options
-          Type: bind
-        - Destination: /usr/share/logstash/config/logstash.keystore
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/logstash.keystore
-          Type: bind
-        - Destination: /usr/share/logstash/config/pipelines.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/pipelines.yml
-          Type: bind
-        - Destination: /usr/share/logstash/config/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/logstash/ssl
-          Type: bind
-        - Destination: /usr/share/logstash/libs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /usr/share/logstash/libs
-          Type: bind
-      Name: /logstash
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: a05e3bedd671d506ea7c75121f96d6f15b58fb25d99f0a761d85522c4cb31c13
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
-        Ports: { }
-        SandboxID: b70e6ce41402ab5de2b13827be954a106a7d738478fee9bd07a2ca753971613b
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/local/bin/docker-entrypoint
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:40.665430732Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 7056
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:55:51.256169421Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - --port
-        - '6379'
-        - --tls-port
-        - '6378'
-        - --appendonly
-        - 'no'
-        - --maxmemory
-        - '0'
-        - --maxclients
-        - '10000'
-        - --bind
-        - 0.0.0.0
-        - --tls-auth-clients
-        - 'no'
-        - --tls-cert-file
-        - /data/ssl/redis.crt
-        - --tls-key-file
-        - /data/ssl/redis.pem
-        - --tls-ca-cert-file
-        - /data/ssl/redis_ca.crt
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - --port
-          - '6379'
-          - --tls-port
-          - '6378'
-          - --appendonly
-          - 'no'
-          - --maxmemory
-          - '0'
-          - --maxclients
-          - '10000'
-          - --bind
-          - 0.0.0.0
-          - --tls-auth-clients
-          - 'no'
-          - --tls-cert-file
-          - /data/ssl/redis.crt
-          - --tls-key-file
-          - /data/ssl/redis.pem
-          - --tls-ca-cert-file
-          - /data/ssl/redis_ca.crt
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.0.1
-          - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
-          - REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
-        ExposedPorts:
-          6379/tcp: { }
-        Hostname: indexer01.novalocal
-        Image: redis:6.0.1
-        Labels:
-          os_contianer_type: redis
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: { }
-          /data/ssl/: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-        WorkingDir: /data
-      Created: '2021-09-08T15:21:08.364900148Z'
-      Driver: overlay2
-      ExecIDs:
-        - 09b5dc8e88df78d954a04edbbfe509aa3a8873b17c434360f0994b166eb661e6
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671-init/diff:/var/lib/docker/overlay2/d729bad126881ac666c1ce86fd53b9fbb89dd31a32982fbe52d7b0348d00a7a5/diff:/var/lib/docker/overlay2/6147c7e4ffcac3df8515c47b85fb28fa9cb14e2eda1ae99024a0ad2d4d2f2564/diff:/var/lib/docker/overlay2/e65a456f02dd73ccbf8fcf90ad6c9cd2d090f59a8419916c39c5e3d2f1f4633e/diff:/var/lib/docker/overlay2/0d37d43d45e3912548e3578ac61ec6ae557a5b096629ca286fc5b07999ccae31/diff:/var/lib/docker/overlay2/2c5d5d7ffd6855efcf3a7788c2a72f12de032ac3d00ffa437e32113ae5706b4d/diff:/var/lib/docker/overlay2/ef4edd4aa9d123bae52ac92f708fb15264ac3036df51240db0e17b7ae280a06d/diff
-          MergedDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/merged
-          UpperDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/diff
-          WorkDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /var/lib/redis:/data:rw
-          - /etc/hosts:/etc/hosts:rw
-          - /etc/localtime:/etc/localtime:rw
-          - /etc/redis/ssl/:/data/ssl/:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/hostname
-      HostsPath: /etc/hosts
-      Id: 9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
-      Image: sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c
-      LogPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/redis
-          Type: bind
-        - Destination: /data/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis/ssl
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-      Name: /redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: c124f14eba8e33d8dfbf7244d810451b50469d02c40f191ac28d6309b4c2fb20
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
-        Ports: { }
-        SandboxID: 12fa0db070f4558f5c022bb880897adb0e4a11662b3ec5143027e742a036611d
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:40.681971343Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 7054
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:55:50.844646575Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.12
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  keepalived:
-    - arch: x86_64
-      epoch: null
-      name: keepalived
-      release: 16.el7
-      source: rpm
-      version: 1.3.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-devel:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-devel
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsepol-devel:
-    - arch: x86_64
-      epoch: null
-      name: libsepol-devel
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mariadb-server:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-server
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp-agent-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-agent-libs
-      release: 48.el7_8.1
-      source: rpm
-      version: 5.7.2
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 48.el7_8.1
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcre-devel:
-    - arch: x86_64
-      epoch: null
-      name: pcre-devel
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
-  perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
-  perl-DBD-MySQL:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBD-MySQL
-      release: 6.el7
-      source: rpm
-      version: '4.023'
-  perl-DBI:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBI
-      release: 4.el7
-      source: rpm
-      version: '1.627'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
-  perl-Net-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-Daemon
-      release: 5.el7
-      source: rpm
-      version: '0.48'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-PlRPC:
-    - arch: noarch
-      epoch: null
-      name: perl-PlRPC
-      release: 14.el7
-      source: rpm
-      version: '0.2020'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  socat:
-    - arch: x86_64
-      epoch: null
-      name: socat
-      release: 2.el7
-      source: rpm
-      version: 1.7.3.2
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '40'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '93'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '173'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '174'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '301'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '306'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '377'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '390'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '391'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '392'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '393'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '394'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '395'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '396'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '397'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '477'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '516'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '541'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '673'
-    ppid: '1'
-    user: polkitd
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '704'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '720'
-    ppid: '1'
-    user: rpc
-  - cmdline: ''
-    pid: '721'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '724'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '731'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '743'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '747'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H indexer01 eth0
-    pid: '976'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - python ./listener.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - python ./listener.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/a312303dbd516f6a692f2fee59852701bd828dd8/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=8dd03e99645c19f49bbb629ce65c46b665ee92a1d94d246418bad6afade89f8d
+      Hostname: indexer01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.1.0-c165633
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /config: {}
+      WorkingDir: ''
+    Created: '2022-06-01T16:32:15.591995742Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521-init/diff:/var/lib/docker/overlay2/48af681efdc26a18db1f454929c8a9008b0c59035b43be3a8ad58e211a309a85/diff:/var/lib/docker/overlay2/c703bb1c40fe2d0178aae8f123e88241c3c6928e189d7ef47a9aaad609439655/diff:/var/lib/docker/overlay2/f0b32c9349991844490375e72f6a025c9d162a7edac7a4e585d295a66f01e782/diff:/var/lib/docker/overlay2/1ed8f7cae0ab8d14f1db25dc40bdc50d71a5ef5555cd05970f9b7ba08b7d7c61/diff:/var/lib/docker/overlay2/5cf6c028fe2b081fdcbda31e8e9133b89a79eccf663de59530b61a61692e97c6/diff:/var/lib/docker/overlay2/8311c64009b57db6fb231a3ca4ca41218abdc03e6b771602908e1a3bff032b13/diff:/var/lib/docker/overlay2/1009cd354b76d65ca194ab211a8ee1209c930aba645d667f0f2de93e7777fef8/diff:/var/lib/docker/overlay2/c7eb8b0108c5013dca78bf4a9eebf3ea41552d7f047664c842ef3f9ec0930f46/diff
+        MergedDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/merged
+        UpperDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/diff
+        WorkDir: /var/lib/docker/overlay2/1eba4bed4f529ec5f50df5c4f6577d5da667f4b2f3f193b1bf43cd21ec5b6521/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/redis-cleaner:/config:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hostname
+    HostsPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/hosts
+    Id: 17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
+    Image: sha256:f4b8014dcf496e8a2dbc8786835825926dbd8db6a8ab8be9d012139a3e59e851
+    LogPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /config
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis-cleaner
+      Type: bind
+    Name: /iometrics-cmdb-redis-cleaner
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 42a46173b8a6a29b240d5e11e26f5142d483daac2b3a9ff7d463656952f656c4
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
+      Ports: {}
+      SandboxID: 35eeca78d95001ee58384d24c44d5c7cb0774fa1d3ccf65135245c3e115b8c64
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 28025
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-01T16:32:15.934702372Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /usr/local/bin/docker-entrypoint
+      Env:
+      - LOGSTASH_KEYSTORE_PASS=secur3it
+      - PATH=/usr/share/logstash/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - ELASTIC_CONTAINER=true
+      - LANG=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+      ExposedPorts:
+        5044/tcp: {}
+        9600/tcp: {}
+      Hostname: indexer01.novalocal
+      Image: nexusregistry.opensolutions.cloud/logstash:7.4.2_iometrics-1
+      Labels:
+        license: Elastic License
+        org.label-schema.build-date: '20190801'
+        org.label-schema.license: GPLv2
+        org.label-schema.name: logstash
+        org.label-schema.schema-version: '1.0'
+        org.label-schema.url: https://www.elastic.co/products/logstash
+        org.label-schema.vcs-url: https://github.com/elastic/logstash
+        org.label-schema.vendor: Elastic
+        org.label-schema.version: 7.4.2
+        os_container_type: logstash
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: logstash
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /usr/share/logstash/config/jvm.options: {}
+        /usr/share/logstash/config/logstash.keystore: {}
+        /usr/share/logstash/config/logstash.yml: {}
+        /usr/share/logstash/config/pipelines.yml: {}
+        /usr/share/logstash/config/ssl: {}
+        /usr/share/logstash/libs: {}
+        /usr/share/logstash/pipelines: {}
+        /usr/share/logstash/scripts: {}
+        /var/lib/logstash/spool: {}
+      WorkingDir: /usr/share/logstash
+    Created: '2021-09-08T15:34:37.283512426Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23-init/diff:/var/lib/docker/overlay2/c0b64f0d978f9438dfbff80ce43ea262a8c3fada60512ae10e10cedf6155f2e5/diff:/var/lib/docker/overlay2/cecec1371061521c9c470de506604b84f0c7115e8afc98364cda87b4dee22fde/diff:/var/lib/docker/overlay2/34ed4ad551160a52e601b1d18bf370daad0f239bc6e77227b16b4c782a0eca06/diff:/var/lib/docker/overlay2/6df2c0f7c377aa12d60990c8c699892ab1b13be249c0c6fb6fbb98fe05480dc6/diff:/var/lib/docker/overlay2/85645c13b8a4234107187513bda39ca87750c745d01739d812905125684a5376/diff:/var/lib/docker/overlay2/571aeec40700310388bbeb8bd6167ff0a4e2e2df9e6c6e0288c409d334f54ca1/diff:/var/lib/docker/overlay2/de0534dca03a3dedda930c1ad97d22dd942c75b9616ab879972f07665838f08c/diff:/var/lib/docker/overlay2/7e8ced8ae7353db588e6473b42bfdc1d316dc47ac5f494dcc3e6d4f7e57da3e3/diff:/var/lib/docker/overlay2/001f9147b6ab66d62b1fbceaf77a9793a753a60559353c6327c50a0e49bc1231/diff:/var/lib/docker/overlay2/5516c130cfbb3f233c5b214316cdd11908b3bda15770c25496f2aa59b8849253/diff:/var/lib/docker/overlay2/68d49fb7cd2f845a36bf22bba766c721fe67274d7f5d0e6e1091071fc01f4fff/diff:/var/lib/docker/overlay2/e1d95b6fcae995ab60f12b75f6fcbeabecc2b02d02bb8ab225e5a55485adc03c/diff:/var/lib/docker/overlay2/09e21e4e8434de7e2800bfdc86f4dbbe999bc89186b7c099e58a58f13b083672/diff:/var/lib/docker/overlay2/7f3df92947c65debb3de8c0ecd1d556e90b355bc3af0163bc8a9862e8f869dac/diff:/var/lib/docker/overlay2/46b9ba93c62b5e0bd35145b2327e060712a85cf1cdd263188c010d5e2554670b/diff:/var/lib/docker/overlay2/f2454d9a3b25399047feb41486803d43fcbb45a81dc710601d5950da79ac8030/diff:/var/lib/docker/overlay2/b27d3ae7aff2ac9754f1c56378012380a1e5c17896c0c71b4759bfcb10a7c40a/diff:/var/lib/docker/overlay2/75d6bdb58f70a62e6ea684d6d3b37652c8b72d9d4f86551e553c6cf6bb7326ab/diff:/var/lib/docker/overlay2/54689b9f778d0fb8970c658303b1f70fd60328cd888dc5b74326b29c57ef8105/diff:/var/lib/docker/overlay2/e6ac2cd447117ff53d3fa9439b80162af5eeb91d20567780a58fa542b04e2a38/diff:/var/lib/docker/overlay2/78435691d0b8543fbe89e1d88f9a7b5fa681432b9a271a097a1fdcae9cb5a9e5/diff:/var/lib/docker/overlay2/229ee1b3a56196e119210269fce872d0fe3fb56b6f87f86a770837a5fa5b1ac7/diff
+        MergedDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/merged
+        UpperDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/diff
+        WorkDir: /var/lib/docker/overlay2/1126fc1590a7e0ef5beda6fc82dc03c1f698923631597d50e54eaaa5de0cce23/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/logstash/ssl:/usr/share/logstash/config/ssl:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/logstash/logstash.yml:/usr/share/logstash/config/logstash.yml:rw
+      - /usr/share/logstash/libs:/usr/share/logstash/libs:rw
+      - /etc/logstash/scripts:/usr/share/logstash/scripts:rw
+      - /etc/logstash/pipelines:/usr/share/logstash/pipelines:rw
+      - /etc/logstash/jvm.options:/usr/share/logstash/config/jvm.options:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/logstash/pipelines.yml:/usr/share/logstash/config/pipelines.yml:rw
+      - /etc/logstash/logstash.keystore:/usr/share/logstash/config/logstash.keystore:rw
+      - /var/lib/logstash/spool:/var/lib/logstash/spool:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/hostname
+    HostsPath: /etc/hosts
+    Id: 1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
+    Image: sha256:6dea016b06dec9bd6649861e6ff6f37fa4cc33f4af5a908d42756f1ff07e1e3a
+    LogPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /usr/share/logstash/config/logstash.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/logstash.yml
+      Type: bind
+    - Destination: /usr/share/logstash/scripts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/scripts
+      Type: bind
+    - Destination: /var/lib/logstash/spool
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/logstash/spool
+      Type: bind
+    - Destination: /usr/share/logstash/pipelines
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/pipelines
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /usr/share/logstash/config/jvm.options
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/jvm.options
+      Type: bind
+    - Destination: /usr/share/logstash/config/logstash.keystore
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/logstash.keystore
+      Type: bind
+    - Destination: /usr/share/logstash/config/pipelines.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/pipelines.yml
+      Type: bind
+    - Destination: /usr/share/logstash/config/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/logstash/ssl
+      Type: bind
+    - Destination: /usr/share/logstash/libs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /usr/share/logstash/libs
+      Type: bind
+    Name: /logstash
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: a05e3bedd671d506ea7c75121f96d6f15b58fb25d99f0a761d85522c4cb31c13
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
+      Ports: {}
+      SandboxID: b70e6ce41402ab5de2b13827be954a106a7d738478fee9bd07a2ca753971613b
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/local/bin/docker-entrypoint
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:40.665430732Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 7056
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:55:51.256169421Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --port
+    - '6379'
+    - --tls-port
+    - '6378'
+    - --appendonly
+    - 'no'
+    - --maxmemory
+    - '0'
+    - --maxclients
+    - '10000'
+    - --bind
+    - 0.0.0.0
+    - --tls-auth-clients
+    - 'no'
+    - --tls-cert-file
+    - /data/ssl/redis.crt
+    - --tls-key-file
+    - /data/ssl/redis.pem
+    - --tls-ca-cert-file
+    - /data/ssl/redis_ca.crt
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - --port
+      - '6379'
+      - --tls-port
+      - '6378'
+      - --appendonly
+      - 'no'
+      - --maxmemory
+      - '0'
+      - --maxclients
+      - '10000'
+      - --bind
+      - 0.0.0.0
+      - --tls-auth-clients
+      - 'no'
+      - --tls-cert-file
+      - /data/ssl/redis.crt
+      - --tls-key-file
+      - /data/ssl/redis.pem
+      - --tls-ca-cert-file
+      - /data/ssl/redis_ca.crt
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.0.1
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
+      - REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: indexer01.novalocal
+      Image: redis:6.0.1
+      Labels:
+        os_contianer_type: redis
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+        /data/ssl/: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+      WorkingDir: /data
+    Created: '2021-09-08T15:21:08.364900148Z'
+    Driver: overlay2
+    ExecIDs:
+    - 09b5dc8e88df78d954a04edbbfe509aa3a8873b17c434360f0994b166eb661e6
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671-init/diff:/var/lib/docker/overlay2/d729bad126881ac666c1ce86fd53b9fbb89dd31a32982fbe52d7b0348d00a7a5/diff:/var/lib/docker/overlay2/6147c7e4ffcac3df8515c47b85fb28fa9cb14e2eda1ae99024a0ad2d4d2f2564/diff:/var/lib/docker/overlay2/e65a456f02dd73ccbf8fcf90ad6c9cd2d090f59a8419916c39c5e3d2f1f4633e/diff:/var/lib/docker/overlay2/0d37d43d45e3912548e3578ac61ec6ae557a5b096629ca286fc5b07999ccae31/diff:/var/lib/docker/overlay2/2c5d5d7ffd6855efcf3a7788c2a72f12de032ac3d00ffa437e32113ae5706b4d/diff:/var/lib/docker/overlay2/ef4edd4aa9d123bae52ac92f708fb15264ac3036df51240db0e17b7ae280a06d/diff
+        MergedDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/merged
+        UpperDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/diff
+        WorkDir: /var/lib/docker/overlay2/c939ea1733b20e7cf2f02d6967d7f1a06b02aa3a2fb23808e764a7d98eea0671/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/redis:/data:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/redis/ssl/:/data/ssl/:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/hostname
+    HostsPath: /etc/hosts
+    Id: 9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
+    Image: sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c
+    LogPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/redis
+      Type: bind
+    - Destination: /data/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis/ssl
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    Name: /redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: c124f14eba8e33d8dfbf7244d810451b50469d02c40f191ac28d6309b4c2fb20
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: a130ce8337630367c51b5f64ebd4d9dd08430ec08e4e165ea5d085e646b5ae7c
+      Ports: {}
+      SandboxID: 12fa0db070f4558f5c022bb880897adb0e4a11662b3ec5143027e742a036611d
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:40.681971343Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 7054
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:55:50.844646575Z'
+      Status: running
+expected_result:
+- bindings: []
+  discovery_time: '2022-07-05T10:42:24+02:00'
+  listening_ports: []
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  process:
+    cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+      /etc/telegraf/telegraf.d
+    cwd: /usr/bin/
     pid: '1037'
     ppid: '1'
     user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1038'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1042'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
-    pid: '1128'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1136'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1140'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1151'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1152'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1153'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '1290'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '1291'
-    ppid: '1290'
-    user: root
-  - cmdline: /usr/sbin/keepalived -D
-    pid: '1292'
-    ppid: '1290'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1346'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1348'
-    ppid: '1346'
-    user: postfix
-  - cmdline: pickup -l -t unix -u
-    pid: '5992'
-    ppid: '1346'
-    user: postfix
-  - cmdline: 'sshd: centos [priv]'
-    pid: '6355'
-    ppid: '1140'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '6357'
-    ppid: '6355'
-    user: centos
-  - cmdline: -bash
-    pid: '6358'
-    ppid: '6357'
-    user: centos
-  - cmdline: sudo su -
-    pid: '6377'
-    ppid: '6358'
-    user: root
-  - cmdline: su -
-    pid: '6378'
-    ppid: '6377'
-    user: root
-  - cmdline: -bash
-    pid: '6379'
-    ppid: '6378'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '6498'
-    ppid: '1140'
-    user: root
-  - cmdline: 'sshd: centos@pts/1'
-    pid: '6500'
-    ppid: '6498'
-    user: centos
-  - cmdline: -bash
-    pid: '6501'
-    ppid: '6500'
-    user: centos
-  - cmdline: sudo su
-    pid: '6520'
-    ppid: '6501'
-    user: root
-  - cmdline: su
-    pid: '6521'
-    ppid: '6520'
-    user: root
-  - cmdline: bash
-    pid: '6522'
-    ppid: '6521'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '6905'
-    ppid: '1042'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '6923'
-    ppid: '1042'
-    user: root
-  - cmdline: redis-server 0.0.0.0:6379
-    pid: '7054'
-    ppid: '6905'
-    user: polkitd
-  - cmdline: /bin/java -Xms2048m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djruby.compile.invokedynamic=true -Djruby.jit.threshold=0 -Djruby.regexp.interruptible=true -Djava.security.egd=file:/dev/urandom -Dlog4j2.isThreadContextMapInheritable=true -Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ -cp /usr/share/logstash/logstash-core/lib/jars/animal-sniffer-annotations-1.14.jar:/usr/share/logstash/logstash-core/lib/jars/commons-codec-1.11.jar:/usr/share/logstash/logstash-core/lib/jars/commons-compiler-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/error_prone_annotations-2.0.18.jar:/usr/share/logstash/logstash-core/lib/jars/google-java-format-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/gradle-license-report-0.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/guava-22.0.jar:/usr/share/logstash/logstash-core/lib/jars/j2objc-annotations-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-annotations-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-core-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-databind-2.9.9.3.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-dataformat-cbor-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/janino-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/javassist-3.24.0-GA.jar:/usr/share/logstash/logstash-core/lib/jars/jruby-complete-9.2.8.0.jar:/usr/share/logstash/logstash-core/lib/jars/jsr305-1.3.9.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-api-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-core-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-slf4j-impl-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/logstash-core.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.commands-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.contenttype-3.4.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.expressions-3.4.300.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.filesystem-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.jobs-3.5.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.resources-3.7.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.runtime-3.7.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.app-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.common-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.preferences-3.4.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.registry-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.jdt.core-3.10.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.osgi-3.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.text-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/reflections-0.9.11.jar:/usr/share/logstash/logstash-core/lib/jars/slf4j-api-1.7.25.jar org.logstash.Logstash
-    pid: '7056'
-    ppid: '6923'
-    user: centos
-  - cmdline: /usr/bin/docker start -a redis
-    pid: '7301'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a logstash
-    pid: '7302'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '9991'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10320'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10499'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '10621'
-    ppid: '1140'
-    user: root
-  - cmdline: 'sshd: centos@pts/2'
-    pid: '10623'
-    ppid: '10621'
-    user: centos
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-fycgcczmjzstmyjtsypgvyikyuztgdmf ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657010524.7502332-47502-26399721902610/AnsiballZ_process_facts.py' && sleep 0
-    pid: '10809'
-    ppid: '10623'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-fycgcczmjzstmyjtsypgvyikyuztgdmf ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657010524.7502332-47502-26399721902610/AnsiballZ_process_facts.py
-    pid: '10824'
-    ppid: '10809'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-fycgcczmjzstmyjtsypgvyikyuztgdmf ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657010524.7502332-47502-26399721902610/AnsiballZ_process_facts.py
-    pid: '10825'
-    ppid: '10824'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657010524.7502332-47502-26399721902610/AnsiballZ_process_facts.py
-    pid: '10826'
-    ppid: '10825'
-    user: root
-  - cmdline: ''
-    pid: '19599'
-    ppid: '2'
-    user: root
-  - cmdline: bash
-    pid: '24140'
-    ppid: '6905'
-    user: root
-  - cmdline: ''
-    pid: '26607'
-    ppid: '2'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '28010'
-    ppid: '1042'
-    user: root
-  - cmdline: /bin/sh -c python ./listener.py
-    pid: '28025'
-    ppid: '28010'
-    user: root
-  - cmdline: python ./listener.py
-    pid: '28039'
-    ppid: '28025'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1346
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:54:56 2022
-    user: root
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 7054
-    port: 6378
-    protocol: tcp
-    stime: Tue Apr 26 15:55:48 2022
-    user: polkitd
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 7054
-    port: 6379
-    protocol: tcp
-    stime: Tue Apr 26 15:55:48 2022
-    user: polkitd
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:54:05 2022
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1140
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:54:48 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1346
-    port: 25
-    protocol: tcp
-    stime: Tue Apr 26 15:54:56 2022
-    user: root
-  - address: '::'
-    name: java
-    pid: 7056
-    port: 5055
-    protocol: tcp
-    stime: Tue Apr 26 15:55:48 2022
-    user: centos
-  - address: '::'
-    name: java
-    pid: 7056
-    port: 9600
-    protocol: tcp
-    stime: Tue Apr 26 15:55:48 2022
-    user: centos
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Tue Apr 26 15:54:05 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1140
-    port: 22
-    protocol: tcp
-    stime: Tue Apr 26 15:54:48 2022
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: Telegraf
+  version:
+  - number: 1.11.3
+    type: package
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 976
-    port: 68
-    protocol: udp
-    stime: Tue Apr 26 15:54:43 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:54:05 2022
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 743
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:54:30 2022
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.12
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  keepalived:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 16.el7
+    source: rpm
+    version: 1.3.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-devel:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-devel
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsepol-devel:
+  - arch: x86_64
+    epoch: null
+    name: libsepol-devel
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mariadb-server:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-server
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 48.el7_8.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 48.el7_8.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcre-devel:
+  - arch: x86_64
+    epoch: null
+    name: pcre-devel
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Compress-Raw-Bzip2:
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
+  perl-Compress-Raw-Zlib:
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
+  perl-DBD-MySQL:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBD-MySQL
+    release: 6.el7
+    source: rpm
+    version: '4.023'
+  perl-DBI:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBI
+    release: 4.el7
+    source: rpm
+    version: '1.627'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-IO-Compress:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
+  perl-Net-Daemon:
+  - arch: noarch
+    epoch: null
+    name: perl-Net-Daemon
+    release: 5.el7
+    source: rpm
+    version: '0.48'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-PlRPC:
+  - arch: noarch
+    epoch: null
+    name: perl-PlRPC
+    release: 14.el7
+    source: rpm
+    version: '0.2020'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 720
-    port: 837
-    protocol: udp
-    stime: Tue Apr 26 15:54:29 2022
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  socat:
+  - arch: x86_64
+    epoch: null
+    name: socat
+    release: 2.el7
+    source: rpm
+    version: 1.7.3.2
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Tue Apr 26 15:54:05 2022
-    user: root
-  - address: ::1
-    name: chronyd
-    pid: 743
-    port: 323
-    protocol: udp
-    stime: Tue Apr 26 15:54:30 2022
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 720
-    port: 837
-    protocol: udp
-    stime: Tue Apr 26 15:54:29 2022
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '40'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '93'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '173'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '174'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '301'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '306'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '377'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '390'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '391'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '392'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '393'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '394'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '395'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '396'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '477'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '516'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '541'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '673'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '704'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '720'
+  ppid: '1'
+  user: rpc
+- cmdline: ''
+  cwd: /
+  pid: '721'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '724'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '731'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '743'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '747'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H indexer01 eth0
+  cwd: /sbin/
+  pid: '976'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1037'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1038'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1042'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1128'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1136'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1140'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1152'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1153'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '1290'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '1291'
+  ppid: '1290'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '1292'
+  ppid: '1290'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1346'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1348'
+  ppid: '1346'
+  user: postfix
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '5992'
+  ppid: '1346'
+  user: postfix
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '6355'
+  ppid: '1140'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '6357'
+  ppid: '6355'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '6358'
+  ppid: '6357'
+  user: centos
+- cmdline: sudo su -
+  cwd: /
+  pid: '6377'
+  ppid: '6358'
+  user: root
+- cmdline: su -
+  cwd: /
+  pid: '6378'
+  ppid: '6377'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '6379'
+  ppid: '6378'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '6498'
+  ppid: '1140'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '6500'
+  ppid: '6498'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '6501'
+  ppid: '6500'
+  user: centos
+- cmdline: sudo su
+  cwd: /
+  pid: '6520'
+  ppid: '6501'
+  user: root
+- cmdline: su
+  cwd: /
+  pid: '6521'
+  ppid: '6520'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '6522'
+  ppid: '6521'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9862bb798ebd9d7b493ab206bcf992110f2b0cf258625d0098d44dbf79f14939
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '6905'
+  ppid: '1042'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/1a479a2904bd47f97639f46aa6a81740fc7c4273785245fcb85e73692dcd85a8
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '6923'
+  ppid: '1042'
+  user: root
+- cmdline: redis-server 0.0.0.0:6379
+  cwd: /
+  pid: '7054'
+  ppid: '6905'
+  user: polkitd
+- cmdline: /bin/java -Xms2048m -Xmx2048m -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75
+    -XX:+UseCMSInitiatingOccupancyOnly -Djava.awt.headless=true -Dfile.encoding=UTF-8
+    -Djruby.compile.invokedynamic=true -Djruby.jit.threshold=0 -Djruby.regexp.interruptible=true
+    -Djava.security.egd=file:/dev/urandom -Dlog4j2.isThreadContextMapInheritable=true
+    -Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ -cp /usr/share/logstash/logstash-core/lib/jars/animal-sniffer-annotations-1.14.jar:/usr/share/logstash/logstash-core/lib/jars/commons-codec-1.11.jar:/usr/share/logstash/logstash-core/lib/jars/commons-compiler-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/error_prone_annotations-2.0.18.jar:/usr/share/logstash/logstash-core/lib/jars/google-java-format-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/gradle-license-report-0.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/guava-22.0.jar:/usr/share/logstash/logstash-core/lib/jars/j2objc-annotations-1.1.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-annotations-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-core-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-databind-2.9.9.3.jar:/usr/share/logstash/logstash-core/lib/jars/jackson-dataformat-cbor-2.9.9.jar:/usr/share/logstash/logstash-core/lib/jars/janino-3.0.11.jar:/usr/share/logstash/logstash-core/lib/jars/javassist-3.24.0-GA.jar:/usr/share/logstash/logstash-core/lib/jars/jruby-complete-9.2.8.0.jar:/usr/share/logstash/logstash-core/lib/jars/jsr305-1.3.9.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-api-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-core-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/log4j-slf4j-impl-2.11.1.jar:/usr/share/logstash/logstash-core/lib/jars/logstash-core.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.commands-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.contenttype-3.4.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.expressions-3.4.300.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.filesystem-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.jobs-3.5.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.resources-3.7.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.core.runtime-3.7.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.app-1.3.100.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.common-3.6.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.preferences-3.4.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.equinox.registry-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.jdt.core-3.10.0.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.osgi-3.7.1.jar:/usr/share/logstash/logstash-core/lib/jars/org.eclipse.text-3.5.101.jar:/usr/share/logstash/logstash-core/lib/jars/reflections-0.9.11.jar:/usr/share/logstash/logstash-core/lib/jars/slf4j-api-1.7.25.jar
+    org.logstash.Logstash
+  cwd: /bin/
+  pid: '7056'
+  ppid: '6923'
+  user: centos
+- cmdline: /usr/bin/docker start -a redis
+  cwd: /usr/bin/
+  pid: '7301'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a logstash
+  cwd: /usr/bin/
+  pid: '7302'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9991'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10499'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '10621'
+  ppid: '1140'
+  user: root
+- cmdline: 'sshd: centos@pts/2'
+  cwd: /
+  pid: '10623'
+  ppid: '10621'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-fycgcczmjzstmyjtsypgvyikyuztgdmf
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657010524.7502332-47502-26399721902610/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '10809'
+  ppid: '10623'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-fycgcczmjzstmyjtsypgvyikyuztgdmf
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657010524.7502332-47502-26399721902610/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '10824'
+  ppid: '10809'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-fycgcczmjzstmyjtsypgvyikyuztgdmf ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1657010524.7502332-47502-26399721902610/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '10825'
+  ppid: '10824'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1657010524.7502332-47502-26399721902610/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '10826'
+  ppid: '10825'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19599'
+  ppid: '2'
+  user: root
+- cmdline: bash
+  cwd: /
+  pid: '24140'
+  ppid: '6905'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26607'
+  ppid: '2'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/17a3a79c81749efed9a2772c171a6c127dc178f04f49b95aff4cb21597b8738e
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '28010'
+  ppid: '1042'
+  user: root
+- cmdline: /bin/sh -c python ./listener.py
+  cwd: /bin/
+  pid: '28025'
+  ppid: '28010'
+  user: root
+- cmdline: python ./listener.py
+  cwd: /
+  pid: '28039'
+  ppid: '28025'
+  user: root
+software_list:
+- cmd_regexp: /usr/bin/telegraf
+  name: Telegraf
+  pkg_regexp: telegraf|iometrics-agent
+  process_type: parent
+  return_children: false
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1346
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:54:56 2022
+  user: root
+- address: 0.0.0.0
+  name: redis-server
+  pid: 7054
+  port: 6378
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: polkitd
+- address: 0.0.0.0
+  name: redis-server
+  pid: 7054
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: polkitd
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1140
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:54:48 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1346
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:54:56 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 7056
+  port: 5055
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: centos
+- address: '::'
+  name: java
+  pid: 7056
+  port: 9600
+  protocol: tcp
+  stime: Tue Apr 26 15:55:48 2022
+  user: centos
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1140
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:54:48 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 976
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:54:43 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 743
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:30 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 720
+  port: 837
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:05 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 743
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:30 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 720
+  port: 837
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/tomcat/docker.yaml
+++ b/tests/unit/plugins/action/auto/resources/tomcat/docker.yaml
@@ -1,6536 +1,6739 @@
-software_list:
-  - name: Apache Tomcat Servlet Engine
-    cmd_regexp: \.apache\.tomcat\.startup|\.apache\.catalina\.startup
-    pkg_regexp: tomcat
-    process_type: child
-    return_children: true
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
-    pid: '1'
-    ppid: '0'
-    user: 'root'
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: 'root'
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '49'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '50'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '51'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '52'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '53'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '54'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '55'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '57'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '58'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '65'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '66'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '68'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '76'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '78'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '79'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '81'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '83'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '98'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '136'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '283'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '298'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '299'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '300'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '302'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '305'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '306'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '308'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '309'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '310'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '311'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '312'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '313'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '314'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '315'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '316'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '317'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '318'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '319'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '320'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '321'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '322'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '323'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '324'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '325'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '326'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '327'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '328'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '329'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '330'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '331'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '332'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '333'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '334'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '335'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '338'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '339'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '340'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '341'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '342'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '343'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '344'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '345'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '346'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '347'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '348'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '349'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '350'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '351'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '352'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '353'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '354'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '355'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '356'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '357'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '358'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '359'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '360'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '361'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '362'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '363'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '364'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '405'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '406'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '420'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '427'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '428'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '429'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '430'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '431'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '432'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '433'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '434'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '435'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '436'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '437'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '438'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '518'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '552'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '607'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '608'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '611'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '612'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '613'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '614'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '615'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '623'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /sbin/auditd
-    pid: '682'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/bin/VGAuthService -s
-    pid: '705'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/bin/vmtoolsd
-    pid: '706'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '708'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '710'
-    ppid: '1'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '713'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/chronyd
-    pid: '719'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/NetworkManager --no-daemon
-    pid: '732'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '734'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/crond -n
-    pid: '738'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '813'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f
-    pid: '999'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1002'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1004'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1005'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1186'
-    ppid: '1'
-    user: 'root'
-  - cmdline: qmgr -l -t unix -u
-    pid: '1207'
-    ppid: '1186'
-    user: 'root'
-  - cmdline: ''
-    pid: '1467'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '1489'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '1498'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '1521'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '2185'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '3002'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '9403'
-    ppid: '2'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d -address
-      /run/containerd/containerd.sock
-    pid: '20044'
-    ppid: '1'
-    user: 'root'
-  - cmdline: 'redis-server 0.0.0.0:6379'
-    pid: '20064'
-    ppid: '20044'
-    user: 'root'
-  - cmdline: /usr/bin/docker start -a redis
-    pid: '20366'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '20383'
-    ppid: '2'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb -address
-      /run/containerd/containerd.sock
-    pid: '23319'
-    ppid: '1'
-    user: 'root'
-  - cmdline: 'nginx: master process nginx -g daemon off;'
-    pid: '23339'
-    ppid: '23319'
-    user: 'root'
-  - cmdline: 'nginx: worker process'
-    pid: '23356'
-    ppid: '23339'
-    user: 'root'
-  - cmdline: /usr/bin/docker start -a nginx
-    pid: '23581'
-    ppid: '1'
-    user: 'root'
-  - cmdline: SCREEN
-    pid: '24403'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /bin/bash
-    pid: '24404'
-    ppid: '24403'
-    user: 'root'
-  - cmdline: ''
-    pid: '25635'
-    ppid: '2'
-    user: 'root'
-  - cmdline: sudo -u postgres psql
-    pid: '28523'
-    ppid: '24404'
-    user: 'root'
-  - cmdline: psql
-    pid: '28524'
-    ppid: '28523'
-    user: 'root'
-  - cmdline: /usr/bin/docker start -a iometrics-cmdb-gateway
-    pid: '28556'
-    ppid: '1'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42 -address
-      /run/containerd/containerd.sock
-    pid: '28596'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /bin/sh -c ./start_cmdb_gateway.sh
-    pid: '28617'
-    ppid: '28596'
-    user: 'root'
-  - cmdline: /bin/sh ./start_cmdb_gateway.sh
-    pid: '28631'
-    ppid: '28617'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28633'
-    ppid: '28631'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28635'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28637'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28638'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28639'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28640'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28641'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28642'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/bin/python /usr/local/bin/gunicorn
-      --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app
-    pid: '28643'
-    ppid: '28633'
-    user: 'root'
-  - cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
-    pid: '28694'
-    ppid: '1'
-    user: 'root'
-  - cmdline: 'postgres: data: checkpointer process'
-    pid: '28697'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: writer process'
-    pid: '28698'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: wal writer process'
-    pid: '28699'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: autovacuum launcher process'
-    pid: '28700'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: stats collector process'
-    pid: '28701'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: bgworker: logical replication launcher'
-    pid: '28702'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: /usr/bin/docker start -a iometrics-cmdbuild
-    pid: '30649'
-    ppid: '1'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443
-      -container-ip 192.168.1.2 -container-port 8443
-    pid: '30674'
-    ppid: '60677'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187 -address
-      /run/containerd/containerd.sock
-    pid: '30689'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
-    pid: '30709'
-    ppid: '30689'
-    user: 'root'
-  - cmdline: >-
-      /usr/local/openjdk-17/bin/java
-      -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      -Xmx7876m -Xms3846m -Djdk.tls.ephemeralDHKeySize=2048
-      -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
-      -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
-      -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
-      -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar
-      -Delastic.apm.service_name=cmdb
-      -Delastic.apm.server_url=http://192.168.8.53:8200
-      -Delastic.apm.environment=dev -Delastic.apm.enabled=true
-      -Delastic.apm.profiling_inferred_spans_enabled=true
-      -Delastic.apm.profiling_inferred_spans_min_duration=250ms
-      -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
-      -Dignore.endorsed.dirs= -classpath
-      /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
-      -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat
-      -Djava.io.tmpdir=/usr/local/tomcat/temp
-      org.apache.catalina.startup.Bootstrap start
-    pid: '30748'
-    ppid: '30709'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42292) idle'
-    pid: '30959'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00 -address
-      /run/containerd/containerd.sock
-    pid: '34186'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /bin/sh -c python ./listener.py
-    pid: '34206'
-    ppid: '34186'
-    user: 'root'
-  - cmdline: python ./listener.py
-    pid: '34220'
-    ppid: '34206'
-    user: 'root'
-  - cmdline: ''
-    pid: '44075'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '45038'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '46732'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '46733'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '46865'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /sbin/rpcbind -w
-    pid: '47374'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '47383'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '47397'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47398'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/sbin/rpc.statd
-    pid: '47406'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/rpc.idmapd
-    pid: '47408'
-    ppid: '1'
-    user: 'root'
-  - cmdline: /usr/sbin/rpc.mountd
-    pid: '47410'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '47415'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47416'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47421'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47422'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47423'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47424'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47425'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47426'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47427'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '47428'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '49443'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '50335'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/bin/containerd
-    pid: '54568'
-    ppid: '1'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33168) idle'
-    pid: '57218'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33436) idle'
-    pid: '58454'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33512) idle'
-    pid: '58550'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33562) idle'
-    pid: '58612'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33642) idle'
-    pid: '58724'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33660) idle'
-    pid: '58766'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33720) idle'
-    pid: '58872'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33738) idle'
-    pid: '58949'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33766) idle'
-    pid: '59000'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33772) idle'
-    pid: '59003'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33778) idle'
-    pid: '59006'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33782) idle'
-    pid: '59008'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33788) idle'
-    pid: '59017'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33790) idle'
-    pid: '59018'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: ''
-    pid: '59036'
-    ppid: '2'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33792) idle'
-    pid: '59049'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33796) idle'
-    pid: '59051'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33798) idle'
-    pid: '59052'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33804) idle'
-    pid: '59064'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33808) idle'
-    pid: '59071'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33810) idle'
-    pid: '59077'
-    ppid: '28694'
-    user: 'root'
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '60677'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '61265'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61266'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61267'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61268'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61269'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61270'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61271'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '61272'
-    ppid: '2'
-    user: 'root'
-  - cmdline: pickup -l -t unix -u
-    pid: '62178'
-    ppid: '1186'
-    user: 'root'
-  - cmdline: ''
-    pid: '63141'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '67115'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /opt/fireeye/bin/xagt -M DAEMON
-    pid: '69963'
-    ppid: '1'
-    user: 'root'
-  - cmdline: >-
-      /opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT
-      --logfd 4
-    pid: '69987'
-    ppid: '69963'
-    user: 'root'
-  - cmdline: 'sshd: root@pts/0'
-    pid: '71236'
-    ppid: '1005'
-    user: 'root'
-  - cmdline: '-bash'
-    pid: '71238'
-    ppid: '71236'
-    user: 'root'
-  - cmdline: ''
-    pid: '72571'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '73404'
-    ppid: '2'
-    user: 'root'
-  - cmdline: /usr/sbin/mariadbd
-    pid: '73979'
-    ppid: '1'
-    user: 'root'
-  - cmdline: ''
-    pid: '75161'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '76377'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '77796'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '78673'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '79907'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '80858'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '81582'
-    ppid: '2'
-    user: 'root'
-  - cmdline: ''
-    pid: '83325'
-    ppid: '2'
-    user: 'root'
-  - cmdline: 'sshd: root@pts/2'
-    pid: '83787'
-    ppid: '1005'
-    user: 'root'
-  - cmdline: ''
-    pid: '83867'
-    ppid: '2'
-    user: 'root'
-  - cmdline: >-
-      /bin/sh -c /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1651076211.87958-95939-60303799464658/AnsiballZ_process_facts.py
-      && sleep 0
-    pid: '83946'
-    ppid: '83787'
-    user: 'root'
-  - cmdline: >-
-      /usr/bin/python
-      /root/.ansible/tmp/ansible-tmp-1651076211.87958-95939-60303799464658/AnsiballZ_process_facts.py
-    pid: '83959'
-    ppid: '83946'
-    user: 'root'
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
-  MariaDB-client:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-client
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
-  MariaDB-common:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-common
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
-  MariaDB-compat:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-compat
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
-  MariaDB-server:
-    - arch: x86_64
-      epoch: null
-      name: MariaDB-server
-      release: 1.el7.centos
-      source: rpm
-      version: 10.5.10
-  NetworkManager:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
-  NetworkManager-libnm:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-libnm
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
-  NetworkManager-team:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-team
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
-  NetworkManager-tui:
-    - arch: x86_64
-      epoch: 1
-      name: NetworkManager-tui
-      release: 2.el7_9
-      source: rpm
-      version: 1.18.8
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  aic94xx-firmware:
-    - arch: noarch
-      epoch: null
-      name: aic94xx-firmware
-      release: 6.el7
-      source: rpm
-      version: '30'
-  alsa-firmware:
-    - arch: noarch
-      epoch: null
-      name: alsa-firmware
-      release: 2.el7
-      source: rpm
-      version: 1.0.28
-  alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
-  alsa-tools-firmware:
-    - arch: x86_64
-      epoch: null
-      name: alsa-tools-firmware
-      release: 1.el7
-      source: rpm
-      version: 1.1.0
-  apr:
-    - arch: x86_64
-      epoch: null
-      name: apr
-      release: 7.el7
-      source: rpm
-      version: 1.4.8
-  apr-util:
-    - arch: x86_64
-      epoch: null
-      name: apr-util
-      release: 6.el7
-      source: rpm
-      version: 1.5.2
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autoconf:
-    - arch: noarch
-      epoch: null
-      name: autoconf
-      release: 11.el7
-      source: rpm
-      version: '2.69'
-  automake:
-    - arch: noarch
-      epoch: null
-      name: automake
-      release: 3.el7
-      source: rpm
-      version: 1.13.4
-  avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 34.el7
-      source: rpm
-      version: 4.2.46
-  bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.5
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.7
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7
-      source: rpm
-      version: '2.27'
-  biosdevname:
-    - arch: x86_64
-      epoch: null
-      name: biosdevname
-      release: 2.el7
-      source: rpm
-      version: 0.7.3
-  bison:
-    - arch: x86_64
-      epoch: null
-      name: bison
-      release: 2.el7
-      source: rpm
-      version: 3.0.4
-  boost-date-time:
-    - arch: x86_64
-      epoch: null
-      name: boost-date-time
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
-  boost-program-options:
-    - arch: x86_64
-      epoch: null
-      name: boost-program-options
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
-  boost-system:
-    - arch: x86_64
-      epoch: null
-      name: boost-system
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
-  boost-thread:
-    - arch: x86_64
-      epoch: null
-      name: boost-thread
-      release: 28.el7
-      source: rpm
-      version: 1.53.0
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  byacc:
-    - arch: x86_64
-      epoch: null
-      name: byacc
-      release: 3.el7
-      source: rpm
-      version: 1.9.20130304
-  bzip2:
-    - arch: x86_64
-      epoch: null
-      name: bzip2
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  c-ares:
-    - arch: x86_64
-      epoch: null
-      name: c-ares
-      release: 3.el7
-      source: rpm
-      version: 1.10.0
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_8
-      source: rpm
-      version: 2020.2.41
-  centos-logos:
-    - arch: noarch
-      epoch: null
-      name: centos-logos
-      release: 3.el7.centos
-      source: rpm
-      version: 70.0.6
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.4.4
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
-  cpp:
-    - arch: x86_64
-      epoch: null
-      name: cpp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 23.el7
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
-  cscope:
-    - arch: x86_64
-      epoch: null
-      name: cscope
-      release: 10.el7
-      source: rpm
-      version: '15.8'
-  ctags:
-    - arch: x86_64
-      epoch: null
-      name: ctags
-      release: 13.el7
-      source: rpm
-      version: '5.8'
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
-  device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 3.el7_9.2
-      source: rpm
-      version: 0.8.5
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffstat:
-    - arch: x86_64
-      epoch: null
-      name: diffstat
-      release: 4.el7
-      source: rpm
-      version: '1.57'
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
-  docker-ce-rootless-extras:
-    - arch: x86_64
-      epoch: 0
-      name: docker-ce-rootless-extras
-      release: 3.el7
-      source: rpm
-      version: 20.10.6
-  docker-scan-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-scan-plugin
-      release: 3.el7
-      source: rpm
-      version: 0.7.0
-  doxygen:
-    - arch: x86_64
-      epoch: 1
-      name: doxygen
-      release: 4.el7
-      source: rpm
-      version: 1.8.5
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dwz:
-    - arch: x86_64
-      epoch: null
-      name: dwz
-      release: 3.el7
-      source: rpm
-      version: '0.11'
-  dyninst:
-    - arch: x86_64
-      epoch: null
-      name: dyninst
-      release: 3.el7
-      source: rpm
-      version: 9.3.1
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  ebtables:
-    - arch: x86_64
-      epoch: null
-      name: ebtables
-      release: 16.el7
-      source: rpm
-      version: 2.0.10
-  efivar-libs:
-    - arch: x86_64
-      epoch: null
-      name: efivar-libs
-      release: 12.el7
-      source: rpm
-      version: '36'
-  elfutils:
-    - arch: x86_64
-      epoch: null
-      name: elfutils
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  emacs-filesystem:
-    - arch: noarch
-      epoch: 1
-      name: emacs-filesystem
-      release: 23.el7
-      source: rpm
-      version: '24.3'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '13'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  firewalld:
-    - arch: noarch
-      epoch: null
-      name: firewalld
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
-  firewalld-filesystem:
-    - arch: noarch
-      epoch: null
-      name: firewalld-filesystem
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
-  flex:
-    - arch: x86_64
-      epoch: null
-      name: flex
-      release: 6.el7
-      source: rpm
-      version: 2.5.37
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fuse:
-    - arch: x86_64
-      epoch: null
-      name: fuse
-      release: 11.el7
-      source: rpm
-      version: 2.9.2
-  fuse-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-libs
-      release: 11.el7
-      source: rpm
-      version: 2.9.2
-  fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
-  fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
-  fxload:
-    - arch: x86_64
-      epoch: null
-      name: fxload
-      release: 16.el7
-      source: rpm
-      version: '2002_04_11'
-  galera-4:
-    - arch: x86_64
-      epoch: null
-      name: galera-4
-      release: 1.el7.centos
-      source: rpm
-      version: 26.4.8
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gcc:
-    - arch: x86_64
-      epoch: null
-      name: gcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gcc-c++:
-    - arch: x86_64
-      epoch: null
-      name: gcc-c++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gcc-gfortran:
-    - arch: x86_64
-      epoch: null
-      name: gcc-gfortran
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  gdb:
-    - arch: x86_64
-      epoch: null
-      name: gdb
-      release: 120.el7
-      source: rpm
-      version: 7.6.1
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-common-devel:
-    - arch: noarch
-      epoch: null
-      name: gettext-common-devel
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-devel:
-    - arch: x86_64
-      epoch: null
-      name: gettext-devel
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  git:
-    - arch: x86_64
-      epoch: null
-      name: git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 8.el7
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 324.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gnutls:
-    - arch: x86_64
-      epoch: null
-      name: gnutls
-      release: 9.el7_6
-      source: rpm
-      version: 3.3.29
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 511147a9
-      source: rpm
-      version: 1bb943db
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 608c8351
-      source: rpm
-      version: 442df0f8
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.6
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  htop:
-    - arch: x86_64
-      epoch: null
-      name: htop
-      release: 3.el7
-      source: rpm
-      version: 2.2.0
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  indent:
-    - arch: x86_64
-      epoch: null
-      name: indent
-      release: 13.el7
-      source: rpm
-      version: 2.2.11
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  intltool:
-    - arch: noarch
-      epoch: null
-      name: intltool
-      release: 7.el7
-      source: rpm
-      version: 0.50.2
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iprutils:
-    - arch: x86_64
-      epoch: null
-      name: iprutils
-      release: 3.el7_7
-      source: rpm
-      version: 2.4.17.1
-  ipset:
-    - arch: x86_64
-      epoch: null
-      name: ipset
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  ipset-libs:
-    - arch: x86_64
-      epoch: null
-      name: ipset-libs
-      release: 1.el7
-      source: rpm
-      version: '7.1'
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  ivtv-firmware:
-    - arch: noarch
-      epoch: 2
-      name: ivtv-firmware
-      release: 26.el7
-      source: rpm
-      version: '20080701'
-  iwl100-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl100-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
-  iwl1000-firmware:
-    - arch: noarch
-      epoch: 1
-      name: iwl1000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 39.31.5.1
-  iwl105-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl105-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl135-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl135-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl2000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl2030-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl2030-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl3160-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3160-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
-  iwl3945-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl3945-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 15.32.2.9
-  iwl4965-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl4965-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 228.61.2.24
-  iwl5000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.83.5.1_1
-  iwl5150-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl5150-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 8.24.2.2
-  iwl6000-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 9.221.4.1
-  iwl6000g2a-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2a-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl6000g2b-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6000g2b-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 18.168.6.1
-  iwl6050-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl6050-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 41.28.5.1
-  iwl7260-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7260-firmware
-      release: 80.el7_9
-      source: rpm
-      version: 25.30.13.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jnettop:
-    - arch: x86_64
-      epoch: null
-      name: jnettop
-      release: 16.el7
-      source: rpm
-      version: 0.13.0
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.21.3.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 862.9.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.10.1.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.15.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-debug-devel:
-    - arch: x86_64
-      epoch: null
-      name: kernel-debug-devel
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.2
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 134.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 50.el7
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libbsd:
-    - arch: x86_64
-      epoch: null
-      name: libbsd
-      release: 1.el7
-      source: rpm
-      version: 0.8.3
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdnet:
-    - arch: x86_64
-      epoch: null
-      name: libdnet
-      release: 13.1.el7
-      source: rpm
-      version: '1.12'
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libdwarf:
-    - arch: x86_64
-      epoch: null
-      name: libdwarf
-      release: 4.el7
-      source: rpm
-      version: '20130207'
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgfortran:
-    - arch: x86_64
-      epoch: null
-      name: libgfortran
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmodman:
-    - arch: x86_64
-      epoch: null
-      name: libmodman
-      release: 8.el7
-      source: rpm
-      version: 2.0.1
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libmpc:
-    - arch: x86_64
-      epoch: null
-      name: libmpc
-      release: 3.el7
-      source: rpm
-      version: 1.0.1
-  libmspack:
-    - arch: x86_64
-      epoch: null
-      name: libmspack
-      release: 0.8.alpha.el7
-      source: rpm
-      version: '0.5'
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libproxy:
-    - arch: x86_64
-      epoch: null
-      name: libproxy
-      release: 11.el7
-      source: rpm
-      version: 0.4.11
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libquadmath:
-    - arch: x86_64
-      epoch: null
-      name: libquadmath
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libquadmath-devel:
-    - arch: x86_64
-      epoch: null
-      name: libquadmath-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libretls:
-    - arch: x86_64
-      epoch: null
-      name: libretls
-      release: 1.el7
-      source: rpm
-      version: 3.4.1
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libsmi:
-    - arch: x86_64
-      epoch: null
-      name: libsmi
-      release: 13.el7
-      source: rpm
-      version: 0.4.8
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libstdc++-devel:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++-devel
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libtool:
-    - arch: x86_64
-      epoch: null
-      name: libtool
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libtool-ltdl:
-    - arch: x86_64
-      epoch: null
-      name: libtool-ltdl
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7.5
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7.5
-      source: rpm
-      version: 2.9.1
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lsof:
-    - arch: x86_64
-      epoch: null
-      name: lsof
-      release: 6.el7
-      source: rpm
-      version: '4.87'
-  lsscsi:
-    - arch: x86_64
-      epoch: null
-      name: lsscsi
-      release: 6.el7
-      source: rpm
-      version: '0.27'
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 2.02.187
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  m4:
-    - arch: x86_64
-      epoch: null
-      name: m4
-      release: 10.el7
-      source: rpm
-      version: 1.4.16
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.8.el7_9
-      source: rpm
-      version: '2.1'
-  mokutil:
-    - arch: x86_64
-      epoch: null
-      name: mokutil
-      release: 8.el7
-      source: rpm
-      version: '15'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  mpfr:
-    - arch: x86_64
-      epoch: null
-      name: mpfr
-      release: 4.el7
-      source: rpm
-      version: 3.1.1
-  nagios-common:
-    - arch: x86_64
-      epoch: null
-      name: nagios-common
-      release: 4.el7
-      source: rpm
-      version: 4.4.6
-  nagios-plugins:
-    - arch: x86_64
-      epoch: null
-      name: nagios-plugins
-      release: 2.el7
-      source: rpm
-      version: 2.3.3
-  nagios-plugins-perl:
-    - arch: x86_64
-      epoch: null
-      name: nagios-plugins-perl
-      release: 2.el7
-      source: rpm
-      version: 2.3.3
-  nano:
-    - arch: x86_64
-      epoch: null
-      name: nano
-      release: 10.el7
-      source: rpm
-      version: 2.3.1
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  neon:
-    - arch: x86_64
-      epoch: null
-      name: neon
-      release: 4.el7
-      source: rpm
-      version: 0.30.0
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  netcat:
-    - arch: x86_64
-      epoch: null
-      name: netcat
-      release: 2.el7
-      source: rpm
-      version: '1.218'
-  nettle:
-    - arch: x86_64
-      epoch: null
-      name: nettle
-      release: 9.el7_9
-      source: rpm
-      version: 2.7.1
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7
-      source: rpm
-      version: 1.3.0
-  nrpe:
-    - arch: x86_64
-      epoch: null
-      name: nrpe
-      release: 6.el7
-      source: rpm
-      version: 4.0.3
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 2.el7_9
-      source: rpm
-      version: 4.25.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 6.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 6.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.el7_9
-      source: rpm
-      version: 3.53.1
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.53.1
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  open-vm-tools:
-    - arch: x86_64
-      epoch: null
-      name: open-vm-tools
-      release: 3.el7_9.3
-      source: rpm
-      version: 11.0.5
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 23.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 21.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 21.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 21.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl11-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl11-libs
-      release: 3.el7
-      source: rpm
-      version: 1.1.1g
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pakchois:
-    - arch: x86_64
-      epoch: null
-      name: pakchois
-      release: 10.el7
-      source: rpm
-      version: '0.4'
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  patch:
-    - arch: x86_64
-      epoch: null
-      name: patch
-      release: 12.el7_7
-      source: rpm
-      version: 2.7.1
-  patchutils:
-    - arch: x86_64
-      epoch: null
-      name: patchutils
-      release: 5.el7_9
-      source: rpm
-      version: 0.3.3
-  pciutils:
-    - arch: x86_64
-      epoch: null
-      name: pciutils
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcre2:
-    - arch: x86_64
-      epoch: null
-      name: pcre2
-      release: 2.el7
-      source: rpm
-      version: '10.23'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Compress-Raw-Bzip2:
-    - arch: x86_64
-      epoch: null
-      name: perl-Compress-Raw-Bzip2
-      release: 3.el7
-      source: rpm
-      version: '2.061'
-  perl-Compress-Raw-Zlib:
-    - arch: x86_64
-      epoch: 1
-      name: perl-Compress-Raw-Zlib
-      release: 4.el7
-      source: rpm
-      version: '2.061'
-  perl-DBD-MySQL:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBD-MySQL
-      release: 6.el7
-      source: rpm
-      version: '4.023'
-  perl-DBI:
-    - arch: x86_64
-      epoch: null
-      name: perl-DBI
-      release: 4.el7
-      source: rpm
-      version: '1.627'
-  perl-Data-Dumper:
-    - arch: x86_64
-      epoch: null
-      name: perl-Data-Dumper
-      release: 3.el7
-      source: rpm
-      version: '2.145'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Error:
-    - arch: noarch
-      epoch: 1
-      name: perl-Error
-      release: 2.el7
-      source: rpm
-      version: '0.17020'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-Git:
-    - arch: noarch
-      epoch: null
-      name: perl-Git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-IO-Compress:
-    - arch: noarch
-      epoch: null
-      name: perl-IO-Compress
-      release: 2.el7
-      source: rpm
-      version: '2.061'
-  perl-Net-Daemon:
-    - arch: noarch
-      epoch: null
-      name: perl-Net-Daemon
-      release: 5.el7
-      source: rpm
-      version: '0.48'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-PlRPC:
-    - arch: noarch
-      epoch: null
-      name: perl-PlRPC
-      release: 14.el7
-      source: rpm
-      version: '0.2020'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 299.el7_9
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Sys-Statistics-Linux:
-    - arch: noarch
-      epoch: null
-      name: perl-Sys-Statistics-Linux
-      release: 14.el7
-      source: rpm
-      version: '0.66'
-  perl-TermReadKey:
-    - arch: x86_64
-      epoch: null
-      name: perl-TermReadKey
-      release: 20.el7
-      source: rpm
-      version: '2.30'
-  perl-Test-Harness:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Harness
-      release: 3.el7
-      source: rpm
-      version: '3.28'
-  perl-Test-Simple:
-    - arch: noarch
-      epoch: null
-      name: perl-Test-Simple
-      release: 243.el7
-      source: rpm
-      version: '0.98'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Thread-Queue:
-    - arch: noarch
-      epoch: null
-      name: perl-Thread-Queue
-      release: 2.el7
-      source: rpm
-      version: '3.02'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-XML-Parser:
-    - arch: x86_64
-      epoch: null
-      name: perl-XML-Parser
-      release: 10.el7
-      source: rpm
-      version: '2.41'
-  perl-YAML-Syck:
-    - arch: x86_64
-      epoch: null
-      name: perl-YAML-Syck
-      release: 3.el7
-      source: rpm
-      version: '1.27'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 299.el7_9
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: perl-srpm-macros
-      release: 8.el7
-      source: rpm
-      version: '1'
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  plymouth:
-    - arch: x86_64
-      epoch: null
-      name: plymouth
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
-  plymouth-core-libs:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-core-libs
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
-  plymouth-scripts:
-    - arch: x86_64
-      epoch: null
-      name: plymouth-scripts
-      release: 0.34.20140113.el7.centos
-      source: rpm
-      version: 0.8.9
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql:
-    - arch: x86_64
-      epoch: null
-      name: postgresql
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-devel:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-devel
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 6.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql10:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
-  postgresql10-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-contrib
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
-  postgresql10-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-libs
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
-  postgresql10-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql10-server
-      release: 1PGDG.rhel7
-      source: rpm
-      version: '10.17'
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 17.el7
-      source: rpm
-      version: '22.20'
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-firewall:
-    - arch: noarch
-      epoch: null
-      name: python-firewall
-      release: 13.el7_9
-      source: rpm
-      version: 0.6.3
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.25.1.el7
-      source: rpm
-      version: 3.10.0
-  python-psycopg2:
-    - arch: x86_64
-      epoch: null
-      name: python-psycopg2
-      release: 1.rhel7
-      source: rpm
-      version: 2.7.5
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-slip:
-    - arch: noarch
-      epoch: null
-      name: python-slip
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-slip-dbus:
-    - arch: noarch
-      epoch: null
-      name: python-slip-dbus
-      release: 4.el7
-      source: rpm
-      version: 0.4.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-devel:
-    - arch: x86_64
-      epoch: null
-      name: python3-devel
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-rpm-generators:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-generators
-      release: 2.el7
-      source: rpm
-      version: '6'
-  python3-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python3-rpm-macros
-      release: 34.el7
-      source: rpm
-      version: '3'
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  rcs:
-    - arch: x86_64
-      epoch: null
-      name: rcs
-      release: 7.el7
-      source: rpm
-      version: 5.9.0
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redhat-rpm-config:
-    - arch: noarch
-      epoch: null
-      name: redhat-rpm-config
-      release: 88.el7.centos
-      source: rpm
-      version: 9.1.0
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rpm-sign:
-    - arch: x86_64
-      epoch: null
-      name: rpm-sign
-      release: 45.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.27.20120314git3c2946.el7_9
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  socat:
-    - arch: x86_64
-      epoch: null
-      name: socat
-      release: 2.el7
-      source: rpm
-      version: 1.7.3.2
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 6.el7
-      source: rpm
-      version: '4.24'
-  subversion:
-    - arch: x86_64
-      epoch: null
-      name: subversion
-      release: 16.el7
-      source: rpm
-      version: 1.7.14
-  subversion-libs:
-    - arch: x86_64
-      epoch: null
-      name: subversion-libs
-      release: 16.el7
-      source: rpm
-      version: 1.7.14
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.1
-      source: rpm
-      version: 1.8.23
-  swig:
-    - arch: x86_64
-      epoch: null
-      name: swig
-      release: 5.el7
-      source: rpm
-      version: 2.0.10
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.3
-      source: rpm
-      version: '219'
-  systemtap:
-    - arch: x86_64
-      epoch: null
-      name: systemtap
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-client:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-client
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-devel:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-devel
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  systemtap-runtime:
-    - arch: x86_64
-      epoch: null
-      name: systemtap-runtime
-      release: 13.el7
-      source: rpm
-      version: '4.0'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 66.el7
-      source: rpm
-      version: '0.17'
-  traceroute:
-    - arch: x86_64
-      epoch: 3
-      name: traceroute
-      release: 2.el7
-      source: rpm
-      version: 2.0.22
-  trousers:
-    - arch: x86_64
-      epoch: null
-      name: trousers
-      release: 2.el7
-      source: rpm
-      version: 0.3.14
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021a
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 21.el7
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  webtatic-release:
-    - arch: noarch
-      epoch: null
-      name: webtatic-release
-      release: '3'
-      source: rpm
-      version: '7'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wireshark:
-    - arch: x86_64
-      epoch: null
-      name: wireshark
-      release: 25.el7
-      source: rpm
-      version: 1.10.14
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xagt:
-    - arch: x86_64
-      epoch: null
-      name: xagt
-      release: 1.el7
-      source: rpm
-      version: 33.46.6
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xmlsec1:
-    - arch: x86_64
-      epoch: null
-      name: xmlsec1
-      release: 7.el7_4
-      source: rpm
-      version: 1.2.20
-  xmlsec1-openssl:
-    - arch: x86_64
-      epoch: null
-      name: xmlsec1-openssl
-      release: 7.el7_4
-      source: rpm
-      version: 1.2.20
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zip:
-    - arch: x86_64
-      epoch: null
-      name: zip
-      release: 11.el7
-      source: rpm
-      version: '3.0'
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-tcp_listen:
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1005
-    port: 22
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: 0.0.0.0
-    name: postmaster
-    pid: 28694
-    port: 5432
-    protocol: tcp
-    stime: 'Mon Apr 18 15:03:42 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1186
-    port: 25
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: 0.0.0.0
-    name: docker-proxy
-    pid: 30674
-    port: 8443
-    protocol: tcp
-    stime: 'Mon Apr 18 15:33:41 2022'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 46171
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 23339
-    port: 443
-    protocol: tcp
-    stime: 'Tue Jun  1 17:04:40 2021'
-    user: root
-  - address: 0.0.0.0
-    name: python
-    pid: 28633
-    port: 8444
-    protocol: tcp
-    stime: 'Mon Apr 18 15:03:28 2022'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: nrpe
-    pid: 999
-    port: 5666
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: nrpe
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 20064
-    port: 6378
-    protocol: tcp
-    stime: 'Tue May 25 11:00:31 2021'
-    user: polkitd
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 20064
-    port: 6379
-    protocol: tcp
-    stime: 'Tue May 25 11:00:31 2021'
-    user: polkitd
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 0.0.0.0
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: 0.0.0.0
-    name: rpc.statd
-    pid: 47406
-    port: 53648
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: 0.0.0.0
-    name: 'nginx:'
-    pid: 23339
-    port: 80
-    protocol: tcp
-    stime: 'Tue Jun  1 17:04:40 2021'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1005
-    port: 22
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1186
-    port: 25
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: root
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 40957
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: tcp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: nrpe
-    pid: 999
-    port: 5666
-    protocol: tcp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: nrpe
-  - address: '::'
-    name: mariadbd
-    pid: 73979
-    port: 3306
-    protocol: tcp
-    stime: 'Tue May 25 15:30:13 2021'
-    user: mysql
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: '::'
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: '::'
-    name: rpc.statd
-    pid: 47406
-    port: 47601
-    protocol: tcp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-udp_listen:
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: 0.0.0.0
-    name: ''
-    pid: 0
-    port: 59970
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: 0.0.0.0
-    name: rpc.statd
-    pid: 47406
-    port: 60822
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 719
-    port: 323
-    protocol: udp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 47374
-    port: 909
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: 127.0.0.1
-    name: rpc.statd
-    pid: 47406
-    port: 942
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 2049
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: rpc.mountd
-    pid: 47410
-    port: 20048
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: root
-  - address: '::'
-    name: rpc.statd
-    pid: 47406
-    port: 42219
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:09 2021'
-    user: rpcuser
-  - address: '::'
-    name: ''
-    pid: 0
-    port: 42799
-    protocol: udp
-    stime: ''
-    user: ''
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 111
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 719
-    port: 323
-    protocol: udp
-    stime: 'Fri May 21 08:55:20 2021'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 47374
-    port: 909
-    protocol: udp
-    stime: 'Fri Jul  9 14:12:03 2021'
-    user: rpc
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - /usr/local/bin/docker-entrypoint.sh
-        - catalina.sh
-        - run
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - catalina.sh
-          - run
-        Domainname: ''
-        Entrypoint:
-          - /bin/sh
-          - '-c'
-          - /usr/local/bin/docker-entrypoint.sh
-        Env:
-          - LANG=C.UTF-8
-          - >-
-            CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
-          - POSTGRES_PORT=5432
-          - CMDBUILD_DUMP=empty.dump.xz
-          - POSTGRES_HOST=192.168.64.34
-          - POSTGRES_PASS=xxxxxxxx
-          - JAVA_OPTS=-Xmx7876m -Xms3846m
-          - POSTGRES_DB=cmdbuild_r2u2
-          - >-
-            PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - TZ=Europe/Madrid
-          - POSTGRES_APP_USER=datadope
-          - POSTGRES_APP_PASSWORD=xxxxxxxx
-          - POSTGRES_USER=datadope
-          - JAVA_HOME=/usr/local/openjdk-17
-          - JAVA_VERSION=17.0.2
-          - CATALINA_HOME=/usr/local/tomcat
-          - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
-          - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
-          - >-
-            GPG_KEYS=48F8E69F6390C9F25CFEDCD268248959359E722B
-            A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
-            DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
-          - TOMCAT_MAJOR=9
-          - TOMCAT_VERSION=9.0.60
-          - >-
-            TOMCAT_SHA512=a4d43ac45f76e29d3dea23a2712c7570a11419aad7a1af2d1533454709c020b59666c7f9e063a77120224e0cbd4020cac06ca596dda7057cacb9a8a7e6d73eea
-          - >-
-            APM_JAR_URL=https://nexus.opensolutions.cloud/repository/datadope-public/elastic-apm/elastic-apm-agent-1.28.1.jar
-        ExposedPorts:
-          8080/tcp: { }
-          8443/tcp: { }
-        Hostname: localhost
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.5.3'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: tomcat
-        Volumes: null
-        WorkingDir: /usr/local/tomcat
-      Created: '2022-03-25T12:04:52.930305974Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794-init/diff:/var/lib/docker/overlay2/0ca2f0e4b67ae95aef370146269b3fb10e55a6859d278f2997e8b84ff9122875/diff:/var/lib/docker/overlay2/308c2efd326216c0efe94e857b82520af6ab116a978811106d99e49ddf15fc1b/diff:/var/lib/docker/overlay2/c0610b1db247b6b1804c3b992e3f89f1ff75375a3b9c395de68e7dd6f0c5af41/diff:/var/lib/docker/overlay2/b49fa08f0f5246651d4fc001af50b8fc4f316d3add326329766d389a5b8597e1/diff:/var/lib/docker/overlay2/30067671d40d8ef3df665781083700fdb08887c64131c247ff8210714dd2d7a8/diff:/var/lib/docker/overlay2/acec1c4357e89e939adefb7160deb62f2e3dd2fb8e2b89c50a84d7e807b27220/diff:/var/lib/docker/overlay2/348d6cd50875127305d1c94e3d700856d51fc4a33a7c735163a54451c6fc3791/diff:/var/lib/docker/overlay2/b2dbb49865766b5568101566c79fdb955744097af5e48de46fc508b6de374d4a/diff:/var/lib/docker/overlay2/679f2167259fbc9d27c7bc3b9c872e59655afc90478754d2774935f005c62a2d/diff:/var/lib/docker/overlay2/1e770257e07955a14878870e1146a4954ff84e3a9a13f439b617d5a93316369b/diff:/var/lib/docker/overlay2/f4ddf2e6b8e7240af6c8026059475c51e762150436d2e78369347e31154144af/diff:/var/lib/docker/overlay2/10a54c98f41b6862c3ffb03a07cc1b23d517b5fce34238706646aa8949467afb/diff:/var/lib/docker/overlay2/f8c4e742a18bbeeaff6a7f3e99d59e12186868fbd68718b9adf44213e51fe1fc/diff:/var/lib/docker/overlay2/eaeac3feaa55318680b5311656bb14d685c03b356403ea6109fa7b1f16e63189/diff:/var/lib/docker/overlay2/5179e1277d7830285af10f6cd4bd09708b36dfe341288a6dcd68c7896718bb75/diff:/var/lib/docker/overlay2/8562f678e444a225812e39cdf950838f4ee626f1264ce3eac883dcc27bb165d2/diff:/var/lib/docker/overlay2/0f25f2ae977f5674027aac8cdd9cf2e07456a422fb88425fde7d3026f1f8ecdc/diff:/var/lib/docker/overlay2/997ff03392129602e78b3f0e6b5879ec656d11d8c3fa536f5577b0e540b40173/diff:/var/lib/docker/overlay2/994f47ca80b9c00cfabf4d1dcff4992f6b0c1647d89589dd5f31fdaa1bf6340f/diff:/var/lib/docker/overlay2/359f2d072fad20815db5e37ab4284e6c3376233db3163033fe04ba8b1153b443/diff:/var/lib/docker/overlay2/8a3f7b2f222926cdf88d12cd34fed89094bd049498fc78b1ddf625ce837f3760/diff:/var/lib/docker/overlay2/6daf829f7b4e94d9cba1f56aeab10d06a317241ee7aa01217ef88d2676fefce8/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw'
-          - '/var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: [ ]
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: [ ]
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: bridge
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/hostname
-      HostsPath: /etc/hosts
-      Id: 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
-      Image: 'sha256:eb3e461a2b2785cb353346a408a9e43b7f0fb86bb8a9a592ada57ca4c52e3bfd'
-      LogPath: >-
-        /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /usr/local/tomcat/certs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics-cmdbuild/certs
-          Type: bind
-        - Destination: /usr/local/tomcat/logs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/iometrics-cmdbuild
-          Type: bind
-      Name: /iometrics-cmdbuild
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 017bc95d4a8a3a2c69f437bc85d8b01d2aa0d2866fc6f05958c3390ada1cb0fb
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: '02:42:ac:11:00:02'
-        Networks:
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 017bc95d4a8a3a2c69f437bc85d8b01d2aa0d2866fc6f05958c3390ada1cb0fb
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:11:00:02'
-            NetworkID: e245cfe31a9637868b704e96aa6cbd268c001dc02bc3d706b7a2abb2276532ff
-        Ports:
-          8080/tcp: null
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        SandboxID: 08059eaa0823850883a85f7287ed265205eae88fb530cc1fd80f64ab83ac8312
-        SandboxKey: /var/run/docker/netns/08059eaa0823
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-18T13:03:32.242247195Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 30709
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-18T13:33:43.249708472Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - ./start_cmdb_gateway.sh
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - ./start_cmdb_gateway.sh
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.5
-          - CMDB_GATEWAY_CONFIG_FILE=config/cmdb_gateway.yaml
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - PYTHON_PIP_VERSION=20.2.2
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-        Hostname: oss-devel-cmdb
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdb-gateway:0.18.0'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: /app
-      Created: '2021-12-16T13:40:54.11945545Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9-init/diff:/var/lib/docker/overlay2/f28f032f19b8e36176d7f5c3c3280960a1f0b2d030b1461fde6f85608b268fb7/diff:/var/lib/docker/overlay2/c812399fd0157a9db6cd588828f224d26a076ebaa05397d46399616d7491559b/diff:/var/lib/docker/overlay2/04dc77fa805a06bb44c58399ae78a7ab110bc9d714c346b0df5a7e5b349ae16c/diff:/var/lib/docker/overlay2/4c9d61501d1130eeaea40e3c6e8c58e3790995f474c04c2bb10c904a71431edb/diff:/var/lib/docker/overlay2/4993b8fafd5a9d9a6023eaf5d25fe51a2fabcb3dbee5ea7549ec9420497d57e5/diff:/var/lib/docker/overlay2/d6460864d519c5967a63083553d16607e9e209a7eab0d4c098a649aaa0cdf0f2/diff:/var/lib/docker/overlay2/70210d890e6f91fbea58cad88a3fce3e126382bc7b33645fc961fdb8faa8542f/diff:/var/lib/docker/overlay2/ca78aa40f8918ea045999b7270f6fd9704cb0cdb7540c93b5b2608c336057ab5/diff:/var/lib/docker/overlay2/a6183d5cdfd1c5842b63dc840de2a5ef55eb86dcd92872076825f6ae35fa240a/diff:/var/lib/docker/overlay2/b46ed7aa9054a838c1438c581e9d770be0a97cf687a962a532c5096af8f4714b/diff:/var/lib/docker/overlay2/46919684c7f455b8be1662fbc502637c471f5ea2fe53e4ea3edceadc8a28b14f/diff:/var/lib/docker/overlay2/764a651bc4126949119711643715095b4394c88d62b64f6c83a1720378145f0b/diff:/var/lib/docker/overlay2/9f37cd3fc4a2444f9ab442262e3f41cc348cee444f14100f61a487031cfe07f5/diff:/var/lib/docker/overlay2/47b0f955a1643f1d46055c3aeaa3a2ffdd59ccb1f5f14e89dcf603db8463b81b/diff:/var/lib/docker/overlay2/f3aa2fa503c8e7277a423cd85d1d8bdfd147fc867f5fab859a097188e0e6d004/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/cmdb/config:/app/config:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: [ ]
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: [ ]
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: 'no'
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hosts
-      Id: da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
-      Image: 'sha256:af61c42a1772b373dbc30a6d3650af40d4e738a5d22959eccea5974946ada9fa'
-      LogPath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/config
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/cmdb/config
-          Type: bind
-      Name: /iometrics-cmdb-gateway
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 1b041d41f399fa6ac0ccc34d3d96526b0fa84512810b48757570433bed164765
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: { }
-        SandboxID: c3b2ea34f7b1786cd8bd15b6e340deedc9620baf1874f751c8afcd6068389315
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-18T13:03:29.226230758Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 28617
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-18T13:03:29.513015518Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - python ./listener.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - /bin/sh
-          - '-c'
-          - python ./listener.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.5
-          - PYTHON_PIP_VERSION=20.2.2
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
-        Hostname: oss-devel-cmdb
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.0.1'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /config: { }
-        WorkingDir: ''
-      Created: '2021-05-25T10:08:10.097442624Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41-init/diff:/var/lib/docker/overlay2/ba78f066d9e46b0f7b41380a42ef0a747aa591e78992e40447ca78b8528de8ed/diff:/var/lib/docker/overlay2/3b784c7b5c126900be4badb31068a06fbfdfe15a2f15049ed151fb2a5a370659/diff:/var/lib/docker/overlay2/c6b744055dfca315c6446e3723460947b34efd1d75325b2caae502367afa3c2e/diff:/var/lib/docker/overlay2/a1a2492e64ab4e7a012e36e61ceabaf1d80bed24e72c2ae69d7172e35a3831de/diff:/var/lib/docker/overlay2/39a5edc9ab57849080990571d9a3f410b66a3bb04f12ca966d3f4a64e0cbbd8a/diff:/var/lib/docker/overlay2/0780a973dbea66c8f367c507554356a5d27303cd0a1d8b5396e7b0aa392b6149/diff:/var/lib/docker/overlay2/e1f23af492edda46763c05b32bcfe283f83fdd27460a55cf1a5dcf437a0e0ae7/diff:/var/lib/docker/overlay2/9f8debce0febecd5e1c4e50351a37d422b1b60f3826ddfd9dadc1961fe3e007f/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/redis-cleaner:/config:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hosts
-      Id: 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
-      Image: 'sha256:70c1ea6bb3f2e939311b21e6b49cd3cce10ffb2e21e8b5b431bd293421ca8472'
-      LogPath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /config
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis-cleaner
-          Type: bind
-      Name: /iometrics-cmdb-redis-cleaner
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: ed464b6f49997d37e646e04846527f61c970de6c91c3deb620c2c3c80fca0b96
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: { }
-        SandboxID: 72ed345048dcc6240fabf7e33835c2a4fd99d59e7fa0972a4685872da6303113
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 34206
-        Restarting: false
-        Running: true
-        StartedAt: '2021-05-25T10:08:10.240751099Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '--tls-port'
-        - '6378'
-        - '--appendonly'
-        - 'no'
-        - '--maxmemory'
-        - '0'
-        - '--maxclients'
-        - '10000'
-        - '--bind'
-        - 0.0.0.0
-        - '--requirepass'
-        - xxxxxxxx
-        - '--tls-auth-clients'
-        - 'no'
-        - '--tls-cert-file'
-        - /data/ssl/redis.crt
-        - '--tls-key-file'
-        - /data/ssl/redis.pem
-        - '--tls-ca-cert-file'
-        - /data/ssl/redis_ca.crt
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '--tls-port'
-          - '6378'
-          - '--appendonly'
-          - 'no'
-          - '--maxmemory'
-          - '0'
-          - '--maxclients'
-          - '10000'
-          - '--bind'
-          - 0.0.0.0
-          - '--requirepass'
-          - xxxxxxxx
-          - '--tls-auth-clients'
-          - 'no'
-          - '--tls-cert-file'
-          - /data/ssl/redis.crt
-          - '--tls-key-file'
-          - /data/ssl/redis.pem
-          - '--tls-ca-cert-file'
-          - /data/ssl/redis_ca.crt
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.0.1
-          - >-
-            REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
-          - >-
-            REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
-        ExposedPorts:
-          6379/tcp: { }
-        Hostname: oss-devel-cmdb
-        Image: 'redis:6.0.1'
-        Labels:
-          os_contianer_type: redis
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: { }
-          /data/ssl/: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-        WorkingDir: /data
-      Created: '2021-05-25T09:00:32.257009145Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce-init/diff:/var/lib/docker/overlay2/895c1f99a736e2df91bfc2a00c7551e51fd433dde75de2279435ff47ea0e6b38/diff:/var/lib/docker/overlay2/a9841cfec194609a7ec73913c03ba7d4155bc5334e801da50362b4a928a3fe93/diff:/var/lib/docker/overlay2/d9cb4756a3d19486043c08cf2b9492aca7b6664e4914a64c4ae7d649510fb8fb/diff:/var/lib/docker/overlay2/348fb45e5b21b874e1972d7abf6267aedb49052fe240ff1ca65c31d01f0cd49e/diff:/var/lib/docker/overlay2/1f6d3088e9933dfa837efd70762bf9724143691931203267ec5ff24aa5dfe170/diff:/var/lib/docker/overlay2/c96ac52a498ef5b1c8f81d0d7ee4cb762e570fee584f3b41148aceca3a8664b5/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/redis:/data:rw'
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/redis/ssl/:/data/ssl/:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/hostname
-      HostsPath: /etc/hosts
-      Id: b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
-      Image: 'sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c'
-      LogPath: >-
-        /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/redis
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /data/ssl
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/redis/ssl
-          Type: bind
-      Name: /redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: beb2a749121a2b11fd9bc6093b92eb8fd64c1abf38a38f39261bc633429fc566
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: { }
-        SandboxID: 6b4a27d90042eb73469fe2c90437f604c16aade938163e14d93d88892703a15f
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 20064
-        Restarting: false
-        Running: true
-        StartedAt: '2021-05-25T09:00:32.529069205Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: { }
-        Hostname: oss-devel-cmdb
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/nginx: { }
-        WorkingDir: ''
-      Created: '2021-05-24T14:27:58.280498639Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098-init/diff:/var/lib/docker/overlay2/572d19da46f80f29256ff94ed86f500ede7764af796338b02e10f781d4387407/diff:/var/lib/docker/overlay2/16e7f7bacf68db89a426b0b90b68188ce3387cd01bad762550e49c926b5879d8/diff:/var/lib/docker/overlay2/26ea1b9023be5dfd133dd9e015e47da4265ab65445bb17899fcc275604d3754d/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/hostname
-      HostsPath: /etc/hosts
-      Id: df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 29d2d1ebe738bc2b3d44373cd6019b50940e82931b720cfd949e7c08c8a110ea
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
-        Ports: { }
-        SandboxID: c2fdaac80977cad0b65bf2e24939c5a22c6ad249d8db4aab83f390a0bb1305d6
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2021-05-24T14:56:41.686346314Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 23339
-        Restarting: false
-        Running: true
-        StartedAt: '2021-06-01T15:04:41.797753434Z'
-        Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - /usr/local/bin/docker-entrypoint.sh
+    - catalina.sh
+    - run
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - catalina.sh
+      - run
+      Domainname: ''
+      Entrypoint:
+      - /bin/sh
+      - -c
+      - /usr/local/bin/docker-entrypoint.sh
+      Env:
+      - LANG=C.UTF-8
+      - CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
+      - POSTGRES_PORT=5432
+      - CMDBUILD_DUMP=empty.dump.xz
+      - POSTGRES_HOST=192.168.64.34
+      - POSTGRES_PASS=xxxxxxxx
+      - JAVA_OPTS=-Xmx7876m -Xms3846m
+      - POSTGRES_DB=cmdbuild_r2u2
+      - PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - TZ=Europe/Madrid
+      - POSTGRES_APP_USER=datadope
+      - POSTGRES_APP_PASSWORD=xxxxxxxx
+      - POSTGRES_USER=datadope
+      - JAVA_HOME=/usr/local/openjdk-17
+      - JAVA_VERSION=17.0.2
+      - CATALINA_HOME=/usr/local/tomcat
+      - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
+      - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
+      - GPG_KEYS=48F8E69F6390C9F25CFEDCD268248959359E722B A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
+        DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
+      - TOMCAT_MAJOR=9
+      - TOMCAT_VERSION=9.0.60
+      - TOMCAT_SHA512=a4d43ac45f76e29d3dea23a2712c7570a11419aad7a1af2d1533454709c020b59666c7f9e063a77120224e0cbd4020cac06ca596dda7057cacb9a8a7e6d73eea
+      - APM_JAR_URL=https://nexus.opensolutions.cloud/repository/datadope-public/elastic-apm/elastic-apm-agent-1.28.1.jar
+      ExposedPorts:
+        8080/tcp: {}
+        8443/tcp: {}
+      Hostname: localhost
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.5.3
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: tomcat
+      Volumes: null
+      WorkingDir: /usr/local/tomcat
+    Created: '2022-03-25T12:04:52.930305974Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794-init/diff:/var/lib/docker/overlay2/0ca2f0e4b67ae95aef370146269b3fb10e55a6859d278f2997e8b84ff9122875/diff:/var/lib/docker/overlay2/308c2efd326216c0efe94e857b82520af6ab116a978811106d99e49ddf15fc1b/diff:/var/lib/docker/overlay2/c0610b1db247b6b1804c3b992e3f89f1ff75375a3b9c395de68e7dd6f0c5af41/diff:/var/lib/docker/overlay2/b49fa08f0f5246651d4fc001af50b8fc4f316d3add326329766d389a5b8597e1/diff:/var/lib/docker/overlay2/30067671d40d8ef3df665781083700fdb08887c64131c247ff8210714dd2d7a8/diff:/var/lib/docker/overlay2/acec1c4357e89e939adefb7160deb62f2e3dd2fb8e2b89c50a84d7e807b27220/diff:/var/lib/docker/overlay2/348d6cd50875127305d1c94e3d700856d51fc4a33a7c735163a54451c6fc3791/diff:/var/lib/docker/overlay2/b2dbb49865766b5568101566c79fdb955744097af5e48de46fc508b6de374d4a/diff:/var/lib/docker/overlay2/679f2167259fbc9d27c7bc3b9c872e59655afc90478754d2774935f005c62a2d/diff:/var/lib/docker/overlay2/1e770257e07955a14878870e1146a4954ff84e3a9a13f439b617d5a93316369b/diff:/var/lib/docker/overlay2/f4ddf2e6b8e7240af6c8026059475c51e762150436d2e78369347e31154144af/diff:/var/lib/docker/overlay2/10a54c98f41b6862c3ffb03a07cc1b23d517b5fce34238706646aa8949467afb/diff:/var/lib/docker/overlay2/f8c4e742a18bbeeaff6a7f3e99d59e12186868fbd68718b9adf44213e51fe1fc/diff:/var/lib/docker/overlay2/eaeac3feaa55318680b5311656bb14d685c03b356403ea6109fa7b1f16e63189/diff:/var/lib/docker/overlay2/5179e1277d7830285af10f6cd4bd09708b36dfe341288a6dcd68c7896718bb75/diff:/var/lib/docker/overlay2/8562f678e444a225812e39cdf950838f4ee626f1264ce3eac883dcc27bb165d2/diff:/var/lib/docker/overlay2/0f25f2ae977f5674027aac8cdd9cf2e07456a422fb88425fde7d3026f1f8ecdc/diff:/var/lib/docker/overlay2/997ff03392129602e78b3f0e6b5879ec656d11d8c3fa536f5577b0e540b40173/diff:/var/lib/docker/overlay2/994f47ca80b9c00cfabf4d1dcff4992f6b0c1647d89589dd5f31fdaa1bf6340f/diff:/var/lib/docker/overlay2/359f2d072fad20815db5e37ab4284e6c3376233db3163033fe04ba8b1153b443/diff:/var/lib/docker/overlay2/8a3f7b2f222926cdf88d12cd34fed89094bd049498fc78b1ddf625ce837f3760/diff:/var/lib/docker/overlay2/6daf829f7b4e94d9cba1f56aeab10d06a317241ee7aa01217ef88d2676fefce8/diff
+        MergedDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/merged
+        UpperDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/diff
+        WorkDir: /var/lib/docker/overlay2/34f1636ab686ccbf03ab8ad6bf02c8f79b57472d8de6c2d4c9728423a7082794/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:ro
+      - /etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw
+      - /var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: []
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: []
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: bridge
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/hostname
+    HostsPath: /etc/hosts
+    Id: 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
+    Image: sha256:eb3e461a2b2785cb353346a408a9e43b7f0fb86bb8a9a592ada57ca4c52e3bfd
+    LogPath: /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /usr/local/tomcat/certs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics-cmdbuild/certs
+      Type: bind
+    - Destination: /usr/local/tomcat/logs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/iometrics-cmdbuild
+      Type: bind
+    Name: /iometrics-cmdbuild
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 017bc95d4a8a3a2c69f437bc85d8b01d2aa0d2866fc6f05958c3390ada1cb0fb
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 017bc95d4a8a3a2c69f437bc85d8b01d2aa0d2866fc6f05958c3390ada1cb0fb
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: e245cfe31a9637868b704e96aa6cbd268c001dc02bc3d706b7a2abb2276532ff
+      Ports:
+        8080/tcp: null
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      SandboxID: 08059eaa0823850883a85f7287ed265205eae88fb530cc1fd80f64ab83ac8312
+      SandboxKey: /var/run/docker/netns/08059eaa0823
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-18T13:03:32.242247195Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 30709
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-18T13:33:43.249708472Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - ./start_cmdb_gateway.sh
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - ./start_cmdb_gateway.sh
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.5
+      - CMDB_GATEWAY_CONFIG_FILE=config/cmdb_gateway.yaml
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - PYTHON_PIP_VERSION=20.2.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
+      - PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      Hostname: oss-devel-cmdb
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-gateway:0.18.0
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: /app
+    Created: '2021-12-16T13:40:54.11945545Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9-init/diff:/var/lib/docker/overlay2/f28f032f19b8e36176d7f5c3c3280960a1f0b2d030b1461fde6f85608b268fb7/diff:/var/lib/docker/overlay2/c812399fd0157a9db6cd588828f224d26a076ebaa05397d46399616d7491559b/diff:/var/lib/docker/overlay2/04dc77fa805a06bb44c58399ae78a7ab110bc9d714c346b0df5a7e5b349ae16c/diff:/var/lib/docker/overlay2/4c9d61501d1130eeaea40e3c6e8c58e3790995f474c04c2bb10c904a71431edb/diff:/var/lib/docker/overlay2/4993b8fafd5a9d9a6023eaf5d25fe51a2fabcb3dbee5ea7549ec9420497d57e5/diff:/var/lib/docker/overlay2/d6460864d519c5967a63083553d16607e9e209a7eab0d4c098a649aaa0cdf0f2/diff:/var/lib/docker/overlay2/70210d890e6f91fbea58cad88a3fce3e126382bc7b33645fc961fdb8faa8542f/diff:/var/lib/docker/overlay2/ca78aa40f8918ea045999b7270f6fd9704cb0cdb7540c93b5b2608c336057ab5/diff:/var/lib/docker/overlay2/a6183d5cdfd1c5842b63dc840de2a5ef55eb86dcd92872076825f6ae35fa240a/diff:/var/lib/docker/overlay2/b46ed7aa9054a838c1438c581e9d770be0a97cf687a962a532c5096af8f4714b/diff:/var/lib/docker/overlay2/46919684c7f455b8be1662fbc502637c471f5ea2fe53e4ea3edceadc8a28b14f/diff:/var/lib/docker/overlay2/764a651bc4126949119711643715095b4394c88d62b64f6c83a1720378145f0b/diff:/var/lib/docker/overlay2/9f37cd3fc4a2444f9ab442262e3f41cc348cee444f14100f61a487031cfe07f5/diff:/var/lib/docker/overlay2/47b0f955a1643f1d46055c3aeaa3a2ffdd59ccb1f5f14e89dcf603db8463b81b/diff:/var/lib/docker/overlay2/f3aa2fa503c8e7277a423cd85d1d8bdfd147fc867f5fab859a097188e0e6d004/diff
+        MergedDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/merged
+        UpperDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/diff
+        WorkDir: /var/lib/docker/overlay2/c3a45971efa389e712de8a781816055583c8a6eb7ebab876b45bee68b6399ef9/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/cmdb/config:/app/config:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: []
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: []
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: 'no'
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hostname
+    HostsPath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/hosts
+    Id: da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
+    Image: sha256:af61c42a1772b373dbc30a6d3650af40d4e738a5d22959eccea5974946ada9fa
+    LogPath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/config
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/cmdb/config
+      Type: bind
+    Name: /iometrics-cmdb-gateway
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 1b041d41f399fa6ac0ccc34d3d96526b0fa84512810b48757570433bed164765
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: c3b2ea34f7b1786cd8bd15b6e340deedc9620baf1874f751c8afcd6068389315
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-18T13:03:29.226230758Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 28617
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-18T13:03:29.513015518Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - python ./listener.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - /bin/sh
+      - -c
+      - python ./listener.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.5
+      - PYTHON_PIP_VERSION=20.2.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/5578af97f8b2b466f4cdbebe18a3ba2d48ad1434/get-pip.py
+      - PYTHON_GET_PIP_SHA256=d4d62a0850fe0c2e6325b2cc20d818c580563de5a2038f917e3cb0e25280b4d1
+      Hostname: oss-devel-cmdb
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdb-redis-cleaner:0.0.1
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /config: {}
+      WorkingDir: ''
+    Created: '2021-05-25T10:08:10.097442624Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41-init/diff:/var/lib/docker/overlay2/ba78f066d9e46b0f7b41380a42ef0a747aa591e78992e40447ca78b8528de8ed/diff:/var/lib/docker/overlay2/3b784c7b5c126900be4badb31068a06fbfdfe15a2f15049ed151fb2a5a370659/diff:/var/lib/docker/overlay2/c6b744055dfca315c6446e3723460947b34efd1d75325b2caae502367afa3c2e/diff:/var/lib/docker/overlay2/a1a2492e64ab4e7a012e36e61ceabaf1d80bed24e72c2ae69d7172e35a3831de/diff:/var/lib/docker/overlay2/39a5edc9ab57849080990571d9a3f410b66a3bb04f12ca966d3f4a64e0cbbd8a/diff:/var/lib/docker/overlay2/0780a973dbea66c8f367c507554356a5d27303cd0a1d8b5396e7b0aa392b6149/diff:/var/lib/docker/overlay2/e1f23af492edda46763c05b32bcfe283f83fdd27460a55cf1a5dcf437a0e0ae7/diff:/var/lib/docker/overlay2/9f8debce0febecd5e1c4e50351a37d422b1b60f3826ddfd9dadc1961fe3e007f/diff
+        MergedDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/merged
+        UpperDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/diff
+        WorkDir: /var/lib/docker/overlay2/ac81de2a80779d619fda9f9446d2a3f8dba3959ca36583af8feb977a84bd1f41/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/redis-cleaner:/config:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hostname
+    HostsPath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/hosts
+    Id: 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
+    Image: sha256:70c1ea6bb3f2e939311b21e6b49cd3cce10ffb2e21e8b5b431bd293421ca8472
+    LogPath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /config
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis-cleaner
+      Type: bind
+    Name: /iometrics-cmdb-redis-cleaner
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: ed464b6f49997d37e646e04846527f61c970de6c91c3deb620c2c3c80fca0b96
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: 72ed345048dcc6240fabf7e33835c2a4fd99d59e7fa0972a4685872da6303113
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 34206
+      Restarting: false
+      Running: true
+      StartedAt: '2021-05-25T10:08:10.240751099Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - --tls-port
+    - '6378'
+    - --appendonly
+    - 'no'
+    - --maxmemory
+    - '0'
+    - --maxclients
+    - '10000'
+    - --bind
+    - 0.0.0.0
+    - --requirepass
+    - xxxxxxxx
+    - --tls-auth-clients
+    - 'no'
+    - --tls-cert-file
+    - /data/ssl/redis.crt
+    - --tls-key-file
+    - /data/ssl/redis.pem
+    - --tls-ca-cert-file
+    - /data/ssl/redis_ca.crt
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - --tls-port
+      - '6378'
+      - --appendonly
+      - 'no'
+      - --maxmemory
+      - '0'
+      - --maxclients
+      - '10000'
+      - --bind
+      - 0.0.0.0
+      - --requirepass
+      - xxxxxxxx
+      - --tls-auth-clients
+      - 'no'
+      - --tls-cert-file
+      - /data/ssl/redis.crt
+      - --tls-key-file
+      - /data/ssl/redis.pem
+      - --tls-ca-cert-file
+      - /data/ssl/redis_ca.crt
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.0.1
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.0.1.tar.gz
+      - REDIS_DOWNLOAD_SHA=b8756e430479edc162ba9c44dc89ac394316cd482f2dc6b91bcd5fe12593f273
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: oss-devel-cmdb
+      Image: redis:6.0.1
+      Labels:
+        os_contianer_type: redis
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+        /data/ssl/: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+      WorkingDir: /data
+    Created: '2021-05-25T09:00:32.257009145Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce-init/diff:/var/lib/docker/overlay2/895c1f99a736e2df91bfc2a00c7551e51fd433dde75de2279435ff47ea0e6b38/diff:/var/lib/docker/overlay2/a9841cfec194609a7ec73913c03ba7d4155bc5334e801da50362b4a928a3fe93/diff:/var/lib/docker/overlay2/d9cb4756a3d19486043c08cf2b9492aca7b6664e4914a64c4ae7d649510fb8fb/diff:/var/lib/docker/overlay2/348fb45e5b21b874e1972d7abf6267aedb49052fe240ff1ca65c31d01f0cd49e/diff:/var/lib/docker/overlay2/1f6d3088e9933dfa837efd70762bf9724143691931203267ec5ff24aa5dfe170/diff:/var/lib/docker/overlay2/c96ac52a498ef5b1c8f81d0d7ee4cb762e570fee584f3b41148aceca3a8664b5/diff
+        MergedDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/merged
+        UpperDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/diff
+        WorkDir: /var/lib/docker/overlay2/a188db32514791558ae18116a33f83340c2abaeb6c80c7a522fd9b9674a5d0ce/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/redis:/data:rw
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/redis/ssl/:/data/ssl/:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/hostname
+    HostsPath: /etc/hosts
+    Id: b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
+    Image: sha256:f9b9909726890b00d2098081642edf32e5211b7ab53563929a47f250bcdc1d7c
+    LogPath: /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/redis
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /data/ssl
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/redis/ssl
+      Type: bind
+    Name: /redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: beb2a749121a2b11fd9bc6093b92eb8fd64c1abf38a38f39261bc633429fc566
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: 6b4a27d90042eb73469fe2c90437f604c16aade938163e14d93d88892703a15f
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 20064
+      Restarting: false
+      Running: true
+      StartedAt: '2021-05-25T09:00:32.529069205Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: oss-devel-cmdb
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2021-05-24T14:27:58.280498639Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098-init/diff:/var/lib/docker/overlay2/572d19da46f80f29256ff94ed86f500ede7764af796338b02e10f781d4387407/diff:/var/lib/docker/overlay2/16e7f7bacf68db89a426b0b90b68188ce3387cd01bad762550e49c926b5879d8/diff:/var/lib/docker/overlay2/26ea1b9023be5dfd133dd9e015e47da4265ab65445bb17899fcc275604d3754d/diff
+        MergedDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/merged
+        UpperDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/diff
+        WorkDir: /var/lib/docker/overlay2/6785564681cd4514444bf896474a11b971abe09aabf390dbca4b806661c8a098/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/hostname
+    HostsPath: /etc/hosts
+    Id: df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 29d2d1ebe738bc2b3d44373cd6019b50940e82931b720cfd949e7c08c8a110ea
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: b0501184160c059ea3972b77eda56632a8248ce30889c75d518c2f74473cf285
+      Ports: {}
+      SandboxID: c2fdaac80977cad0b65bf2e24939c5a22c6ad249d8db4aab83f390a0bb1305d6
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2021-05-24T14:56:41.686346314Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 23339
+      Restarting: false
+      Running: true
+      StartedAt: '2021-06-01T15:04:41.797753434Z'
+      Status: running
 expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 8443
-        protocol: 'tcp'
-    type: Apache Tomcat Servlet Engine
-    discovery_time: '2022-05-26T18:00:00+02:00'
-    process:
-      children:
-        - children: [ ]
-          cmdline: >-
-            /usr/local/openjdk-17/bin/java
-            -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
-            -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-            -Xmx7876m -Xms3846m -Djdk.tls.ephemeralDHKeySize=2048
-            -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
-            -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
-            -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
-            -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar
-            -Delastic.apm.service_name=cmdb
-            -Delastic.apm.server_url=http://192.168.8.53:8200
-            -Delastic.apm.environment=dev -Delastic.apm.enabled=true
-            -Delastic.apm.profiling_inferred_spans_enabled=true
-            -Delastic.apm.profiling_inferred_spans_min_duration=250ms
-            -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
-            -Dignore.endorsed.dirs= -classpath
-            /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
-            -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat
-            -Djava.io.tmpdir=/usr/local/tomcat/temp
-            org.apache.catalina.startup.Bootstrap start
-          pid: '30748'
-          ppid: '30709'
-          user: 'root'
-      cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
-      pid: '30709'
-      ppid: '30689'
-      user: 'root'
-      listening_ports:
-        - 8443
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 8443
+    protocol: tcp
+  discovery_time: '2022-05-26T18:00:00+02:00'
+  docker:
+    exposed_ports:
+      8080/tcp: {}
+      8443/tcp: {}
+    id: 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
+    image: nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.5.3
+    name: /iometrics-cmdbuild
+    network_mode: bridge
+    port_bindings:
+      8443/tcp:
+      - HostIp: 0.0.0.0
+        HostPort: '8443'
+  listening_ports:
+  - 8443
+  process:
+    children:
+    - children: []
+      cmdline: /usr/local/openjdk-17/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
+        -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx7876m
+        -Xms3846m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+        -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
+        -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar -Delastic.apm.service_name=cmdb
+        -Delastic.apm.server_url=http://192.168.8.53:8200 -Delastic.apm.environment=dev
+        -Delastic.apm.enabled=true -Delastic.apm.profiling_inferred_spans_enabled=true
+        -Delastic.apm.profiling_inferred_spans_min_duration=250ms -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
+        -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
+        -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp
+        org.apache.catalina.startup.Bootstrap start
+      cwd: /usr/local/openjdk-17/bin/
+      pid: '30748'
+      ppid: '30709'
+      user: root
+    cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
+    cwd: /bin/
     listening_ports:
-      - 8443
-    version:
-      - type: docker
-        number: 0.5.3
-    docker:
-      id: 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
-      name: /iometrics-cmdbuild
-      network_mode: 'bridge'
-      image: nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.5.3
-      exposed_ports:
-        8080/tcp: { }
-        8443/tcp: { }
-      port_bindings:
-        '8443/tcp':
-          - 'HostIp': '0.0.0.0'
-            'HostPort': '8443'
+    - 8443
+    pid: '30709'
+    ppid: '30689'
+    user: root
+  type: Apache Tomcat Servlet Engine
+  version:
+  - number: 0.5.3
+    type: docker
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
+  MariaDB-client:
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-client
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
+  MariaDB-common:
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-common
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
+  MariaDB-compat:
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-compat
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
+  MariaDB-server:
+  - arch: x86_64
+    epoch: null
+    name: MariaDB-server
+    release: 1.el7.centos
+    source: rpm
+    version: 10.5.10
+  NetworkManager:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
+  NetworkManager-libnm:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-libnm
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
+  NetworkManager-team:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-team
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
+  NetworkManager-tui:
+  - arch: x86_64
+    epoch: 1
+    name: NetworkManager-tui
+    release: 2.el7_9
+    source: rpm
+    version: 1.18.8
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  aic94xx-firmware:
+  - arch: noarch
+    epoch: null
+    name: aic94xx-firmware
+    release: 6.el7
+    source: rpm
+    version: '30'
+  alsa-firmware:
+  - arch: noarch
+    epoch: null
+    name: alsa-firmware
+    release: 2.el7
+    source: rpm
+    version: 1.0.28
+  alsa-lib:
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
+  alsa-tools-firmware:
+  - arch: x86_64
+    epoch: null
+    name: alsa-tools-firmware
+    release: 1.el7
+    source: rpm
+    version: 1.1.0
+  apr:
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
+  apr-util:
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autoconf:
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
+  automake:
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
+  avahi-libs:
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
+  bc:
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.5
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.7
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7
+    source: rpm
+    version: '2.27'
+  biosdevname:
+  - arch: x86_64
+    epoch: null
+    name: biosdevname
+    release: 2.el7
+    source: rpm
+    version: 0.7.3
+  bison:
+  - arch: x86_64
+    epoch: null
+    name: bison
+    release: 2.el7
+    source: rpm
+    version: 3.0.4
+  boost-date-time:
+  - arch: x86_64
+    epoch: null
+    name: boost-date-time
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
+  boost-program-options:
+  - arch: x86_64
+    epoch: null
+    name: boost-program-options
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
+  boost-system:
+  - arch: x86_64
+    epoch: null
+    name: boost-system
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
+  boost-thread:
+  - arch: x86_64
+    epoch: null
+    name: boost-thread
+    release: 28.el7
+    source: rpm
+    version: 1.53.0
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  byacc:
+  - arch: x86_64
+    epoch: null
+    name: byacc
+    release: 3.el7
+    source: rpm
+    version: 1.9.20130304
+  bzip2:
+  - arch: x86_64
+    epoch: null
+    name: bzip2
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  c-ares:
+  - arch: x86_64
+    epoch: null
+    name: c-ares
+    release: 3.el7
+    source: rpm
+    version: 1.10.0
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_8
+    source: rpm
+    version: 2020.2.41
+  centos-logos:
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.4.4
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
+  cscope:
+  - arch: x86_64
+    epoch: null
+    name: cscope
+    release: 10.el7
+    source: rpm
+    version: '15.8'
+  ctags:
+  - arch: x86_64
+    epoch: null
+    name: ctags
+    release: 13.el7
+    source: rpm
+    version: '5.8'
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  device-mapper-event:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  device-mapper-event-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
+  device-mapper-persistent-data:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 3.el7_9.2
+    source: rpm
+    version: 0.8.5
+  dhclient:
+  - arch: x86_64
+    epoch: 12
+    name: dhclient
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffstat:
+  - arch: x86_64
+    epoch: null
+    name: diffstat
+    release: 4.el7
+    source: rpm
+    version: '1.57'
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
+  docker-ce-rootless-extras:
+  - arch: x86_64
+    epoch: 0
+    name: docker-ce-rootless-extras
+    release: 3.el7
+    source: rpm
+    version: 20.10.6
+  docker-scan-plugin:
+  - arch: x86_64
+    epoch: 0
+    name: docker-scan-plugin
+    release: 3.el7
+    source: rpm
+    version: 0.7.0
+  doxygen:
+  - arch: x86_64
+    epoch: 1
+    name: doxygen
+    release: 4.el7
+    source: rpm
+    version: 1.8.5
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dwz:
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
+  dyninst:
+  - arch: x86_64
+    epoch: null
+    name: dyninst
+    release: 3.el7
+    source: rpm
+    version: 9.3.1
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  ebtables:
+  - arch: x86_64
+    epoch: null
+    name: ebtables
+    release: 16.el7
+    source: rpm
+    version: 2.0.10
+  efivar-libs:
+  - arch: x86_64
+    epoch: null
+    name: efivar-libs
+    release: 12.el7
+    source: rpm
+    version: '36'
+  elfutils:
+  - arch: x86_64
+    epoch: null
+    name: elfutils
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  emacs-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: emacs-filesystem
+    release: 23.el7
+    source: rpm
+    version: '24.3'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '13'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  firewalld:
+  - arch: noarch
+    epoch: null
+    name: firewalld
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
+  firewalld-filesystem:
+  - arch: noarch
+    epoch: null
+    name: firewalld-filesystem
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
+  flex:
+  - arch: x86_64
+    epoch: null
+    name: flex
+    release: 6.el7
+    source: rpm
+    version: 2.5.37
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fuse:
+  - arch: x86_64
+    epoch: null
+    name: fuse
+    release: 11.el7
+    source: rpm
+    version: 2.9.2
+  fuse-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-libs
+    release: 11.el7
+    source: rpm
+    version: 2.9.2
+  fuse-overlayfs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
+  fuse3-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
+  fxload:
+  - arch: x86_64
+    epoch: null
+    name: fxload
+    release: 16.el7
+    source: rpm
+    version: '2002_04_11'
+  galera-4:
+  - arch: x86_64
+    epoch: null
+    name: galera-4
+    release: 1.el7.centos
+    source: rpm
+    version: 26.4.8
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-gfortran:
+  - arch: x86_64
+    epoch: null
+    name: gcc-gfortran
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gdb:
+  - arch: x86_64
+    epoch: null
+    name: gdb
+    release: 120.el7
+    source: rpm
+    version: 7.6.1
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-common-devel:
+  - arch: noarch
+    epoch: null
+    name: gettext-common-devel
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-devel:
+  - arch: x86_64
+    epoch: null
+    name: gettext-devel
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  git:
+  - arch: x86_64
+    epoch: null
+    name: git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 8.el7
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gnutls:
+  - arch: x86_64
+    epoch: null
+    name: gnutls
+    release: 9.el7_6
+    source: rpm
+    version: 3.3.29
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 511147a9
+    source: rpm
+    version: 1bb943db
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.6
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  htop:
+  - arch: x86_64
+    epoch: null
+    name: htop
+    release: 3.el7
+    source: rpm
+    version: 2.2.0
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  indent:
+  - arch: x86_64
+    epoch: null
+    name: indent
+    release: 13.el7
+    source: rpm
+    version: 2.2.11
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  intltool:
+  - arch: noarch
+    epoch: null
+    name: intltool
+    release: 7.el7
+    source: rpm
+    version: 0.50.2
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iprutils:
+  - arch: x86_64
+    epoch: null
+    name: iprutils
+    release: 3.el7_7
+    source: rpm
+    version: 2.4.17.1
+  ipset:
+  - arch: x86_64
+    epoch: null
+    name: ipset
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  ivtv-firmware:
+  - arch: noarch
+    epoch: 2
+    name: ivtv-firmware
+    release: 26.el7
+    source: rpm
+    version: '20080701'
+  iwl100-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl100-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
+  iwl1000-firmware:
+  - arch: noarch
+    epoch: 1
+    name: iwl1000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 39.31.5.1
+  iwl105-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl105-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl135-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl135-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl2000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl2000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl2030-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl2030-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl3160-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl3160-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
+  iwl3945-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl3945-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 15.32.2.9
+  iwl4965-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl4965-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 228.61.2.24
+  iwl5000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl5000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.83.5.1_1
+  iwl5150-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl5150-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 8.24.2.2
+  iwl6000-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 9.221.4.1
+  iwl6000g2a-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2a-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl6000g2b-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6000g2b-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 18.168.6.1
+  iwl6050-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl6050-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 41.28.5.1
+  iwl7260-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7260-firmware
+    release: 80.el7_9
+    source: rpm
+    version: 25.30.13.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jnettop:
+  - arch: x86_64
+    epoch: null
+    name: jnettop
+    release: 16.el7
+    source: rpm
+    version: 0.13.0
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.21.3.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 862.9.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.10.1.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.15.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-debug-devel:
+  - arch: x86_64
+    epoch: null
+    name: kernel-debug-devel
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.2
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 134.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 50.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libbsd:
+  - arch: x86_64
+    epoch: null
+    name: libbsd
+    release: 1.el7
+    source: rpm
+    version: 0.8.3
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdnet:
+  - arch: x86_64
+    epoch: null
+    name: libdnet
+    release: 13.1.el7
+    source: rpm
+    version: '1.12'
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libdwarf:
+  - arch: x86_64
+    epoch: null
+    name: libdwarf
+    release: 4.el7
+    source: rpm
+    version: '20130207'
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgfortran:
+  - arch: x86_64
+    epoch: null
+    name: libgfortran
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmodman:
+  - arch: x86_64
+    epoch: null
+    name: libmodman
+    release: 8.el7
+    source: rpm
+    version: 2.0.1
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libmspack:
+  - arch: x86_64
+    epoch: null
+    name: libmspack
+    release: 0.8.alpha.el7
+    source: rpm
+    version: '0.5'
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libproxy:
+  - arch: x86_64
+    epoch: null
+    name: libproxy
+    release: 11.el7
+    source: rpm
+    version: 0.4.11
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libquadmath:
+  - arch: x86_64
+    epoch: null
+    name: libquadmath
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libquadmath-devel:
+  - arch: x86_64
+    epoch: null
+    name: libquadmath-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libretls:
+  - arch: x86_64
+    epoch: null
+    name: libretls
+    release: 1.el7
+    source: rpm
+    version: 3.4.1
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libsmi:
+  - arch: x86_64
+    epoch: null
+    name: libsmi
+    release: 13.el7
+    source: rpm
+    version: 0.4.8
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libtool:
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libtool-ltdl:
+  - arch: x86_64
+    epoch: null
+    name: libtool-ltdl
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.5
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.5
+    source: rpm
+    version: 2.9.1
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lsof:
+  - arch: x86_64
+    epoch: null
+    name: lsof
+    release: 6.el7
+    source: rpm
+    version: '4.87'
+  lsscsi:
+  - arch: x86_64
+    epoch: null
+    name: lsscsi
+    release: 6.el7
+    source: rpm
+    version: '0.27'
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 2.02.187
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.8.el7_9
+    source: rpm
+    version: '2.1'
+  mokutil:
+  - arch: x86_64
+    epoch: null
+    name: mokutil
+    release: 8.el7
+    source: rpm
+    version: '15'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  nagios-common:
+  - arch: x86_64
+    epoch: null
+    name: nagios-common
+    release: 4.el7
+    source: rpm
+    version: 4.4.6
+  nagios-plugins:
+  - arch: x86_64
+    epoch: null
+    name: nagios-plugins
+    release: 2.el7
+    source: rpm
+    version: 2.3.3
+  nagios-plugins-perl:
+  - arch: x86_64
+    epoch: null
+    name: nagios-plugins-perl
+    release: 2.el7
+    source: rpm
+    version: 2.3.3
+  nano:
+  - arch: x86_64
+    epoch: null
+    name: nano
+    release: 10.el7
+    source: rpm
+    version: 2.3.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  neon:
+  - arch: x86_64
+    epoch: null
+    name: neon
+    release: 4.el7
+    source: rpm
+    version: 0.30.0
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  netcat:
+  - arch: x86_64
+    epoch: null
+    name: netcat
+    release: 2.el7
+    source: rpm
+    version: '1.218'
+  nettle:
+  - arch: x86_64
+    epoch: null
+    name: nettle
+    release: 9.el7_9
+    source: rpm
+    version: 2.7.1
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7
+    source: rpm
+    version: 1.3.0
+  nrpe:
+  - arch: x86_64
+    epoch: null
+    name: nrpe
+    release: 6.el7
+    source: rpm
+    version: 4.0.3
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 2.el7_9
+    source: rpm
+    version: 4.25.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 6.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 6.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_9
+    source: rpm
+    version: 3.53.1
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.53.1
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  open-vm-tools:
+  - arch: x86_64
+    epoch: null
+    name: open-vm-tools
+    release: 3.el7_9.3
+    source: rpm
+    version: 11.0.5
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 23.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 21.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 21.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pakchois:
+  - arch: x86_64
+    epoch: null
+    name: pakchois
+    release: 10.el7
+    source: rpm
+    version: '0.4'
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  patch:
+  - arch: x86_64
+    epoch: null
+    name: patch
+    release: 12.el7_7
+    source: rpm
+    version: 2.7.1
+  patchutils:
+  - arch: x86_64
+    epoch: null
+    name: patchutils
+    release: 5.el7_9
+    source: rpm
+    version: 0.3.3
+  pciutils:
+  - arch: x86_64
+    epoch: null
+    name: pciutils
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcre2:
+  - arch: x86_64
+    epoch: null
+    name: pcre2
+    release: 2.el7
+    source: rpm
+    version: '10.23'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Compress-Raw-Bzip2:
+  - arch: x86_64
+    epoch: null
+    name: perl-Compress-Raw-Bzip2
+    release: 3.el7
+    source: rpm
+    version: '2.061'
+  perl-Compress-Raw-Zlib:
+  - arch: x86_64
+    epoch: 1
+    name: perl-Compress-Raw-Zlib
+    release: 4.el7
+    source: rpm
+    version: '2.061'
+  perl-DBD-MySQL:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBD-MySQL
+    release: 6.el7
+    source: rpm
+    version: '4.023'
+  perl-DBI:
+  - arch: x86_64
+    epoch: null
+    name: perl-DBI
+    release: 4.el7
+    source: rpm
+    version: '1.627'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Error:
+  - arch: noarch
+    epoch: 1
+    name: perl-Error
+    release: 2.el7
+    source: rpm
+    version: '0.17020'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-Git:
+  - arch: noarch
+    epoch: null
+    name: perl-Git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-IO-Compress:
+  - arch: noarch
+    epoch: null
+    name: perl-IO-Compress
+    release: 2.el7
+    source: rpm
+    version: '2.061'
+  perl-Net-Daemon:
+  - arch: noarch
+    epoch: null
+    name: perl-Net-Daemon
+    release: 5.el7
+    source: rpm
+    version: '0.48'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-PlRPC:
+  - arch: noarch
+    epoch: null
+    name: perl-PlRPC
+    release: 14.el7
+    source: rpm
+    version: '0.2020'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Sys-Statistics-Linux:
+  - arch: noarch
+    epoch: null
+    name: perl-Sys-Statistics-Linux
+    release: 14.el7
+    source: rpm
+    version: '0.66'
+  perl-TermReadKey:
+  - arch: x86_64
+    epoch: null
+    name: perl-TermReadKey
+    release: 20.el7
+    source: rpm
+    version: '2.30'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Test-Simple:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Simple
+    release: 243.el7
+    source: rpm
+    version: '0.98'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Thread-Queue:
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-XML-Parser:
+  - arch: x86_64
+    epoch: null
+    name: perl-XML-Parser
+    release: 10.el7
+    source: rpm
+    version: '2.41'
+  perl-YAML-Syck:
+  - arch: x86_64
+    epoch: null
+    name: perl-YAML-Syck
+    release: 3.el7
+    source: rpm
+    version: '1.27'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  plymouth:
+  - arch: x86_64
+    epoch: null
+    name: plymouth
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
+  plymouth-core-libs:
+  - arch: x86_64
+    epoch: null
+    name: plymouth-core-libs
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
+  plymouth-scripts:
+  - arch: x86_64
+    epoch: null
+    name: plymouth-scripts
+    release: 0.34.20140113.el7.centos
+    source: rpm
+    version: 0.8.9
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql:
+  - arch: x86_64
+    epoch: null
+    name: postgresql
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-devel:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-devel
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 6.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql10:
+  - arch: x86_64
+    epoch: null
+    name: postgresql10
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
+  postgresql10-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
+  postgresql10-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
+  postgresql10-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql10-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '10.17'
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  psmisc:
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 17.el7
+    source: rpm
+    version: '22.20'
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-firewall:
+  - arch: noarch
+    epoch: null
+    name: python-firewall
+    release: 13.el7_9
+    source: rpm
+    version: 0.6.3
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.25.1.el7
+    source: rpm
+    version: 3.10.0
+  python-psycopg2:
+  - arch: x86_64
+    epoch: null
+    name: python-psycopg2
+    release: 1.rhel7
+    source: rpm
+    version: 2.7.5
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-slip:
+  - arch: noarch
+    epoch: null
+    name: python-slip
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-slip-dbus:
+  - arch: noarch
+    epoch: null
+    name: python-slip-dbus
+    release: 4.el7
+    source: rpm
+    version: 0.4.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  rcs:
+  - arch: x86_64
+    epoch: null
+    name: rcs
+    release: 7.el7
+    source: rpm
+    version: 5.9.0
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
+    name: rpcbind
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rpm-sign:
+  - arch: x86_64
+    epoch: null
+    name: rpm-sign
+    release: 45.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.27.20120314git3c2946.el7_9
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  socat:
+  - arch: x86_64
+    epoch: null
+    name: socat
+    release: 2.el7
+    source: rpm
+    version: 1.7.3.2
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 6.el7
+    source: rpm
+    version: '4.24'
+  subversion:
+  - arch: x86_64
+    epoch: null
+    name: subversion
+    release: 16.el7
+    source: rpm
+    version: 1.7.14
+  subversion-libs:
+  - arch: x86_64
+    epoch: null
+    name: subversion-libs
+    release: 16.el7
+    source: rpm
+    version: 1.7.14
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.1
+    source: rpm
+    version: 1.8.23
+  swig:
+  - arch: x86_64
+    epoch: null
+    name: swig
+    release: 5.el7
+    source: rpm
+    version: 2.0.10
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.3
+    source: rpm
+    version: '219'
+  systemtap:
+  - arch: x86_64
+    epoch: null
+    name: systemtap
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-client:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-client
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-devel:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-devel
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  systemtap-runtime:
+  - arch: x86_64
+    epoch: null
+    name: systemtap-runtime
+    release: 13.el7
+    source: rpm
+    version: '4.0'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 66.el7
+    source: rpm
+    version: '0.17'
+  traceroute:
+  - arch: x86_64
+    epoch: 3
+    name: traceroute
+    release: 2.el7
+    source: rpm
+    version: 2.0.22
+  trousers:
+  - arch: x86_64
+    epoch: null
+    name: trousers
+    release: 2.el7
+    source: rpm
+    version: 0.3.14
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 21.el7
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  webtatic-release:
+  - arch: noarch
+    epoch: null
+    name: webtatic-release
+    release: '3'
+    source: rpm
+    version: '7'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wireshark:
+  - arch: x86_64
+    epoch: null
+    name: wireshark
+    release: 25.el7
+    source: rpm
+    version: 1.10.14
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xagt:
+  - arch: x86_64
+    epoch: null
+    name: xagt
+    release: 1.el7
+    source: rpm
+    version: 33.46.6
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xmlsec1:
+  - arch: x86_64
+    epoch: null
+    name: xmlsec1
+    release: 7.el7_4
+    source: rpm
+    version: 1.2.20
+  xmlsec1-openssl:
+  - arch: x86_64
+    epoch: null
+    name: xmlsec1-openssl
+    release: 7.el7_4
+    source: rpm
+    version: 1.2.20
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 22
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '54'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '55'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '66'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '68'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '78'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '98'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '136'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '283'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '302'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '305'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '306'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '308'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '309'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '310'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '311'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '312'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '313'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '314'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '315'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '316'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '317'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '318'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '319'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '320'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '321'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '322'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '323'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '324'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '325'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '326'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '327'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '328'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '329'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '330'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '331'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '332'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '333'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '334'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '335'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '338'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '339'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '340'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '341'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '342'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '344'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '345'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '346'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '347'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '348'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '349'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '350'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '351'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '352'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '353'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '354'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '355'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '356'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '357'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '358'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '359'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '360'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '361'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '362'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '363'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '364'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '405'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '406'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '420'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '427'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '428'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '429'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '430'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '431'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '432'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '433'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '434'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '435'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '436'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '437'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '438'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '518'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '552'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '607'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '608'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '611'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '612'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '613'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '614'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '615'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '623'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '682'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/VGAuthService -s
+  cwd: /usr/bin/
+  pid: '705'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/vmtoolsd
+  cwd: /usr/bin/
+  pid: '706'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '708'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '710'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '713'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '719'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/NetworkManager --no-daemon
+  cwd: /usr/sbin/
+  pid: '732'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '734'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '738'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '813'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f
+  cwd: /usr/sbin/
+  pid: '999'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1002'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1004'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1005'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1186'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1207'
+  ppid: '1186'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1467'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1489'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1498'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '1521'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2185'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '3002'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9403'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '20044'
+  ppid: '1'
+  user: root
+- cmdline: redis-server 0.0.0.0:6379
+  cwd: /
+  pid: '20064'
+  ppid: '20044'
+  user: root
+- cmdline: /usr/bin/docker start -a redis
+  cwd: /usr/bin/
+  pid: '20366'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20383'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '23319'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: master process nginx -g daemon off;'
+  cwd: /
+  pid: '23339'
+  ppid: '23319'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '23356'
+  ppid: '23339'
+  user: root
+- cmdline: /usr/bin/docker start -a nginx
+  cwd: /usr/bin/
+  pid: '23581'
+  ppid: '1'
+  user: root
+- cmdline: SCREEN
+  cwd: /
+  pid: '24403'
+  ppid: '1'
+  user: root
+- cmdline: /bin/bash
+  cwd: /bin/
+  pid: '24404'
+  ppid: '24403'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25635'
+  ppid: '2'
+  user: root
+- cmdline: sudo -u postgres psql
+  cwd: /
+  pid: '28523'
+  ppid: '24404'
+  user: root
+- cmdline: psql
+  cwd: /
+  pid: '28524'
+  ppid: '28523'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-cmdb-gateway
+  cwd: /usr/bin/
+  pid: '28556'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '28596'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c ./start_cmdb_gateway.sh
+  cwd: /bin/
+  pid: '28617'
+  ppid: '28596'
+  user: root
+- cmdline: /bin/sh ./start_cmdb_gateway.sh
+  cwd: /bin/
+  pid: '28631'
+  ppid: '28617'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28633'
+  ppid: '28631'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28635'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28637'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28638'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28639'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28640'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28641'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28642'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py
+    cmdb_gateway.main:app
+  cwd: /usr/local/bin/
+  pid: '28643'
+  ppid: '28633'
+  user: root
+- cmdline: /usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data
+  cwd: /usr/pgsql-10/bin/
+  pid: '28694'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: data: checkpointer process'
+  cwd: /
+  pid: '28697'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: writer process'
+  cwd: /
+  pid: '28698'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: wal writer process'
+  cwd: /
+  pid: '28699'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: autovacuum launcher process'
+  cwd: /
+  pid: '28700'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: stats collector process'
+  cwd: /
+  pid: '28701'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: bgworker: logical replication launcher'
+  cwd: /
+  pid: '28702'
+  ppid: '28694'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-cmdbuild
+  cwd: /usr/bin/
+  pid: '30649'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 -container-ip
+    192.168.1.2 -container-port 8443
+  cwd: /usr/bin/
+  pid: '30674'
+  ppid: '60677'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '30689'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
+  cwd: /bin/
+  pid: '30709'
+  ppid: '30689'
+  user: root
+- cmdline: /usr/local/openjdk-17/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx7876m -Xms3846m
+    -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+    -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
+    -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar -Delastic.apm.service_name=cmdb
+    -Delastic.apm.server_url=http://192.168.8.53:8200 -Delastic.apm.environment=dev
+    -Delastic.apm.enabled=true -Delastic.apm.profiling_inferred_spans_enabled=true
+    -Delastic.apm.profiling_inferred_spans_min_duration=250ms -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.*
+    -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
+    -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp
+    org.apache.catalina.startup.Bootstrap start
+  cwd: /usr/local/openjdk-17/bin/
+  pid: '30748'
+  ppid: '30709'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42292) idle'
+  cwd: /
+  pid: '30959'
+  ppid: '28694'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '34186'
+  ppid: '1'
+  user: root
+- cmdline: /bin/sh -c python ./listener.py
+  cwd: /bin/
+  pid: '34206'
+  ppid: '34186'
+  user: root
+- cmdline: python ./listener.py
+  cwd: /
+  pid: '34220'
+  ppid: '34206'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44075'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45038'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46732'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46733'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '46865'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '47374'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '47383'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47397'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47398'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/rpc.statd
+  cwd: /usr/sbin/
+  pid: '47406'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rpc.idmapd
+  cwd: /usr/sbin/
+  pid: '47408'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rpc.mountd
+  cwd: /usr/sbin/
+  pid: '47410'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47415'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47416'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47421'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47422'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47423'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47424'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47425'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47426'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47427'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47428'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49443'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50335'
+  ppid: '2'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '54568'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33168) idle'
+  cwd: /
+  pid: '57218'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33436) idle'
+  cwd: /
+  pid: '58454'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33512) idle'
+  cwd: /
+  pid: '58550'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33562) idle'
+  cwd: /
+  pid: '58612'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33642) idle'
+  cwd: /
+  pid: '58724'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33660) idle'
+  cwd: /
+  pid: '58766'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33720) idle'
+  cwd: /
+  pid: '58872'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33738) idle'
+  cwd: /
+  pid: '58949'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33766) idle'
+  cwd: /
+  pid: '59000'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33772) idle'
+  cwd: /
+  pid: '59003'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33778) idle'
+  cwd: /
+  pid: '59006'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33782) idle'
+  cwd: /
+  pid: '59008'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33788) idle'
+  cwd: /
+  pid: '59017'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33790) idle'
+  cwd: /
+  pid: '59018'
+  ppid: '28694'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59036'
+  ppid: '2'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33792) idle'
+  cwd: /
+  pid: '59049'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33796) idle'
+  cwd: /
+  pid: '59051'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33798) idle'
+  cwd: /
+  pid: '59052'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33804) idle'
+  cwd: /
+  pid: '59064'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33808) idle'
+  cwd: /
+  pid: '59071'
+  ppid: '28694'
+  user: root
+- cmdline: 'postgres: data: datadope cmdbuild_r2u2 192.168.1.2(33810) idle'
+  cwd: /
+  pid: '59077'
+  ppid: '28694'
+  user: root
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '60677'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61266'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61271'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '61272'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '62178'
+  ppid: '1186'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '63141'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '67115'
+  ppid: '2'
+  user: root
+- cmdline: /opt/fireeye/bin/xagt -M DAEMON
+  cwd: /opt/fireeye/bin/
+  pid: '69963'
+  ppid: '1'
+  user: root
+- cmdline: /opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT --logfd
+    4
+  cwd: /opt/fireeye/bin/
+  pid: '69987'
+  ppid: '69963'
+  user: root
+- cmdline: 'sshd: root@pts/0'
+  cwd: /
+  pid: '71236'
+  ppid: '1005'
+  user: root
+- cmdline: -bash
+  cwd: /
+  pid: '71238'
+  ppid: '71236'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '72571'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '73404'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/mariadbd
+  cwd: /usr/sbin/
+  pid: '73979'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '75161'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '76377'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '77796'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '78673'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '79907'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '80858'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '81582'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83325'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: root@pts/2'
+  cwd: /
+  pid: '83787'
+  ppid: '1005'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '83867'
+  ppid: '2'
+  user: root
+- cmdline: /bin/sh -c /usr/bin/python /root/.ansible/tmp/ansible-tmp-1651076211.87958-95939-60303799464658/AnsiballZ_process_facts.py
+    && sleep 0
+  cwd: /bin/
+  pid: '83946'
+  ppid: '83787'
+  user: root
+- cmdline: /usr/bin/python /root/.ansible/tmp/ansible-tmp-1651076211.87958-95939-60303799464658/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '83959'
+  ppid: '83946'
+  user: root
+software_list:
+- cmd_regexp: \.apache\.tomcat\.startup|\.apache\.catalina\.startup
+  name: Apache Tomcat Servlet Engine
+  pkg_regexp: tomcat
+  process_type: child
+  return_children: true
+tcp_listen:
+- address: 0.0.0.0
+  name: sshd
+  pid: 1005
+  port: 22
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: 0.0.0.0
+  name: postmaster
+  pid: 28694
+  port: 5432
+  protocol: tcp
+  stime: Mon Apr 18 15:03:42 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1186
+  port: 25
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: 0.0.0.0
+  name: docker-proxy
+  pid: 30674
+  port: 8443
+  protocol: tcp
+  stime: Mon Apr 18 15:33:41 2022
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 46171
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 23339
+  port: 443
+  protocol: tcp
+  stime: Tue Jun  1 17:04:40 2021
+  user: root
+- address: 0.0.0.0
+  name: python
+  pid: 28633
+  port: 8444
+  protocol: tcp
+  stime: Mon Apr 18 15:03:28 2022
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: nrpe
+  pid: 999
+  port: 5666
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: nrpe
+- address: 0.0.0.0
+  name: redis-server
+  pid: 20064
+  port: 6378
+  protocol: tcp
+  stime: Tue May 25 11:00:31 2021
+  user: polkitd
+- address: 0.0.0.0
+  name: redis-server
+  pid: 20064
+  port: 6379
+  protocol: tcp
+  stime: Tue May 25 11:00:31 2021
+  user: polkitd
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: tcp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 0.0.0.0
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: 0.0.0.0
+  name: rpc.statd
+  pid: 47406
+  port: 53648
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 23339
+  port: 80
+  protocol: tcp
+  stime: Tue Jun  1 17:04:40 2021
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1005
+  port: 22
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: ::1
+  name: master
+  pid: 1186
+  port: 25
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: root
+- address: '::'
+  name: ''
+  pid: 0
+  port: 40957
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: '::'
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: tcp
+  stime: ''
+  user: ''
+- address: '::'
+  name: nrpe
+  pid: 999
+  port: 5666
+  protocol: tcp
+  stime: Fri May 21 08:55:20 2021
+  user: nrpe
+- address: '::'
+  name: mariadbd
+  pid: 73979
+  port: 3306
+  protocol: tcp
+  stime: Tue May 25 15:30:13 2021
+  user: mysql
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: tcp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: '::'
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: '::'
+  name: rpc.statd
+  pid: 47406
+  port: 47601
+  protocol: tcp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+udp_listen:
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: udp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: 0.0.0.0
+  name: ''
+  pid: 0
+  port: 59970
+  protocol: udp
+  stime: ''
+  user: ''
+- address: 0.0.0.0
+  name: rpc.statd
+  pid: 47406
+  port: 60822
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 719
+  port: 323
+  protocol: udp
+  stime: Fri May 21 08:55:20 2021
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 47374
+  port: 909
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: 127.0.0.1
+  name: rpc.statd
+  pid: 47406
+  port: 942
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: '::'
+  name: ''
+  pid: 0
+  port: 2049
+  protocol: udp
+  stime: ''
+  user: ''
+- address: '::'
+  name: rpc.mountd
+  pid: 47410
+  port: 20048
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: root
+- address: '::'
+  name: rpc.statd
+  pid: 47406
+  port: 42219
+  protocol: udp
+  stime: Fri Jul  9 14:12:09 2021
+  user: rpcuser
+- address: '::'
+  name: ''
+  pid: 0
+  port: 42799
+  protocol: udp
+  stime: ''
+  user: ''
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 111
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 719
+  port: 323
+  protocol: udp
+  stime: Fri May 21 08:55:20 2021
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 47374
+  port: 909
+  protocol: udp
+  stime: Fri Jul  9 14:12:03 2021
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/tomcat/tomcat7.0.16_config_dict.yaml
+++ b/tests/unit/plugins/action/auto/resources/tomcat/tomcat7.0.16_config_dict.yaml
@@ -1,4870 +1,5079 @@
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - analyzer
+    - -c
+    - /etc/iometrics/skydive/skydive.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - analyzer
+      - -c
+      - /etc/iometrics/skydive/skydive.yml
+      Domainname: ''
+      Entrypoint:
+      - /usr/local/bin/skydive
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      ExposedPorts:
+        8082/tcp: {}
+      Hostname: test-ram-norm01.novalocal
+      Image: nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-4
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/iometrics/skydive/skydive.yml: {}
+        /var/lib/skydive: {}
+      WorkingDir: ''
+    Created: '2022-02-11T16:39:16.436847232Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631-init/diff:/var/lib/docker/overlay2/98c8fc8a1198391d57b52bfc7481b12d8fcb3f1460fa681558aaa7306730bd9a/diff:/var/lib/docker/overlay2/9b3407fa7b3cf45082812007500f2249298b9522aeeb6b5e8c324eb8e7291ad5/diff:/var/lib/docker/overlay2/2a70d40f778c8683b234911bdff488726b2d1931d804bca86b612015cabbcfec/diff
+        MergedDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/merged
+        UpperDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/diff
+        WorkDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/iometrics/skydive/:/var/lib/skydive:rw
+      - /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hostname
+    HostsPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hosts
+    Id: 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
+    Image: sha256:7b966f2ba2092efb97f038f14563b84b32e98879ad8d52189af823c594b185ed
+    LogPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/iometrics/skydive/skydive.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics/skydive/skydive.yml
+      Type: bind
+    - Destination: /var/lib/skydive
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/iometrics/skydive
+      Type: bind
+    Name: /skydive-analyzer
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 36711925279b4b1ac03d5cdb68a3d4d765d86759714aaae8c976b8bce04ce890
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 6e919553642bae0550eee9382a797f886036f8f6f296d65183121041f1da3b83
+      Ports: {}
+      SandboxID: be98496481fa878c6ad9f140fbcae075d3bccea63ad36757fecf011ab94b6dd3
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/local/bin/skydive
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T14:45:04.915207484Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1512
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:45:08.126872087Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 11870
+    protocol: tcp
+  - address: 127.0.0.1
+    class: service
+    port: 8005
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8009
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8082
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8050
+    protocol: tcp
+  - class: port_http
+    port: 8080
+  - class: port_jmx
+    port: 8050
+  configuration:
+    Server:
+      GlobalNamingResources:
+        Resource:
+          attr-auth: Container
+          attr-description: User database that can be updated and saved
+          attr-factory: org.apache.catalina.users.MemoryUserDatabaseFactory
+          attr-name: UserDatabase
+          attr-pathname: conf/tomcat-users.xml
+          attr-type: org.apache.catalina.UserDatabase
+      Listener:
+      - attr-className: org.apache.catalina.startup.VersionLoggerListener
+      - attr-SSLEngine: 'on'
+        attr-className: org.apache.catalina.core.AprLifecycleListener
+      - attr-className: org.apache.catalina.core.JreMemoryLeakPreventionListener
+      - attr-className: org.apache.catalina.mbeans.GlobalResourcesLifecycleListener
+      - attr-className: org.apache.catalina.core.ThreadLocalLeakPreventionListener
+      Service:
+        Connector:
+          attr-connectionTimeout: '20000'
+          attr-port: '8080'
+          attr-protocol: HTTP/1.1
+          attr-redirectPort: '8443'
+        Engine:
+          Host:
+            Valve:
+              attr-className: org.apache.catalina.valves.AccessLogValve
+              attr-directory: logs
+              attr-pattern: '%h %l %u %t "%r" %s %b'
+              attr-prefix: localhost_access_log
+              attr-suffix: .txt
+            attr-appBase: webapps
+            attr-autoDeploy: 'true'
+            attr-name: localhost
+            attr-unpackWARs: 'true'
+          Realm:
+            Realm:
+              attr-className: org.apache.catalina.realm.UserDatabaseRealm
+              attr-resourceName: UserDatabase
+            attr-className: org.apache.catalina.realm.LockOutRealm
+          attr-defaultHost: localhost
+          attr-name: Catalina
+        attr-name: Catalina
+      attr-port: '-1'
+      attr-shutdown: SHUTDOWN
+  discovery_time: '2022-06-23T08:56:15+02:00'
+  files:
+  - path: /usr/share/tomcat
+    subtype: base
+    type: config
+  - path: /usr/share/tomcat
+    subtype: home
+    type: config
+  - path: /usr/lib/jvm/jre
+    subtype: java_home
+    type: config
+  - name: server.xml
+    path: /usr/share/tomcat/conf
+    subtype: generic
+    type: config
+  listening_ports:
+  - 8005
+  - 8009
+  - 8050
+  - 8082
+  - 11870
+  packages:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-docs-webapp
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-javadoc
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  process:
+    children: []
+    cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+      -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050 -Dcom.sun.management.jmxremote.rmi.port=8050
+      -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
+      -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+      -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+      -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+      start
+    cwd: /usr/lib/jvm/jre/bin/
+    listening_ports:
+    - 8005
+    - 8009
+    - 8050
+    - 8082
+    - 11870
+    pid: '881'
+    ppid: '1'
+    user: tomcat
+  type: Apache Tomcat Servlet Engine
+  version:
+  - number: 7.0.76
+    type: file
+  - number: 7.0.76
+    type: package
+expected_tasks_calls:
+  Check if server file in base is accessible: 1
+  Check if server file in home is accessible: 1
+  Check if xml_file is accessible: 1
+  Get config from cmdline: 1
+  Get config_file: 1
+  Read config file: 1
+  Read file version 1: 1
+  Read file version 2: 1
+  Read process environment: 1
 mocked_plugin_tasks:
-  Get config from cmdline:
-    number_of_calls: 1
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Get config_file:
-    number_of_calls: 1
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Read process environment:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      parsed: {
-        "TOMCATS_BASE": "/var/lib/tomcats/",
-        "SHELL": "/sbin/nologin",
-        "CATALINA_HOME": "/usr/share/tomcat",
-        "OLDPWD": "/",
-        "JAVA_OPTS": "-Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050 -Dcom.sun.management.jmxremote.rmi.port=8050 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io",
-        "NAME": "",
-        "USER": "tomcat",
-        "TOMCAT_CFG_LOADED": "1",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
-        "PWD": "/usr/share/tomcat",
-        "JAVA_HOME": "/usr/lib/jvm/jre",
-        "LANG": "en_US.UTF-8",
-        "SHLVL": "0",
-        "HOME": "/usr/share/tomcat",
-        "SECURITY_MANAGER": "false",
-        "LOGNAME": "tomcat",
-        "CATALINA_TMPDIR": "/var/cache/tomcat/temp"
-    }
-
-  Read file version 1:
-    number_of_calls: 1
-    plugin_result:
-      failed: true
-
-  Read file version 2:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      content: "================================================================================\n  Licensed to the Apache Software Foundation (ASF) under one or more\n  contributor license agreements.  See the NOTICE file distributed with\n  this work for additional information regarding copyright ownership.\n  The ASF licenses this file to You under the Apache License, Version 2.0\n  (the \"License\"); you may not use this file except in compliance with\n  the License.  You may obtain a copy of the License at\n\n      http://www.apache.org/licenses/LICENSE-2.0\n\n  Unless required by applicable law or agreed to in writing, software\n  distributed under the License is distributed on an \"AS IS\" BASIS,\n  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n  See the License for the specific language governing permissions and\n  limitations under the License.\n================================================================================\n\n\n                     Apache Tomcat Version 7.0.76\n                            Release Notes\n\n\n=========\nCONTENTS:\n=========\n\n* Dependency Changes\n* API Stability\n* JNI Based Applications\n* Bundled APIs\n* Web application reloading and static fields in shared libraries\n* Tomcat on Linux\n* Enabling SSI and CGI Support\n* Security manager URLs\n* Symlinking static resources\n* Viewing the Tomcat Change Log\n* Cryptographic software notice\n* When all else fails\n\n\n===================\nDependency Changes:\n===================\nTomcat 7.0 is designed to run on Java SE 6 and later.\n\nIn addition, Tomcat 7.0 uses the Eclipse JDT Java compiler for\ncompiling JSP pages.  This means you no longer need to have the complete\nJava Development Kit (JDK) to run Tomcat, but a Java Runtime Environment\n(JRE) is sufficient.  The Eclipse JDT Java compiler is bundled with the\nbinary Tomcat distributions.  Tomcat can also be configured to use the\ncompiler from the JDK to compile JSPs, or any other Java compiler supported\nby Apache Ant.\n\n\n==============\nAPI Stability:\n==============\nThe public interfaces for the following classes are fixed and will not be\nchanged at all during the remaining lifetime of the 7.x series:\n- javax/**/*\n\nThe public interfaces for the following classes may be added to in order to\nresolve bugs and/or add new features. No existing interface will be removed or\nchanged although it may be deprecated.\n- org/apache/catalina/*\n- org/apache/catalina/comet/*\n\nNote: As Tomcat 7 matures, the above list will be added to. The list is not\n      considered complete at this time.\n\nThe remaining classes are considered part of the Tomcat internals and may change\nwithout notice between point releases.\n\n\n=======================\nJNI Based Applications:\n=======================\nApplications that require native libraries must ensure that the libraries have\nbeen loaded prior to use.  Typically, this is done with a call like:\n\n  static {\n    System.loadLibrary(\"path-to-library-file\");\n  }\n\nin some class.  However, the application must also ensure that the library is\nnot loaded more than once.  If the above code were placed in a class inside\nthe web application (i.e. under /WEB-INF/classes or /WEB-INF/lib), and the\napplication were reloaded, the loadLibrary() call would be attempted a second\ntime.\n\nTo avoid this problem, place classes that load native libraries outside of the\nweb application, and ensure that the loadLibrary() call is executed only once\nduring the lifetime of a particular JVM.\n\n\n=============\nBundled APIs:\n=============\nA standard installation of Tomcat 7.0 makes all of the following APIs available\nfor use by web applications (by placing them in \"lib\"):\n* annotations-api.jar (Annotations package)\n* catalina.jar (Tomcat Catalina implementation)\n* catalina-ant.jar (Tomcat Catalina Ant tasks)\n* catalina-ha.jar (High availability package)\n* catalina-tribes.jar (Group communication)\n* ecj-4.4.2.jar (Eclipse JDT Java compiler)\n* el-api.jar (EL 2.2 API)\n* jasper.jar (Jasper 2 Compiler and Runtime)\n* jasper-el.jar (Jasper 2 EL implementation)\n* jsp-api.jar (JSP 2.2 API)\n* servlet-api.jar (Servlet 3.0 API)\n* tomcat7-websocket.jar (WebSocket 1.1 implementation)\n* tomcat-api.jar (Interfaces shared by Catalina and Jasper)\n* tomcat-coyote.jar (Tomcat connectors and utility classes)\n* tomcat-dbcp.jar (package renamed database connection pool based on Commons DBCP)\n* tomcat-jdbc.jar (Tomcat's database connection pooling solution)\n* tomcat-util.jar (Various utilities)\n* websocket-api.jar (WebSocket 1.1 API)\n\nYou can make additional APIs available to all of your web applications by\nputting unpacked classes into a \"classes\" directory (not created by default),\nor by placing them in JAR files in the \"lib\" directory.\n\nTo override the XML parser implementation or interfaces, use the endorsed\nmechanism of the JVM. The default configuration defines JARs located in\n\"endorsed\" as endorsed.\n\n\n================================================================\nWeb application reloading and static fields in shared libraries:\n================================================================\nSome shared libraries (many are part of the JDK) keep references to objects\ninstantiated by the web application. To avoid class loading related problems\n(ClassCastExceptions, messages indicating that the classloader\nis stopped, etc.), the shared libraries state should be reinitialized.\n\nSomething which might help is to avoid putting classes which would be\nreferenced by a shared static field in the web application classloader,\nand putting them in the shared classloader instead (JARs should be put in the\n\"lib\" folder, and classes should be put in the \"classes\" folder).\n\n\n================\nTomcat on Linux:\n================\nGLIBC 2.2 / Linux 2.4 users should define an environment variable:\nexport LD_ASSUME_KERNEL=2.2.5\n\nRedhat Linux 9.0 users should use the following setting to avoid\nstability problems:\nexport LD_ASSUME_KERNEL=2.4.1\n\nThere are some Linux bugs reported against the NIO sendfile behavior, make sure you\nhave a JDK that is up to date, or disable sendfile behavior in the Connector.<br/>\n6427312: (fc) FileChannel.transferTo() throws IOException \"system call interrupted\"<br/>\n5103988: (fc) FileChannel.transferTo should return -1 for EAGAIN instead throws IOException<br/>\n6253145: (fc) FileChannel.transferTo on Linux fails when going beyond 2GB boundary<br/>\n6470086: (fc) FileChannel.transferTo(2147483647, 1, channel) cause \"Value too large\" exception<br/>\n\n\n=============================\nEnabling SSI and CGI Support:\n=============================\nBecause of the security risks associated with CGI and SSI available\nto web applications, these features are disabled by default.  \n\nTo enable and configure CGI support, please see the cgi-howto.html page.\n\nTo enable and configue SSI support, please see the ssi-howto.html page.\n\n\n======================\nSecurity manager URLs:\n======================\nIn order to grant security permissions to JARs located inside the\nweb application repository, use URLs of of the following format\nin your policy file:\n\nfile:${catalina.base}/webapps/examples/WEB-INF/lib/driver.jar\n\n\n============================\nSymlinking static resources:\n============================\nBy default, Unix symlinks will not work when used in a web application to link\nresources located outside the web application root directory.\n\nThis behavior is optional, and the \"allowLinking\" flag may be used to disable\nthe check.\n\n\n==============================\nViewing the Tomcat Change Log:\n==============================\nSee changelog.html in this directory.\n\n\n=============================\nCryptographic software notice\n=============================\nThis distribution includes cryptographic software.  The country in\nwhich you currently reside may have restrictions on the import,\npossession, use, and/or re-export to another country, of\nencryption software.  BEFORE using any encryption software, please\ncheck your country's laws, regulations and policies concerning the\nimport, possession, or use, and re-export of encryption software, to\nsee if this is permitted.  See <http://www.wassenaar.org/> for more\ninformation.\n\nThe U.S. Government Department of Commerce, Bureau of Industry and\nSecurity (BIS), has classified this software as Export Commodity\nControl Number (ECCN) 5D002.C.1, which includes information security\nsoftware using or performing cryptographic functions with asymmetric\nalgorithms.  The form and manner of this Apache Software Foundation\ndistribution makes it eligible for export under the License Exception\nENC Technology Software Unrestricted (TSU) exception (see the BIS\nExport Administration Regulations, Section 740.13) for both object\ncode and source code.\n\nThe following provides more details on the included cryptographic\nsoftware:\n  - Tomcat includes code designed to work with JSSE\n  - Tomcat includes code designed to work with OpenSSL\n\n\n====================\nWhen all else fails:\n====================\nSee the FAQ\nhttp://tomcat.apache.org/faq/\n"
-
-  Check if xml_file is accessible:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-
   Check if server file in base is accessible:
     number_of_calls: 1
     plugin_result:
       failed: false
-
   Check if server file in home is accessible:
     number_of_calls: 1
     plugin_result:
       failed: false
-
+  Check if xml_file is accessible:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+  Get config from cmdline:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+    number_of_calls: 1
+  Get config_file:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+    number_of_calls: 1
   Read config file:
     number_of_calls: 1
     plugin_result:
       failed: false
-      parsed: {
-        "Server": {
-          "attr-port": "-1",
-          "attr-shutdown": "SHUTDOWN",
-          "Listener": [
-            {
-              "attr-className": "org.apache.catalina.startup.VersionLoggerListener"
-            },
-            {
-              "attr-className": "org.apache.catalina.core.AprLifecycleListener",
-              "attr-SSLEngine": "on"
-            },
-            {
-              "attr-className": "org.apache.catalina.core.JreMemoryLeakPreventionListener"
-            },
-            {
-              "attr-className": "org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"
-            },
-            {
-              "attr-className": "org.apache.catalina.core.ThreadLocalLeakPreventionListener"
-            }
-          ],
-          "GlobalNamingResources": {
-            "Resource": {
-              "attr-name": "UserDatabase",
-              "attr-auth": "Container",
-              "attr-type": "org.apache.catalina.UserDatabase",
-              "attr-description": "User database that can be updated and saved",
-              "attr-factory": "org.apache.catalina.users.MemoryUserDatabaseFactory",
-              "attr-pathname": "conf/tomcat-users.xml"
-            }
-          },
-          "Service": {
-            "attr-name": "Catalina",
-            "Connector": {
-              "attr-port": "8080",
-              "attr-protocol": "HTTP/1.1",
-              "attr-connectionTimeout": "20000",
-              "attr-redirectPort": "8443"
-            },
-            "Engine": {
-              "attr-name": "Catalina",
-              "attr-defaultHost": "localhost",
-              "Realm": {
-                "attr-className": "org.apache.catalina.realm.LockOutRealm",
-                "Realm": {
-                  "attr-className": "org.apache.catalina.realm.UserDatabaseRealm",
-                  "attr-resourceName": "UserDatabase"
-                }
-              },
-              "Host": {
-                "attr-name": "localhost",
-                "attr-appBase": "webapps",
-                "attr-unpackWARs": "true",
-                "attr-autoDeploy": "true",
-                "Valve": {
-                  "attr-className": "org.apache.catalina.valves.AccessLogValve",
-                  "attr-directory": "logs",
-                  "attr-prefix": "localhost_access_log",
-                  "attr-suffix": ".txt",
-                  "attr-pattern": "%h %l %u %t \"%r\" %s %b"
-                }
-              }
-            }
-          }
-        }
-    }
-
-
-expected_tasks_calls:
-  Get config_file: 1
-  Get config from cmdline: 1
-  Read process environment: 1
-  Read file version 1: 1
-  Read file version 2: 1
-  Check if xml_file is accessible: 1
-  Check if server file in base is accessible: 1
-  Check if server file in home is accessible: 1
-  Read config file: 1
-
-expected_result:
-  - bindings:
-      - address: '::'
-        class: 'service'
-        port: 11870
-        protocol: 'tcp'
-      - address: '127.0.0.1'
-        class: 'service'
-        port: 8005
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 8009
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 8082
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 8050
-        protocol: 'tcp'
-      - class: port_http
-        port: 8080
-      - class: port_jmx
-        port: 8050
-    configuration:
-      Server:
-        attr-port: '-1'
-        attr-shutdown: SHUTDOWN
-        Listener:
+      parsed:
+        Server:
+          GlobalNamingResources:
+            Resource:
+              attr-auth: Container
+              attr-description: User database that can be updated and saved
+              attr-factory: org.apache.catalina.users.MemoryUserDatabaseFactory
+              attr-name: UserDatabase
+              attr-pathname: conf/tomcat-users.xml
+              attr-type: org.apache.catalina.UserDatabase
+          Listener:
           - attr-className: org.apache.catalina.startup.VersionLoggerListener
-          - attr-className: org.apache.catalina.core.AprLifecycleListener
-            attr-SSLEngine: 'on'
+          - attr-SSLEngine: 'on'
+            attr-className: org.apache.catalina.core.AprLifecycleListener
           - attr-className: org.apache.catalina.core.JreMemoryLeakPreventionListener
           - attr-className: org.apache.catalina.mbeans.GlobalResourcesLifecycleListener
           - attr-className: org.apache.catalina.core.ThreadLocalLeakPreventionListener
-        GlobalNamingResources:
-          Resource:
-            attr-name: UserDatabase
-            attr-auth: Container
-            attr-type: org.apache.catalina.UserDatabase
-            attr-description: User database that can be updated and saved
-            attr-factory: org.apache.catalina.users.MemoryUserDatabaseFactory
-            attr-pathname: conf/tomcat-users.xml
-        Service:
-          attr-name: Catalina
-          Connector:
-            attr-port: '8080'
-            attr-protocol: HTTP/1.1
-            attr-connectionTimeout: '20000'
-            attr-redirectPort: '8443'
-          Engine:
-            attr-name: Catalina
-            attr-defaultHost: localhost
-            Realm:
-              attr-className: org.apache.catalina.realm.LockOutRealm
+          Service:
+            Connector:
+              attr-connectionTimeout: '20000'
+              attr-port: '8080'
+              attr-protocol: HTTP/1.1
+              attr-redirectPort: '8443'
+            Engine:
+              Host:
+                Valve:
+                  attr-className: org.apache.catalina.valves.AccessLogValve
+                  attr-directory: logs
+                  attr-pattern: '%h %l %u %t "%r" %s %b'
+                  attr-prefix: localhost_access_log
+                  attr-suffix: .txt
+                attr-appBase: webapps
+                attr-autoDeploy: 'true'
+                attr-name: localhost
+                attr-unpackWARs: 'true'
               Realm:
-                attr-className: org.apache.catalina.realm.UserDatabaseRealm
-                attr-resourceName: UserDatabase
-            Host:
-              attr-name: localhost
-              attr-appBase: webapps
-              attr-unpackWARs: 'true'
-              attr-autoDeploy: 'true'
-              Valve:
-                attr-className: org.apache.catalina.valves.AccessLogValve
-                attr-directory: logs
-                attr-prefix: localhost_access_log
-                attr-suffix: .txt
-                attr-pattern: '%h %l %u %t "%r" %s %b'
-    discovery_time: '2022-06-23T08:56:15+02:00'
-    files:
-      - path: /usr/share/tomcat
-        subtype: base
-        type: config
-      - path: /usr/share/tomcat
-        subtype: home
-        type: config
-      - path: /usr/lib/jvm/jre
-        subtype: java_home
-        type: config
-      - name: server.xml
-        path: /usr/share/tomcat/conf
-        subtype: generic
-        type: config
-    listening_ports:
-      - 8005
-      - 8009
-      - 8050
-      - 8082
-      - 11870
-    packages:
-      - arch: noarch
-        epoch: 0
-        name: tomcat
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-admin-webapps
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-docs-webapp
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-el-2.2-api
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-javadoc
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-jsp-2.2-api
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-lib
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-servlet-3.0-api
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-webapps
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-    process:
-      children: []
-      cmdline: >-
-        /usr/lib/jvm/jre/bin/java
-        -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
-        -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050
-        -Dcom.sun.management.jmxremote.rmi.port=8050
-        -Dcom.sun.management.jmxremote.ssl=false
-        -Dcom.sun.management.jmxremote.authenticate=false
-        -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath
-        /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
-        -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat
-        -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp
-        -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
-        -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-        org.apache.catalina.startup.Bootstrap start
-      listening_ports:
-        - 8005
-        - 8009
-        - 8050
-        - 8082
-        - 11870
-      pid: '881'
-      ppid: '1'
-      user: tomcat
-    type: Apache Tomcat Servlet Engine
-    version:
-      - number: 7.0.76
-        type: file
-      - number: 7.0.76
-        type: package
-software_list:
-  - name: Apache Tomcat Servlet Engine
-    cmd_regexp: \.apache\.tomcat\.startup|\.apache\.catalina\.startup
-    pkg_regexp: tomcat
-    process_type: parent
-    return_children: true
-    return_packages: true
-    custom_tasks:
-      - name: Include Apache Tomcat Servlet Engine specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/tomcat.yaml"
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - analyzer
-        - '-c'
-        - /etc/iometrics/skydive/skydive.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - analyzer
-          - '-c'
-          - /etc/iometrics/skydive/skydive.yml
-        Domainname: ''
-        Entrypoint:
-          - /usr/local/bin/skydive
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-        ExposedPorts:
-          8082/tcp: {}
-        Hostname: test-ram-norm01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-4'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/iometrics/skydive/skydive.yml: {}
-          /var/lib/skydive: {}
-        WorkingDir: ''
-      Created: '2022-02-11T16:39:16.436847232Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631-init/diff:/var/lib/docker/overlay2/98c8fc8a1198391d57b52bfc7481b12d8fcb3f1460fa681558aaa7306730bd9a/diff:/var/lib/docker/overlay2/9b3407fa7b3cf45082812007500f2249298b9522aeeb6b5e8c324eb8e7291ad5/diff:/var/lib/docker/overlay2/2a70d40f778c8683b234911bdff488726b2d1931d804bca86b612015cabbcfec/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/iometrics/skydive/:/var/lib/skydive:rw'
-          - >-
-            /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hosts
-      Id: 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
-      Image: 'sha256:7b966f2ba2092efb97f038f14563b84b32e98879ad8d52189af823c594b185ed'
-      LogPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/iometrics/skydive/skydive.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics/skydive/skydive.yml
-          Type: bind
-        - Destination: /var/lib/skydive
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/iometrics/skydive
-          Type: bind
-      Name: /skydive-analyzer
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 36711925279b4b1ac03d5cdb68a3d4d765d86759714aaae8c976b8bce04ce890
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 6e919553642bae0550eee9382a797f886036f8f6f296d65183121041f1da3b83
-        Ports: {}
-        SandboxID: be98496481fa878c6ad9f140fbcae075d3bccea63ad36757fecf011ab94b6dd3
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/local/bin/skydive
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T14:45:04.915207484Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1512
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:45:08.126872087Z'
-        Status: running
+                Realm:
+                  attr-className: org.apache.catalina.realm.UserDatabaseRealm
+                  attr-resourceName: UserDatabase
+                attr-className: org.apache.catalina.realm.LockOutRealm
+              attr-defaultHost: localhost
+              attr-name: Catalina
+            attr-name: Catalina
+          attr-port: '-1'
+          attr-shutdown: SHUTDOWN
+  Read file version 1:
+    number_of_calls: 1
+    plugin_result:
+      failed: true
+  Read file version 2:
+    number_of_calls: 1
+    plugin_result:
+      content: "================================================================================\n\
+        \  Licensed to the Apache Software Foundation (ASF) under one or more\n  contributor\
+        \ license agreements.  See the NOTICE file distributed with\n  this work for\
+        \ additional information regarding copyright ownership.\n  The ASF licenses\
+        \ this file to You under the Apache License, Version 2.0\n  (the \"License\"\
+        ); you may not use this file except in compliance with\n  the License.  You\
+        \ may obtain a copy of the License at\n\n      http://www.apache.org/licenses/LICENSE-2.0\n\
+        \n  Unless required by applicable law or agreed to in writing, software\n\
+        \  distributed under the License is distributed on an \"AS IS\" BASIS,\n \
+        \ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n\
+        \  See the License for the specific language governing permissions and\n \
+        \ limitations under the License.\n================================================================================\n\
+        \n\n                     Apache Tomcat Version 7.0.76\n                  \
+        \          Release Notes\n\n\n=========\nCONTENTS:\n=========\n\n* Dependency\
+        \ Changes\n* API Stability\n* JNI Based Applications\n* Bundled APIs\n* Web\
+        \ application reloading and static fields in shared libraries\n* Tomcat on\
+        \ Linux\n* Enabling SSI and CGI Support\n* Security manager URLs\n* Symlinking\
+        \ static resources\n* Viewing the Tomcat Change Log\n* Cryptographic software\
+        \ notice\n* When all else fails\n\n\n===================\nDependency Changes:\n\
+        ===================\nTomcat 7.0 is designed to run on Java SE 6 and later.\n\
+        \nIn addition, Tomcat 7.0 uses the Eclipse JDT Java compiler for\ncompiling\
+        \ JSP pages.  This means you no longer need to have the complete\nJava Development\
+        \ Kit (JDK) to run Tomcat, but a Java Runtime Environment\n(JRE) is sufficient.\
+        \  The Eclipse JDT Java compiler is bundled with the\nbinary Tomcat distributions.\
+        \  Tomcat can also be configured to use the\ncompiler from the JDK to compile\
+        \ JSPs, or any other Java compiler supported\nby Apache Ant.\n\n\n==============\n\
+        API Stability:\n==============\nThe public interfaces for the following classes\
+        \ are fixed and will not be\nchanged at all during the remaining lifetime\
+        \ of the 7.x series:\n- javax/**/*\n\nThe public interfaces for the following\
+        \ classes may be added to in order to\nresolve bugs and/or add new features.\
+        \ No existing interface will be removed or\nchanged although it may be deprecated.\n\
+        - org/apache/catalina/*\n- org/apache/catalina/comet/*\n\nNote: As Tomcat\
+        \ 7 matures, the above list will be added to. The list is not\n      considered\
+        \ complete at this time.\n\nThe remaining classes are considered part of the\
+        \ Tomcat internals and may change\nwithout notice between point releases.\n\
+        \n\n=======================\nJNI Based Applications:\n=======================\n\
+        Applications that require native libraries must ensure that the libraries\
+        \ have\nbeen loaded prior to use.  Typically, this is done with a call like:\n\
+        \n  static {\n    System.loadLibrary(\"path-to-library-file\");\n  }\n\nin\
+        \ some class.  However, the application must also ensure that the library\
+        \ is\nnot loaded more than once.  If the above code were placed in a class\
+        \ inside\nthe web application (i.e. under /WEB-INF/classes or /WEB-INF/lib),\
+        \ and the\napplication were reloaded, the loadLibrary() call would be attempted\
+        \ a second\ntime.\n\nTo avoid this problem, place classes that load native\
+        \ libraries outside of the\nweb application, and ensure that the loadLibrary()\
+        \ call is executed only once\nduring the lifetime of a particular JVM.\n\n\
+        \n=============\nBundled APIs:\n=============\nA standard installation of\
+        \ Tomcat 7.0 makes all of the following APIs available\nfor use by web applications\
+        \ (by placing them in \"lib\"):\n* annotations-api.jar (Annotations package)\n\
+        * catalina.jar (Tomcat Catalina implementation)\n* catalina-ant.jar (Tomcat\
+        \ Catalina Ant tasks)\n* catalina-ha.jar (High availability package)\n* catalina-tribes.jar\
+        \ (Group communication)\n* ecj-4.4.2.jar (Eclipse JDT Java compiler)\n* el-api.jar\
+        \ (EL 2.2 API)\n* jasper.jar (Jasper 2 Compiler and Runtime)\n* jasper-el.jar\
+        \ (Jasper 2 EL implementation)\n* jsp-api.jar (JSP 2.2 API)\n* servlet-api.jar\
+        \ (Servlet 3.0 API)\n* tomcat7-websocket.jar (WebSocket 1.1 implementation)\n\
+        * tomcat-api.jar (Interfaces shared by Catalina and Jasper)\n* tomcat-coyote.jar\
+        \ (Tomcat connectors and utility classes)\n* tomcat-dbcp.jar (package renamed\
+        \ database connection pool based on Commons DBCP)\n* tomcat-jdbc.jar (Tomcat's\
+        \ database connection pooling solution)\n* tomcat-util.jar (Various utilities)\n\
+        * websocket-api.jar (WebSocket 1.1 API)\n\nYou can make additional APIs available\
+        \ to all of your web applications by\nputting unpacked classes into a \"classes\"\
+        \ directory (not created by default),\nor by placing them in JAR files in\
+        \ the \"lib\" directory.\n\nTo override the XML parser implementation or interfaces,\
+        \ use the endorsed\nmechanism of the JVM. The default configuration defines\
+        \ JARs located in\n\"endorsed\" as endorsed.\n\n\n================================================================\n\
+        Web application reloading and static fields in shared libraries:\n================================================================\n\
+        Some shared libraries (many are part of the JDK) keep references to objects\n\
+        instantiated by the web application. To avoid class loading related problems\n\
+        (ClassCastExceptions, messages indicating that the classloader\nis stopped,\
+        \ etc.), the shared libraries state should be reinitialized.\n\nSomething\
+        \ which might help is to avoid putting classes which would be\nreferenced\
+        \ by a shared static field in the web application classloader,\nand putting\
+        \ them in the shared classloader instead (JARs should be put in the\n\"lib\"\
+        \ folder, and classes should be put in the \"classes\" folder).\n\n\n================\n\
+        Tomcat on Linux:\n================\nGLIBC 2.2 / Linux 2.4 users should define\
+        \ an environment variable:\nexport LD_ASSUME_KERNEL=2.2.5\n\nRedhat Linux\
+        \ 9.0 users should use the following setting to avoid\nstability problems:\n\
+        export LD_ASSUME_KERNEL=2.4.1\n\nThere are some Linux bugs reported against\
+        \ the NIO sendfile behavior, make sure you\nhave a JDK that is up to date,\
+        \ or disable sendfile behavior in the Connector.<br/>\n6427312: (fc) FileChannel.transferTo()\
+        \ throws IOException \"system call interrupted\"<br/>\n5103988: (fc) FileChannel.transferTo\
+        \ should return -1 for EAGAIN instead throws IOException<br/>\n6253145: (fc)\
+        \ FileChannel.transferTo on Linux fails when going beyond 2GB boundary<br/>\n\
+        6470086: (fc) FileChannel.transferTo(2147483647, 1, channel) cause \"Value\
+        \ too large\" exception<br/>\n\n\n=============================\nEnabling\
+        \ SSI and CGI Support:\n=============================\nBecause of the security\
+        \ risks associated with CGI and SSI available\nto web applications, these\
+        \ features are disabled by default.  \n\nTo enable and configure CGI support,\
+        \ please see the cgi-howto.html page.\n\nTo enable and configue SSI support,\
+        \ please see the ssi-howto.html page.\n\n\n======================\nSecurity\
+        \ manager URLs:\n======================\nIn order to grant security permissions\
+        \ to JARs located inside the\nweb application repository, use URLs of of the\
+        \ following format\nin your policy file:\n\nfile:${catalina.base}/webapps/examples/WEB-INF/lib/driver.jar\n\
+        \n\n============================\nSymlinking static resources:\n============================\n\
+        By default, Unix symlinks will not work when used in a web application to\
+        \ link\nresources located outside the web application root directory.\n\n\
+        This behavior is optional, and the \"allowLinking\" flag may be used to disable\n\
+        the check.\n\n\n==============================\nViewing the Tomcat Change\
+        \ Log:\n==============================\nSee changelog.html in this directory.\n\
+        \n\n=============================\nCryptographic software notice\n=============================\n\
+        This distribution includes cryptographic software.  The country in\nwhich\
+        \ you currently reside may have restrictions on the import,\npossession, use,\
+        \ and/or re-export to another country, of\nencryption software.  BEFORE using\
+        \ any encryption software, please\ncheck your country's laws, regulations\
+        \ and policies concerning the\nimport, possession, or use, and re-export of\
+        \ encryption software, to\nsee if this is permitted.  See <http://www.wassenaar.org/>\
+        \ for more\ninformation.\n\nThe U.S. Government Department of Commerce, Bureau\
+        \ of Industry and\nSecurity (BIS), has classified this software as Export\
+        \ Commodity\nControl Number (ECCN) 5D002.C.1, which includes information security\n\
+        software using or performing cryptographic functions with asymmetric\nalgorithms.\
+        \  The form and manner of this Apache Software Foundation\ndistribution makes\
+        \ it eligible for export under the License Exception\nENC Technology Software\
+        \ Unrestricted (TSU) exception (see the BIS\nExport Administration Regulations,\
+        \ Section 740.13) for both object\ncode and source code.\n\nThe following\
+        \ provides more details on the included cryptographic\nsoftware:\n  - Tomcat\
+        \ includes code designed to work with JSSE\n  - Tomcat includes code designed\
+        \ to work with OpenSSL\n\n\n====================\nWhen all else fails:\n====================\n\
+        See the FAQ\nhttp://tomcat.apache.org/faq/\n"
+      failed: false
+  Read process environment:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      parsed:
+        CATALINA_HOME: /usr/share/tomcat
+        CATALINA_TMPDIR: /var/cache/tomcat/temp
+        HOME: /usr/share/tomcat
+        JAVA_HOME: /usr/lib/jvm/jre
+        JAVA_OPTS: -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+          -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050
+          -Dcom.sun.management.jmxremote.rmi.port=8050 -Dcom.sun.management.jmxremote.ssl=false
+          -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io
+        LANG: en_US.UTF-8
+        LOGNAME: tomcat
+        NAME: ''
+        OLDPWD: /
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+        PWD: /usr/share/tomcat
+        SECURITY_MANAGER: 'false'
+        SHELL: /sbin/nologin
+        SHLVL: '0'
+        TOMCATS_BASE: /var/lib/tomcats/
+        TOMCAT_CFG_LOADED: '1'
+        USER: tomcat
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   apache-commons-collections:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-collections
-      release: 22.el7_2
-      source: rpm
-      version: 3.2.1
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
   apache-commons-daemon:
-    - arch: x86_64
-      epoch: null
-      name: apache-commons-daemon
-      release: 7.el7
-      source: rpm
-      version: 1.0.13
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
   apache-commons-dbcp:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-dbcp
-      release: 17.el7
-      source: rpm
-      version: '1.4'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
   apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
   apache-commons-pool:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-pool
-      release: 9.el7
-      source: rpm
-      version: '1.6'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
   avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 35.el7_9
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 35.el7_9
+    source: rpm
+    version: 4.2.46
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 72.el7_9
-      source: rpm
-      version: 2021.2.50
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 72.el7_9
+    source: rpm
+    version: 2021.2.50
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 7.el7.centos.5
-      source: rpm
-      version: '19.4'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 7.el7.centos.5
+    source: rpm
+    version: '19.4'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.4.12
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.4.12
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: i686
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: i686
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-ce-rootless-extras:
-    - arch: x86_64
-      epoch: 0
-      name: docker-ce-rootless-extras
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-scan-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-scan-plugin
-      release: 3.el7
-      source: rpm
-      version: 0.12.0
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  ecj:
-    - arch: x86_64
-      epoch: 1
-      name: ecj
-      release: 3.el7
-      source: rpm
-      version: 4.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '14'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
-  fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  geronimo-jta:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jta
-      release: 17.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 467e318a
-      source: rpm
-      version: 00f97f56
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iometrics-agent-plugin-oracle-lib-connector:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-lib-connector
-      release: '25'
-      source: rpm
-      version: 18.5.0_1.11.3
-  iometrics-agent-plugin-oracle-libs:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-libs
-      release: '1'
-      source: rpm
-      version: 18.5.0
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-taglibs-standard:
-    - arch: noarch
-      epoch: 0
-      name: jakarta-taglibs-standard
-      release: 14.el7_1
-      source: rpm
-      version: 1.1.2
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.3
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: i686
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 135.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: i686
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  ksh:
-    - arch: x86_64
-      epoch: null
-      name: ksh
-      release: 143.el7_9
-      source: rpm
-      version: '20120801'
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXmu:
-    - arch: x86_64
-      epoch: null
-      name: libXmu
-      release: 2.el7
-      source: rpm
-      version: 1.1.2
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXt:
-    - arch: x86_64
-      epoch: null
-      name: libXt
-      release: 3.el7
-      source: rpm
-      version: 1.1.5
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXv:
-    - arch: x86_64
-      epoch: null
-      name: libXv
-      release: 1.el7
-      source: rpm
-      version: 1.0.11
-  libXxf86dga:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86dga
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.4
-  libXxf86misc:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86misc
-      release: 7.1.el7
-      source: rpm
-      version: 1.0.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-    - arch: i686
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: i686
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdmx:
-    - arch: x86_64
-      epoch: null
-      name: libdmx
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: i686
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-    - arch: i686
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 18.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  mailx:
-    - arch: x86_64
-      epoch: null
-      name: mailx
-      release: 19.el7
-      source: rpm
-      version: '12.5'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-    - arch: i686
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7.2
-      source: rpm
-      version: 1.3.0
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: i686
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-    - arch: i686
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-    - arch: i686
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-    - arch: i686
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  oracle-database-preinstall-21c:
-    - arch: x86_64
-      epoch: null
-      name: oracle-database-preinstall-21c
-      release: 1.el7
-      source: rpm
-      version: '1.0'
-  oracle-database-xe-21c:
-    - arch: x86_64
-      epoch: null
-      name: oracle-database-xe-21c
-      release: '1'
-      source: rpm
-      version: '1.0'
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: i686
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql:
-    - arch: x86_64
-      epoch: null
-      name: postgresql
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-contrib
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-    - arch: i686
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-server
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 17.el7
-      source: rpm
-      version: '22.20'
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 10.el7
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: i686
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redis:
-    - arch: x86_64
-      epoch: null
-      name: redis
-      release: 1.el7.remi
-      source: rpm
-      version: 6.2.6
-  remi-release:
-    - arch: noarch
-      epoch: null
-      name: remi-release
-      release: 2.el7.remi
-      source: rpm
-      version: '7.9'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9.1
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  smartmontools:
-    - arch: x86_64
-      epoch: 1
-      name: smartmontools
-      release: 2.el7
-      source: rpm
-      version: '7.0'
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: i686
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.2
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  tomcat:
-    - arch: noarch
-      epoch: 0
-      name: tomcat
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-admin-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-admin-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-docs-webapp:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-docs-webapp
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-el-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-el-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-javadoc:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-javadoc
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-jsp-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-jsp-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-lib:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-lib
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 24.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  uuid:
-    - arch: x86_64
-      epoch: null
-      name: uuid
-      release: 26.el7
-      source: rpm
-      version: 1.6.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7_9.1
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-utils
-      release: 23.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-xauth:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-xauth
-      release: 1.el7
-      source: rpm
-      version: 1.0.9
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-    - arch: i686
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '127'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '194'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '195'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '267'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '273'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '294'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '411'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '453'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '481'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '486'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '515'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '551'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '552'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '566'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/smartd -n -q never
-    pid: '567'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '570'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '573'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '584'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '594'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H test-ram-norm01 eth0
-    pid: '826'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/lib/jvm/jre/bin/java
-      -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
-      -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050
-      -Dcom.sun.management.jmxremote.rmi.port=8050
-      -Dcom.sun.management.jmxremote.ssl=false
-      -Dcom.sun.management.jmxremote.authenticate=false
-      -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath
-      /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
-      -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat
-      -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp
-      -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      org.apache.catalina.startup.Bootstrap start
-    pid: '881'
-    ppid: '1'
-    user: tomcat
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '883'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '902'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1058'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1063'
-    ppid: '1058'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1103'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1105'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/redis-server 127.0.0.1:6379'
-    pid: '1109'
-    ppid: '1'
-    user: redis
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1110'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1114'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1115'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1116'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9 -address
-      /run/containerd/containerd.sock
-    pid: '1494'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
-    pid: '1512'
-    ppid: '1494'
-    user: root
-  - cmdline: /usr/bin/docker start -a skydive-analyzer
-    pid: '1561'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '2573'
-    ppid: '2'
-    user: root
-  - cmdline: xe_m002_XE
-    pid: '6043'
-    ppid: '1'
-    user: oracle
-  - cmdline: /usr/bin/postgres -D /var/lib/pgsql/data -p 5432
-    pid: '7291'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: logger process'
-    pid: '7292'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: checkpointer process'
-    pid: '7294'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: writer process'
-    pid: '7295'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: wal writer process'
-    pid: '7296'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: autovacuum launcher process'
-    pid: '7297'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: stats collector process'
-    pid: '7298'
-    ppid: '7291'
-    user: postgres
-  - cmdline: pickup -l -t unix -u
-    pid: '7673'
-    ppid: '1058'
-    user: postfix
-  - cmdline: >-
-      /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml
-      -path.home /usr/share/filebeat -path.config /etc/filebeat -path.data
-      /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '11133'
-    ppid: '1'
-    user: root
-  - cmdline: xe_m005_XE
-    pid: '11706'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '15343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15997'
-    ppid: '2'
-    user: root
-  - cmdline: xe_m000_XE
-    pid: '16346'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '16694'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '16699'
-    ppid: '1103'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '16701'
-    ppid: '16699'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '16859'
-    ppid: '16701'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
-    pid: '16872'
-    ppid: '16859'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
-    pid: '16873'
-    ppid: '16872'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
-    pid: '16874'
-    ppid: '16873'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '19386'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: postgres datadope [local] idle'
-    pid: '19444'
-    ppid: '7291'
-    user: postgres
-  - cmdline: xe_m004_XE
-    pid: '21779'
-    ppid: '1'
-    user: oracle
-  - cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
-    pid: '22926'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pmon_XE
-    pid: '22942'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_clmn_XE
-    pid: '22946'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_psp0_XE
-    pid: '22950'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vktm_XE
-    pid: '22954'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen0_XE
-    pid: '22961'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mman_XE
-    pid: '22967'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen1_XE
-    pid: '22971'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen2_XE
-    pid: '22973'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vosd_XE
-    pid: '22975'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_diag_XE
-    pid: '22979'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_ofsd_XE
-    pid: '22985'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dbrm_XE
-    pid: '22990'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vkrm_XE
-    pid: '22993'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_svcb_XE
-    pid: '22996'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pman_XE
-    pid: '23001'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dia0_XE
-    pid: '23004'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dbw0_XE
-    pid: '23008'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_lgwr_XE
-    pid: '23012'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_ckpt_XE
-    pid: '23015'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_smon_XE
-    pid: '23020'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_smco_XE
-    pid: '23023'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_reco_XE
-    pid: '23030'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_lreg_XE
-    pid: '23033'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pxmn_XE
-    pid: '23035'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mmon_XE
-    pid: '23041'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mmnl_XE
-    pid: '23045'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_bg00_XE
-    pid: '23049'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_d000_XE
-    pid: '23051'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w000_XE
-    pid: '23054'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_bg01_XE
-    pid: '23058'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_s000_XE
-    pid: '23060'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w001_XE
-    pid: '23063'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tmon_XE
-    pid: '23068'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt00_XE
-    pid: '23074'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt01_XE
-    pid: '23076'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt02_XE
-    pid: '23078'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_rcbg_XE
-    pid: '23098'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_aqpc_XE
-    pid: '23109'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w002_XE
-    pid: '23114'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w003_XE
-    pid: '23120'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w004_XE
-    pid: '23299'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_cjq0_XE
-    pid: '23309'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_qm02_XE
-    pid: '23311'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_q003_XE
-    pid: '23318'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_q005_XE
-    pid: '23374'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_cl00_XE
-    pid: '23486'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w005_XE
-    pid: '24218'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w006_XE
-    pid: '24731'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w007_XE
-    pid: '24736'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '27392'
-    ppid: '2'
-    user: root
-  - cmdline: xe_m006_XE
-    pid: '28429'
-    ppid: '1'
-    user: oracle
-tcp_listen:
-  - address: 127.0.0.1
-    name: postgres
-    pid: 7291
-    port: 5432
-    protocol: tcp
-    stime: 'Fri Jun  3 09:22:29 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1058
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:01 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 1512
-    port: 12379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 1512
-    port: 12380
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: 192.168.0.26
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: 127.0.0.1
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1103
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: root
-  - address: '::1'
-    name: postgres
-    pid: 7291
-    port: 5432
-    protocol: tcp
-    stime: 'Fri Jun  3 09:22:29 2022'
-    user: postgres
-  - address: '::1'
-    name: master
-    pid: 1058
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:01 2022'
-    user: root
-  - address: '::'
-    name: tnslsnr
-    pid: 22926
-    port: 5500
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:34 2022'
-    user: oracle
-  - address: '::'
-    name: java
-    pid: 881
-    port: 11870
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 4000
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: tnslsnr
-    pid: 22926
-    port: 1539
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:34 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: java
-    pid: 881
-    port: 8005
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8009
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: xe_d000_XE
-    pid: 23051
-    port: 21899
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::1'
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8080
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8081
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8082
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8050
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: sshd
-    pid: 1103
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: root
-udp_listen:
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 584
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:54 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 566
-    port: 719
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 826
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: root
-  - address: 0.0.0.0
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-ce-rootless-extras:
+  - arch: x86_64
+    epoch: 0
+    name: docker-ce-rootless-extras
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-scan-plugin:
+  - arch: x86_64
+    epoch: 0
+    name: docker-scan-plugin
+    release: 3.el7
+    source: rpm
+    version: 0.12.0
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '14'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  fuse-overlayfs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
+  fuse3-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 467e318a
+    source: rpm
+    version: 00f97f56
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iometrics-agent-plugin-oracle-lib-connector:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-lib-connector
+    release: '25'
+    source: rpm
+    version: 18.5.0_1.11.3
+  iometrics-agent-plugin-oracle-libs:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-libs
+    release: '1'
+    source: rpm
+    version: 18.5.0
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.3
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: i686
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 135.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: i686
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  ksh:
+  - arch: x86_64
+    epoch: null
+    name: ksh
+    release: 143.el7_9
+    source: rpm
+    version: '20120801'
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXmu:
+  - arch: x86_64
+    epoch: null
+    name: libXmu
+    release: 2.el7
+    source: rpm
+    version: 1.1.2
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXt:
+  - arch: x86_64
+    epoch: null
+    name: libXt
+    release: 3.el7
+    source: rpm
+    version: 1.1.5
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXv:
+  - arch: x86_64
+    epoch: null
+    name: libXv
+    release: 1.el7
+    source: rpm
+    version: 1.0.11
+  libXxf86dga:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86dga
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.4
+  libXxf86misc:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86misc
+    release: 7.1.el7
+    source: rpm
+    version: 1.0.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  - arch: i686
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: i686
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdmx:
+  - arch: x86_64
+    epoch: null
+    name: libdmx
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: i686
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  - arch: i686
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 18.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  mailx:
+  - arch: x86_64
+    epoch: null
+    name: mailx
+    release: 19.el7
+    source: rpm
+    version: '12.5'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  - arch: i686
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7.2
+    source: rpm
+    version: 1.3.0
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: i686
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  - arch: i686
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  - arch: i686
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  - arch: i686
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  oracle-database-preinstall-21c:
+  - arch: x86_64
+    epoch: null
+    name: oracle-database-preinstall-21c
+    release: 1.el7
+    source: rpm
+    version: '1.0'
+  oracle-database-xe-21c:
+  - arch: x86_64
+    epoch: null
+    name: oracle-database-xe-21c
+    release: '1'
+    source: rpm
+    version: '1.0'
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: i686
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql:
+  - arch: x86_64
+    epoch: null
+    name: postgresql
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-contrib
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  - arch: i686
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-server
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  psmisc:
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 17.el7
+    source: rpm
+    version: '22.20'
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 10.el7
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: i686
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redis:
+  - arch: x86_64
+    epoch: null
+    name: redis
+    release: 1.el7.remi
+    source: rpm
+    version: 6.2.6
+  remi-release:
+  - arch: noarch
+    epoch: null
+    name: remi-release
+    release: 2.el7.remi
+    source: rpm
+    version: '7.9'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 566
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 584
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:54 2022'
-    user: chrony
-  - address: '::1'
-    name: xe_lreg_XE
-    pid: 23033
-    port: 33176
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 719
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::1'
-    name: xe_s000_XE
-    pid: 23060
-    port: 64452
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:38 2022'
-    user: oracle
-  - address: '::1'
-    name: xe_d000_XE
-    pid: 23051
-    port: 32251
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8081
-    protocol: udp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9.1
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  smartmontools:
+  - arch: x86_64
+    epoch: 1
+    name: smartmontools
+    release: 2.el7
+    source: rpm
+    version: '7.0'
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: i686
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.2
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-docs-webapp:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-docs-webapp
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-javadoc:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-javadoc
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 24.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  uuid:
+  - arch: x86_64
+    epoch: null
+    name: uuid
+    release: 26.el7
+    source: rpm
+    version: 1.6.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7_9.1
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-utils:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-utils
+    release: 23.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-xauth:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-xauth
+    release: 1.el7
+    source: rpm
+    version: 1.0.9
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+  - arch: i686
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '127'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '194'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '195'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '273'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '411'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '453'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '481'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '486'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '515'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '551'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '552'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '566'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/smartd -n -q never
+  cwd: /usr/sbin/
+  pid: '567'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '570'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '573'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '584'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '594'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H test-ram-norm01 eth0
+  cwd: /sbin/
+  pid: '826'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+    -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050 -Dcom.sun.management.jmxremote.rmi.port=8050
+    -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
+    -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+    -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+    -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+    start
+  cwd: /usr/lib/jvm/jre/bin/
+  pid: '881'
+  ppid: '1'
+  user: tomcat
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '883'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '902'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1058'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1063'
+  ppid: '1058'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1103'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1105'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/redis-server 127.0.0.1:6379
+  cwd: /usr/bin/
+  pid: '1109'
+  ppid: '1'
+  user: redis
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1110'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1114'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1115'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1116'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1494'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
+  cwd: /usr/local/bin/
+  pid: '1512'
+  ppid: '1494'
+  user: root
+- cmdline: /usr/bin/docker start -a skydive-analyzer
+  cwd: /usr/bin/
+  pid: '1561'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2573'
+  ppid: '2'
+  user: root
+- cmdline: xe_m002_XE
+  cwd: /
+  pid: '6043'
+  ppid: '1'
+  user: oracle
+- cmdline: /usr/bin/postgres -D /var/lib/pgsql/data -p 5432
+  cwd: /usr/bin/
+  pid: '7291'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: logger process'
+  cwd: /
+  pid: '7292'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: checkpointer process'
+  cwd: /
+  pid: '7294'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: writer process'
+  cwd: /
+  pid: '7295'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: wal writer process'
+  cwd: /
+  pid: '7296'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: autovacuum launcher process'
+  cwd: /
+  pid: '7297'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: stats collector process'
+  cwd: /
+  pid: '7298'
+  ppid: '7291'
+  user: postgres
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '7673'
+  ppid: '1058'
+  user: postfix
+- cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '11133'
+  ppid: '1'
+  user: root
+- cmdline: xe_m005_XE
+  cwd: /
+  pid: '11706'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '15343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15997'
+  ppid: '2'
+  user: root
+- cmdline: xe_m000_XE
+  cwd: /
+  pid: '16346'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '16694'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '16699'
+  ppid: '1103'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '16701'
+  ppid: '16699'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '16859'
+  ppid: '16701'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '16872'
+  ppid: '16859'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '16873'
+  ppid: '16872'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '16874'
+  ppid: '16873'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '19386'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: postgres datadope [local] idle'
+  cwd: /
+  pid: '19444'
+  ppid: '7291'
+  user: postgres
+- cmdline: xe_m004_XE
+  cwd: /
+  pid: '21779'
+  ppid: '1'
+  user: oracle
+- cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
+  cwd: /opt/oracle/product/21c/dbhomeXE/bin/
+  pid: '22926'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pmon_XE
+  cwd: /
+  pid: '22942'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_clmn_XE
+  cwd: /
+  pid: '22946'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_psp0_XE
+  cwd: /
+  pid: '22950'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vktm_XE
+  cwd: /
+  pid: '22954'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen0_XE
+  cwd: /
+  pid: '22961'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mman_XE
+  cwd: /
+  pid: '22967'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen1_XE
+  cwd: /
+  pid: '22971'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen2_XE
+  cwd: /
+  pid: '22973'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vosd_XE
+  cwd: /
+  pid: '22975'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_diag_XE
+  cwd: /
+  pid: '22979'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_ofsd_XE
+  cwd: /
+  pid: '22985'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dbrm_XE
+  cwd: /
+  pid: '22990'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vkrm_XE
+  cwd: /
+  pid: '22993'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_svcb_XE
+  cwd: /
+  pid: '22996'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pman_XE
+  cwd: /
+  pid: '23001'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dia0_XE
+  cwd: /
+  pid: '23004'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dbw0_XE
+  cwd: /
+  pid: '23008'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_lgwr_XE
+  cwd: /
+  pid: '23012'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_ckpt_XE
+  cwd: /
+  pid: '23015'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_smon_XE
+  cwd: /
+  pid: '23020'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_smco_XE
+  cwd: /
+  pid: '23023'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_reco_XE
+  cwd: /
+  pid: '23030'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_lreg_XE
+  cwd: /
+  pid: '23033'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pxmn_XE
+  cwd: /
+  pid: '23035'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mmon_XE
+  cwd: /
+  pid: '23041'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mmnl_XE
+  cwd: /
+  pid: '23045'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_bg00_XE
+  cwd: /
+  pid: '23049'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_d000_XE
+  cwd: /
+  pid: '23051'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w000_XE
+  cwd: /
+  pid: '23054'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_bg01_XE
+  cwd: /
+  pid: '23058'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_s000_XE
+  cwd: /
+  pid: '23060'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w001_XE
+  cwd: /
+  pid: '23063'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tmon_XE
+  cwd: /
+  pid: '23068'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt00_XE
+  cwd: /
+  pid: '23074'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt01_XE
+  cwd: /
+  pid: '23076'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt02_XE
+  cwd: /
+  pid: '23078'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_rcbg_XE
+  cwd: /
+  pid: '23098'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_aqpc_XE
+  cwd: /
+  pid: '23109'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w002_XE
+  cwd: /
+  pid: '23114'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w003_XE
+  cwd: /
+  pid: '23120'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w004_XE
+  cwd: /
+  pid: '23299'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_cjq0_XE
+  cwd: /
+  pid: '23309'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_qm02_XE
+  cwd: /
+  pid: '23311'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_q003_XE
+  cwd: /
+  pid: '23318'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_q005_XE
+  cwd: /
+  pid: '23374'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_cl00_XE
+  cwd: /
+  pid: '23486'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w005_XE
+  cwd: /
+  pid: '24218'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w006_XE
+  cwd: /
+  pid: '24731'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w007_XE
+  cwd: /
+  pid: '24736'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '27392'
+  ppid: '2'
+  user: root
+- cmdline: xe_m006_XE
+  cwd: /
+  pid: '28429'
+  ppid: '1'
+  user: oracle
+software_list:
+- cmd_regexp: \.apache\.tomcat\.startup|\.apache\.catalina\.startup
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/tomcat.yaml'
+    name: Include Apache Tomcat Servlet Engine specific plugins
+  name: Apache Tomcat Servlet Engine
+  pkg_regexp: tomcat
+  process_type: parent
+  return_children: true
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: postgres
+  pid: 7291
+  port: 5432
+  protocol: tcp
+  stime: Fri Jun  3 09:22:29 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1058
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 14:45:01 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 1512
+  port: 12379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 1512
+  port: 12380
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: 192.168.0.26
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: 127.0.0.1
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: 0.0.0.0
+  name: sshd
+  pid: 1103
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: root
+- address: ::1
+  name: postgres
+  pid: 7291
+  port: 5432
+  protocol: tcp
+  stime: Fri Jun  3 09:22:29 2022
+  user: postgres
+- address: ::1
+  name: master
+  pid: 1058
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 14:45:01 2022
+  user: root
+- address: '::'
+  name: tnslsnr
+  pid: 22926
+  port: 5500
+  protocol: tcp
+  stime: Thu Jun  9 09:15:34 2022
+  user: oracle
+- address: '::'
+  name: java
+  pid: 881
+  port: 11870
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 4000
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: tnslsnr
+  pid: 22926
+  port: 1539
+  protocol: tcp
+  stime: Thu Jun  9 09:15:34 2022
+  user: oracle
+- address: 127.0.0.1
+  name: java
+  pid: 881
+  port: 8005
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 881
+  port: 8009
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: xe_d000_XE
+  pid: 23051
+  port: 21899
+  protocol: tcp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: ::1
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8080
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8081
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 881
+  port: 8082
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 881
+  port: 8050
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: sshd
+  pid: 1103
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: root
+udp_listen:
+- address: 127.0.0.1
+  name: chronyd
+  pid: 584
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 14:44:54 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 719
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 826
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 14:44:59 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 584
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 14:44:54 2022
+  user: chrony
+- address: ::1
+  name: xe_lreg_XE
+  pid: 23033
+  port: 33176
+  protocol: udp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 719
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: ::1
+  name: xe_s000_XE
+  pid: 23060
+  port: 64452
+  protocol: udp
+  stime: Thu Jun  9 09:15:38 2022
+  user: oracle
+- address: ::1
+  name: xe_d000_XE
+  pid: 23051
+  port: 32251
+  protocol: udp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8081
+  protocol: udp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/tomcat/tomcat7.0.76_tomcat.yaml
+++ b/tests/unit/plugins/action/auto/resources/tomcat/tomcat7.0.76_tomcat.yaml
@@ -1,4886 +1,5089 @@
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - analyzer
+    - -c
+    - /etc/iometrics/skydive/skydive.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - analyzer
+      - -c
+      - /etc/iometrics/skydive/skydive.yml
+      Domainname: ''
+      Entrypoint:
+      - /usr/local/bin/skydive
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      ExposedPorts:
+        8082/tcp: {}
+      Hostname: test-ram-norm01.novalocal
+      Image: nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-4
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/iometrics/skydive/skydive.yml: {}
+        /var/lib/skydive: {}
+      WorkingDir: ''
+    Created: '2022-02-11T16:39:16.436847232Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631-init/diff:/var/lib/docker/overlay2/98c8fc8a1198391d57b52bfc7481b12d8fcb3f1460fa681558aaa7306730bd9a/diff:/var/lib/docker/overlay2/9b3407fa7b3cf45082812007500f2249298b9522aeeb6b5e8c324eb8e7291ad5/diff:/var/lib/docker/overlay2/2a70d40f778c8683b234911bdff488726b2d1931d804bca86b612015cabbcfec/diff
+        MergedDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/merged
+        UpperDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/diff
+        WorkDir: /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/iometrics/skydive/:/var/lib/skydive:rw
+      - /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Cgroup: ''
+      CgroupParent: ''
+      CgroupnsMode: host
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hostname
+    HostsPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hosts
+    Id: 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
+    Image: sha256:7b966f2ba2092efb97f038f14563b84b32e98879ad8d52189af823c594b185ed
+    LogPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/iometrics/skydive/skydive.yml
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics/skydive/skydive.yml
+      Type: bind
+    - Destination: /var/lib/skydive
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/iometrics/skydive
+      Type: bind
+    Name: /skydive-analyzer
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 36711925279b4b1ac03d5cdb68a3d4d765d86759714aaae8c976b8bce04ce890
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 6e919553642bae0550eee9382a797f886036f8f6f296d65183121041f1da3b83
+      Ports: {}
+      SandboxID: be98496481fa878c6ad9f140fbcae075d3bccea63ad36757fecf011ab94b6dd3
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /usr/local/bin/skydive
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T14:45:04.915207484Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1512
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T14:45:08.126872087Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: '::'
+    class: service
+    port: 11870
+    protocol: tcp
+  - address: 127.0.0.1
+    class: service
+    port: 8005
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8009
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8082
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 8050
+    protocol: tcp
+  - class: port_ajp
+    port: 8009
+  - class: port_http
+    port: 8082
+  - class: port_jmx
+    port: 8050
+  configuration:
+    Server:
+      GlobalNamingResources:
+        Resource:
+          attr-auth: Container
+          attr-description: User database that can be updated and saved
+          attr-factory: org.apache.catalina.users.MemoryUserDatabaseFactory
+          attr-name: UserDatabase
+          attr-pathname: conf/tomcat-users.xml
+          attr-type: org.apache.catalina.UserDatabase
+      Listener:
+      - attr-className: org.apache.catalina.startup.VersionLoggerListener
+      - attr-SSLEngine: 'on'
+        attr-className: org.apache.catalina.core.AprLifecycleListener
+      - attr-className: org.apache.catalina.core.JasperListener
+      - attr-className: org.apache.catalina.core.JreMemoryLeakPreventionListener
+      - attr-className: org.apache.catalina.mbeans.GlobalResourcesLifecycleListener
+      - attr-className: org.apache.catalina.core.ThreadLocalLeakPreventionListener
+      Service:
+        Connector:
+        - attr-connectionTimeout: '20000'
+          attr-port: '8082'
+          attr-protocol: HTTP/1.1
+          attr-redirectPort: '8443'
+        - attr-port: '8009'
+          attr-protocol: AJP/1.3
+          attr-redirectPort: '8443'
+        Engine:
+          Host:
+            Valve:
+              attr-className: org.apache.catalina.valves.AccessLogValve
+              attr-directory: logs
+              attr-pattern: '%h %l %u %t "%r" %s %b'
+              attr-prefix: localhost_access_log.
+              attr-suffix: .txt
+            attr-appBase: webapps
+            attr-autoDeploy: 'true'
+            attr-name: localhost
+            attr-unpackWARs: 'true'
+          Realm:
+            Realm:
+              attr-className: org.apache.catalina.realm.UserDatabaseRealm
+              attr-resourceName: UserDatabase
+            attr-className: org.apache.catalina.realm.LockOutRealm
+          attr-defaultHost: localhost
+          attr-name: Catalina
+        attr-name: Catalina
+      attr-port: '8005'
+      attr-shutdown: SHUTDOWN
+  discovery_time: '2022-06-23T08:56:15+02:00'
+  files:
+  - path: /usr/share/tomcat
+    subtype: base
+    type: config
+  - path: /usr/share/tomcat
+    subtype: home
+    type: config
+  - path: /usr/lib/jvm/jre
+    subtype: java_home
+    type: config
+  - name: server.xml
+    path: /usr/share/tomcat/conf
+    subtype: generic
+    type: config
+  listening_ports:
+  - 8005
+  - 8009
+  - 8050
+  - 8082
+  - 11870
+  packages:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-docs-webapp
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-javadoc
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  process:
+    children: []
+    cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+      -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050 -Dcom.sun.management.jmxremote.rmi.port=8050
+      -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
+      -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+      -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+      -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+      start
+    cwd: /usr/lib/jvm/jre/bin/
+    listening_ports:
+    - 8005
+    - 8009
+    - 8050
+    - 8082
+    - 11870
+    pid: '881'
+    ppid: '1'
+    user: tomcat
+  type: Apache Tomcat Servlet Engine
+  version:
+  - number: 7.0.76
+    type: file
+  - number: 7.0.76
+    type: package
+expected_tasks_calls:
+  Check if server file in base is accessible: 1
+  Check if server file in home is accessible: 1
+  Check if xml_file is accessible: 1
+  Get config from cmdline: 1
+  Get config_file: 1
+  Read config file: 1
+  Read file version 1: 1
+  Read file version 2: 1
+  Read process environment: 1
 mocked_plugin_tasks:
-  Get config from cmdline:
-    number_of_calls: 1
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Get config_file:
-    number_of_calls: 1
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Read process environment:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      parsed: {
-        "TOMCATS_BASE": "/var/lib/tomcats/",
-        "SHELL": "/sbin/nologin",
-        "CATALINA_HOME": "/usr/share/tomcat",
-        "OLDPWD": "/",
-        "JAVA_OPTS": "-Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050 -Dcom.sun.management.jmxremote.rmi.port=8050 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io",
-        "NAME": "",
-        "USER": "tomcat",
-        "TOMCAT_CFG_LOADED": "1",
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin",
-        "PWD": "/usr/share/tomcat",
-        "JAVA_HOME": "/usr/lib/jvm/jre",
-        "LANG": "en_US.UTF-8",
-        "SHLVL": "0",
-        "HOME": "/usr/share/tomcat",
-        "SECURITY_MANAGER": "false",
-        "LOGNAME": "tomcat",
-        "CATALINA_TMPDIR": "/var/cache/tomcat/temp"
-    }
-
-  Read file version 1:
-    number_of_calls: 1
-    plugin_result:
-      failed: true
-
-  Read file version 2:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      content: "================================================================================\n  Licensed to the Apache Software Foundation (ASF) under one or more\n  contributor license agreements.  See the NOTICE file distributed with\n  this work for additional information regarding copyright ownership.\n  The ASF licenses this file to You under the Apache License, Version 2.0\n  (the \"License\"); you may not use this file except in compliance with\n  the License.  You may obtain a copy of the License at\n\n      http://www.apache.org/licenses/LICENSE-2.0\n\n  Unless required by applicable law or agreed to in writing, software\n  distributed under the License is distributed on an \"AS IS\" BASIS,\n  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n  See the License for the specific language governing permissions and\n  limitations under the License.\n================================================================================\n\n\n                     Apache Tomcat Version 7.0.76\n                            Release Notes\n\n\n=========\nCONTENTS:\n=========\n\n* Dependency Changes\n* API Stability\n* JNI Based Applications\n* Bundled APIs\n* Web application reloading and static fields in shared libraries\n* Tomcat on Linux\n* Enabling SSI and CGI Support\n* Security manager URLs\n* Symlinking static resources\n* Viewing the Tomcat Change Log\n* Cryptographic software notice\n* When all else fails\n\n\n===================\nDependency Changes:\n===================\nTomcat 7.0 is designed to run on Java SE 6 and later.\n\nIn addition, Tomcat 7.0 uses the Eclipse JDT Java compiler for\ncompiling JSP pages.  This means you no longer need to have the complete\nJava Development Kit (JDK) to run Tomcat, but a Java Runtime Environment\n(JRE) is sufficient.  The Eclipse JDT Java compiler is bundled with the\nbinary Tomcat distributions.  Tomcat can also be configured to use the\ncompiler from the JDK to compile JSPs, or any other Java compiler supported\nby Apache Ant.\n\n\n==============\nAPI Stability:\n==============\nThe public interfaces for the following classes are fixed and will not be\nchanged at all during the remaining lifetime of the 7.x series:\n- javax/**/*\n\nThe public interfaces for the following classes may be added to in order to\nresolve bugs and/or add new features. No existing interface will be removed or\nchanged although it may be deprecated.\n- org/apache/catalina/*\n- org/apache/catalina/comet/*\n\nNote: As Tomcat 7 matures, the above list will be added to. The list is not\n      considered complete at this time.\n\nThe remaining classes are considered part of the Tomcat internals and may change\nwithout notice between point releases.\n\n\n=======================\nJNI Based Applications:\n=======================\nApplications that require native libraries must ensure that the libraries have\nbeen loaded prior to use.  Typically, this is done with a call like:\n\n  static {\n    System.loadLibrary(\"path-to-library-file\");\n  }\n\nin some class.  However, the application must also ensure that the library is\nnot loaded more than once.  If the above code were placed in a class inside\nthe web application (i.e. under /WEB-INF/classes or /WEB-INF/lib), and the\napplication were reloaded, the loadLibrary() call would be attempted a second\ntime.\n\nTo avoid this problem, place classes that load native libraries outside of the\nweb application, and ensure that the loadLibrary() call is executed only once\nduring the lifetime of a particular JVM.\n\n\n=============\nBundled APIs:\n=============\nA standard installation of Tomcat 7.0 makes all of the following APIs available\nfor use by web applications (by placing them in \"lib\"):\n* annotations-api.jar (Annotations package)\n* catalina.jar (Tomcat Catalina implementation)\n* catalina-ant.jar (Tomcat Catalina Ant tasks)\n* catalina-ha.jar (High availability package)\n* catalina-tribes.jar (Group communication)\n* ecj-4.4.2.jar (Eclipse JDT Java compiler)\n* el-api.jar (EL 2.2 API)\n* jasper.jar (Jasper 2 Compiler and Runtime)\n* jasper-el.jar (Jasper 2 EL implementation)\n* jsp-api.jar (JSP 2.2 API)\n* servlet-api.jar (Servlet 3.0 API)\n* tomcat7-websocket.jar (WebSocket 1.1 implementation)\n* tomcat-api.jar (Interfaces shared by Catalina and Jasper)\n* tomcat-coyote.jar (Tomcat connectors and utility classes)\n* tomcat-dbcp.jar (package renamed database connection pool based on Commons DBCP)\n* tomcat-jdbc.jar (Tomcat's database connection pooling solution)\n* tomcat-util.jar (Various utilities)\n* websocket-api.jar (WebSocket 1.1 API)\n\nYou can make additional APIs available to all of your web applications by\nputting unpacked classes into a \"classes\" directory (not created by default),\nor by placing them in JAR files in the \"lib\" directory.\n\nTo override the XML parser implementation or interfaces, use the endorsed\nmechanism of the JVM. The default configuration defines JARs located in\n\"endorsed\" as endorsed.\n\n\n================================================================\nWeb application reloading and static fields in shared libraries:\n================================================================\nSome shared libraries (many are part of the JDK) keep references to objects\ninstantiated by the web application. To avoid class loading related problems\n(ClassCastExceptions, messages indicating that the classloader\nis stopped, etc.), the shared libraries state should be reinitialized.\n\nSomething which might help is to avoid putting classes which would be\nreferenced by a shared static field in the web application classloader,\nand putting them in the shared classloader instead (JARs should be put in the\n\"lib\" folder, and classes should be put in the \"classes\" folder).\n\n\n================\nTomcat on Linux:\n================\nGLIBC 2.2 / Linux 2.4 users should define an environment variable:\nexport LD_ASSUME_KERNEL=2.2.5\n\nRedhat Linux 9.0 users should use the following setting to avoid\nstability problems:\nexport LD_ASSUME_KERNEL=2.4.1\n\nThere are some Linux bugs reported against the NIO sendfile behavior, make sure you\nhave a JDK that is up to date, or disable sendfile behavior in the Connector.<br/>\n6427312: (fc) FileChannel.transferTo() throws IOException \"system call interrupted\"<br/>\n5103988: (fc) FileChannel.transferTo should return -1 for EAGAIN instead throws IOException<br/>\n6253145: (fc) FileChannel.transferTo on Linux fails when going beyond 2GB boundary<br/>\n6470086: (fc) FileChannel.transferTo(2147483647, 1, channel) cause \"Value too large\" exception<br/>\n\n\n=============================\nEnabling SSI and CGI Support:\n=============================\nBecause of the security risks associated with CGI and SSI available\nto web applications, these features are disabled by default.  \n\nTo enable and configure CGI support, please see the cgi-howto.html page.\n\nTo enable and configue SSI support, please see the ssi-howto.html page.\n\n\n======================\nSecurity manager URLs:\n======================\nIn order to grant security permissions to JARs located inside the\nweb application repository, use URLs of of the following format\nin your policy file:\n\nfile:${catalina.base}/webapps/examples/WEB-INF/lib/driver.jar\n\n\n============================\nSymlinking static resources:\n============================\nBy default, Unix symlinks will not work when used in a web application to link\nresources located outside the web application root directory.\n\nThis behavior is optional, and the \"allowLinking\" flag may be used to disable\nthe check.\n\n\n==============================\nViewing the Tomcat Change Log:\n==============================\nSee changelog.html in this directory.\n\n\n=============================\nCryptographic software notice\n=============================\nThis distribution includes cryptographic software.  The country in\nwhich you currently reside may have restrictions on the import,\npossession, use, and/or re-export to another country, of\nencryption software.  BEFORE using any encryption software, please\ncheck your country's laws, regulations and policies concerning the\nimport, possession, or use, and re-export of encryption software, to\nsee if this is permitted.  See <http://www.wassenaar.org/> for more\ninformation.\n\nThe U.S. Government Department of Commerce, Bureau of Industry and\nSecurity (BIS), has classified this software as Export Commodity\nControl Number (ECCN) 5D002.C.1, which includes information security\nsoftware using or performing cryptographic functions with asymmetric\nalgorithms.  The form and manner of this Apache Software Foundation\ndistribution makes it eligible for export under the License Exception\nENC Technology Software Unrestricted (TSU) exception (see the BIS\nExport Administration Regulations, Section 740.13) for both object\ncode and source code.\n\nThe following provides more details on the included cryptographic\nsoftware:\n  - Tomcat includes code designed to work with JSSE\n  - Tomcat includes code designed to work with OpenSSL\n\n\n====================\nWhen all else fails:\n====================\nSee the FAQ\nhttp://tomcat.apache.org/faq/\n"
-
-  Check if xml_file is accessible:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-
   Check if server file in base is accessible:
     number_of_calls: 1
     plugin_result:
       failed: false
-
   Check if server file in home is accessible:
     number_of_calls: 1
     plugin_result:
       failed: false
-
+  Check if xml_file is accessible:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+  Get config from cmdline:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+    number_of_calls: 1
+  Get config_file:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+    number_of_calls: 1
   Read config file:
     number_of_calls: 1
     plugin_result:
       failed: false
-      parsed: {
-        "Server": {
-            "attr-port": "8005",
-            "attr-shutdown": "SHUTDOWN",
-            "Listener": [
-                {
-                    "attr-className": "org.apache.catalina.startup.VersionLoggerListener"
-                },
-                {
-                    "attr-className": "org.apache.catalina.core.AprLifecycleListener",
-                    "attr-SSLEngine": "on"
-                },
-                {
-                    "attr-className": "org.apache.catalina.core.JasperListener"
-                },
-                {
-                    "attr-className": "org.apache.catalina.core.JreMemoryLeakPreventionListener"
-                },
-                {
-                    "attr-className": "org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"
-                },
-                {
-                    "attr-className": "org.apache.catalina.core.ThreadLocalLeakPreventionListener"
-                }
-            ],
-            "GlobalNamingResources": {
-                "Resource": {
-                    "attr-name": "UserDatabase",
-                    "attr-auth": "Container",
-                    "attr-type": "org.apache.catalina.UserDatabase",
-                    "attr-description": "User database that can be updated and saved",
-                    "attr-factory": "org.apache.catalina.users.MemoryUserDatabaseFactory",
-                    "attr-pathname": "conf/tomcat-users.xml"
-                }
-            },
-            "Service": {
-                "attr-name": "Catalina",
-                "Connector": [
-                    {
-                        "attr-port": "8082",
-                        "attr-protocol": "HTTP/1.1",
-                        "attr-connectionTimeout": "20000",
-                        "attr-redirectPort": "8443"
-                    },
-                    {
-                        "attr-port": "8009",
-                        "attr-protocol": "AJP/1.3",
-                        "attr-redirectPort": "8443"
-                    }
-                ],
-                "Engine": {
-                    "attr-name": "Catalina",
-                    "attr-defaultHost": "localhost",
-                    "Realm": {
-                        "attr-className": "org.apache.catalina.realm.LockOutRealm",
-                        "Realm": {
-                            "attr-className": "org.apache.catalina.realm.UserDatabaseRealm",
-                            "attr-resourceName": "UserDatabase"
-                        }
-                    },
-                    "Host": {
-                        "attr-name": "localhost",
-                        "attr-appBase": "webapps",
-                        "attr-unpackWARs": "true",
-                        "attr-autoDeploy": "true",
-                        "Valve": {
-                            "attr-className": "org.apache.catalina.valves.AccessLogValve",
-                            "attr-directory": "logs",
-                            "attr-prefix": "localhost_access_log.",
-                            "attr-suffix": ".txt",
-                            "attr-pattern": "%h %l %u %t \"%r\" %s %b"
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-
-expected_tasks_calls:
-  Get config_file: 1
-  Get config from cmdline: 1
-  Read process environment: 1
-  Read file version 1: 1
-  Read file version 2: 1
-  Check if xml_file is accessible: 1
-  Check if server file in base is accessible: 1
-  Check if server file in home is accessible: 1
-  Read config file: 1
-
-expected_result:
-  - bindings:
-      - address: '::'
-        class: 'service'
-        port: 11870
-        protocol: 'tcp'
-      - address: '127.0.0.1'
-        class: 'service'
-        port: 8005
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 8009
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 8082
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 8050
-        protocol: 'tcp'
-      - class: port_ajp
-        port: 8009
-      - class: port_http
-        port: 8082
-      - class: port_jmx
-        port: 8050
-    configuration:
-      Server:
-        attr-port: '8005'
-        attr-shutdown: SHUTDOWN
-        Listener:
+      parsed:
+        Server:
+          GlobalNamingResources:
+            Resource:
+              attr-auth: Container
+              attr-description: User database that can be updated and saved
+              attr-factory: org.apache.catalina.users.MemoryUserDatabaseFactory
+              attr-name: UserDatabase
+              attr-pathname: conf/tomcat-users.xml
+              attr-type: org.apache.catalina.UserDatabase
+          Listener:
           - attr-className: org.apache.catalina.startup.VersionLoggerListener
-          - attr-className: org.apache.catalina.core.AprLifecycleListener
-            attr-SSLEngine: 'on'
+          - attr-SSLEngine: 'on'
+            attr-className: org.apache.catalina.core.AprLifecycleListener
           - attr-className: org.apache.catalina.core.JasperListener
           - attr-className: org.apache.catalina.core.JreMemoryLeakPreventionListener
           - attr-className: org.apache.catalina.mbeans.GlobalResourcesLifecycleListener
           - attr-className: org.apache.catalina.core.ThreadLocalLeakPreventionListener
-        GlobalNamingResources:
-          Resource:
-            attr-name: UserDatabase
-            attr-auth: Container
-            attr-type: org.apache.catalina.UserDatabase
-            attr-description: User database that can be updated and saved
-            attr-factory: org.apache.catalina.users.MemoryUserDatabaseFactory
-            attr-pathname: conf/tomcat-users.xml
-        Service:
-          attr-name: Catalina
-          Connector:
-            - attr-port: '8082'
+          Service:
+            Connector:
+            - attr-connectionTimeout: '20000'
+              attr-port: '8082'
               attr-protocol: HTTP/1.1
-              attr-connectionTimeout: '20000'
               attr-redirectPort: '8443'
             - attr-port: '8009'
               attr-protocol: AJP/1.3
               attr-redirectPort: '8443'
-          Engine:
-            attr-name: Catalina
-            attr-defaultHost: localhost
-            Realm:
-              attr-className: org.apache.catalina.realm.LockOutRealm
+            Engine:
+              Host:
+                Valve:
+                  attr-className: org.apache.catalina.valves.AccessLogValve
+                  attr-directory: logs
+                  attr-pattern: '%h %l %u %t "%r" %s %b'
+                  attr-prefix: localhost_access_log.
+                  attr-suffix: .txt
+                attr-appBase: webapps
+                attr-autoDeploy: 'true'
+                attr-name: localhost
+                attr-unpackWARs: 'true'
               Realm:
-                attr-className: org.apache.catalina.realm.UserDatabaseRealm
-                attr-resourceName: UserDatabase
-            Host:
-              attr-name: localhost
-              attr-appBase: webapps
-              attr-unpackWARs: 'true'
-              attr-autoDeploy: 'true'
-              Valve:
-                attr-className: org.apache.catalina.valves.AccessLogValve
-                attr-directory: logs
-                attr-prefix: localhost_access_log.
-                attr-suffix: .txt
-                attr-pattern: '%h %l %u %t "%r" %s %b'
-    discovery_time: '2022-06-23T08:56:15+02:00'
-    files:
-      - path: /usr/share/tomcat
-        subtype: base
-        type: config
-      - path: /usr/share/tomcat
-        subtype: home
-        type: config
-      - path: /usr/lib/jvm/jre
-        subtype: java_home
-        type: config
-      - name: server.xml
-        path: /usr/share/tomcat/conf
-        subtype: generic
-        type: config
-    listening_ports:
-      - 8005
-      - 8009
-      - 8050
-      - 8082
-      - 11870
-    packages:
-      - arch: noarch
-        epoch: 0
-        name: tomcat
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-admin-webapps
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-docs-webapp
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-el-2.2-api
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-javadoc
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-jsp-2.2-api
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-lib
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-servlet-3.0-api
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-      - arch: noarch
-        epoch: 0
-        name: tomcat-webapps
-        release: 16.el7_9
-        source: rpm
-        version: 7.0.76
-    process:
-      children: []
-      cmdline: >-
-        /usr/lib/jvm/jre/bin/java
-        -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
-        -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050
-        -Dcom.sun.management.jmxremote.rmi.port=8050
-        -Dcom.sun.management.jmxremote.ssl=false
-        -Dcom.sun.management.jmxremote.authenticate=false
-        -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath
-        /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
-        -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat
-        -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp
-        -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
-        -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-        org.apache.catalina.startup.Bootstrap start
-      listening_ports:
-        - 8005
-        - 8009
-        - 8050
-        - 8082
-        - 11870
-      pid: '881'
-      ppid: '1'
-      user: tomcat
-    type: Apache Tomcat Servlet Engine
-    version:
-      - number: 7.0.76
-        type: file
-      - number: 7.0.76
-        type: package
-software_list:
-  - name: Apache Tomcat Servlet Engine
-    cmd_regexp: \.apache\.tomcat\.startup|\.apache\.catalina\.startup
-    pkg_regexp: tomcat
-    process_type: parent
-    return_children: true
-    return_packages: true
-    custom_tasks:
-      - name: Include Apache Tomcat Servlet Engine specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/tomcat.yaml"
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - analyzer
-        - '-c'
-        - /etc/iometrics/skydive/skydive.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - analyzer
-          - '-c'
-          - /etc/iometrics/skydive/skydive.yml
-        Domainname: ''
-        Entrypoint:
-          - /usr/local/bin/skydive
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-        ExposedPorts:
-          8082/tcp: {}
-        Hostname: test-ram-norm01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/skydive:v0.28.0_datadope-4'
-        Labels: {}
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/iometrics/skydive/skydive.yml: {}
-          /var/lib/skydive: {}
-        WorkingDir: ''
-      Created: '2022-02-11T16:39:16.436847232Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631-init/diff:/var/lib/docker/overlay2/98c8fc8a1198391d57b52bfc7481b12d8fcb3f1460fa681558aaa7306730bd9a/diff:/var/lib/docker/overlay2/9b3407fa7b3cf45082812007500f2249298b9522aeeb6b5e8c324eb8e7291ad5/diff:/var/lib/docker/overlay2/2a70d40f778c8683b234911bdff488726b2d1931d804bca86b612015cabbcfec/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/95597d27cce9c368af0c576390ecaa731f4a0875b8429d3a948b5d0f0cc22631/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/iometrics/skydive/:/var/lib/skydive:rw'
-          - >-
-            /etc/iometrics/skydive/skydive.yml:/etc/iometrics/skydive/skydive.yml:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Cgroup: ''
-        CgroupParent: ''
-        CgroupnsMode: host
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: []
-        DnsOptions: []
-        DnsSearch: []
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/hosts
-      Id: 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
-      Image: 'sha256:7b966f2ba2092efb97f038f14563b84b32e98879ad8d52189af823c594b185ed'
-      LogPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/iometrics/skydive/skydive.yml
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics/skydive/skydive.yml
-          Type: bind
-        - Destination: /var/lib/skydive
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/iometrics/skydive
-          Type: bind
-      Name: /skydive-analyzer
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 36711925279b4b1ac03d5cdb68a3d4d765d86759714aaae8c976b8bce04ce890
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 6e919553642bae0550eee9382a797f886036f8f6f296d65183121041f1da3b83
-        Ports: {}
-        SandboxID: be98496481fa878c6ad9f140fbcae075d3bccea63ad36757fecf011ab94b6dd3
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /usr/local/bin/skydive
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T14:45:04.915207484Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1512
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T14:45:08.126872087Z'
-        Status: running
+                Realm:
+                  attr-className: org.apache.catalina.realm.UserDatabaseRealm
+                  attr-resourceName: UserDatabase
+                attr-className: org.apache.catalina.realm.LockOutRealm
+              attr-defaultHost: localhost
+              attr-name: Catalina
+            attr-name: Catalina
+          attr-port: '8005'
+          attr-shutdown: SHUTDOWN
+  Read file version 1:
+    number_of_calls: 1
+    plugin_result:
+      failed: true
+  Read file version 2:
+    number_of_calls: 1
+    plugin_result:
+      content: "================================================================================\n\
+        \  Licensed to the Apache Software Foundation (ASF) under one or more\n  contributor\
+        \ license agreements.  See the NOTICE file distributed with\n  this work for\
+        \ additional information regarding copyright ownership.\n  The ASF licenses\
+        \ this file to You under the Apache License, Version 2.0\n  (the \"License\"\
+        ); you may not use this file except in compliance with\n  the License.  You\
+        \ may obtain a copy of the License at\n\n      http://www.apache.org/licenses/LICENSE-2.0\n\
+        \n  Unless required by applicable law or agreed to in writing, software\n\
+        \  distributed under the License is distributed on an \"AS IS\" BASIS,\n \
+        \ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n\
+        \  See the License for the specific language governing permissions and\n \
+        \ limitations under the License.\n================================================================================\n\
+        \n\n                     Apache Tomcat Version 7.0.76\n                  \
+        \          Release Notes\n\n\n=========\nCONTENTS:\n=========\n\n* Dependency\
+        \ Changes\n* API Stability\n* JNI Based Applications\n* Bundled APIs\n* Web\
+        \ application reloading and static fields in shared libraries\n* Tomcat on\
+        \ Linux\n* Enabling SSI and CGI Support\n* Security manager URLs\n* Symlinking\
+        \ static resources\n* Viewing the Tomcat Change Log\n* Cryptographic software\
+        \ notice\n* When all else fails\n\n\n===================\nDependency Changes:\n\
+        ===================\nTomcat 7.0 is designed to run on Java SE 6 and later.\n\
+        \nIn addition, Tomcat 7.0 uses the Eclipse JDT Java compiler for\ncompiling\
+        \ JSP pages.  This means you no longer need to have the complete\nJava Development\
+        \ Kit (JDK) to run Tomcat, but a Java Runtime Environment\n(JRE) is sufficient.\
+        \  The Eclipse JDT Java compiler is bundled with the\nbinary Tomcat distributions.\
+        \  Tomcat can also be configured to use the\ncompiler from the JDK to compile\
+        \ JSPs, or any other Java compiler supported\nby Apache Ant.\n\n\n==============\n\
+        API Stability:\n==============\nThe public interfaces for the following classes\
+        \ are fixed and will not be\nchanged at all during the remaining lifetime\
+        \ of the 7.x series:\n- javax/**/*\n\nThe public interfaces for the following\
+        \ classes may be added to in order to\nresolve bugs and/or add new features.\
+        \ No existing interface will be removed or\nchanged although it may be deprecated.\n\
+        - org/apache/catalina/*\n- org/apache/catalina/comet/*\n\nNote: As Tomcat\
+        \ 7 matures, the above list will be added to. The list is not\n      considered\
+        \ complete at this time.\n\nThe remaining classes are considered part of the\
+        \ Tomcat internals and may change\nwithout notice between point releases.\n\
+        \n\n=======================\nJNI Based Applications:\n=======================\n\
+        Applications that require native libraries must ensure that the libraries\
+        \ have\nbeen loaded prior to use.  Typically, this is done with a call like:\n\
+        \n  static {\n    System.loadLibrary(\"path-to-library-file\");\n  }\n\nin\
+        \ some class.  However, the application must also ensure that the library\
+        \ is\nnot loaded more than once.  If the above code were placed in a class\
+        \ inside\nthe web application (i.e. under /WEB-INF/classes or /WEB-INF/lib),\
+        \ and the\napplication were reloaded, the loadLibrary() call would be attempted\
+        \ a second\ntime.\n\nTo avoid this problem, place classes that load native\
+        \ libraries outside of the\nweb application, and ensure that the loadLibrary()\
+        \ call is executed only once\nduring the lifetime of a particular JVM.\n\n\
+        \n=============\nBundled APIs:\n=============\nA standard installation of\
+        \ Tomcat 7.0 makes all of the following APIs available\nfor use by web applications\
+        \ (by placing them in \"lib\"):\n* annotations-api.jar (Annotations package)\n\
+        * catalina.jar (Tomcat Catalina implementation)\n* catalina-ant.jar (Tomcat\
+        \ Catalina Ant tasks)\n* catalina-ha.jar (High availability package)\n* catalina-tribes.jar\
+        \ (Group communication)\n* ecj-4.4.2.jar (Eclipse JDT Java compiler)\n* el-api.jar\
+        \ (EL 2.2 API)\n* jasper.jar (Jasper 2 Compiler and Runtime)\n* jasper-el.jar\
+        \ (Jasper 2 EL implementation)\n* jsp-api.jar (JSP 2.2 API)\n* servlet-api.jar\
+        \ (Servlet 3.0 API)\n* tomcat7-websocket.jar (WebSocket 1.1 implementation)\n\
+        * tomcat-api.jar (Interfaces shared by Catalina and Jasper)\n* tomcat-coyote.jar\
+        \ (Tomcat connectors and utility classes)\n* tomcat-dbcp.jar (package renamed\
+        \ database connection pool based on Commons DBCP)\n* tomcat-jdbc.jar (Tomcat's\
+        \ database connection pooling solution)\n* tomcat-util.jar (Various utilities)\n\
+        * websocket-api.jar (WebSocket 1.1 API)\n\nYou can make additional APIs available\
+        \ to all of your web applications by\nputting unpacked classes into a \"classes\"\
+        \ directory (not created by default),\nor by placing them in JAR files in\
+        \ the \"lib\" directory.\n\nTo override the XML parser implementation or interfaces,\
+        \ use the endorsed\nmechanism of the JVM. The default configuration defines\
+        \ JARs located in\n\"endorsed\" as endorsed.\n\n\n================================================================\n\
+        Web application reloading and static fields in shared libraries:\n================================================================\n\
+        Some shared libraries (many are part of the JDK) keep references to objects\n\
+        instantiated by the web application. To avoid class loading related problems\n\
+        (ClassCastExceptions, messages indicating that the classloader\nis stopped,\
+        \ etc.), the shared libraries state should be reinitialized.\n\nSomething\
+        \ which might help is to avoid putting classes which would be\nreferenced\
+        \ by a shared static field in the web application classloader,\nand putting\
+        \ them in the shared classloader instead (JARs should be put in the\n\"lib\"\
+        \ folder, and classes should be put in the \"classes\" folder).\n\n\n================\n\
+        Tomcat on Linux:\n================\nGLIBC 2.2 / Linux 2.4 users should define\
+        \ an environment variable:\nexport LD_ASSUME_KERNEL=2.2.5\n\nRedhat Linux\
+        \ 9.0 users should use the following setting to avoid\nstability problems:\n\
+        export LD_ASSUME_KERNEL=2.4.1\n\nThere are some Linux bugs reported against\
+        \ the NIO sendfile behavior, make sure you\nhave a JDK that is up to date,\
+        \ or disable sendfile behavior in the Connector.<br/>\n6427312: (fc) FileChannel.transferTo()\
+        \ throws IOException \"system call interrupted\"<br/>\n5103988: (fc) FileChannel.transferTo\
+        \ should return -1 for EAGAIN instead throws IOException<br/>\n6253145: (fc)\
+        \ FileChannel.transferTo on Linux fails when going beyond 2GB boundary<br/>\n\
+        6470086: (fc) FileChannel.transferTo(2147483647, 1, channel) cause \"Value\
+        \ too large\" exception<br/>\n\n\n=============================\nEnabling\
+        \ SSI and CGI Support:\n=============================\nBecause of the security\
+        \ risks associated with CGI and SSI available\nto web applications, these\
+        \ features are disabled by default.  \n\nTo enable and configure CGI support,\
+        \ please see the cgi-howto.html page.\n\nTo enable and configue SSI support,\
+        \ please see the ssi-howto.html page.\n\n\n======================\nSecurity\
+        \ manager URLs:\n======================\nIn order to grant security permissions\
+        \ to JARs located inside the\nweb application repository, use URLs of of the\
+        \ following format\nin your policy file:\n\nfile:${catalina.base}/webapps/examples/WEB-INF/lib/driver.jar\n\
+        \n\n============================\nSymlinking static resources:\n============================\n\
+        By default, Unix symlinks will not work when used in a web application to\
+        \ link\nresources located outside the web application root directory.\n\n\
+        This behavior is optional, and the \"allowLinking\" flag may be used to disable\n\
+        the check.\n\n\n==============================\nViewing the Tomcat Change\
+        \ Log:\n==============================\nSee changelog.html in this directory.\n\
+        \n\n=============================\nCryptographic software notice\n=============================\n\
+        This distribution includes cryptographic software.  The country in\nwhich\
+        \ you currently reside may have restrictions on the import,\npossession, use,\
+        \ and/or re-export to another country, of\nencryption software.  BEFORE using\
+        \ any encryption software, please\ncheck your country's laws, regulations\
+        \ and policies concerning the\nimport, possession, or use, and re-export of\
+        \ encryption software, to\nsee if this is permitted.  See <http://www.wassenaar.org/>\
+        \ for more\ninformation.\n\nThe U.S. Government Department of Commerce, Bureau\
+        \ of Industry and\nSecurity (BIS), has classified this software as Export\
+        \ Commodity\nControl Number (ECCN) 5D002.C.1, which includes information security\n\
+        software using or performing cryptographic functions with asymmetric\nalgorithms.\
+        \  The form and manner of this Apache Software Foundation\ndistribution makes\
+        \ it eligible for export under the License Exception\nENC Technology Software\
+        \ Unrestricted (TSU) exception (see the BIS\nExport Administration Regulations,\
+        \ Section 740.13) for both object\ncode and source code.\n\nThe following\
+        \ provides more details on the included cryptographic\nsoftware:\n  - Tomcat\
+        \ includes code designed to work with JSSE\n  - Tomcat includes code designed\
+        \ to work with OpenSSL\n\n\n====================\nWhen all else fails:\n====================\n\
+        See the FAQ\nhttp://tomcat.apache.org/faq/\n"
+      failed: false
+  Read process environment:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      parsed:
+        CATALINA_HOME: /usr/share/tomcat
+        CATALINA_TMPDIR: /var/cache/tomcat/temp
+        HOME: /usr/share/tomcat
+        JAVA_HOME: /usr/lib/jvm/jre
+        JAVA_OPTS: -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+          -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050
+          -Dcom.sun.management.jmxremote.rmi.port=8050 -Dcom.sun.management.jmxremote.ssl=false
+          -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io
+        LANG: en_US.UTF-8
+        LOGNAME: tomcat
+        NAME: ''
+        OLDPWD: /
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+        PWD: /usr/share/tomcat
+        SECURITY_MANAGER: 'false'
+        SHELL: /sbin/nologin
+        SHLVL: '0'
+        TOMCATS_BASE: /var/lib/tomcats/
+        TOMCAT_CFG_LOADED: '1'
+        USER: tomcat
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 14.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 14.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
   alsa-lib:
-    - arch: x86_64
-      epoch: null
-      name: alsa-lib
-      release: 1.el7
-      source: rpm
-      version: 1.1.8
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
   apache-commons-collections:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-collections
-      release: 22.el7_2
-      source: rpm
-      version: 3.2.1
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
   apache-commons-daemon:
-    - arch: x86_64
-      epoch: null
-      name: apache-commons-daemon
-      release: 7.el7
-      source: rpm
-      version: 1.0.13
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
   apache-commons-dbcp:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-dbcp
-      release: 17.el7
-      source: rpm
-      version: '1.4'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
   apache-commons-logging:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-logging
-      release: 7.el7
-      source: rpm
-      version: 1.1.2
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
   apache-commons-pool:
-    - arch: noarch
-      epoch: null
-      name: apache-commons-pool
-      release: 9.el7
-      source: rpm
-      version: '1.6'
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
   atk:
-    - arch: x86_64
-      epoch: null
-      name: atk
-      release: 2.el7
-      source: rpm
-      version: 2.28.1
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.5
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   avahi-libs:
-    - arch: x86_64
-      epoch: null
-      name: avahi-libs
-      release: 20.el7
-      source: rpm
-      version: 0.6.31
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
   avalon-framework:
-    - arch: noarch
-      epoch: 0
-      name: avalon-framework
-      release: 10.el7
-      source: rpm
-      version: '4.3'
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
   avalon-logkit:
-    - arch: noarch
-      epoch: 0
-      name: avalon-logkit
-      release: 14.el7
-      source: rpm
-      version: '2.1'
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 35.el7_9
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 35.el7_9
+    source: rpm
+    version: 4.2.46
   bc:
-    - arch: x86_64
-      epoch: null
-      name: bc
-      release: 13.el7
-      source: rpm
-      version: 1.06.95
+  - arch: x86_64
+    epoch: null
+    name: bc
+    release: 13.el7
+    source: rpm
+    version: 1.06.95
   bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.8
-      source: rpm
-      version: 9.11.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.8
+    source: rpm
+    version: 9.11.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 44.base.el7_9.1
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 44.base.el7_9.1
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 72.el7_9
-      source: rpm
-      version: 2021.2.50
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 72.el7_9
+    source: rpm
+    version: 2021.2.50
   cairo:
-    - arch: x86_64
-      epoch: null
-      name: cairo
-      release: 4.el7
-      source: rpm
-      version: 1.15.12
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 9.2009.1.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 9.2009.1.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.6
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.6
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 1.el7
-      source: rpm
-      version: '3.4'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 7.el7.centos.5
-      source: rpm
-      version: '19.4'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 7.el7.centos.5
+    source: rpm
+    version: '19.4'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 5.el7
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.911c772.el7_8
-      source: rpm
-      version: 2.119.2
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.911c772.el7_8
+    source: rpm
+    version: 2.119.2
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.4.12
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.4.12
   copy-jdk-configs:
-    - arch: noarch
-      epoch: null
-      name: copy-jdk-configs
-      release: 10.el7_5
-      source: rpm
-      version: '3.3'
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 24.el7_9.2
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7_9.2
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 28.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 28.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 24.el7_9
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 24.el7_9
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 6.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
   cups-libs:
-    - arch: x86_64
-      epoch: 1
-      name: cups-libs
-      release: 51.el7
-      source: rpm
-      version: 1.6.3
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: i686
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: i686
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 15.el7
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 15.el7
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   dejavu-fonts-common:
-    - arch: noarch
-      epoch: null
-      name: dejavu-fonts-common
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   dejavu-sans-fonts:
-    - arch: noarch
-      epoch: null
-      name: dejavu-sans-fonts
-      release: 6.el7
-      source: rpm
-      version: '2.33'
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 6.el7_9.5
-      source: rpm
-      version: 1.02.170
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 6.el7_9.5
+    source: rpm
+    version: 1.02.170
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 83.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 5.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 5.el7_9.1
-      source: rpm
-      version: '3.2'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-ce-rootless-extras:
-    - arch: x86_64
-      epoch: 0
-      name: docker-ce-rootless-extras
-      release: 3.el7
-      source: rpm
-      version: 20.10.12
-  docker-scan-plugin:
-    - arch: x86_64
-      epoch: 0
-      name: docker-scan-plugin
-      release: 3.el7
-      source: rpm
-      version: 0.12.0
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 572.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 572.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  ecj:
-    - arch: x86_64
-      epoch: 1
-      name: ecj
-      release: 3.el7
-      source: rpm
-      version: 4.5.2
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 5.el7
-      source: rpm
-      version: '0.176'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '14'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 10.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 12.el7
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 37.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fontconfig:
-    - arch: x86_64
-      epoch: null
-      name: fontconfig
-      release: 4.3.el7
-      source: rpm
-      version: 2.13.0
-  fontpackages-filesystem:
-    - arch: noarch
-      epoch: null
-      name: fontpackages-filesystem
-      release: 8.el7
-      source: rpm
-      version: '1.44'
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 14.el7_9.1
-      source: rpm
-      version: '2.8'
-  fribidi:
-    - arch: x86_64
-      epoch: null
-      name: fribidi
-      release: 1.el7_7.1
-      source: rpm
-      version: 1.0.2
-  fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
-  fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gdk-pixbuf2:
-    - arch: x86_64
-      epoch: null
-      name: gdk-pixbuf2
-      release: 3.el7
-      source: rpm
-      version: 2.36.12
-  geoipupdate:
-    - arch: x86_64
-      epoch: null
-      name: geoipupdate
-      release: 1.el7
-      source: rpm
-      version: 2.5.0
-  geronimo-jms:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jms
-      release: 19.el7
-      source: rpm
-      version: 1.1.1
-  geronimo-jta:
-    - arch: noarch
-      epoch: null
-      name: geronimo-jta
-      release: 17.el7
-      source: rpm
-      version: 1.1.1
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 3.el7
-      source: rpm
-      version: 0.19.8.1
-  giflib:
-    - arch: x86_64
-      epoch: null
-      name: giflib
-      release: 9.el7
-      source: rpm
-      version: 4.1.6
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 9.el7_9
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-    - arch: i686
-      epoch: null
-      name: glibc
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-devel:
-    - arch: x86_64
-      epoch: null
-      name: glibc-devel
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  glibc-headers:
-    - arch: x86_64
-      epoch: null
-      name: glibc-headers
-      release: 325.el7_9
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 467e318a
-      source: rpm
-      version: 00f97f56
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  graphite2:
-    - arch: x86_64
-      epoch: null
-      name: graphite2
-      release: 1.el7_3
-      source: rpm
-      version: 1.3.10
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.87.el7.centos.7
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 26.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 30.el7_9
-      source: rpm
-      version: 0.7.0
-  gtk-update-icon-cache:
-    - arch: x86_64
-      epoch: null
-      name: gtk-update-icon-cache
-      release: 6.el7
-      source: rpm
-      version: 3.22.30
-  gtk2:
-    - arch: x86_64
-      epoch: null
-      name: gtk2
-      release: 1.el7
-      source: rpm
-      version: 2.24.31
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  harfbuzz:
-    - arch: x86_64
-      epoch: null
-      name: harfbuzz
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  hicolor-icon-theme:
-    - arch: noarch
-      epoch: null
-      name: hicolor-icon-theme
-      release: 7.el7
-      source: rpm
-      version: '0.12'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7_7.1
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.7.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7_9.1
-      source: rpm
-      version: 9.49.53
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '25'
-      source: rpm
-      version: 1.11.3
-  iometrics-agent-plugin-oracle-lib-connector:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-lib-connector
-      release: '25'
-      source: rpm
-      version: 18.5.0_1.11.3
-  iometrics-agent-plugin-oracle-libs:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent-plugin-oracle-libs
-      release: '1'
-      source: rpm
-      version: 18.5.0
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 30.el7
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 35.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 12.el7
-      source: rpm
-      version: 1.0.7
-  jakarta-taglibs-standard:
-    - arch: noarch
-      epoch: 0
-      name: jakarta-taglibs-standard
-      release: 14.el7_1
-      source: rpm
-      version: 1.1.2
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jasper-libs:
-    - arch: x86_64
-      epoch: null
-      name: jasper-libs
-      release: 33.el7
-      source: rpm
-      version: 1.900.1
-  java-1.8.0-openjdk:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  java-1.8.0-openjdk-headless:
-    - arch: x86_64
-      epoch: 1
-      name: java-1.8.0-openjdk-headless
-      release: 1.el7_9
-      source: rpm
-      version: 1.8.0.322.b06
-  javamail:
-    - arch: noarch
-      epoch: null
-      name: javamail
-      release: 8.el7
-      source: rpm
-      version: 1.4.6
-  javapackages-tools:
-    - arch: noarch
-      epoch: null
-      name: javapackages-tools
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  jbigkit-libs:
-    - arch: x86_64
-      epoch: null
-      name: jbigkit-libs
-      release: 11.el7
-      source: rpm
-      version: '2.0'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 16.el7_9
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1127.el7
-      source: rpm
-      version: 3.10.0
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-headers:
-    - arch: x86_64
-      epoch: null
-      name: kernel-headers
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 51.el7_9.3
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: i686
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 28.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 135.el7_9
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: i686
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 51.el7_9
-      source: rpm
-      version: 1.15.1
-  ksh:
-    - arch: x86_64
-      epoch: null
-      name: ksh
-      release: 143.el7_9
-      source: rpm
-      version: '20120801'
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libICE:
-    - arch: x86_64
-      epoch: null
-      name: libICE
-      release: 9.el7
-      source: rpm
-      version: 1.0.9
-  libSM:
-    - arch: x86_64
-      epoch: null
-      name: libSM
-      release: 2.el7
-      source: rpm
-      version: 1.2.2
-  libX11:
-    - arch: x86_64
-      epoch: null
-      name: libX11
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libX11-common:
-    - arch: noarch
-      epoch: null
-      name: libX11-common
-      release: 4.el7_9
-      source: rpm
-      version: 1.6.7
-  libXau:
-    - arch: x86_64
-      epoch: null
-      name: libXau
-      release: 2.1.el7
-      source: rpm
-      version: 1.0.8
-  libXcomposite:
-    - arch: x86_64
-      epoch: null
-      name: libXcomposite
-      release: 4.1.el7
-      source: rpm
-      version: 0.4.4
-  libXcursor:
-    - arch: x86_64
-      epoch: null
-      name: libXcursor
-      release: 1.el7
-      source: rpm
-      version: 1.1.15
-  libXdamage:
-    - arch: x86_64
-      epoch: null
-      name: libXdamage
-      release: 4.1.el7
-      source: rpm
-      version: 1.1.4
-  libXext:
-    - arch: x86_64
-      epoch: null
-      name: libXext
-      release: 3.el7
-      source: rpm
-      version: 1.3.3
-  libXfixes:
-    - arch: x86_64
-      epoch: null
-      name: libXfixes
-      release: 1.el7
-      source: rpm
-      version: 5.0.3
-  libXft:
-    - arch: x86_64
-      epoch: null
-      name: libXft
-      release: 2.el7
-      source: rpm
-      version: 2.3.2
-  libXi:
-    - arch: x86_64
-      epoch: null
-      name: libXi
-      release: 1.el7
-      source: rpm
-      version: 1.7.9
-  libXinerama:
-    - arch: x86_64
-      epoch: null
-      name: libXinerama
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.3
-  libXmu:
-    - arch: x86_64
-      epoch: null
-      name: libXmu
-      release: 2.el7
-      source: rpm
-      version: 1.1.2
-  libXrandr:
-    - arch: x86_64
-      epoch: null
-      name: libXrandr
-      release: 2.el7
-      source: rpm
-      version: 1.5.1
-  libXrender:
-    - arch: x86_64
-      epoch: null
-      name: libXrender
-      release: 1.el7
-      source: rpm
-      version: 0.9.10
-  libXt:
-    - arch: x86_64
-      epoch: null
-      name: libXt
-      release: 3.el7
-      source: rpm
-      version: 1.1.5
-  libXtst:
-    - arch: x86_64
-      epoch: null
-      name: libXtst
-      release: 1.el7
-      source: rpm
-      version: 1.2.3
-  libXv:
-    - arch: x86_64
-      epoch: null
-      name: libXv
-      release: 1.el7
-      source: rpm
-      version: 1.0.11
-  libXxf86dga:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86dga
-      release: 2.1.el7
-      source: rpm
-      version: 1.1.4
-  libXxf86misc:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86misc
-      release: 7.1.el7
-      source: rpm
-      version: 1.0.3
-  libXxf86vm:
-    - arch: x86_64
-      epoch: null
-      name: libXxf86vm
-      release: 1.el7
-      source: rpm
-      version: 1.1.4
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 15.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 11.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 21.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-    - arch: i686
-      epoch: null
-      name: libcom_err
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 6.el7_9
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 59.el7_9.1
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: i686
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 25.el7
-      source: rpm
-      version: 5.3.21
-  libdmx:
-    - arch: x86_64
-      epoch: null
-      name: libdmx
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libdrm:
-    - arch: x86_64
-      epoch: null
-      name: libdrm
-      release: 2.el7
-      source: rpm
-      version: 2.4.97
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 19.el7
-      source: rpm
-      version: 3.0.13
-  libfontenc:
-    - arch: x86_64
-      epoch: null
-      name: libfontenc
-      release: 3.el7
-      source: rpm
-      version: 1.1.3
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libgcc
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libglvnd:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-egl:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-egl
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libglvnd-glx:
-    - arch: x86_64
-      epoch: 1
-      name: libglvnd-glx
-      release: 0.8.git5baa1e5.el7
-      source: rpm
-      version: 1.0.1
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libicu:
-    - arch: x86_64
-      epoch: null
-      name: libicu
-      release: 4.el7_7
-      source: rpm
-      version: '50.2'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libjpeg-turbo:
-    - arch: x86_64
-      epoch: null
-      name: libjpeg-turbo
-      release: 8.el7
-      source: rpm
-      version: 1.2.90
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 9.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpciaccess:
-    - arch: x86_64
-      epoch: null
-      name: libpciaccess
-      release: 1.el7
-      source: rpm
-      version: '0.14'
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 8.el7
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 4.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-    - arch: i686
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: i686
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 19.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 4.el7
-      source: rpm
-      version: 1.8.0
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-    - arch: i686
-      epoch: null
-      name: libstdc++
-      release: 44.el7
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  libthai:
-    - arch: x86_64
-      epoch: null
-      name: libthai
-      release: 9.el7
-      source: rpm
-      version: 0.1.14
-  libtiff:
-    - arch: x86_64
-      epoch: null
-      name: libtiff
-      release: 35.el7
-      source: rpm
-      version: 4.0.3
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.16.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-    - arch: i686
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libwayland-client:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-client
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libwayland-server:
-    - arch: x86_64
-      epoch: null
-      name: libwayland-server
-      release: 1.el7
-      source: rpm
-      version: 1.15.0
-  libxcb:
-    - arch: x86_64
-      epoch: null
-      name: libxcb
-      release: 1.el7
-      source: rpm
-      version: '1.13'
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_9.6
-      source: rpm
-      version: 2.9.1
-  libxshmfence:
-    - arch: x86_64
-      epoch: null
-      name: libxshmfence
-      release: 1.el7
-      source: rpm
-      version: '1.2'
-  libxslt:
-    - arch: x86_64
-      epoch: null
-      name: libxslt
-      release: 6.el7
-      source: rpm
-      version: 1.1.28
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  linux-firmware:
-    - arch: noarch
-      epoch: null
-      name: linux-firmware
-      release: 80.git78c0348.el7_9
-      source: rpm
-      version: '20200421'
-  lksctp-tools:
-    - arch: x86_64
-      epoch: null
-      name: lksctp-tools
-      release: 2.el7
-      source: rpm
-      version: 1.0.17
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  log4j:
-    - arch: noarch
-      epoch: 0
-      name: log4j
-      release: 18.el7_4
-      source: rpm
-      version: 1.2.17
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 19.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 17.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 1.el7
-      source: rpm
-      version: 1.8.3
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  mailx:
-    - arch: x86_64
-      epoch: null
-      name: mailx
-      release: 19.el7
-      source: rpm
-      version: '12.5'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 24.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7
-      source: rpm
-      version: 5.5.68
-  mesa-libEGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libEGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libGL:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libGL
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libgbm:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libgbm
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  mesa-libglapi:
-    - arch: x86_64
-      epoch: null
-      name: mesa-libglapi
-      release: 12.el7_9
-      source: rpm
-      version: 18.3.4
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 73.11.el7_9
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-    - arch: i686
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.25.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.68.el7.2
-      source: rpm
-      version: 1.3.0
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: i686
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_9
-      source: rpm
-      version: 4.32.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-    - arch: i686
-      epoch: null
-      name: nss-pem
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss-softokn
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-softokn-freebl:
-    - arch: i686
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 3.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 4.el7_9
-      source: rpm
-      version: 3.67.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-    - arch: i686
-      epoch: null
-      name: nss-util
-      release: 1.el7_9
-      source: rpm
-      version: 3.67.0
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 5.el7
-      source: rpm
-      version: 2.0.12
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-    - arch: i686
-      epoch: null
-      name: openldap
-      release: 24.el7_9
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 22.el7_9
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-    - arch: i686
-      epoch: 1
-      name: openssl-libs
-      release: 24.el7_9
-      source: rpm
-      version: 1.0.2k
-  oracle-database-preinstall-21c:
-    - arch: x86_64
-      epoch: null
-      name: oracle-database-preinstall-21c
-      release: 1.el7
-      source: rpm
-      version: '1.0'
-  oracle-database-xe-21c:
-    - arch: x86_64
-      epoch: null
-      name: oracle-database-xe-21c
-      release: '1'
-      source: rpm
-      version: '1.0'
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 23.el7
-      source: rpm
-      version: 1.1.8
-  pango:
-    - arch: x86_64
-      epoch: null
-      name: pango
-      release: 4.el7_7
-      source: rpm
-      version: 1.42.4
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 32.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 6.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: i686
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  pcsc-lite-libs:
-    - arch: x86_64
-      epoch: null
-      name: pcsc-lite-libs
-      release: 8.el7
-      source: rpm
-      version: 1.8.8
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pixman:
-    - arch: x86_64
-      epoch: null
-      name: pixman
-      release: 1.el7
-      source: rpm
-      version: 0.34.0
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 34.el7
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 26.el7_9.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 9.el7
-      source: rpm
-      version: 2.10.1
-  postgresql:
-    - arch: x86_64
-      epoch: null
-      name: postgresql
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-contrib:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-contrib
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-    - arch: i686
-      epoch: null
-      name: postgresql-libs
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  postgresql-server:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-server
-      release: 7.el7_9
-      source: rpm
-      version: 9.2.24
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 28.el7
-      source: rpm
-      version: 3.3.10
-  psmisc:
-    - arch: x86_64
-      epoch: null
-      name: psmisc
-      release: 17.el7
-      source: rpm
-      version: '22.20'
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 3.el7
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-javapackages:
-    - arch: noarch
-      epoch: null
-      name: python-javapackages
-      release: 11.el7
-      source: rpm
-      version: 3.4.1
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 4.el7
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 90.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.11
-  python-lxml:
-    - arch: x86_64
-      epoch: null
-      name: python-lxml
-      release: 4.el7
-      source: rpm
-      version: 3.2.1
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 1160.53.1.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 10.el7
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 10.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 7.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 18.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 8.el7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 3.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 19.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: i686
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 11.el7
-      source: rpm
-      version: '6.2'
-  redis:
-    - arch: x86_64
-      epoch: null
-      name: redis
-      release: 1.el7.remi
-      source: rpm
-      version: 6.2.6
-  remi-release:
-    - arch: noarch
-      epoch: null
-      name: remi-release
-      release: 2.el7.remi
-      source: rpm
-      version: '7.9'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 49.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 48.el7_9
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 10.el7
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 57.el7_9.1
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 7.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 268.el7_9.2
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 11.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: 1
-      name: sg3_utils-libs
-      release: 19.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 5.el7
-      source: rpm
-      version: '4.6'
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 5.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  smartmontools:
-    - arch: x86_64
-      epoch: 1
-      name: smartmontools
-      release: 2.el7
-      source: rpm
-      version: '7.0'
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: i686
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7_7.1
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 10.el7_9.2
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 78.el7_9.5
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 3.el7
-      source: rpm
-      version: '1.29'
-  tomcat:
-    - arch: noarch
-      epoch: 0
-      name: tomcat
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-admin-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-admin-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-docs-webapp:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-docs-webapp
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-el-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-el-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-javadoc:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-javadoc
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-jsp-2.2-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-jsp-2.2-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-lib:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-lib
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-servlet-3.0-api:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-servlet-3.0-api
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  tomcat-webapps:
-    - arch: noarch
-      epoch: 0
-      name: tomcat-webapps
-      release: 16.el7_9
-      source: rpm
-      version: 7.0.76
-  ttmkfdir:
-    - arch: x86_64
-      epoch: null
-      name: ttmkfdir
-      release: 42.el7
-      source: rpm
-      version: 3.0.9
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 11.el7_9
-      source: rpm
-      version: 2.11.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  tzdata-java:
-    - arch: noarch
-      epoch: null
-      name: tzdata-java
-      release: 1.el7
-      source: rpm
-      version: 2021e
-  unzip:
-    - arch: x86_64
-      epoch: null
-      name: unzip
-      release: 24.el7_9
-      source: rpm
-      version: '6.0'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 65.el7_9.1
-      source: rpm
-      version: 2.23.2
-  uuid:
-    - arch: x86_64
-      epoch: null
-      name: uuid
-      release: 26.el7
-      source: rpm
-      version: 1.6.2
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7_9.1
-      source: rpm
-      version: '1.18'
-  wget:
-    - arch: x86_64
-      epoch: null
-      name: wget
-      release: 18.el7_6.1
-      source: rpm
-      version: '1.14'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7_9.2
-      source: rpm
-      version: '2.6'
-  xalan-j2:
-    - arch: noarch
-      epoch: 0
-      name: xalan-j2
-      release: 23.el7
-      source: rpm
-      version: 2.7.1
-  xerces-j2:
-    - arch: noarch
-      epoch: null
-      name: xerces-j2
-      release: 17.el7_0
-      source: rpm
-      version: 2.11.0
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 22.el7
-      source: rpm
-      version: 4.5.0
-  xml-commons-apis:
-    - arch: noarch
-      epoch: null
-      name: xml-commons-apis
-      release: 16.el7
-      source: rpm
-      version: 1.4.01
-  xml-commons-resolver:
-    - arch: noarch
-      epoch: 0
-      name: xml-commons-resolver
-      release: 15.el7
-      source: rpm
-      version: '1.2'
-  xorg-x11-font-utils:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-font-utils
-      release: 21.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-fonts-Type1:
-    - arch: noarch
-      epoch: null
-      name: xorg-x11-fonts-Type1
-      release: 9.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-utils:
-    - arch: x86_64
-      epoch: null
-      name: xorg-x11-utils
-      release: 23.el7
-      source: rpm
-      version: '7.5'
-  xorg-x11-xauth:
-    - arch: x86_64
-      epoch: 1
-      name: xorg-x11-xauth
-      release: 1.el7
-      source: rpm
-      version: 1.0.9
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 168.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 54.el7_8
-      source: rpm
-      version: 1.1.31
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-    - arch: i686
-      epoch: null
-      name: zlib
-      release: 19.el7_9
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '4'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '6'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '41'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '59'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '127'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '194'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '195'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '265'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '267'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '268'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '269'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '270'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '273'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '284'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '285'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '286'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '287'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '288'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '289'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '290'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '292'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '293'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '294'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '411'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '453'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '481'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '486'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '515'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '551'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '552'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '566'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/smartd -n -q never
-    pid: '567'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '570'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '573'
-    ppid: '1'
-    user: polkitd
-  - cmdline: /usr/sbin/chronyd
-    pid: '584'
-    ppid: '1'
-    user: chrony
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '594'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H test-ram-norm01 eth0
-    pid: '826'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/lib/jvm/jre/bin/java
-      -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
-      -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050
-      -Dcom.sun.management.jmxremote.rmi.port=8050
-      -Dcom.sun.management.jmxremote.ssl=false
-      -Dcom.sun.management.jmxremote.authenticate=false
-      -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath
-      /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
-      -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat
-      -Djava.endorsed.dirs= -Djava.io.tmpdir=/var/cache/tomcat/temp
-      -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      org.apache.catalina.startup.Bootstrap start
-    pid: '881'
-    ppid: '1'
-    user: tomcat
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '883'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '902'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1058'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1063'
-    ppid: '1058'
-    user: postfix
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1103'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1105'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/bin/redis-server 127.0.0.1:6379'
-    pid: '1109'
-    ppid: '1'
-    user: redis
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1110'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1114'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1115'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1116'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/containerd-shim-runc-v2 -namespace moby -id
-      430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9 -address
-      /run/containerd/containerd.sock
-    pid: '1494'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
-    pid: '1512'
-    ppid: '1494'
-    user: root
-  - cmdline: /usr/bin/docker start -a skydive-analyzer
-    pid: '1561'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '2573'
-    ppid: '2'
-    user: root
-  - cmdline: xe_m002_XE
-    pid: '6043'
-    ppid: '1'
-    user: oracle
-  - cmdline: /usr/bin/postgres -D /var/lib/pgsql/data -p 5432
-    pid: '7291'
-    ppid: '1'
-    user: postgres
-  - cmdline: 'postgres: logger process'
-    pid: '7292'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: checkpointer process'
-    pid: '7294'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: writer process'
-    pid: '7295'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: wal writer process'
-    pid: '7296'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: autovacuum launcher process'
-    pid: '7297'
-    ppid: '7291'
-    user: postgres
-  - cmdline: 'postgres: stats collector process'
-    pid: '7298'
-    ppid: '7291'
-    user: postgres
-  - cmdline: pickup -l -t unix -u
-    pid: '7673'
-    ppid: '1058'
-    user: postfix
-  - cmdline: >-
-      /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml
-      -path.home /usr/share/filebeat -path.config /etc/filebeat -path.data
-      /var/lib/filebeat -path.logs /var/log/filebeat
-    pid: '11133'
-    ppid: '1'
-    user: root
-  - cmdline: xe_m005_XE
-    pid: '11706'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '15343'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '15997'
-    ppid: '2'
-    user: root
-  - cmdline: xe_m000_XE
-    pid: '16346'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '16694'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '16699'
-    ppid: '1103'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '16701'
-    ppid: '16699'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '16859'
-    ppid: '16701'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
-    pid: '16872'
-    ppid: '16859'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
-    pid: '16873'
-    ppid: '16872'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
-    pid: '16874'
-    ppid: '16873'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '19386'
-    ppid: '1'
-    user: root
-  - cmdline: 'postgres: postgres datadope [local] idle'
-    pid: '19444'
-    ppid: '7291'
-    user: postgres
-  - cmdline: xe_m004_XE
-    pid: '21779'
-    ppid: '1'
-    user: oracle
-  - cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
-    pid: '22926'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pmon_XE
-    pid: '22942'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_clmn_XE
-    pid: '22946'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_psp0_XE
-    pid: '22950'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vktm_XE
-    pid: '22954'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen0_XE
-    pid: '22961'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mman_XE
-    pid: '22967'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen1_XE
-    pid: '22971'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_gen2_XE
-    pid: '22973'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vosd_XE
-    pid: '22975'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_diag_XE
-    pid: '22979'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_ofsd_XE
-    pid: '22985'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dbrm_XE
-    pid: '22990'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_vkrm_XE
-    pid: '22993'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_svcb_XE
-    pid: '22996'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pman_XE
-    pid: '23001'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dia0_XE
-    pid: '23004'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_dbw0_XE
-    pid: '23008'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_lgwr_XE
-    pid: '23012'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_ckpt_XE
-    pid: '23015'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_smon_XE
-    pid: '23020'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_smco_XE
-    pid: '23023'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_reco_XE
-    pid: '23030'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_lreg_XE
-    pid: '23033'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_pxmn_XE
-    pid: '23035'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mmon_XE
-    pid: '23041'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_mmnl_XE
-    pid: '23045'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_bg00_XE
-    pid: '23049'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_d000_XE
-    pid: '23051'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w000_XE
-    pid: '23054'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_bg01_XE
-    pid: '23058'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_s000_XE
-    pid: '23060'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w001_XE
-    pid: '23063'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tmon_XE
-    pid: '23068'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt00_XE
-    pid: '23074'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt01_XE
-    pid: '23076'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_tt02_XE
-    pid: '23078'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_rcbg_XE
-    pid: '23098'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_aqpc_XE
-    pid: '23109'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w002_XE
-    pid: '23114'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w003_XE
-    pid: '23120'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w004_XE
-    pid: '23299'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_cjq0_XE
-    pid: '23309'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_qm02_XE
-    pid: '23311'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_q003_XE
-    pid: '23318'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_q005_XE
-    pid: '23374'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_cl00_XE
-    pid: '23486'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w005_XE
-    pid: '24218'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w006_XE
-    pid: '24731'
-    ppid: '1'
-    user: oracle
-  - cmdline: xe_w007_XE
-    pid: '24736'
-    ppid: '1'
-    user: oracle
-  - cmdline: ''
-    pid: '27392'
-    ppid: '2'
-    user: root
-  - cmdline: xe_m006_XE
-    pid: '28429'
-    ppid: '1'
-    user: oracle
-tcp_listen:
-  - address: 127.0.0.1
-    name: postgres
-    pid: 7291
-    port: 5432
-    protocol: tcp
-    stime: 'Fri Jun  3 09:22:29 2022'
-    user: postgres
-  - address: 127.0.0.1
-    name: master
-    pid: 1058
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:01 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 1512
-    port: 12379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: 127.0.0.1
-    name: skydive
-    pid: 1512
-    port: 12380
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: 192.168.0.26
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: 127.0.0.1
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1103
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: root
-  - address: '::1'
-    name: postgres
-    pid: 7291
-    port: 5432
-    protocol: tcp
-    stime: 'Fri Jun  3 09:22:29 2022'
-    user: postgres
-  - address: '::1'
-    name: master
-    pid: 1058
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:01 2022'
-    user: root
-  - address: '::'
-    name: tnslsnr
-    pid: 22926
-    port: 5500
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:34 2022'
-    user: oracle
-  - address: '::'
-    name: java
-    pid: 881
-    port: 11870
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 4000
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: tnslsnr
-    pid: 22926
-    port: 1539
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:34 2022'
-    user: oracle
-  - address: 127.0.0.1
-    name: java
-    pid: 881
-    port: 8005
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8009
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: xe_d000_XE
-    pid: 23051
-    port: 21899
-    protocol: tcp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::1'
-    name: redis-server
-    pid: 1109
-    port: 6379
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: redis
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8080
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8081
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8082
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: java
-    pid: 881
-    port: 8050
-    protocol: tcp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: tomcat
-  - address: '::'
-    name: sshd
-    pid: 1103
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 14:45:02 2022'
-    user: root
-udp_listen:
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 584
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:54 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 566
-    port: 719
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 826
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:59 2022'
-    user: root
-  - address: 0.0.0.0
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 83.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 5.el7_9.1
+    source: rpm
+    version: '3.2'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-ce-rootless-extras:
+  - arch: x86_64
+    epoch: 0
+    name: docker-ce-rootless-extras
+    release: 3.el7
+    source: rpm
+    version: 20.10.12
+  docker-scan-plugin:
+  - arch: x86_64
+    epoch: 0
+    name: docker-scan-plugin
+    release: 3.el7
+    source: rpm
+    version: 0.12.0
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 572.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 572.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 5.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '14'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 37.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7_9.1
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  fuse-overlayfs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
+  fuse3-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geoipupdate:
+  - arch: x86_64
+    epoch: null
+    name: geoipupdate
+    release: 1.el7
+    source: rpm
+    version: 2.5.0
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 9.el7_9
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  - arch: i686
+    epoch: null
+    name: glibc
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 325.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 467e318a
+    source: rpm
+    version: 00f97f56
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.87.el7.centos.7
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 30.el7_9
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.7.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7_9.1
+    source: rpm
+    version: 9.49.53
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '25'
+    source: rpm
+    version: 1.11.3
+  iometrics-agent-plugin-oracle-lib-connector:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-lib-connector
+    release: '25'
+    source: rpm
+    version: 18.5.0_1.11.3
+  iometrics-agent-plugin-oracle-libs:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent-plugin-oracle-libs
+    release: '1'
+    source: rpm
+    version: 18.5.0
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 30.el7
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 35.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 1.el7_9
+    source: rpm
+    version: 1.8.0.322.b06
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 16.el7_9
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 51.el7_9.3
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: i686
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 135.el7_9
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: i686
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 51.el7_9
+    source: rpm
+    version: 1.15.1
+  ksh:
+  - arch: x86_64
+    epoch: null
+    name: ksh
+    release: 143.el7_9
+    source: rpm
+    version: '20120801'
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXmu:
+  - arch: x86_64
+    epoch: null
+    name: libXmu
+    release: 2.el7
+    source: rpm
+    version: 1.1.2
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXt:
+  - arch: x86_64
+    epoch: null
+    name: libXt
+    release: 3.el7
+    source: rpm
+    version: 1.1.5
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXv:
+  - arch: x86_64
+    epoch: null
+    name: libXv
+    release: 1.el7
+    source: rpm
+    version: 1.0.11
+  libXxf86dga:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86dga
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.4
+  libXxf86misc:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86misc
+    release: 7.1.el7
+    source: rpm
+    version: 1.0.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  - arch: i686
+    epoch: null
+    name: libcom_err
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 6.el7_9
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 59.el7_9.1
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: i686
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdmx:
+  - arch: x86_64
+    epoch: null
+    name: libdmx
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 8.el7
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  - arch: i686
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: i686
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 19.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 4.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  - arch: i686
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  - arch: i686
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_9.6
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  linux-firmware:
+  - arch: noarch
+    epoch: null
+    name: linux-firmware
+    release: 80.git78c0348.el7_9
+    source: rpm
+    version: '20200421'
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 18.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 17.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 1.el7
+    source: rpm
+    version: 1.8.3
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  mailx:
+  - arch: x86_64
+    epoch: null
+    name: mailx
+    release: 19.el7
+    source: rpm
+    version: '12.5'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.68
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 73.11.el7_9
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  - arch: i686
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.68.el7.2
+    source: rpm
+    version: 1.3.0
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: i686
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_9
+    source: rpm
+    version: 4.32.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  - arch: i686
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss-softokn
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-softokn-freebl:
+  - arch: i686
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 3.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 4.el7_9
+    source: rpm
+    version: 3.67.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  - arch: i686
+    epoch: null
+    name: nss-util
+    release: 1.el7_9
+    source: rpm
+    version: 3.67.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  - arch: i686
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 22.el7_9
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  - arch: i686
+    epoch: 1
+    name: openssl-libs
+    release: 24.el7_9
+    source: rpm
+    version: 1.0.2k
+  oracle-database-preinstall-21c:
+  - arch: x86_64
+    epoch: null
+    name: oracle-database-preinstall-21c
+    release: 1.el7
+    source: rpm
+    version: '1.0'
+  oracle-database-xe-21c:
+  - arch: x86_64
+    epoch: null
+    name: oracle-database-xe-21c
+    release: '1'
+    source: rpm
+    version: '1.0'
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: i686
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7_9.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql:
+  - arch: x86_64
+    epoch: null
+    name: postgresql
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-contrib
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  - arch: i686
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-server
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 28.el7
+    source: rpm
+    version: 3.3.10
+  psmisc:
+  - arch: x86_64
+    epoch: null
+    name: psmisc
+    release: 17.el7
+    source: rpm
+    version: '22.20'
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1160.53.1.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 10.el7
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: i686
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redis:
+  - arch: x86_64
+    epoch: null
+    name: redis
+    release: 1.el7.remi
+    source: rpm
+    version: 6.2.6
+  remi-release:
+  - arch: noarch
+    epoch: null
+    name: remi-release
+    release: 2.el7.remi
+    source: rpm
+    version: '7.9'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 566
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::1'
-    name: chronyd
-    pid: 584
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:54 2022'
-    user: chrony
-  - address: '::1'
-    name: xe_lreg_XE
-    pid: 23033
-    port: 33176
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 719
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
-  - address: '::1'
-    name: xe_s000_XE
-    pid: 23060
-    port: 64452
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:38 2022'
-    user: oracle
-  - address: '::1'
-    name: xe_d000_XE
-    pid: 23051
-    port: 32251
-    protocol: udp
-    stime: 'Thu Jun  9 09:15:37 2022'
-    user: oracle
-  - address: '::'
-    name: skydive
-    pid: 1512
-    port: 8081
-    protocol: udp
-    stime: 'Tue Apr 26 14:45:06 2022'
-    user: root
-  - address: '::'
-    name: rpcbind
-    pid: 566
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 14:44:53 2022'
-    user: rpc
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 48.el7_9
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 57.el7_9.1
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 7.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 268.el7_9.2
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  smartmontools:
+  - arch: x86_64
+    epoch: 1
+    name: smartmontools
+    release: 2.el7
+    source: rpm
+    version: '7.0'
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: i686
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 10.el7_9.2
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 78.el7_9.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 3.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-docs-webapp:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-docs-webapp
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-javadoc:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-javadoc
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 11.el7_9
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021e
+  unzip:
+  - arch: x86_64
+    epoch: null
+    name: unzip
+    release: 24.el7_9
+    source: rpm
+    version: '6.0'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 65.el7_9.1
+    source: rpm
+    version: 2.23.2
+  uuid:
+  - arch: x86_64
+    epoch: null
+    name: uuid
+    release: 26.el7
+    source: rpm
+    version: 1.6.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7_9.1
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7_9.2
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 22.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-utils:
+  - arch: x86_64
+    epoch: null
+    name: xorg-x11-utils
+    release: 23.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-xauth:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-xauth
+    release: 1.el7
+    source: rpm
+    version: 1.0.9
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 168.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 54.el7_8
+    source: rpm
+    version: 1.1.31
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+  - arch: i686
+    epoch: null
+    name: zlib
+    release: 19.el7_9
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '41'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '59'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '127'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '194'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '195'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '265'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '267'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '269'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '270'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '273'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '284'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '285'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '286'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '287'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '288'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '289'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '411'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '453'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '481'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '486'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '515'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '551'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '552'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '566'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/smartd -n -q never
+  cwd: /usr/sbin/
+  pid: '567'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '570'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '573'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '584'
+  ppid: '1'
+  user: chrony
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '594'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H test-ram-norm01 eth0
+  cwd: /sbin/
+  pid: '826'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+    -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8050 -Dcom.sun.management.jmxremote.rmi.port=8050
+    -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
+    -Djava.rmi.server.hostname=test-ram-norm01.lab.iometrics.io -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+    -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+    -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+    start
+  cwd: /usr/lib/jvm/jre/bin/
+  pid: '881'
+  ppid: '1'
+  user: tomcat
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '883'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '902'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1058'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1063'
+  ppid: '1058'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1103'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1105'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/redis-server 127.0.0.1:6379
+  cwd: /usr/bin/
+  pid: '1109'
+  ppid: '1'
+  user: redis
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1110'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1114'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1115'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1116'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd-shim-runc-v2 -namespace moby -id 430f69be340bdb1beb2b20e4d25cf341061c3daa759b6b34ab61c1f55cf806b9
+    -address /run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1494'
+  ppid: '1'
+  user: root
+- cmdline: /usr/local/bin/skydive analyzer -c /etc/iometrics/skydive/skydive.yml
+  cwd: /usr/local/bin/
+  pid: '1512'
+  ppid: '1494'
+  user: root
+- cmdline: /usr/bin/docker start -a skydive-analyzer
+  cwd: /usr/bin/
+  pid: '1561'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2573'
+  ppid: '2'
+  user: root
+- cmdline: xe_m002_XE
+  cwd: /
+  pid: '6043'
+  ppid: '1'
+  user: oracle
+- cmdline: /usr/bin/postgres -D /var/lib/pgsql/data -p 5432
+  cwd: /usr/bin/
+  pid: '7291'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: logger process'
+  cwd: /
+  pid: '7292'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: checkpointer process'
+  cwd: /
+  pid: '7294'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: writer process'
+  cwd: /
+  pid: '7295'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: wal writer process'
+  cwd: /
+  pid: '7296'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: autovacuum launcher process'
+  cwd: /
+  pid: '7297'
+  ppid: '7291'
+  user: postgres
+- cmdline: 'postgres: stats collector process'
+  cwd: /
+  pid: '7298'
+  ppid: '7291'
+  user: postgres
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '7673'
+  ppid: '1058'
+  user: postfix
+- cmdline: /usr/share/filebeat/bin/filebeat -e -c /etc/filebeat/filebeat.yml -path.home
+    /usr/share/filebeat -path.config /etc/filebeat -path.data /var/lib/filebeat -path.logs
+    /var/log/filebeat
+  cwd: /usr/share/filebeat/bin/
+  pid: '11133'
+  ppid: '1'
+  user: root
+- cmdline: xe_m005_XE
+  cwd: /
+  pid: '11706'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '15343'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15997'
+  ppid: '2'
+  user: root
+- cmdline: xe_m000_XE
+  cwd: /
+  pid: '16346'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '16694'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '16699'
+  ppid: '1103'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '16701'
+  ppid: '16699'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '16859'
+  ppid: '16701'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '16872'
+  ppid: '16859'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-ojzfhiedixwtglpjfgwshzdzbfvciiyz ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '16873'
+  ppid: '16872'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655967355.8912516-9023-239657095128306/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '16874'
+  ppid: '16873'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '19386'
+  ppid: '1'
+  user: root
+- cmdline: 'postgres: postgres datadope [local] idle'
+  cwd: /
+  pid: '19444'
+  ppid: '7291'
+  user: postgres
+- cmdline: xe_m004_XE
+  cwd: /
+  pid: '21779'
+  ppid: '1'
+  user: oracle
+- cmdline: /opt/oracle/product/21c/dbhomeXE/bin/tnslsnr LISTENER -inherit
+  cwd: /opt/oracle/product/21c/dbhomeXE/bin/
+  pid: '22926'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pmon_XE
+  cwd: /
+  pid: '22942'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_clmn_XE
+  cwd: /
+  pid: '22946'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_psp0_XE
+  cwd: /
+  pid: '22950'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vktm_XE
+  cwd: /
+  pid: '22954'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen0_XE
+  cwd: /
+  pid: '22961'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mman_XE
+  cwd: /
+  pid: '22967'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen1_XE
+  cwd: /
+  pid: '22971'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_gen2_XE
+  cwd: /
+  pid: '22973'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vosd_XE
+  cwd: /
+  pid: '22975'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_diag_XE
+  cwd: /
+  pid: '22979'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_ofsd_XE
+  cwd: /
+  pid: '22985'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dbrm_XE
+  cwd: /
+  pid: '22990'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_vkrm_XE
+  cwd: /
+  pid: '22993'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_svcb_XE
+  cwd: /
+  pid: '22996'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pman_XE
+  cwd: /
+  pid: '23001'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dia0_XE
+  cwd: /
+  pid: '23004'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_dbw0_XE
+  cwd: /
+  pid: '23008'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_lgwr_XE
+  cwd: /
+  pid: '23012'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_ckpt_XE
+  cwd: /
+  pid: '23015'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_smon_XE
+  cwd: /
+  pid: '23020'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_smco_XE
+  cwd: /
+  pid: '23023'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_reco_XE
+  cwd: /
+  pid: '23030'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_lreg_XE
+  cwd: /
+  pid: '23033'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_pxmn_XE
+  cwd: /
+  pid: '23035'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mmon_XE
+  cwd: /
+  pid: '23041'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_mmnl_XE
+  cwd: /
+  pid: '23045'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_bg00_XE
+  cwd: /
+  pid: '23049'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_d000_XE
+  cwd: /
+  pid: '23051'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w000_XE
+  cwd: /
+  pid: '23054'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_bg01_XE
+  cwd: /
+  pid: '23058'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_s000_XE
+  cwd: /
+  pid: '23060'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w001_XE
+  cwd: /
+  pid: '23063'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tmon_XE
+  cwd: /
+  pid: '23068'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt00_XE
+  cwd: /
+  pid: '23074'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt01_XE
+  cwd: /
+  pid: '23076'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_tt02_XE
+  cwd: /
+  pid: '23078'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_rcbg_XE
+  cwd: /
+  pid: '23098'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_aqpc_XE
+  cwd: /
+  pid: '23109'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w002_XE
+  cwd: /
+  pid: '23114'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w003_XE
+  cwd: /
+  pid: '23120'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w004_XE
+  cwd: /
+  pid: '23299'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_cjq0_XE
+  cwd: /
+  pid: '23309'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_qm02_XE
+  cwd: /
+  pid: '23311'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_q003_XE
+  cwd: /
+  pid: '23318'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_q005_XE
+  cwd: /
+  pid: '23374'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_cl00_XE
+  cwd: /
+  pid: '23486'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w005_XE
+  cwd: /
+  pid: '24218'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w006_XE
+  cwd: /
+  pid: '24731'
+  ppid: '1'
+  user: oracle
+- cmdline: xe_w007_XE
+  cwd: /
+  pid: '24736'
+  ppid: '1'
+  user: oracle
+- cmdline: ''
+  cwd: /
+  pid: '27392'
+  ppid: '2'
+  user: root
+- cmdline: xe_m006_XE
+  cwd: /
+  pid: '28429'
+  ppid: '1'
+  user: oracle
+software_list:
+- cmd_regexp: \.apache\.tomcat\.startup|\.apache\.catalina\.startup
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/tomcat.yaml'
+    name: Include Apache Tomcat Servlet Engine specific plugins
+  name: Apache Tomcat Servlet Engine
+  pkg_regexp: tomcat
+  process_type: parent
+  return_children: true
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: postgres
+  pid: 7291
+  port: 5432
+  protocol: tcp
+  stime: Fri Jun  3 09:22:29 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1058
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 14:45:01 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 1512
+  port: 12379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: 127.0.0.1
+  name: skydive
+  pid: 1512
+  port: 12380
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: 192.168.0.26
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: 127.0.0.1
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: 0.0.0.0
+  name: sshd
+  pid: 1103
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: root
+- address: ::1
+  name: postgres
+  pid: 7291
+  port: 5432
+  protocol: tcp
+  stime: Fri Jun  3 09:22:29 2022
+  user: postgres
+- address: ::1
+  name: master
+  pid: 1058
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 14:45:01 2022
+  user: root
+- address: '::'
+  name: tnslsnr
+  pid: 22926
+  port: 5500
+  protocol: tcp
+  stime: Thu Jun  9 09:15:34 2022
+  user: oracle
+- address: '::'
+  name: java
+  pid: 881
+  port: 11870
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 4000
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: tnslsnr
+  pid: 22926
+  port: 1539
+  protocol: tcp
+  stime: Thu Jun  9 09:15:34 2022
+  user: oracle
+- address: 127.0.0.1
+  name: java
+  pid: 881
+  port: 8005
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 881
+  port: 8009
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: xe_d000_XE
+  pid: 23051
+  port: 21899
+  protocol: tcp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: ::1
+  name: redis-server
+  pid: 1109
+  port: 6379
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: redis
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8080
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8081
+  protocol: tcp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: java
+  pid: 881
+  port: 8082
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 881
+  port: 8050
+  protocol: tcp
+  stime: Tue Apr 26 14:44:59 2022
+  user: tomcat
+- address: '::'
+  name: sshd
+  pid: 1103
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 14:45:02 2022
+  user: root
+udp_listen:
+- address: 127.0.0.1
+  name: chronyd
+  pid: 584
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 14:44:54 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 719
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 826
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 14:44:59 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 584
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 14:44:54 2022
+  user: chrony
+- address: ::1
+  name: xe_lreg_XE
+  pid: 23033
+  port: 33176
+  protocol: udp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 719
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc
+- address: ::1
+  name: xe_s000_XE
+  pid: 23060
+  port: 64452
+  protocol: udp
+  stime: Thu Jun  9 09:15:38 2022
+  user: oracle
+- address: ::1
+  name: xe_d000_XE
+  pid: 23051
+  port: 32251
+  protocol: udp
+  stime: Thu Jun  9 09:15:37 2022
+  user: oracle
+- address: '::'
+  name: skydive
+  pid: 1512
+  port: 8081
+  protocol: udp
+  stime: Tue Apr 26 14:45:06 2022
+  user: root
+- address: '::'
+  name: rpcbind
+  pid: 566
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 14:44:53 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/tomcat/tomcat9.0.31_cmdb.yaml
+++ b/tests/unit/plugins/action/auto/resources/tomcat/tomcat9.0.31_cmdb.yaml
@@ -1,3966 +1,4077 @@
+dockers:
+  containers:
+  - AppArmorProfile: ''
+    Args:
+    - -c
+    - /usr/local/bin/docker-entrypoint.sh
+    - catalina.sh
+    - run
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - catalina.sh
+      - run
+      Domainname: ''
+      Entrypoint:
+      - /bin/sh
+      - -c
+      - /usr/local/bin/docker-entrypoint.sh
+      Env:
+      - POSTGRES_HOST=cmdb-db01-integracion-internal.iometrics.io
+      - TZ=Europe/Madrid
+      - POSTGRES_PASS=ta5Puid4et2aemeveeshaeha
+      - JAVA_OPTS=-Xmx4000m -Xms2000m
+      - POSTGRES_APP_USER=datadope
+      - POSTGRES_DB=cmdbuild_r2u2
+      - POSTGRES_APP_PASSWORD=ta5Puid4et2aemeveeshaeha
+      - POSTGRES_USER=datadope
+      - PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - JAVA_HOME=/usr/local/openjdk-11
+      - JAVA_VERSION=11.0.6
+      - JAVA_BASE_URL=https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_
+      - JAVA_URL_VERSION=11.0.6_10
+      - CATALINA_HOME=/usr/local/tomcat
+      - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
+      - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
+      - GPG_KEYS=05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42
+        47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7
+        61B832AC2F1C5A90F0F9B00A1C506407564C17A3 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED
+        9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC
+        A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
+        F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+      - TOMCAT_MAJOR=9
+      - TOMCAT_VERSION=9.0.31
+      - TOMCAT_SHA512=75045ce54ad1b6ea66fd112e8b2ffa32a0740c018ab9392c7217a6dd6b829e8645b6810ab4b28dd186c12ce6045c1eb18ed19743c5d4b22c9e613e76294f22f5
+      - CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
+      - POSTGRES_PORT=5432
+      - CMDBUILD_DUMP=empty.dump.xz
+      ExposedPorts:
+        8080/tcp: {}
+        8443/tcp: {}
+      Hostname: localhost
+      Image: nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.4.1
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: tomcat
+      Volumes:
+        /etc/hosts: {}
+        /usr/local/tomcat/certs: {}
+        /usr/local/tomcat/logs: {}
+      WorkingDir: /usr/local/tomcat
+    Created: '2021-11-11T10:02:57.904221801Z'
+    Driver: overlay2
+    ExecIDs:
+    - f5e80c464940e29fe42a391831fab140b08c3ab532c8d60879b50ba3b3dad834
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440-init/diff:/var/lib/docker/overlay2/c0100c5fc0888fad72adf7c709d3142ccba8797311803c32b1c6ee9fdc1de50e/diff:/var/lib/docker/overlay2/63d738012f51ff7170406467832e013db70f935f583552a7886aa38962e82982/diff:/var/lib/docker/overlay2/47cd80f7dedb3bc34c2bca3fa92244ea9c185fcf0542caef919e1cc857cfdd3b/diff:/var/lib/docker/overlay2/a2db2a600330275b614855b67ddd415e3a75afa829346adfa0bb03a7333b402e/diff:/var/lib/docker/overlay2/9379979c9dd250c039f4afc2567766061715e709bfc36ee01ae3c3239025986b/diff:/var/lib/docker/overlay2/18f67ad491d73a59df5e91b962f57ef4869ddd92c6ebd3e44102469697624266/diff:/var/lib/docker/overlay2/137a09117ac770c6d5fc56e5112ebc5b08ef3c3d9efff29df177409a565a87b0/diff:/var/lib/docker/overlay2/de594fddde953514eeacfe63c99be98087989c214e4e5de974831664ffbe66a8/diff:/var/lib/docker/overlay2/4e4b98753830b09fce6331e4e11cb57368a29059ef703c11757668499e1a5a6b/diff:/var/lib/docker/overlay2/43329bb8f930dbaf651a0f9ec89f9a81ca1177bcda97d444ef43dffa082d7d30/diff:/var/lib/docker/overlay2/93fb2b626f5a929d0e2aef75b0a4504b487754c638f06ef853846011b1b04f90/diff:/var/lib/docker/overlay2/d7655bb3f45fb79b3810a732adf321480912998b29d65842ce8546dbd67ca402/diff:/var/lib/docker/overlay2/dae7334ac1a1ee12d6b8def3204d21f3c259a623f01098a682d52185f87f53b1/diff:/var/lib/docker/overlay2/bd55b267f3dc2165fe8ae6ca4d7ad01824c9f073f3d9a209b4aabb15f1e3f628/diff:/var/lib/docker/overlay2/7038e40fc28165f150bb277854f7fe37c3b19967a7fe07fe70eb5663343ec96c/diff:/var/lib/docker/overlay2/04ddf62add125112aeeef17f32406bf3e5a42a342ee771e8f4fe30f12794c4b4/diff:/var/lib/docker/overlay2/f38683ed385ddb64de321621e8f8e7b8cb161f8100a64417c64a152429822c63/diff:/var/lib/docker/overlay2/9101a62094b1ab60a4e9477e952bbc50c513103b178d2f07c51449876454d328/diff:/var/lib/docker/overlay2/a61859f12ba2af9c9dc4b9318ddc2efa3636248af9c1c5819afcaa93cdd478a6/diff:/var/lib/docker/overlay2/7bbd2fba82cda8d8110a79811738382f993dfbbcaec424690f81f0f602188578/diff:/var/lib/docker/overlay2/fc177696896be4d18ffb7582249deb2e6bc004fa6c1b59bd2cca3b3165e6240e/diff
+        MergedDir: /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/merged
+        UpperDir: /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/diff
+        WorkDir: /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:ro
+      - /etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw
+      - /var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 4194304000
+      MemoryReservation: 2097152000
+      MemorySwap: 8388608000
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: bridge
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: ''
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/hostname
+    HostsPath: /etc/hosts
+    Id: 54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
+    Image: sha256:4963cc7d5cdaa74048cc3a833584e1634a8245490d8f6c206a97b163157817ff
+    LogPath: /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /usr/local/tomcat/certs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/iometrics-cmdbuild/certs
+      Type: bind
+    - Destination: /usr/local/tomcat/logs
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/iometrics-cmdbuild
+      Type: bind
+    Name: /iometrics-cmdbuild
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 02e4de3309dc5c39396033b01289e18cc722789b4cb582ed92d84d69d7400c2b
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 02e4de3309dc5c39396033b01289e18cc722789b4cb582ed92d84d69d7400c2b
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: 91d42730928d475ba307be852a455668b8122288ceb5c15f12d313f2ce0b4255
+      Ports:
+        8080/tcp: null
+        8443/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '8443'
+      SandboxID: 94356f6fa85936e5a3a3aed208d5e20fd01af15632851df7a80174f8b92f6549
+      SandboxKey: /var/run/docker/netns/94356f6fa859
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /bin/sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:42.531448015Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 6175
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:55:58.071033978Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      - GF_RENDERER_PLUGIN_CHROME_BIN=/usr/bin/chromium-browser
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: cmdb01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui-enterprise:6.6.2.3
+      Labels:
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-01-15T12:45:30.765987178Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1-init/diff:/var/lib/docker/overlay2/0d2c44c827bfb7dabdebae887d8683db32d93d4d76b196d7ad89704e0fcb1389/diff:/var/lib/docker/overlay2/f0e1f1f418c2281b381cf1865c8f26dcd6b3d932f40f52d1b1fdca5b51f59403/diff:/var/lib/docker/overlay2/55a6a205817b93c52fb9fd4c2cc8f934d19e4b2ccfbcf3c08b298753a45ae973/diff:/var/lib/docker/overlay2/6eb3c76533ef49d07490c8c83d99533de21abd3109451cf52fc0c67b69ab611b/diff:/var/lib/docker/overlay2/e2815a71b491409711b3d35eea90c0dd86fd08cf49d3cef7a3b8975805873009/diff:/var/lib/docker/overlay2/7a4561e76b8114bef56fd08e6cb03450a148795b234a3d8dc8236b8fe76c8bcd/diff:/var/lib/docker/overlay2/54dd3972aadb529dba440730f58fa712249b38347dd0c302925e87327062d273/diff:/var/lib/docker/overlay2/67b520bda1cd13ae235e8248930218fdf9fb9d3a9677961b748af89d704c3f26/diff:/var/lib/docker/overlay2/39a352a4de1195eb0ea5d56384fcb82143edf4b381d039933cfdfc8437742018/diff:/var/lib/docker/overlay2/8bba506a78e1be76f9df4721f9e1d9b803663b7b7de87f041d8089ef1f641d5a/diff:/var/lib/docker/overlay2/f5ed7d8d022525cf8f03f3be2493851803cd595469b11b32f183255bddca9349/diff:/var/lib/docker/overlay2/14f5fd087aa9d77e5433f13239715857e7bf55e03bf0369c3369e1d0f2fc805e/diff
+        MergedDir: /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/merged
+        UpperDir: /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/diff
+        WorkDir: /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/hostname
+    HostsPath: /etc/hosts
+    Id: 9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60
+    Image: sha256:d3c19e6207531bc75d6e96acb05ba4e07aa8497c67ffb7300c22f09129e7c6ac
+    LogPath: /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 4be9102529bde6561a20aef10b892eaeb6db6ff824a222a50ac373182b510706
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 1ab6c0eaf33ebf3437299022cf3d1481c808eb54b77862bc018876a78726b0f4
+      Ports: {}
+      SandboxID: 20caa57c43e433507a96073c6dc1cf2134b03a9874406acdb6540325c821a29f
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:55:42.531786634Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 5645
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:55:52.595384652Z'
+      Status: running
+expected_result:
+- bindings:
+  - class: port_http
+    port: 8080
+  - class: port_jmx
+    port: 8050
+  configuration:
+    Server:
+      GlobalNamingResources:
+        Resource:
+          attr-auth: Container
+          attr-description: User database that can be updated and saved
+          attr-factory: org.apache.catalina.users.MemoryUserDatabaseFactory
+          attr-name: UserDatabase
+          attr-pathname: conf/tomcat-users.xml
+          attr-type: org.apache.catalina.UserDatabase
+      Listener:
+      - attr-className: org.apache.catalina.startup.VersionLoggerListener
+      - attr-SSLEngine: 'on'
+        attr-className: org.apache.catalina.core.AprLifecycleListener
+      - attr-className: org.apache.catalina.core.JreMemoryLeakPreventionListener
+      - attr-className: org.apache.catalina.mbeans.GlobalResourcesLifecycleListener
+      - attr-className: org.apache.catalina.core.ThreadLocalLeakPreventionListener
+      Service:
+        Connector:
+        - attr-connectionTimeout: '20000'
+          attr-maxHttpHeaderSize: '2097152'
+          attr-port: '8080'
+          attr-protocol: HTTP/1.1
+          attr-redirectPort: '8443'
+        - SSLHostConfig:
+            Certificate:
+              attr-certificateChainFile: certs/rsa-chain.pem
+              attr-certificateFile: certs/rsa-cert.pem
+              attr-certificateKeyFile: certs/rsa-key.pem
+              attr-type: RSA
+          UpgradeProtocol:
+            attr-className: org.apache.coyote.http2.Http2Protocol
+          attr-SSLEnabled: 'true'
+          attr-connectionTimeout: '300000'
+          attr-maxHttpHeaderSize: '2097152'
+          attr-maxThreads: '500'
+          attr-port: '8443'
+          attr-protocol: org.apache.coyote.http11.Http11AprProtocol
+        Engine:
+          Host:
+            Valve:
+              attr-className: org.apache.catalina.valves.AccessLogValve
+              attr-directory: logs
+              attr-pattern: '%h %l %u %t "%r" %s %b'
+              attr-prefix: localhost_access
+              attr-rotatable: 'false'
+              attr-suffix: .log
+            attr-appBase: webapps
+            attr-autoDeploy: 'true'
+            attr-name: localhost
+            attr-unpackWARs: 'true'
+          Realm:
+            Realm:
+              attr-className: org.apache.catalina.realm.UserDatabaseRealm
+              attr-resourceName: UserDatabase
+            attr-className: org.apache.catalina.realm.LockOutRealm
+          attr-defaultHost: localhost
+          attr-name: Catalina
+        attr-name: Catalina
+      attr-port: '8005'
+      attr-shutdown: SHUTDOWN
+  discovery_time: '2022-06-23T12:29:34+02:00'
+  docker:
+    exposed_ports:
+      8080/tcp: {}
+      8443/tcp: {}
+    id: 54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
+    image: nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.4.1
+    name: /iometrics-cmdbuild
+    network_mode: bridge
+    port_bindings:
+      8443/tcp:
+      - HostIp: 0.0.0.0
+        HostPort: '8443'
+  files:
+  - path: /usr/local/tomcat
+    subtype: base
+    type: config
+  - path: /usr/local/tomcat
+    subtype: home
+    type: config
+  - path: /usr/local/openjdk-11
+    subtype: java_home
+    type: config
+  - name: server.xml
+    path: /usr/local/tomcat/conf
+    subtype: generic
+    type: config
+  listening_ports:
+  - 8443
+  packages: []
+  process:
+    children: []
+    cmdline: /usr/local/openjdk-11/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
+      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx4000m
+      -Xms2000m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+      -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
+      -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
+      -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp
+      org.apache.catalina.startup.Bootstrap start
+    cwd: /usr/local/openjdk-11/bin/
+    pid: '6362'
+    ppid: '6175'
+    user: centos
+  type: Apache Tomcat Servlet Engine
+  version:
+  - number: 0.4.1
+    type: docker
+  - number: 9.0.31
+    type: file
+expected_tasks_calls:
+  Check if server file in base is accessible: 1
+  Check if server file in home is accessible: 1
+  Check if xml_file is accessible: 1
+  Get config from cmdline: 1
+  Get config_file: 1
+  Read config file: 1
+  Read file version 1: 1
+  Read process environment: 1
+  Regrex from jmx port: 1
 mocked_plugin_tasks:
-  Get config from cmdline:
-    number_of_calls: 1
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Get config_file:
-    number_of_calls: 1
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Regrex from jmx port:
-    number_of_calls: 1
-    expected_exception:
-      message: "'NoneType' object is not iterable"
-
-  Read process environment:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      parsed: {
-        "POSTGRES_HOST": "cmdb-db01-integracion-internal.iometrics.io",
-        "HOSTNAME": "localhost",
-        "JAVA_HOME": "/usr/local/openjdk-11",
-        "GPG_KEYS": "05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42 47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7 61B832AC2F1C5A90F0F9B00A1C506407564C17A3 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED 9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243 F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23",
-        "JAVA_BASE_URL": "https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_",
-        "JAVA_OPTS": "-Xmx4000m -Xms2000m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dorg.apache.catalina.security.SecurityListener.UMASK=0027",
-        "PWD": "/usr/local/tomcat",
-        "JAVA_URL_VERSION": "11.0.6_10",
-        "CMDBUILD_URL": "https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war",
-        "CATALINA_OPTS": " -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m",
-        "TOMCAT_SHA512": "75045ce54ad1b6ea66fd112e8b2ffa32a0740c018ab9392c7217a6dd6b829e8645b6810ab4b28dd186c12ce6045c1eb18ed19743c5d4b22c9e613e76294f22f5",
-        "TZ": "Europe/Madrid",
-        "TOMCAT_MAJOR": "9",
-        "HOME": "/usr/local/tomcat",
-        "LANG": "C.UTF-8",
-        "TOMCAT_NATIVE_LIBDIR": "/usr/local/tomcat/native-jni-lib",
-        "POSTGRES_APP_PASSWORD": "ta5Puid4et2aemeveeshaeha",
-        "POSTGRES_APP_USER": "datadope",
-        "CATALINA_HOME": "/usr/local/tomcat",
-        "POSTGRES_PORT": "5432",
-        "SHLVL": "0",
-        "POSTGRES_USER": "datadope",
-        "JDK_JAVA_OPTIONS": " --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED",
-        "LD_LIBRARY_PATH": "/usr/local/tomcat/native-jni-lib",
-        "PATH": "/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "CMDBUILD_DUMP": "empty.dump.xz",
-        "POSTGRES_PASS": "ta5Puid4et2aemeveeshaeha",
-        "POSTGRES_DB": "cmdbuild_r2u2",
-        "TOMCAT_VERSION": "9.0.31",
-        "JAVA_VERSION": "11.0.6"
-      }
-
-  Read file version 1:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-      content: "================================================================================\n  Licensed to the Apache Software Foundation (ASF) under one or more\n  contributor license agreements.  See the NOTICE file distributed with\n  this work for additional information regarding copyright ownership.\n  The ASF licenses this file to You under the Apache License, Version 2.0\n  (the \"License\"); you may not use this file except in compliance with\n  the License.  You may obtain a copy of the License at\n\n      http://www.apache.org/licenses/LICENSE-2.0\n\n  Unless required by applicable law or agreed to in writing, software\n  distributed under the License is distributed on an \"AS IS\" BASIS,\n  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n  See the License for the specific language governing permissions and\n  limitations under the License.\n================================================================================\n\n\n                     Apache Tomcat Version 9.0.31\n                            Release Notes\n\n\n=========\nCONTENTS:\n=========\n\n* Dependency Changes\n* API Stability\n* Bundled APIs\n* Web application reloading and static fields in shared libraries\n* Security manager URLs\n* Symlinking static resources\n* Viewing the Tomcat Change Log\n* Cryptographic software notice\n* When all else fails\n\n\n===================\nDependency Changes:\n===================\nTomcat 9.0 is designed to run on Java 8 and later.\n\n\n==============\nAPI Stability:\n==============\n\nThe public interfaces for the following classes are fixed and will not be\nchanged at all during the remaining lifetime of the 9.x series:\n- All classes in the javax namespace\n\nThe public interfaces for the following classes may be added to in order to\nresolve bugs and/or add new features. No existing interface method will be\nremoved or changed although it may be deprecated.\n- org.apache.catalina.* (excluding sub-packages)\n\nNote: As Tomcat 9 matures, the above list will be added to. The list is not\n      considered complete at this time.\n\nThe remaining classes are considered part of the Tomcat internals and may change\nwithout notice between point releases.\n\n\n=============\nBundled APIs:\n=============\nA standard installation of Tomcat 9.0 makes all of the following APIs available\nfor use by web applications (by placing them in \"lib\"):\n* annotations-api.jar (Annotations package)\n* catalina.jar (Tomcat Catalina implementation)\n* catalina-ant.jar (Tomcat Catalina Ant tasks)\n* catalina-ha.jar (High availability package)\n* catalina-ssi.jar (Server-side Includes module)\n* catalina-storeconfig.jar (Generation of XML configuration from current state)\n* catalina-tribes.jar (Group communication)\n* ecj-4.13.jar (Eclipse JDT Java compiler)\n* el-api.jar (EL 3.0 API)\n* jasper.jar (Jasper 2 Compiler and Runtime)\n* jasper-el.jar (Jasper 2 EL implementation)\n* jsp-api.jar (JSP 2.3 API)\n* servlet-api.jar (Servlet 4.0 API)\n* tomcat-api.jar (Interfaces shared by Catalina and Jasper)\n* tomcat-coyote.jar (Tomcat connectors and utility classes)\n* tomcat-dbcp.jar (package renamed database connection pool based on Commons DBCP 2)\n* tomcat-jdbc.jar (Tomcat's database connection pooling solution)\n* tomcat-jni.jar (Interface to the native component of the APR/native connector)\n* tomcat-util.jar (Various utilities)\n* tomcat-websocket.jar (WebSocket 1.1 implementation)\n* websocket-api.jar (WebSocket 1.1 API)\n\nYou can make additional APIs available to all of your web applications by\nputting unpacked classes into a \"classes\" directory (not created by default),\nor by placing them in JAR files in the \"lib\" directory.\n\nTo override the XML parser implementation or interfaces, use the appropriate\nfeature for your JVM. For Java <= 8 use the endorsed standards override\nfeature. The default configuration defines JARs located in \"endorsed\" as endorsed.\nFor Java 9+ use the upgradeable modules feature.\n\n\n================================================================\nWeb application reloading and static fields in shared libraries:\n================================================================\nSome shared libraries (many are part of the JDK) keep references to objects\ninstantiated by the web application. To avoid class loading related problems\n(ClassCastExceptions, messages indicating that the classloader\nis stopped, etc.), the shared libraries state should be reinitialized.\n\nSomething which might help is to avoid putting classes which would be\nreferenced by a shared static field in the web application classloader,\nand putting them in the shared classloader instead (JARs should be put in the\n\"lib\" folder, and classes should be put in the \"classes\" folder).\n\n\n======================\nSecurity manager URLs:\n======================\nIn order to grant security permissions to JARs located inside the\nweb application repository, use URLs of the following format\nin your policy file:\n\nfile:${catalina.base}/webapps/examples/WEB-INF/lib/driver.jar\n\n\n============================\nSymlinking static resources:\n============================\nBy default, Unix symlinks will not work when used in a web application to link\nresources located outside the web application root directory.\n\nThis behavior is optional, and the \"allowLinking\" flag may be used to disable\nthe check.\n\n\n==============================\nViewing the Tomcat Change Log:\n==============================\nThe full change log is available from https://tomcat.apache.org and is also\nincluded in the documentation web application.\n\n\n=============================\nCryptographic software notice\n=============================\nThis distribution includes cryptographic software.  The country in\nwhich you currently reside may have restrictions on the import,\npossession, use, and/or re-export to another country, of\nencryption software.  BEFORE using any encryption software, please\ncheck your country's laws, regulations and policies concerning the\nimport, possession, or use, and re-export of encryption software, to\nsee if this is permitted.  See <http://www.wassenaar.org/> for more\ninformation.\n\nThe U.S. Government Department of Commerce, Bureau of Industry and\nSecurity (BIS), has classified this software as Export Commodity\nControl Number (ECCN) 5D002.C.1, which includes information security\nsoftware using or performing cryptographic functions with asymmetric\nalgorithms.  The form and manner of this Apache Software Foundation\ndistribution makes it eligible for export under the License Exception\nENC Technology Software Unrestricted (TSU) exception (see the BIS\nExport Administration Regulations, Section 740.13) for both object\ncode and source code.\n\nThe following provides more details on the included cryptographic\nsoftware:\n  - Tomcat includes code designed to work with JSSE\n  - Tomcat includes code designed to work with OpenSSL\n\n\n====================\nWhen all else fails:\n====================\nSee the FAQ\nhttps://tomcat.apache.org/faq/\n"
-
-  Check if xml_file is accessible:
-    number_of_calls: 1
-    plugin_result:
-      failed: false
-
   Check if server file in base is accessible:
     number_of_calls: 1
     plugin_result:
       failed: false
-
   Check if server file in home is accessible:
     number_of_calls: 1
     plugin_result:
       failed: false
-
+  Check if xml_file is accessible:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+  Get config from cmdline:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+    number_of_calls: 1
+  Get config_file:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+    number_of_calls: 1
   Read config file:
     number_of_calls: 1
     plugin_result:
       failed: false
-      parsed: {
-        "Server": {
-          "attr-port": "8005",
-          "attr-shutdown": "SHUTDOWN",
-          "Listener": [
-            {
-              "attr-className": "org.apache.catalina.startup.VersionLoggerListener"
-            },
-            {
-              "attr-className": "org.apache.catalina.core.AprLifecycleListener",
-              "attr-SSLEngine": "on"
-            },
-            {
-              "attr-className": "org.apache.catalina.core.JreMemoryLeakPreventionListener"
-            },
-            {
-              "attr-className": "org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"
-            },
-            {
-              "attr-className": "org.apache.catalina.core.ThreadLocalLeakPreventionListener"
-            }
-          ],
-          "GlobalNamingResources": {
-            "Resource": {
-              "attr-name": "UserDatabase",
-              "attr-auth": "Container",
-              "attr-type": "org.apache.catalina.UserDatabase",
-              "attr-description": "User database that can be updated and saved",
-              "attr-factory": "org.apache.catalina.users.MemoryUserDatabaseFactory",
-              "attr-pathname": "conf/tomcat-users.xml"
-            }
-          },
-          "Service": {
-            "attr-name": "Catalina",
-            "Connector": [
-              {
-                "attr-port": "8080",
-                "attr-protocol": "HTTP/1.1",
-                "attr-connectionTimeout": "20000",
-                "attr-redirectPort": "8443",
-                "attr-maxHttpHeaderSize": "2097152"
-              },
-              {
-                "attr-port": "8443",
-                "attr-protocol": "org.apache.coyote.http11.Http11AprProtocol",
-                "attr-connectionTimeout": "300000",
-                "attr-maxThreads": "500",
-                "attr-SSLEnabled": "true",
-                "attr-maxHttpHeaderSize": "2097152",
-                "UpgradeProtocol": {
-                  "attr-className": "org.apache.coyote.http2.Http2Protocol"
-                },
-                "SSLHostConfig": {
-                  "Certificate": {
-                    "attr-certificateKeyFile": "certs/rsa-key.pem",
-                    "attr-certificateFile": "certs/rsa-cert.pem",
-                    "attr-certificateChainFile": "certs/rsa-chain.pem",
-                    "attr-type": "RSA"
-                  }
-                }
-              }
-            ],
-            "Engine": {
-              "attr-name": "Catalina",
-              "attr-defaultHost": "localhost",
-              "Realm": {
-                "attr-className": "org.apache.catalina.realm.LockOutRealm",
-                "Realm": {
-                  "attr-className": "org.apache.catalina.realm.UserDatabaseRealm",
-                  "attr-resourceName": "UserDatabase"
-                }
-              },
-              "Host": {
-                "attr-name": "localhost",
-                "attr-appBase": "webapps",
-                "attr-unpackWARs": "true",
-                "attr-autoDeploy": "true",
-                "Valve": {
-                  "attr-className": "org.apache.catalina.valves.AccessLogValve",
-                  "attr-directory": "logs",
-                  "attr-prefix": "localhost_access",
-                  "attr-suffix": ".log",
-                  "attr-pattern": "%h %l %u %t \"%r\" %s %b",
-                  "attr-rotatable": "false"
-                }
-              }
-            }
-          }
-        }
-      }
-
-expected_tasks_calls:
-  Get config from cmdline: 1
-  Get config_file: 1
-  Regrex from jmx port: 1
-  Read process environment: 1
-  Read file version 1: 1
-  Check if xml_file is accessible: 1
-  Check if server file in base is accessible: 1
-  Check if server file in home is accessible: 1
-  Read config file: 1
-
-
-expected_result:
-  - bindings:
-      - class: port_http
-        port: 8080
-      - class: port_jmx
-        port: 8050
-    configuration:
-      Server:
-        attr-port: '8005'
-        attr-shutdown: SHUTDOWN
-        Listener:
+      parsed:
+        Server:
+          GlobalNamingResources:
+            Resource:
+              attr-auth: Container
+              attr-description: User database that can be updated and saved
+              attr-factory: org.apache.catalina.users.MemoryUserDatabaseFactory
+              attr-name: UserDatabase
+              attr-pathname: conf/tomcat-users.xml
+              attr-type: org.apache.catalina.UserDatabase
+          Listener:
           - attr-className: org.apache.catalina.startup.VersionLoggerListener
-          - attr-className: org.apache.catalina.core.AprLifecycleListener
-            attr-SSLEngine: 'on'
+          - attr-SSLEngine: 'on'
+            attr-className: org.apache.catalina.core.AprLifecycleListener
           - attr-className: org.apache.catalina.core.JreMemoryLeakPreventionListener
           - attr-className: org.apache.catalina.mbeans.GlobalResourcesLifecycleListener
           - attr-className: org.apache.catalina.core.ThreadLocalLeakPreventionListener
-        GlobalNamingResources:
-          Resource:
-            attr-name: UserDatabase
-            attr-auth: Container
-            attr-type: org.apache.catalina.UserDatabase
-            attr-description: User database that can be updated and saved
-            attr-factory: org.apache.catalina.users.MemoryUserDatabaseFactory
-            attr-pathname: conf/tomcat-users.xml
-        Service:
-          attr-name: Catalina
-          Connector:
-            - attr-port: '8080'
+          Service:
+            Connector:
+            - attr-connectionTimeout: '20000'
+              attr-maxHttpHeaderSize: '2097152'
+              attr-port: '8080'
               attr-protocol: HTTP/1.1
-              attr-connectionTimeout: '20000'
               attr-redirectPort: '8443'
-              attr-maxHttpHeaderSize: '2097152'
-            - attr-port: '8443'
-              attr-protocol: org.apache.coyote.http11.Http11AprProtocol
-              attr-connectionTimeout: '300000'
-              attr-maxThreads: '500'
-              attr-SSLEnabled: 'true'
-              attr-maxHttpHeaderSize: '2097152'
+            - SSLHostConfig:
+                Certificate:
+                  attr-certificateChainFile: certs/rsa-chain.pem
+                  attr-certificateFile: certs/rsa-cert.pem
+                  attr-certificateKeyFile: certs/rsa-key.pem
+                  attr-type: RSA
               UpgradeProtocol:
                 attr-className: org.apache.coyote.http2.Http2Protocol
-              SSLHostConfig:
-                Certificate:
-                  attr-certificateKeyFile: certs/rsa-key.pem
-                  attr-certificateFile: certs/rsa-cert.pem
-                  attr-certificateChainFile: certs/rsa-chain.pem
-                  attr-type: RSA
-          Engine:
-            attr-name: Catalina
-            attr-defaultHost: localhost
-            Realm:
-              attr-className: org.apache.catalina.realm.LockOutRealm
+              attr-SSLEnabled: 'true'
+              attr-connectionTimeout: '300000'
+              attr-maxHttpHeaderSize: '2097152'
+              attr-maxThreads: '500'
+              attr-port: '8443'
+              attr-protocol: org.apache.coyote.http11.Http11AprProtocol
+            Engine:
+              Host:
+                Valve:
+                  attr-className: org.apache.catalina.valves.AccessLogValve
+                  attr-directory: logs
+                  attr-pattern: '%h %l %u %t "%r" %s %b'
+                  attr-prefix: localhost_access
+                  attr-rotatable: 'false'
+                  attr-suffix: .log
+                attr-appBase: webapps
+                attr-autoDeploy: 'true'
+                attr-name: localhost
+                attr-unpackWARs: 'true'
               Realm:
-                attr-className: org.apache.catalina.realm.UserDatabaseRealm
-                attr-resourceName: UserDatabase
-            Host:
-              attr-name: localhost
-              attr-appBase: webapps
-              attr-unpackWARs: 'true'
-              attr-autoDeploy: 'true'
-              Valve:
-                attr-className: org.apache.catalina.valves.AccessLogValve
-                attr-directory: logs
-                attr-prefix: localhost_access
-                attr-suffix: .log
-                attr-pattern: '%h %l %u %t "%r" %s %b'
-                attr-rotatable: 'false'
-    discovery_time: '2022-06-23T12:29:34+02:00'
-    files:
-      - path: /usr/local/tomcat
-        subtype: base
-        type: config
-      - path: /usr/local/tomcat
-        subtype: home
-        type: config
-      - path: /usr/local/openjdk-11
-        subtype: java_home
-        type: config
-      - name: server.xml
-        path: /usr/local/tomcat/conf
-        subtype: generic
-        type: config
-    docker:
-      exposed_ports:
-        8080/tcp: { }
-        8443/tcp: { }
-      id: 54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
-      image: 'nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.4.1'
-      name: /iometrics-cmdbuild
-      network_mode: 'bridge'
-      port_bindings:
-        '8443/tcp':
-          - 'HostIp': '0.0.0.0'
-            'HostPort': '8443'
-    listening_ports:
-      - 8443
-    packages: [ ]
-    process:
-      children: [ ]
-      cmdline: >-
-        /usr/local/openjdk-11/bin/java
-        -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
-        -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-        -Xmx4000m -Xms2000m -Djdk.tls.ephemeralDHKeySize=2048
-        -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
-        -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
-        -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
-        -Dignore.endorsed.dirs= -classpath
-        /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
-        -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat
-        -Djava.io.tmpdir=/usr/local/tomcat/temp
-        org.apache.catalina.startup.Bootstrap start
-      pid: '6362'
-      ppid: '6175'
-      user: centos
-    type: Apache Tomcat Servlet Engine
-    version:
-      - number: 0.4.1
-        type: docker
-      - number: 9.0.31
-        type: file
-software_list:
-  - name: Apache Tomcat Servlet Engine
-    cmd_regexp: \.apache\.tomcat\.startup|\.apache\.catalina\.startup
-    pkg_regexp: tomcat
-    process_type: parent
-    return_children: true
-    return_packages: true
-    custom_tasks:
-      - name: Include Apache Tomcat Servlet Engine specific plugins
-        include_tasks:
-          file: "{{ software_discovery__custom_tasks_definition_files_path }}/tomcat.yaml"
-dockers:
-  containers:
-    - AppArmorProfile: ''
-      Args:
-        - '-c'
-        - /usr/local/bin/docker-entrypoint.sh
-        - catalina.sh
-        - run
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - catalina.sh
-          - run
-        Domainname: ''
-        Entrypoint:
-          - /bin/sh
-          - '-c'
-          - /usr/local/bin/docker-entrypoint.sh
-        Env:
-          - POSTGRES_HOST=cmdb-db01-integracion-internal.iometrics.io
-          - TZ=Europe/Madrid
-          - POSTGRES_PASS=ta5Puid4et2aemeveeshaeha
-          - JAVA_OPTS=-Xmx4000m -Xms2000m
-          - POSTGRES_APP_USER=datadope
-          - POSTGRES_DB=cmdbuild_r2u2
-          - POSTGRES_APP_PASSWORD=ta5Puid4et2aemeveeshaeha
-          - POSTGRES_USER=datadope
-          - >-
-            PATH=/usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - JAVA_HOME=/usr/local/openjdk-11
-          - JAVA_VERSION=11.0.6
-          - >-
-            JAVA_BASE_URL=https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_
-          - JAVA_URL_VERSION=11.0.6_10
-          - CATALINA_HOME=/usr/local/tomcat
-          - TOMCAT_NATIVE_LIBDIR=/usr/local/tomcat/native-jni-lib
-          - LD_LIBRARY_PATH=/usr/local/tomcat/native-jni-lib
-          - >-
-            GPG_KEYS=05AB33110949707C93A279E3D3EFE6B686867BA6
-            07E48665A34DCAFAE522E5E6266191C37C037D42
-            47309207D818FFD8DCD3F83F1931D684307A10A5
-            541FBE7D8F78B25E055DDEE13C370389288584E7
-            61B832AC2F1C5A90F0F9B00A1C506407564C17A3
-            79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED
-            9BA44C2621385CB966EBA586F72C284D731FABEE
-            A27677289986DB50844682F8ACB77FC2E86E29AC
-            A9C5DF4D22E99998D9875A5110C01C5A2F6059E7
-            DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
-            F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE
-            F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
-          - TOMCAT_MAJOR=9
-          - TOMCAT_VERSION=9.0.31
-          - >-
-            TOMCAT_SHA512=75045ce54ad1b6ea66fd112e8b2ffa32a0740c018ab9392c7217a6dd6b829e8645b6810ab4b28dd186c12ce6045c1eb18ed19743c5d4b22c9e613e76294f22f5
-          - >-
-            CMDBUILD_URL=https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
-          - POSTGRES_PORT=5432
-          - CMDBUILD_DUMP=empty.dump.xz
-        ExposedPorts:
-          8080/tcp: { }
-          8443/tcp: { }
-        Hostname: localhost
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-cmdbuild:0.4.1'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: tomcat
-        Volumes:
-          /etc/hosts: { }
-          /usr/local/tomcat/certs: { }
-          /usr/local/tomcat/logs: { }
-        WorkingDir: /usr/local/tomcat
-      Created: '2021-11-11T10:02:57.904221801Z'
-      Driver: overlay2
-      ExecIDs:
-        - f5e80c464940e29fe42a391831fab140b08c3ab532c8d60879b50ba3b3dad834
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440-init/diff:/var/lib/docker/overlay2/c0100c5fc0888fad72adf7c709d3142ccba8797311803c32b1c6ee9fdc1de50e/diff:/var/lib/docker/overlay2/63d738012f51ff7170406467832e013db70f935f583552a7886aa38962e82982/diff:/var/lib/docker/overlay2/47cd80f7dedb3bc34c2bca3fa92244ea9c185fcf0542caef919e1cc857cfdd3b/diff:/var/lib/docker/overlay2/a2db2a600330275b614855b67ddd415e3a75afa829346adfa0bb03a7333b402e/diff:/var/lib/docker/overlay2/9379979c9dd250c039f4afc2567766061715e709bfc36ee01ae3c3239025986b/diff:/var/lib/docker/overlay2/18f67ad491d73a59df5e91b962f57ef4869ddd92c6ebd3e44102469697624266/diff:/var/lib/docker/overlay2/137a09117ac770c6d5fc56e5112ebc5b08ef3c3d9efff29df177409a565a87b0/diff:/var/lib/docker/overlay2/de594fddde953514eeacfe63c99be98087989c214e4e5de974831664ffbe66a8/diff:/var/lib/docker/overlay2/4e4b98753830b09fce6331e4e11cb57368a29059ef703c11757668499e1a5a6b/diff:/var/lib/docker/overlay2/43329bb8f930dbaf651a0f9ec89f9a81ca1177bcda97d444ef43dffa082d7d30/diff:/var/lib/docker/overlay2/93fb2b626f5a929d0e2aef75b0a4504b487754c638f06ef853846011b1b04f90/diff:/var/lib/docker/overlay2/d7655bb3f45fb79b3810a732adf321480912998b29d65842ce8546dbd67ca402/diff:/var/lib/docker/overlay2/dae7334ac1a1ee12d6b8def3204d21f3c259a623f01098a682d52185f87f53b1/diff:/var/lib/docker/overlay2/bd55b267f3dc2165fe8ae6ca4d7ad01824c9f073f3d9a209b4aabb15f1e3f628/diff:/var/lib/docker/overlay2/7038e40fc28165f150bb277854f7fe37c3b19967a7fe07fe70eb5663343ec96c/diff:/var/lib/docker/overlay2/04ddf62add125112aeeef17f32406bf3e5a42a342ee771e8f4fe30f12794c4b4/diff:/var/lib/docker/overlay2/f38683ed385ddb64de321621e8f8e7b8cb161f8100a64417c64a152429822c63/diff:/var/lib/docker/overlay2/9101a62094b1ab60a4e9477e952bbc50c513103b178d2f07c51449876454d328/diff:/var/lib/docker/overlay2/a61859f12ba2af9c9dc4b9318ddc2efa3636248af9c1c5819afcaa93cdd478a6/diff:/var/lib/docker/overlay2/7bbd2fba82cda8d8110a79811738382f993dfbbcaec424690f81f0f602188578/diff:/var/lib/docker/overlay2/fc177696896be4d18ffb7582249deb2e6bc004fa6c1b59bd2cca3b3165e6240e/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/50672f420a01e7919954ed65bda888f26020123cb2703dbd556457ab0b8b1440/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:ro'
-          - '/etc/iometrics-cmdbuild/certs:/usr/local/tomcat/certs:rw'
-          - '/var/log/iometrics-cmdbuild:/usr/local/tomcat/logs:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 4194304000
-        MemoryReservation: 2097152000
-        MemorySwap: 8388608000
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: bridge
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: ''
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/hostname
-      HostsPath: /etc/hosts
-      Id: 54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
-      Image: 'sha256:4963cc7d5cdaa74048cc3a833584e1634a8245490d8f6c206a97b163157817ff'
-      LogPath: >-
-        /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /usr/local/tomcat/certs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/iometrics-cmdbuild/certs
-          Type: bind
-        - Destination: /usr/local/tomcat/logs
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/iometrics-cmdbuild
-          Type: bind
-      Name: /iometrics-cmdbuild
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 02e4de3309dc5c39396033b01289e18cc722789b4cb582ed92d84d69d7400c2b
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: '02:42:ac:11:00:02'
-        Networks:
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 02e4de3309dc5c39396033b01289e18cc722789b4cb582ed92d84d69d7400c2b
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: '02:42:ac:11:00:02'
-            NetworkID: 91d42730928d475ba307be852a455668b8122288ceb5c15f12d313f2ce0b4255
-        Ports:
-          8080/tcp: null
-          8443/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '8443'
-        SandboxID: 94356f6fa85936e5a3a3aed208d5e20fd01af15632851df7a80174f8b92f6549
-        SandboxKey: /var/run/docker/netns/94356f6fa859
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /bin/sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:42.531448015Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 6175
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:55:58.071033978Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-          - GF_RENDERER_PLUGIN_CHROME_BIN=/usr/bin/chromium-browser
-        ExposedPorts:
-          3000/tcp: { }
-        Hostname: cmdb01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui-enterprise:6.6.2.3'
-        Labels:
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /var/lib/grafana: { }
-          /var/log/grafana: { }
-        WorkingDir: /usr/share/grafana
-      Created: '2021-01-15T12:45:30.765987178Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1-init/diff:/var/lib/docker/overlay2/0d2c44c827bfb7dabdebae887d8683db32d93d4d76b196d7ad89704e0fcb1389/diff:/var/lib/docker/overlay2/f0e1f1f418c2281b381cf1865c8f26dcd6b3d932f40f52d1b1fdca5b51f59403/diff:/var/lib/docker/overlay2/55a6a205817b93c52fb9fd4c2cc8f934d19e4b2ccfbcf3c08b298753a45ae973/diff:/var/lib/docker/overlay2/6eb3c76533ef49d07490c8c83d99533de21abd3109451cf52fc0c67b69ab611b/diff:/var/lib/docker/overlay2/e2815a71b491409711b3d35eea90c0dd86fd08cf49d3cef7a3b8975805873009/diff:/var/lib/docker/overlay2/7a4561e76b8114bef56fd08e6cb03450a148795b234a3d8dc8236b8fe76c8bcd/diff:/var/lib/docker/overlay2/54dd3972aadb529dba440730f58fa712249b38347dd0c302925e87327062d273/diff:/var/lib/docker/overlay2/67b520bda1cd13ae235e8248930218fdf9fb9d3a9677961b748af89d704c3f26/diff:/var/lib/docker/overlay2/39a352a4de1195eb0ea5d56384fcb82143edf4b381d039933cfdfc8437742018/diff:/var/lib/docker/overlay2/8bba506a78e1be76f9df4721f9e1d9b803663b7b7de87f041d8089ef1f641d5a/diff:/var/lib/docker/overlay2/f5ed7d8d022525cf8f03f3be2493851803cd595469b11b32f183255bddca9349/diff:/var/lib/docker/overlay2/14f5fd087aa9d77e5433f13239715857e7bf55e03bf0369c3369e1d0f2fc805e/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/76b4e75eb8e16adee85d2d781f02590780ab71575f0470aedb7cbfb960a177d1/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/hostname
-      HostsPath: /etc/hosts
-      Id: 9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60
-      Image: 'sha256:d3c19e6207531bc75d6e96acb05ba4e07aa8497c67ffb7300c22f09129e7c6ac'
-      LogPath: >-
-        /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 4be9102529bde6561a20aef10b892eaeb6db6ff824a222a50ac373182b510706
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 1ab6c0eaf33ebf3437299022cf3d1481c808eb54b77862bc018876a78726b0f4
-        Ports: { }
-        SandboxID: 20caa57c43e433507a96073c6dc1cf2134b03a9874406acdb6540325c821a29f
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:55:42.531786634Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 5645
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:55:52.595384652Z'
-        Status: running
+                Realm:
+                  attr-className: org.apache.catalina.realm.UserDatabaseRealm
+                  attr-resourceName: UserDatabase
+                attr-className: org.apache.catalina.realm.LockOutRealm
+              attr-defaultHost: localhost
+              attr-name: Catalina
+            attr-name: Catalina
+          attr-port: '8005'
+          attr-shutdown: SHUTDOWN
+  Read file version 1:
+    number_of_calls: 1
+    plugin_result:
+      content: "================================================================================\n\
+        \  Licensed to the Apache Software Foundation (ASF) under one or more\n  contributor\
+        \ license agreements.  See the NOTICE file distributed with\n  this work for\
+        \ additional information regarding copyright ownership.\n  The ASF licenses\
+        \ this file to You under the Apache License, Version 2.0\n  (the \"License\"\
+        ); you may not use this file except in compliance with\n  the License.  You\
+        \ may obtain a copy of the License at\n\n      http://www.apache.org/licenses/LICENSE-2.0\n\
+        \n  Unless required by applicable law or agreed to in writing, software\n\
+        \  distributed under the License is distributed on an \"AS IS\" BASIS,\n \
+        \ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n\
+        \  See the License for the specific language governing permissions and\n \
+        \ limitations under the License.\n================================================================================\n\
+        \n\n                     Apache Tomcat Version 9.0.31\n                  \
+        \          Release Notes\n\n\n=========\nCONTENTS:\n=========\n\n* Dependency\
+        \ Changes\n* API Stability\n* Bundled APIs\n* Web application reloading and\
+        \ static fields in shared libraries\n* Security manager URLs\n* Symlinking\
+        \ static resources\n* Viewing the Tomcat Change Log\n* Cryptographic software\
+        \ notice\n* When all else fails\n\n\n===================\nDependency Changes:\n\
+        ===================\nTomcat 9.0 is designed to run on Java 8 and later.\n\n\
+        \n==============\nAPI Stability:\n==============\n\nThe public interfaces\
+        \ for the following classes are fixed and will not be\nchanged at all during\
+        \ the remaining lifetime of the 9.x series:\n- All classes in the javax namespace\n\
+        \nThe public interfaces for the following classes may be added to in order\
+        \ to\nresolve bugs and/or add new features. No existing interface method will\
+        \ be\nremoved or changed although it may be deprecated.\n- org.apache.catalina.*\
+        \ (excluding sub-packages)\n\nNote: As Tomcat 9 matures, the above list will\
+        \ be added to. The list is not\n      considered complete at this time.\n\n\
+        The remaining classes are considered part of the Tomcat internals and may\
+        \ change\nwithout notice between point releases.\n\n\n=============\nBundled\
+        \ APIs:\n=============\nA standard installation of Tomcat 9.0 makes all of\
+        \ the following APIs available\nfor use by web applications (by placing them\
+        \ in \"lib\"):\n* annotations-api.jar (Annotations package)\n* catalina.jar\
+        \ (Tomcat Catalina implementation)\n* catalina-ant.jar (Tomcat Catalina Ant\
+        \ tasks)\n* catalina-ha.jar (High availability package)\n* catalina-ssi.jar\
+        \ (Server-side Includes module)\n* catalina-storeconfig.jar (Generation of\
+        \ XML configuration from current state)\n* catalina-tribes.jar (Group communication)\n\
+        * ecj-4.13.jar (Eclipse JDT Java compiler)\n* el-api.jar (EL 3.0 API)\n* jasper.jar\
+        \ (Jasper 2 Compiler and Runtime)\n* jasper-el.jar (Jasper 2 EL implementation)\n\
+        * jsp-api.jar (JSP 2.3 API)\n* servlet-api.jar (Servlet 4.0 API)\n* tomcat-api.jar\
+        \ (Interfaces shared by Catalina and Jasper)\n* tomcat-coyote.jar (Tomcat\
+        \ connectors and utility classes)\n* tomcat-dbcp.jar (package renamed database\
+        \ connection pool based on Commons DBCP 2)\n* tomcat-jdbc.jar (Tomcat's database\
+        \ connection pooling solution)\n* tomcat-jni.jar (Interface to the native\
+        \ component of the APR/native connector)\n* tomcat-util.jar (Various utilities)\n\
+        * tomcat-websocket.jar (WebSocket 1.1 implementation)\n* websocket-api.jar\
+        \ (WebSocket 1.1 API)\n\nYou can make additional APIs available to all of\
+        \ your web applications by\nputting unpacked classes into a \"classes\" directory\
+        \ (not created by default),\nor by placing them in JAR files in the \"lib\"\
+        \ directory.\n\nTo override the XML parser implementation or interfaces, use\
+        \ the appropriate\nfeature for your JVM. For Java <= 8 use the endorsed standards\
+        \ override\nfeature. The default configuration defines JARs located in \"\
+        endorsed\" as endorsed.\nFor Java 9+ use the upgradeable modules feature.\n\
+        \n\n================================================================\nWeb\
+        \ application reloading and static fields in shared libraries:\n================================================================\n\
+        Some shared libraries (many are part of the JDK) keep references to objects\n\
+        instantiated by the web application. To avoid class loading related problems\n\
+        (ClassCastExceptions, messages indicating that the classloader\nis stopped,\
+        \ etc.), the shared libraries state should be reinitialized.\n\nSomething\
+        \ which might help is to avoid putting classes which would be\nreferenced\
+        \ by a shared static field in the web application classloader,\nand putting\
+        \ them in the shared classloader instead (JARs should be put in the\n\"lib\"\
+        \ folder, and classes should be put in the \"classes\" folder).\n\n\n======================\n\
+        Security manager URLs:\n======================\nIn order to grant security\
+        \ permissions to JARs located inside the\nweb application repository, use\
+        \ URLs of the following format\nin your policy file:\n\nfile:${catalina.base}/webapps/examples/WEB-INF/lib/driver.jar\n\
+        \n\n============================\nSymlinking static resources:\n============================\n\
+        By default, Unix symlinks will not work when used in a web application to\
+        \ link\nresources located outside the web application root directory.\n\n\
+        This behavior is optional, and the \"allowLinking\" flag may be used to disable\n\
+        the check.\n\n\n==============================\nViewing the Tomcat Change\
+        \ Log:\n==============================\nThe full change log is available from\
+        \ https://tomcat.apache.org and is also\nincluded in the documentation web\
+        \ application.\n\n\n=============================\nCryptographic software\
+        \ notice\n=============================\nThis distribution includes cryptographic\
+        \ software.  The country in\nwhich you currently reside may have restrictions\
+        \ on the import,\npossession, use, and/or re-export to another country, of\n\
+        encryption software.  BEFORE using any encryption software, please\ncheck\
+        \ your country's laws, regulations and policies concerning the\nimport, possession,\
+        \ or use, and re-export of encryption software, to\nsee if this is permitted.\
+        \  See <http://www.wassenaar.org/> for more\ninformation.\n\nThe U.S. Government\
+        \ Department of Commerce, Bureau of Industry and\nSecurity (BIS), has classified\
+        \ this software as Export Commodity\nControl Number (ECCN) 5D002.C.1, which\
+        \ includes information security\nsoftware using or performing cryptographic\
+        \ functions with asymmetric\nalgorithms.  The form and manner of this Apache\
+        \ Software Foundation\ndistribution makes it eligible for export under the\
+        \ License Exception\nENC Technology Software Unrestricted (TSU) exception\
+        \ (see the BIS\nExport Administration Regulations, Section 740.13) for both\
+        \ object\ncode and source code.\n\nThe following provides more details on\
+        \ the included cryptographic\nsoftware:\n  - Tomcat includes code designed\
+        \ to work with JSSE\n  - Tomcat includes code designed to work with OpenSSL\n\
+        \n\n====================\nWhen all else fails:\n====================\nSee\
+        \ the FAQ\nhttps://tomcat.apache.org/faq/\n"
+      failed: false
+  Read process environment:
+    number_of_calls: 1
+    plugin_result:
+      failed: false
+      parsed:
+        CATALINA_HOME: /usr/local/tomcat
+        CATALINA_OPTS: ' -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m'
+        CMDBUILD_DUMP: empty.dump.xz
+        CMDBUILD_URL: https://nexus.opensolutions.cloud/repository/datadope-public/cmdbuild/ready2use-2.0-3.3.2.war
+        GPG_KEYS: 05AB33110949707C93A279E3D3EFE6B686867BA6 07E48665A34DCAFAE522E5E6266191C37C037D42
+          47309207D818FFD8DCD3F83F1931D684307A10A5 541FBE7D8F78B25E055DDEE13C370389288584E7
+          61B832AC2F1C5A90F0F9B00A1C506407564C17A3 79F7026C690BAA50B92CD8B66A3AD3F4F22C4FED
+          9BA44C2621385CB966EBA586F72C284D731FABEE A27677289986DB50844682F8ACB77FC2E86E29AC
+          A9C5DF4D22E99998D9875A5110C01C5A2F6059E7 DCFD35E0BF8CA7344752DE8B6FB21E8933C60243
+          F3A04C595DB5B6A5F1ECA43E3B7BBB100D811BBE F7DA48BB64BCB84ECBA7EE6935CD23C10D498E23
+        HOME: /usr/local/tomcat
+        HOSTNAME: localhost
+        JAVA_BASE_URL: https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_
+        JAVA_HOME: /usr/local/openjdk-11
+        JAVA_OPTS: -Xmx4000m -Xms2000m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+          -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
+        JAVA_URL_VERSION: 11.0.6_10
+        JAVA_VERSION: 11.0.6
+        JDK_JAVA_OPTIONS: ' --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED
+          --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED'
+        LANG: C.UTF-8
+        LD_LIBRARY_PATH: /usr/local/tomcat/native-jni-lib
+        PATH: /usr/local/tomcat/bin:/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        POSTGRES_APP_PASSWORD: ta5Puid4et2aemeveeshaeha
+        POSTGRES_APP_USER: datadope
+        POSTGRES_DB: cmdbuild_r2u2
+        POSTGRES_HOST: cmdb-db01-integracion-internal.iometrics.io
+        POSTGRES_PASS: ta5Puid4et2aemeveeshaeha
+        POSTGRES_PORT: '5432'
+        POSTGRES_USER: datadope
+        PWD: /usr/local/tomcat
+        SHLVL: '0'
+        TOMCAT_MAJOR: '9'
+        TOMCAT_NATIVE_LIBDIR: /usr/local/tomcat/native-jni-lib
+        TOMCAT_SHA512: 75045ce54ad1b6ea66fd112e8b2ffa32a0740c018ab9392c7217a6dd6b829e8645b6810ab4b28dd186c12ce6045c1eb18ed19743c5d4b22c9e613e76294f22f5
+        TOMCAT_VERSION: 9.0.31
+        TZ: Europe/Madrid
+  Regrex from jmx port:
+    expected_exception:
+      message: '''NoneType'' object is not iterable'
+    number_of_calls: 1
 packages:
   GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
   PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
   acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
   audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
   authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
   autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
   basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
   bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
   bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 74.el7_6.2
-      source: rpm
-      version: 9.9.4
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 74.el7_6.2
+    source: rpm
+    version: 9.9.4
   binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
   btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
   bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
   ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
   centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
   checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
   chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
   chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
   cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
   cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
   container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
   containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.2.el7
-      source: rpm
-      version: 1.2.13
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.2.el7
+    source: rpm
+    version: 1.2.13
   coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
   cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
   cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
   cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
   crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
   cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
   curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
   cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
   dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
   dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
   dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
   device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 10.el7_6.8
-      source: rpm
-      version: 1.02.149
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 10.el7_6.8
+    source: rpm
+    version: 1.02.149
   dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 68.el7.centos.1
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.11
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 297.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 297.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 80.el7_6
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 12.el7
-      source: rpm
-      version: 8.1.2
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '25'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '27'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '46'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '47'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '48'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '62'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '95'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '178'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '179'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '280'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '296'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '303'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '307'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '310'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '385'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '398'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '399'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '400'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '401'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '402'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '403'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '404'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '405'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '406'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '407'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '408'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '487'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '527'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '565'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '570'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '573'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '582'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '742'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '743'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '745'
-    ppid: '1'
-    user: polkitd
-  - cmdline: >-
-      /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
-      --systemd-activation
-    pid: '746'
-    ppid: '1'
-    user: dbus
-  - cmdline: /sbin/rpcbind -w
-    pid: '747'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '750'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/chronyd
-    pid: '757'
-    ppid: '1'
-    user: chrony
-  - cmdline: >-
-      /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf
-      /var/run/dhclient-eth0.pid -H cmdb01 eth0
-    pid: '990'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
-      /etc/telegraf/telegraf.d
-    pid: '1049'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1051'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1058'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '1066'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '1067'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '1068'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '1069'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '1070'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '1071'
-    ppid: '1066'
-    user: zabbix
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1151'
-    ppid: '1'
-    user: root
-  - cmdline: qmgr -l -t unix -u
-    pid: '1153'
-    ppid: '1151'
-    user: postfix
-  - cmdline: '/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock'
-    pid: '1192'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1194'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1197'
-    ppid: '1'
-    user: root
-  - cmdline: '/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220'
-    pid: '1201'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1209'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1210'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '5539'
-    ppid: '1058'
-    user: root
-  - cmdline: >-
-      grafana-server --homepath=/usr/share/grafana
-      --config=/etc/grafana/grafana.ini --packaging=docker
-      cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
-      cfg:default.paths.logs=/var/log/grafana
-      cfg:default.paths.plugins=/usr/share/grafana/plugins
-      cfg:default.paths.provisioning=/etc/grafana/provisioning
-    pid: '5645'
-    ppid: '5539'
-    user: grafana
-  - cmdline: /usr/bin/docker start -a grafana
-    pid: '5846'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-cmdbuild
-    pid: '5847'
-    ppid: '1'
-    user: root
-  - cmdline: >-
-      /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443
-      -container-ip 192.168.1.2 -container-port 8443
-    pid: '6068'
-    ppid: '1192'
-    user: root
-  - cmdline: >-
-      containerd-shim -namespace moby -workdir
-      /var/lib/containerd/io.containerd.runtime.v1.linux/moby/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
-      -address /run/containerd/containerd.sock -containerd-binary
-      /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '6144'
-    ppid: '1058'
-    user: root
-  - cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
-    pid: '6175'
-    ppid: '6144'
-    user: centos
-  - cmdline: bash
-    pid: '6258'
-    ppid: '6144'
-    user: centos
-  - cmdline: >-
-      /usr/local/openjdk-11/bin/java
-      -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
-      -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager
-      -Xmx4000m -Xms2000m -Djdk.tls.ephemeralDHKeySize=2048
-      -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
-      -Dorg.apache.catalina.security.SecurityListener.UMASK=0027
-      -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
-      -Dignore.endorsed.dirs= -classpath
-      /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
-      -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat
-      -Djava.io.tmpdir=/usr/local/tomcat/temp
-      org.apache.catalina.startup.Bootstrap start
-    pid: '6362'
-    ppid: '6175'
-    user: centos
-  - cmdline: pickup -l -t unix -u
-    pid: '19000'
-    ppid: '1151'
-    user: postfix
-  - cmdline: ''
-    pid: '19076'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19579'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19816'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20032'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20246'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '20381'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1655980128
-    pid: '20544'
-    ppid: '1049'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '20546'
-    ppid: '1197'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '20548'
-    ppid: '20546'
-    user: centos
-  - cmdline: >-
-      /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo
-      BECOME-SUCCESS-yvddolluqaqurngzgidswbxxwamxvaug ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655980154.048625-26023-237210726082155/AnsiballZ_process_facts.py'
-      && sleep 0
-    pid: '20739'
-    ppid: '20548'
-    user: centos
-  - cmdline: >-
-      sudo -H -S -n -u root /bin/sh -c echo
-      BECOME-SUCCESS-yvddolluqaqurngzgidswbxxwamxvaug ; /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655980154.048625-26023-237210726082155/AnsiballZ_process_facts.py
-    pid: '20754'
-    ppid: '20739'
-    user: root
-  - cmdline: >-
-      /bin/sh -c echo BECOME-SUCCESS-yvddolluqaqurngzgidswbxxwamxvaug ;
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655980154.048625-26023-237210726082155/AnsiballZ_process_facts.py
-    pid: '20755'
-    ppid: '20754'
-    user: root
-  - cmdline: >-
-      /usr/bin/python
-      /home/centos/.ansible/tmp/ansible-tmp-1655980154.048625-26023-237210726082155/AnsiballZ_process_facts.py
-    pid: '20756'
-    ppid: '20755'
-    user: root
-  - cmdline: ''
-    pid: '27861'
-    ppid: '2'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1151
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:08 2022'
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 1066
-    port: 10050
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:04 2022'
-    user: zabbix
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1197
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:10 2022'
-    user: root
-  - address: '::1'
-    name: master
-    pid: 1151
-    port: 25
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:08 2022'
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 6068
-    port: 8443
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:55 2022'
-    user: root
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1197
-    port: 22
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:10 2022'
-    user: root
-  - address: '::'
-    name: grafana-server
-    pid: 5645
-    port: 3000
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:51 2022'
-    user: grafana
-udp_listen:
-  - address: 0.0.0.0
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 990
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:03 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 757
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:50 2022'
-    user: chrony
-  - address: 0.0.0.0
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 68.el7.centos.1
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.11
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 297.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 297.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 80.el7_6
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 12.el7
+    source: rpm
+    version: 8.1.2
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 747
-    port: 905
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:49 2022'
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:29 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 757
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:50 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 747
-    port: 905
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:49 2022'
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '46'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '48'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '62'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '95'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '178'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '179'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '280'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '303'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '307'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '310'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '385'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '398'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '399'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '400'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '401'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '402'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '403'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '404'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '405'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '406'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '407'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '408'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '487'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '527'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '565'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '570'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '573'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '582'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '742'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '743'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '745'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '746'
+  ppid: '1'
+  user: dbus
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '747'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '750'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '757'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H cmdb01 eth0
+  cwd: /sbin/
+  pid: '990'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1049'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1051'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1058'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '1066'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1067'
+  ppid: '1066'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1068'
+  ppid: '1066'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1069'
+  ppid: '1066'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1070'
+  ppid: '1066'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1071'
+  ppid: '1066'
+  user: zabbix
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1153'
+  ppid: '1151'
+  user: postfix
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '1192'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1194'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1197'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1201'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1209'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1210'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/9739f22aa6c5e9ff69f0daf4ee31ea0b27a436d2444eb0018ec1054deccc8b60
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '5539'
+  ppid: '1058'
+  user: root
+- cmdline: grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini
+    --packaging=docker cfg:default.log.mode=console cfg:default.paths.data=/var/lib/grafana
+    cfg:default.paths.logs=/var/log/grafana cfg:default.paths.plugins=/usr/share/grafana/plugins
+    cfg:default.paths.provisioning=/etc/grafana/provisioning
+  cwd: /
+  pid: '5645'
+  ppid: '5539'
+  user: grafana
+- cmdline: /usr/bin/docker start -a grafana
+  cwd: /usr/bin/
+  pid: '5846'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-cmdbuild
+  cwd: /usr/bin/
+  pid: '5847'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 -container-ip
+    192.168.1.2 -container-port 8443
+  cwd: /usr/bin/
+  pid: '6068'
+  ppid: '1192'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/54550f43387aef84c991c068d34f9bc90cae449e2ebdeda7353d578c10fcc607
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '6144'
+  ppid: '1058'
+  user: root
+- cmdline: /bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run
+  cwd: /bin/
+  pid: '6175'
+  ppid: '6144'
+  user: centos
+- cmdline: bash
+  cwd: /
+  pid: '6258'
+  ppid: '6144'
+  user: centos
+- cmdline: /usr/local/openjdk-11/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx4000m -Xms2000m
+    -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources
+    -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m
+    -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar
+    -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp
+    org.apache.catalina.startup.Bootstrap start
+  cwd: /usr/local/openjdk-11/bin/
+  pid: '6362'
+  ppid: '6175'
+  user: centos
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '19000'
+  ppid: '1151'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '19076'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19579'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19816'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20032'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20246'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20381'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib64/sa/sadc -S DISK 44 2 /tmp/sysstat-1655980128
+  cwd: /usr/lib64/sa/
+  pid: '20544'
+  ppid: '1049'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '20546'
+  ppid: '1197'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '20548'
+  ppid: '20546'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-yvddolluqaqurngzgidswbxxwamxvaug
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655980154.048625-26023-237210726082155/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '20739'
+  ppid: '20548'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-yvddolluqaqurngzgidswbxxwamxvaug
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655980154.048625-26023-237210726082155/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '20754'
+  ppid: '20739'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-yvddolluqaqurngzgidswbxxwamxvaug ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1655980154.048625-26023-237210726082155/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '20755'
+  ppid: '20754'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655980154.048625-26023-237210726082155/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '20756'
+  ppid: '20755'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27861'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: \.apache\.tomcat\.startup|\.apache\.catalina\.startup
+  custom_tasks:
+  - include_tasks:
+      file: '{{ software_discovery__custom_tasks_definition_files_path }}/tomcat.yaml'
+    name: Include Apache Tomcat Servlet Engine specific plugins
+  name: Apache Tomcat Servlet Engine
+  pkg_regexp: tomcat
+  process_type: parent
+  return_children: true
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1151
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:08 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 1066
+  port: 10050
+  protocol: tcp
+  stime: Tue Apr 26 15:55:04 2022
+  user: zabbix
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:29 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1197
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:10 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1151
+  port: 25
+  protocol: tcp
+  stime: Tue Apr 26 15:55:08 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 6068
+  port: 8443
+  protocol: tcp
+  stime: Tue Apr 26 15:55:55 2022
+  user: root
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Tue Apr 26 15:54:29 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1197
+  port: 22
+  protocol: tcp
+  stime: Tue Apr 26 15:55:10 2022
+  user: root
+- address: '::'
+  name: grafana-server
+  pid: 5645
+  port: 3000
+  protocol: tcp
+  stime: Tue Apr 26 15:55:51 2022
+  user: grafana
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 990
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:03 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 757
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:50 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 747
+  port: 905
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:29 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 757
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:54:50 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 747
+  port: 905
+  protocol: udp
+  stime: Tue Apr 26 15:54:49 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/xymon/xymon_test.yaml
+++ b/tests/unit/plugins/action/auto/resources/xymon/xymon_test.yaml
@@ -1,1485 +1,1441 @@
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 53314
-        protocol: 'tcp'
-    discovery_time: '2022-07-05T18:11:55+02:00'
-    listening_ports:
-      - 53314
-    process:
-      cmdline: /usr/lib/systemd/xymonlaunch -b config.yaml
-      listening_ports:
-        - 53314
-      pid: '121'
-      ppid: '0'
-      user: root
-    type: Xymon
-    version: [ ]
-
-software_list:
-  - cmd_regexp: xymonlaunch
-    name: Xymon
-    process_type: parent
-    return_children: false
-    return_packages: false
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - ./main.py
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - python
-          - ./main.py
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - TZ=Europe/Madrid
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.13
-          - PYTHON_PIP_VERSION=22.0.4
-          - PYTHON_SETUPTOOLS_VERSION=57.5.0
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
-        ExposedPorts:
-          3003/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: >-
-          nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /usr/src/app/config.yml: { }
-        WorkingDir: /usr/src/app
-      Created: '2022-07-01T10:19:13.828744881Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: null
-        DnsOptions: null
-        DnsSearch: null
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
-      Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
-      Image: 'sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25'
-      LogPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /usr/src/app/config.yml
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/iometrics/visualizer_api.yml
-          Type: bind
-      Name: /iometrics-visualizer-api
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-01T10:19:17.320021144Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 1464
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-01T10:19:21.335877833Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /run.sh
-        Env:
-          - 'NO_PROXY=localhost,127.0.0.1'
-          - HTTPS_PROXY=
-          - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
-          - HTTP_PROXY=
-          - >-
-            PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
-          - GF_PATHS_DATA=/var/lib/grafana
-          - GF_PATHS_HOME=/usr/share/grafana
-          - GF_PATHS_LOGS=/var/log/grafana
-          - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-          - GF_USERS_DEFAULT_THEME=light
-        ExposedPorts:
-          3000/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9'
-        Labels:
-          maintainer: Grafana team <hello@grafana.com>
-          os_container_type: grafana
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: grafana
-        Volumes:
-          /etc/grafana: { }
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /var/lib/grafana: { }
-          /var/log/grafana: { }
-        WorkingDir: /usr/share/grafana
-      Created: '2021-09-27T08:31:19.822793809Z'
-      Driver: overlay2
-      ExecIDs:
-        - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/grafana:/etc/grafana:rw'
-          - '/var/lib/grafana:/var/lib/grafana:rw'
-          - '/var/log/grafana:/var/log/grafana:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
-      HostsPath: /etc/hosts
-      Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
-      Image: 'sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5'
-      LogPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/grafana
-          Type: bind
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /var/lib/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/grafana
-          Type: bind
-        - Destination: /var/log/grafana
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/log/grafana
-          Type: bind
-      Name: /grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /run.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:57:03.953904795Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10876
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:57:07.542217497Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - postgres
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - postgres
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
-          - TZ=Europe/Madrid
-          - POSTGRES_DB=grafana
-          - >-
-            PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
-          - GOSU_VERSION=1.12
-          - LANG=en_US.utf8
-          - PG_MAJOR=12
-          - PG_VERSION=12.5-1.pgdg100+1
-          - PGDATA=/var/lib/postgresql/data
-        ExposedPorts:
-          5432/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/postgres:12'
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGINT
-        Tty: false
-        User: ''
-        Volumes:
-          /docker-entrypoint-initdb.d: { }
-          /var/lib/postgresql/data: { }
-        WorkingDir: ''
-      Created: '2020-12-17T09:26:36.676895901Z'
-      Driver: overlay2
-      ExecIDs:
-        - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw'
-          - '/etc/postgres_init:/docker-entrypoint-initdb.d:ro'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
-      Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
-      Image: 'sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6'
-      LogPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /docker-entrypoint-initdb.d
-          Mode: ro
-          Propagation: rprivate
-          RW: false
-          Source: /etc/postgres_init
-          Type: bind
-        - Destination: /var/lib/postgresql/data
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /var/lib/postgresql_grafana/data
-          Type: bind
-      Name: /postgres-grafana
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.84481573Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10435
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.428443571Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - '-g'
-        - daemon off;
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - nginx
-          - '-g'
-          - daemon off;
-        Domainname: ''
-        Entrypoint: null
-        Env:
-          - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-          - NGINX_VERSION=1.17.9
-          - NJS_VERSION=0.3.9
-          - PKG_RELEASE=1~buster
-        ExposedPorts:
-          80/tcp: { }
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/nginx:1.17.9'
-        Labels:
-          maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
-          os_contianer_type: nginx
-          os_environment: default
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        StopSignal: SIGTERM
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/hosts: { }
-          /etc/localtime: { }
-          /etc/nginx: { }
-        WorkingDir: ''
-      Created: '2020-11-10T16:50:27.911193137Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/hosts:/etc/hosts:rw'
-          - '/etc/localtime:/etc/localtime:rw'
-          - '/etc/nginx:/etc/nginx:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
-      HostsPath: /etc/hosts
-      Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
-      Image: 'sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663'
-      LogPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/hosts
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/hosts
-          Type: bind
-        - Destination: /etc/localtime
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/localtime
-          Type: bind
-        - Destination: /etc/nginx
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/nginx
-          Type: bind
-      Name: /nginx
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: nginx
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:35.859574137Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 10501
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:53.285690919Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - es-kg-sync.py
-        - '-c'
-        - /app/etc/config.yml
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - '-c'
-          - /app/etc/config.yml
-        Domainname: ''
-        Entrypoint:
-          - python3
-          - es-kg-sync.py
-        Env:
-          - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
-          - >-
-            PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
-          - PYTHON_VERSION=3.8.6
-          - PYTHON_PIP_VERSION=20.2.4
-          - >-
-            PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
-          - >-
-            PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
-          - PYTHONUNBUFFERED=true
-        Hostname: grafana01.novalocal
-        Image: 'nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4'
-        Labels:
-          maintainer: fgonzalez
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /app/etc: { }
-        WorkingDir: /app
-      Created: '2020-11-06T15:49:46.647862103Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
-          MergedDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
-          UpperDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
-          WorkDir: >-
-            /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - '/etc/datadope/es_kg_sync:/app/etc:rw'
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '3'
-            max-size: 20m
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: unless-stopped
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
-      HostsPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
-      Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
-      Image: 'sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e'
-      LogPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /app/etc
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/es_kg_sync
-          Type: bind
-      Name: /es_kg_sync
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 41646a2e4cefe3075ce860a5b43a7fd895356fab3f730fb2fbf31eab4b3b63b8
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
-        Ports: { }
-        SandboxID: 6be7362230495d2759721f5bb7d6cccdfc95270e72eb2f0ce0281b3576039ae4
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: python3
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: >-
-        /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
-      RestartCount: 1
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-07-05T16:21:19.700599103Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 21867
-        Restarting: false
-        Running: true
-        StartedAt: '2022-07-05T16:21:20.43263416Z'
-        Status: running
-processes:
-  - cmdline: /usr/lib/systemd/xymonlaunch -b config.yaml
+  - AppArmorProfile: ''
+    Args:
+    - ./main.py
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - python
+      - ./main.py
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.13
+      - PYTHON_PIP_VERSION=22.0.4
+      - PYTHON_SETUPTOOLS_VERSION=57.5.0
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/6ce3639da143c5d79b44f94b04080abf2531fd6e/public/get-pip.py
+      - PYTHON_GET_PIP_SHA256=ba3ab8267d91fd41c58dbce08f76db99f747f716d85ce1865813842bb035524d
+      ExposedPorts:
+        3003/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-visualizer-api:2.9.0-117ca93
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /usr/src/app/config.yml: {}
+      WorkingDir: /usr/src/app
+    Created: '2022-07-01T10:19:13.828744881Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2-init/diff:/var/lib/docker/overlay2/a7c3de64ba4481a9730e65bec2ae918b31d3ca95c1b3f929d535164342cfe625/diff:/var/lib/docker/overlay2/aecee580350a6caf0a584fbb144e9482aa6ed513b55ccd1f3107278b33f8c43c/diff:/var/lib/docker/overlay2/0bd5b6a7b67be8a25bc3efd2e29a92540f1b61319f8d5b666b6335200d30f1fd/diff:/var/lib/docker/overlay2/33b9cfc65d17c7e3ae80d874291c1e03eba48891235ed74751c332b89f497f56/diff:/var/lib/docker/overlay2/6b159a6c3e221de5dfc7294cf9b4d8ff95724a4be576a2acb8f37a255b8a0936/diff:/var/lib/docker/overlay2/7baf41714b8cde3ab7bc2d8b4da4796ed4981e11fcc3a226fd4b19103dfbe285/diff:/var/lib/docker/overlay2/ac925fdfdb073fbd242ccf6b46099b8fde68a91f45f7f1542948eafa32793c06/diff:/var/lib/docker/overlay2/d4c1fad72ecaf728f98d9db229f0bf845d5367d7c23d898b6d5a4144c7359355/diff:/var/lib/docker/overlay2/67190cdd2710c883dce5444e2a4b71fa1cbb96e0f83d3cf304e88c73bd71f5dc/diff:/var/lib/docker/overlay2/9bbdcf16e20272655e3c6dcf27ab8bc1ec3a7e2d49ab6195aa7f829922f04e51/diff:/var/lib/docker/overlay2/99285430c4c8a4587bbf2a749f8769bc0b938f6cdffe27efb3d243ce569fdf8e/diff:/var/lib/docker/overlay2/88b4dded6426c9fe9e65b6777231d4450c18285ee38b9e3644d6b4843ddb3985/diff
+        MergedDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/merged
+        UpperDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/diff
+        WorkDir: /var/lib/docker/overlay2/574bcf973ec6be2fa5c7647d7fb76598a9f8e7fe06722f358fd65b50143adcd2/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/iometrics/visualizer_api.yml:/usr/src/app/config.yml:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: null
+      DnsOptions: null
+      DnsSearch: null
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hostname
+    HostsPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/hosts
+    Id: a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17
+    Image: sha256:cb568b4ec7a6c6229ea267a88e68a5b3689a73d81605292badd91d5ff3693c25
+    LogPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /usr/src/app/config.yml
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/iometrics/visualizer_api.yml
+      Type: bind
+    Name: /iometrics-visualizer-api
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: deea1a5daf36026c50067ab1448d7778b4ae017dbc12b321110de5a27a4cd9fe
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 30c2b5ce70d79f7ea74b90637407889503acf4e92898e793f490ef220da83db8
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/a4b38b3959751680ce9d2af647ef4bc34d3cc032dad331e75f19ece54d114f17/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-01T10:19:17.320021144Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 1464
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-01T10:19:21.335877833Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /run.sh
+      Env:
+      - NO_PROXY=localhost,127.0.0.1
+      - HTTPS_PROXY=
+      - GF_PATHS_PLUGINS=/usr/share/grafana/plugins
+      - HTTP_PROXY=
+      - PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+      - GF_PATHS_DATA=/var/lib/grafana
+      - GF_PATHS_HOME=/usr/share/grafana
+      - GF_PATHS_LOGS=/var/log/grafana
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_USERS_DEFAULT_THEME=light
+      ExposedPorts:
+        3000/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-ui:6.6.2_iometrics-9
+      Labels:
+        maintainer: Grafana team <hello@grafana.com>
+        os_container_type: grafana
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: grafana
+      Volumes:
+        /etc/grafana: {}
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /var/lib/grafana: {}
+        /var/log/grafana: {}
+      WorkingDir: /usr/share/grafana
+    Created: '2021-09-27T08:31:19.822793809Z'
+    Driver: overlay2
+    ExecIDs:
+    - 64683dbfa93ab6f59f4b0e67bc65143db85b7fa9d1a797d94bcf010e2846b865
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614-init/diff:/var/lib/docker/overlay2/60eab00eb9fabe5ba0a23e0a466bce2b00f4fe995c3c76de971fd168325090a2/diff:/var/lib/docker/overlay2/edb08e77bf8e9df0e2be9572e009a912be5df7edffb054fbbf49ce51df492f91/diff:/var/lib/docker/overlay2/32482813dd1954cd14348ef87f07f8be832a804c565390b151e07b8bdcde068a/diff:/var/lib/docker/overlay2/b52983972d4056c0e7d9b431c15cfb7b1338c693929659f60bbeaa87bc2b06fd/diff:/var/lib/docker/overlay2/9a7fd779a1b87114dec1335d0005553834c52b75f51d50bfebc79d1920b28f72/diff:/var/lib/docker/overlay2/43cbfa43d5ba7ec40b7fdd9950d16a46e1b8649821efd9a7e52e7c3c6a9f70f9/diff:/var/lib/docker/overlay2/ea6298eb0454ef0d21da5ee6f673282091c84450ed84d240831e8243d0ccf296/diff:/var/lib/docker/overlay2/a63bb3f03cd931dae0647353d985b083452885f308a0eec5142e29d2b85d6a3a/diff:/var/lib/docker/overlay2/8b69840bb467575ee80ee7fc2213564c73e7ed8e0dc2eff00ac9796b21ab554d/diff:/var/lib/docker/overlay2/56678a247e5c0af0d3fb04f2e8afb2d3eedd20608e02c4757c7456620d4f7700/diff:/var/lib/docker/overlay2/a9824716686ce55b21d9ebeb5db3db5b56442cb594c61372aaebd5d69e1bd631/diff:/var/lib/docker/overlay2/1ff8aa475bda01d333f09b7837c6431fd7da33285ab31323d42c4bb450f8bf9f/diff:/var/lib/docker/overlay2/1bc0395e11179850815244df6dd7d1e8a56c19a9b10497a956e17b942e9e371c/diff
+        MergedDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/merged
+        UpperDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/diff
+        WorkDir: /var/lib/docker/overlay2/97a551cf8c09153f22e51bac5c5ab5258f7e19228316ba27ea6e0fac4e529614/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/grafana:/etc/grafana:rw
+      - /var/lib/grafana:/var/lib/grafana:rw
+      - /var/log/grafana:/var/log/grafana:rw
+      - /etc/localtime:/etc/localtime:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/hostname
+    HostsPath: /etc/hosts
+    Id: 45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf
+    Image: sha256:0acaf089aba85b7d445ce677b22a9390074493bf12fba4a8c8d5908ebc1034b5
+    LogPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/grafana
+      Type: bind
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /var/lib/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/grafana
+      Type: bind
+    - Destination: /var/log/grafana
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/log/grafana
+      Type: bind
+    Name: /grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 83785f8ce5e374560837912661e8b8057acd3131516d06c4198768d72498e38d
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e08560d904cfb84acb94ad6b8dddcf0096427bde2931546391b7634d49db3aa
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /run.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/45b1547f48483d7edfc528a908042b053880aeb37a003915a06aac061854bacf/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:57:03.953904795Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10876
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:57:07.542217497Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - postgres
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - postgres
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - POSTGRES_PASSWORD=Zzs8uv<w3>gZYJ>utf@m
+      - TZ=Europe/Madrid
+      - POSTGRES_DB=grafana
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/postgresql/12/bin
+      - GOSU_VERSION=1.12
+      - LANG=en_US.utf8
+      - PG_MAJOR=12
+      - PG_VERSION=12.5-1.pgdg100+1
+      - PGDATA=/var/lib/postgresql/data
+      ExposedPorts:
+        5432/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/postgres:12
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGINT
+      Tty: false
+      User: ''
+      Volumes:
+        /docker-entrypoint-initdb.d: {}
+        /var/lib/postgresql/data: {}
+      WorkingDir: ''
+    Created: '2020-12-17T09:26:36.676895901Z'
+    Driver: overlay2
+    ExecIDs:
+    - 93047f7627a4586cda091f300aebc11241a38a3cbaacb7bd23310e07742e8f0d
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429-init/diff:/var/lib/docker/overlay2/bc137b6e30eccddfaa5ad00d60415fee06b4945ad5183e048a79ae8ccc3e2160/diff:/var/lib/docker/overlay2/375b7137e55997093f69d73adf172b531d4ae6c028250e1057ce5df4e341acb2/diff:/var/lib/docker/overlay2/690b06be0c588f9a19ee5ca8da640eccbead09cdef07998dc19df4a6731f912d/diff:/var/lib/docker/overlay2/d8d27fae62379c9caac0cfbbccb6a2a63d6069a52f75efc73961a43466d978e3/diff:/var/lib/docker/overlay2/ebaea625a104e39e4c99224242031855eb17d771f234a0cb331cca76ada8210e/diff:/var/lib/docker/overlay2/e1a23343bb5307e73c288885a07feba5c5d562efcf72eae0fb7702c2a59f94da/diff:/var/lib/docker/overlay2/a7d7fad7fb26d98128b39ecd2fcbe918b7bf673817966b575edc755df3ec50a2/diff:/var/lib/docker/overlay2/a8ff0e63bdc7d497743e7c286be73a751e9622545b6b778ef2bc38bfddc5a235/diff:/var/lib/docker/overlay2/2329a53df5e0abfccf0babaffbb4f022c19e82661973352b4a8a85cdd4296c3e/diff:/var/lib/docker/overlay2/b42c82e4b141eac5f4537b55ac47c092e160fcd967c7b53563827a97f14404ba/diff:/var/lib/docker/overlay2/b1640cd6fd6faa4a3492bd188d06c2ff7bf759ba31bb284a12799dd62ac21b65/diff:/var/lib/docker/overlay2/f6ea6239be6ef1774f0969d5b35b138445847f7b69d3f88e2744e9e0ffee437f/diff:/var/lib/docker/overlay2/d2b1752471feba9f98252e2e8b0a7c24db452a57ab54ccc2d8a67bba51799cde/diff:/var/lib/docker/overlay2/e9273e415b8dd36766130b496c47d8b7576e191ca752b9b8584df6d6c48d4aff/diff
+        MergedDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/merged
+        UpperDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/diff
+        WorkDir: /var/lib/docker/overlay2/662cb0610dabd866292fea547108cc9c0c8cca18e38331a3b1d151bdab6d0429/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /var/lib/postgresql_grafana/data:/var/lib/postgresql/data:rw
+      - /etc/postgres_init:/docker-entrypoint-initdb.d:ro
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hostname
+    HostsPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/hosts
+    Id: e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40
+    Image: sha256:386fd8c60839b215769740e718232f704cf38e0faed924a2d55c7ae012492fd6
+    LogPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /docker-entrypoint-initdb.d
+      Mode: ro
+      Propagation: rprivate
+      RW: false
+      Source: /etc/postgres_init
+      Type: bind
+    - Destination: /var/lib/postgresql/data
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /var/lib/postgresql_grafana/data
+      Type: bind
+    Name: /postgres-grafana
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 867e10fdf347aa83e5947ac63860cf64360acd942d29c969029d448dc45889fb
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 9e798f638ddfdf2ca330c8c62bb4dea7c31a5a569ed2843bd4cca0e0b398248e
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e20d969a92f5e88a116b24784f9b43b1fa326f1a17b8e6bbe754cb224cff5a40/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.84481573Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10435
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.428443571Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - -g
+    - daemon off;
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - nginx
+      - -g
+      - daemon off;
+      Domainname: ''
+      Entrypoint: null
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.17.9
+      - NJS_VERSION=0.3.9
+      - PKG_RELEASE=1~buster
+      ExposedPorts:
+        80/tcp: {}
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/nginx:1.17.9
+      Labels:
+        maintainer: NGINX Docker Maintainers <docker-maint@nginx.com>
+        os_contianer_type: nginx
+        os_environment: default
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      StopSignal: SIGTERM
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/hosts: {}
+        /etc/localtime: {}
+        /etc/nginx: {}
+      WorkingDir: ''
+    Created: '2020-11-10T16:50:27.911193137Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb-init/diff:/var/lib/docker/overlay2/6a2922602060526fa64479e796822524952f6a9953962de666fc1600cac1c1dc/diff:/var/lib/docker/overlay2/4f02c4085ee5f463d8ca5b115780fefd4ef7b7153c260e5897e6fccfde9944a2/diff:/var/lib/docker/overlay2/4996d0413102f08e30ed9b152595f59c1f3e7c99d74472c321333a388a8b8e19/diff
+        MergedDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/merged
+        UpperDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/diff
+        WorkDir: /var/lib/docker/overlay2/1a64f2984fb524442e714c9f269a015764c3ec7e79af02825ebd881aea84edfb/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/hosts:/etc/hosts:rw
+      - /etc/localtime:/etc/localtime:rw
+      - /etc/nginx:/etc/nginx:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/hostname
+    HostsPath: /etc/hosts
+    Id: 048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a
+    Image: sha256:6678c7c2e56c970388f8d5a398aa30f2ab60e85f20165e101053c3d3a11e6663
+    LogPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/hosts
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/hosts
+      Type: bind
+    - Destination: /etc/localtime
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/localtime
+      Type: bind
+    - Destination: /etc/nginx
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/nginx
+      Type: bind
+    Name: /nginx
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: cc5fe108a25d65ff687c7f0bf2d2adb8fc2d6d0f927c22c91351ae98ff19c6f2
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 8a70c2fe3e69b976146e6ae0f3113bb5be2e0a8185f1c14d1dc639766907c479
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: nginx
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/048eff94641c3bd9fc2e2aec9f434ab2a3a028c8f6d76dd1899c5c47ee21ad4a/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:35.859574137Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 10501
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:53.285690919Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - es-kg-sync.py
+    - -c
+    - /app/etc/config.yml
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - -c
+      - /app/etc/config.yml
+      Domainname: ''
+      Entrypoint:
+      - python3
+      - es-kg-sync.py
+      Env:
+      - GOOGLE_APPLICATION_CREDENTIALS=/app/etc/credentials.json
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - GPG_KEY=E3FF2839C048B25C084DEBE9B26995E310250568
+      - PYTHON_VERSION=3.8.6
+      - PYTHON_PIP_VERSION=20.2.4
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/fa7dc83944936bf09a0e4cb5d5ec852c0d256599/get-pip.py
+      - PYTHON_GET_PIP_SHA256=6e0bb0a2c2533361d7f297ed547237caf1b7507f197835974c0dd7eba998c53c
+      - PYTHONUNBUFFERED=true
+      Hostname: grafana01.novalocal
+      Image: nexusregistry.opensolutions.cloud/es-kg-sync:1.3.4
+      Labels:
+        maintainer: fgonzalez
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /app/etc: {}
+      WorkingDir: /app
+    Created: '2020-11-06T15:49:46.647862103Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7-init/diff:/var/lib/docker/overlay2/20785a6672262cd131687a278bc4b48442436ee9eb7027fc8a0b0db9e829cec0/diff:/var/lib/docker/overlay2/bb789e0d27794838938b60addf99ea82a15bc853c6d7f8860ee9bfd4c80e060c/diff:/var/lib/docker/overlay2/5945abe0f336bf5998fd77dda863da52dd6633d16ae77f37a806e3028bb7004d/diff:/var/lib/docker/overlay2/5b96b4410e0bff57c24c2d2fc9de1412a01454bca5179aad853c31afe445a83e/diff:/var/lib/docker/overlay2/69c86d2ff3b70e251a0119f05dc78e8ede6e1803ac816453d989f7aed28f4f30/diff:/var/lib/docker/overlay2/9ab680cacc4c1081f79bc8af516ddc73413befa0183e6753f6a5b87196df1891/diff:/var/lib/docker/overlay2/e5039299ff6b760921408c90406254c371d3ad6bb1a7803ab2bb419a393ed66b/diff:/var/lib/docker/overlay2/5b85515f7cc254ab6c71a720df9c2009ca8ddb4c1b57d545cddf8b0cec34c3a6/diff:/var/lib/docker/overlay2/ceaa1d45c24cc7ca8ef623ecc2c691226c181133f8dcb01cf7b6912bd8afc395/diff:/var/lib/docker/overlay2/de5f6f22702f280955ccd50cfa7790f2a24dfd69d5affde1cc3da1880390aef6/diff
+        MergedDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/merged
+        UpperDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/diff
+        WorkDir: /var/lib/docker/overlay2/caf72c37755a777b68d58b6d1da8799f6886bb0b535adee6a53cac19f46f60c7/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/es_kg_sync:/app/etc:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '3'
+          max-size: 20m
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: unless-stopped
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hostname
+    HostsPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/hosts
+    Id: ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c
+    Image: sha256:2a55385bb40904bddc8e07595f478e16f8b73db1a5c161acfe49029ff2aba86e
+    LogPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /app/etc
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/es_kg_sync
+      Type: bind
+    Name: /es_kg_sync
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 41646a2e4cefe3075ce860a5b43a7fd895356fab3f730fb2fbf31eab4b3b63b8
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: d166e90a3e65452bcc73f9d1b143c0b6ea9afe4a6ca40c4da418b55d54714fe4
+      Ports: {}
+      SandboxID: 6be7362230495d2759721f5bb7d6cccdfc95270e72eb2f0ce0281b3576039ae4
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: python3
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/ae71b1f21f85bed81466cce31da9f63d9c448782cc36c1c9d76c59834769c05c/resolv.conf
+    RestartCount: 1
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-07-05T16:21:19.700599103Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 21867
+      Restarting: false
+      Running: true
+      StartedAt: '2022-07-05T16:21:20.43263416Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 53314
+    protocol: tcp
+  discovery_time: '2022-07-05T18:11:55+02:00'
+  listening_ports:
+  - 53314
+  process:
+    cmdline: /usr/lib/systemd/xymonlaunch -b config.yaml
+    cwd: /usr/lib/systemd/
+    listening_ports:
+    - 53314
     pid: '121'
     ppid: '0'
     user: root
-  - cmdline: /usr/bin/icmanager -i
-    pid: '124'
-    ppid: '0'
-    user: root
-  - cmdline: /usr/bin/ms.sap -P
-    pid: '125'
-    ppid: '0'
-    user: root
+  type: Xymon
+  version: []
 packages:
   freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
   gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
   gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
   gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
   gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
   glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
   glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
   glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
   gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
   gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
   gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
   gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
   gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
   gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
   grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
   groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
   grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
   grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
   gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
   gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
   hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
   hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
   hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
   info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
   iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
   iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
   iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
   iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+processes:
+- cmdline: /usr/lib/systemd/xymonlaunch -b config.yaml
+  cwd: /usr/lib/systemd/
+  pid: '121'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/icmanager -i
+  cwd: /usr/bin/
+  pid: '124'
+  ppid: '0'
+  user: root
+- cmdline: /usr/bin/ms.sap -P
+  cwd: /usr/bin/
+  pid: '125'
+  ppid: '0'
+  user: root
+software_list:
+- cmd_regexp: xymonlaunch
+  name: Xymon
+  process_type: parent
+  return_children: false
+  return_packages: false
 tcp_listen:
-  - address: 0.0.0.0
-    name: port1
-    pid: 121
-    port: 53314
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 127.0.0.1
-    name: port2
-    pid: 122
-    port: 3388
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 192.168.1.35
-    name: port3
-    pid: 123
-    port: 52914
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port4
-    pid: 124
-    port: 53213
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
-  - address: 0.0.0.0
-    name: port5
-    pid: 125
-    port: 52614
-    protocol: tcp
-    stime: 'Tue Apr 26 15:55:30 2022'
-    user: root
+- address: 0.0.0.0
+  name: port1
+  pid: 121
+  port: 53314
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 127.0.0.1
+  name: port2
+  pid: 122
+  port: 3388
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 192.168.1.35
+  name: port3
+  pid: 123
+  port: 52914
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port4
+  pid: 124
+  port: 53213
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
+- address: 0.0.0.0
+  name: port5
+  pid: 125
+  port: 52614
+  protocol: tcp
+  stime: Tue Apr 26 15:55:30 2022
+  user: root
 udp_listen:
-  - address: 0.0.0.0
-    name: dhclient
-    pid: 978
-    port: 68
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:26 2022'
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: 127.0.0.1
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: 0.0.0.0
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: 'Tue Apr 26 15:54:45 2022'
-    user: root
-  - address: '::1'
-    name: chronyd
-    pid: 728
-    port: 323
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: chrony
-  - address: '::'
-    name: rpcbind
-    pid: 730
-    port: 879
-    protocol: udp
-    stime: 'Tue Apr 26 15:55:13 2022'
-    user: rpc
+- address: 0.0.0.0
+  name: dhclient
+  pid: 978
+  port: 68
+  protocol: udp
+  stime: Tue Apr 26 15:55:26 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: 127.0.0.1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Tue Apr 26 15:54:45 2022
+  user: root
+- address: ::1
+  name: chronyd
+  pid: 728
+  port: 323
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 730
+  port: 879
+  protocol: udp
+  stime: Tue Apr 26 15:55:13 2022
+  user: rpc

--- a/tests/unit/plugins/action/auto/resources/zabbix_server/zabbix_server4.0.20_centos7.6.yaml
+++ b/tests/unit/plugins/action/auto/resources/zabbix_server/zabbix_server4.0.20_centos7.6.yaml
@@ -1,6633 +1,7688 @@
-expected_result:
-  - bindings:
-      - address: '0.0.0.0'
-        class: 'service'
-        port: 10051
-        protocol: 'tcp'
-      - address: '::'
-        class: 'service'
-        port: 10051
-        protocol: 'tcp'
-    discovery_time: '2022-07-04T15:06:31+02:00'
-    listening_ports:
-      - 10051
-    packages:
-      - arch: x86_64
-        epoch: null
-        name: zabbix-server-pgsql
-        release: 1.el7
-        source: rpm
-        version: 4.0.20
-    process:
-      children:
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: configuration syncer [synced configuration in 1.574989 sec, idle 60 sec]'
-          pid: '1178'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: housekeeper [deleted 0 hist/trends, 0 items/triggers, 69 events, 2 sessions, 0 alarms, 2 audit items in 1.195076 sec, idle for 1 hour(s)]'
-          pid: '1255'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #1 [updated 0 hosts, suppressed 0 events in 0.001907 sec, idle 59 sec]'
-          pid: '1256'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #2 [suppressed 0 events in 0.035586 sec, idle 58 sec]'
-          pid: '1257'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #3 [suppressed 0 events in 0.032545 sec, idle 58 sec]'
-          pid: '1258'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #4 [suppressed 0 events in 0.043363 sec, idle 58 sec]'
-          pid: '1259'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #5 [suppressed 0 events in 0.066465 sec, idle 58 sec]'
-          pid: '1260'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #6 [suppressed 0 events in 0.064149 sec, idle 58 sec]'
-          pid: '1261'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #7 [suppressed 0 events in 0.044135 sec, idle 58 sec]'
-          pid: '1262'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #8 [suppressed 0 events in 0.066614 sec, idle 58 sec]'
-          pid: '1263'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #9 [suppressed 0 events in 0.070274 sec, idle 58 sec]'
-          pid: '1264'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #10 [suppressed 0 events in 0.033935 sec, idle 58 sec]'
-          pid: '1265'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #11 [suppressed 0 events in 0.033549 sec, idle 59 sec]'
-          pid: '1266'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #12 [suppressed 0 events in 0.056936 sec, idle 58 sec]'
-          pid: '1267'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #13 [suppressed 0 events in 0.060405 sec, idle 58 sec]'
-          pid: '1268'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #14 [suppressed 0 events in 0.045167 sec, idle 58 sec]'
-          pid: '1269'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: timer #15 [suppressed 0 events in 0.038825 sec, idle 58 sec]'
-          pid: '1270'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #1 [got 0 values in 0.001601 sec, idle 5 sec]'
-          pid: '1271'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #2 [got 0 values in 0.001186 sec, idle 5 sec]'
-          pid: '1272'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #3 [got 0 values in 0.001257 sec, idle 5 sec]'
-          pid: '1273'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #4 [got 0 values in 0.001622 sec, idle 5 sec]'
-          pid: '1274'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #5 [got 0 values in 0.001709 sec, idle 5 sec]'
-          pid: '1275'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #6 [got 0 values in 0.001607 sec, idle 5 sec]'
-          pid: '1276'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #7 [got 0 values in 0.001650 sec, idle 5 sec]'
-          pid: '1277'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #8 [got 0 values in 0.001241 sec, idle 5 sec]'
-          pid: '1278'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #9 [got 0 values in 0.001343 sec, idle 5 sec]'
-          pid: '1279'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #10 [got 0 values in 0.001719 sec, idle 5 sec]'
-          pid: '1280'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #11 [got 0 values in 0.002388 sec, idle 5 sec]'
-          pid: '1281'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: http poller #12 [got 0 values in 0.001564 sec, idle 5 sec]'
-          pid: '1282'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: discoverer #1 [processed 0 rules in 0.001910 sec, idle 60 sec]'
-          pid: '1283'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: discoverer #2 [processed 0 rules in 0.002141 sec, idle 60 sec]'
-          pid: '1284'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: discoverer #3 [processed 0 rules in 0.002326 sec, idle 60 sec]'
-          pid: '1285'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: discoverer #4 [processed 0 rules in 0.001887 sec, idle 60 sec]'
-          pid: '1286'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: discoverer #5 [processed 0 rules in 0.001595 sec, idle 60 sec]'
-          pid: '1287'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: discoverer #6 [processed 0 rules in 0.001633 sec, idle 60 sec]'
-          pid: '1288'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #1 [processed 0 values, 0 triggers in 0.000042 sec, idle 1 sec]'
-          pid: '1289'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #2 [processed 22 values, 15 triggers in 0.017126 sec, idle 1 sec]'
-          pid: '1290'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #3 [processed 0 values, 0 triggers in 0.000042 sec, idle 1 sec]'
-          pid: '1291'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #4 [processed 0 values, 0 triggers in 0.000037 sec, idle 1 sec]'
-          pid: '1292'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #5 [processed 0 values, 0 triggers in 0.000041 sec, idle 1 sec]'
-          pid: '1293'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #6 [processed 0 values, 0 triggers in 0.000051 sec, idle 1 sec]'
-          pid: '1294'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #7 [processed 0 values, 11 triggers in 0.002103 sec, idle 1 sec]'
-          pid: '1295'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #8 [processed 0 values, 0 triggers in 0.000052 sec, idle 1 sec]'
-          pid: '1296'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #9 [processed 0 values, 0 triggers in 0.000042 sec, idle 1 sec]'
-          pid: '1297'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: history syncer #10 [processed 0 values, 0 triggers in 0.000050 sec, idle 1 sec]'
-          pid: '1298'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: escalator #1 [processed 0 escalations in 0.002789 sec, idle 3 sec]'
-          pid: '1299'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: escalator #2 [processed 0 escalations in 0.003336 sec, idle 3 sec]'
-          pid: '1300'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: escalator #3 [processed 0 escalations in 0.003633 sec, idle 3 sec]'
-          pid: '1301'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: snmp trapper [processed data in 0.000042 sec, idle 1 sec]'
-          pid: '1302'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: self-monitoring [processed data in 0.000065 sec, idle 1 sec]'
-          pid: '1303'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: task manager [processed 0 task(s) in 0.001448 sec, idle 5 sec]'
-          pid: '1304'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #1 [got 0 values in 0.000092 sec, idle 1 sec]'
-          pid: '1305'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #2 [got 0 values in 0.000065 sec, idle 1 sec]'
-          pid: '1306'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #3 [got 0 values in 0.000042 sec, idle 1 sec]'
-          pid: '1307'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #4 [got 0 values in 0.000110 sec, idle 1 sec]'
-          pid: '1308'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #5 [got 0 values in 0.000333 sec, idle 1 sec]'
-          pid: '1309'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #6 [got 0 values in 0.000057 sec, idle 1 sec]'
-          pid: '1310'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #7 [got 0 values in 0.000043 sec, idle 1 sec]'
-          pid: '1311'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #8 [got 0 values in 0.000052 sec, idle 1 sec]'
-          pid: '1312'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #9 [got 0 values in 0.000204 sec, idle 1 sec]'
-          pid: '1313'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #10 [got 5 values in 0.001876 sec, idle 1 sec]'
-          pid: '1314'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #11 [got 0 values in 0.000029 sec, idle 1 sec]'
-          pid: '1315'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #12 [got 0 values in 0.000033 sec, idle 1 sec]'
-          pid: '1316'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #13 [got 0 values in 0.000040 sec, idle 1 sec]'
-          pid: '1317'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #14 [got 0 values in 0.000040 sec, idle 1 sec]'
-          pid: '1318'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #15 [got 0 values in 0.000023 sec, idle 1 sec]'
-          pid: '1319'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #16 [got 0 values in 0.000037 sec, idle 1 sec]'
-          pid: '1320'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #17 [got 0 values in 0.000046 sec, idle 1 sec]'
-          pid: '1321'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #18 [got 0 values in 0.000031 sec, idle 1 sec]'
-          pid: '1322'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #19 [got 0 values in 0.000022 sec, idle 1 sec]'
-          pid: '1323'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #20 [got 0 values in 0.000106 sec, idle 1 sec]'
-          pid: '1324'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #21 [got 0 values in 0.000057 sec, idle 1 sec]'
-          pid: '1325'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #22 [got 0 values in 0.000043 sec, idle 1 sec]'
-          pid: '1326'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #23 [got 0 values in 0.000079 sec, idle 1 sec]'
-          pid: '1327'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #24 [got 0 values in 0.000032 sec, idle 1 sec]'
-          pid: '1328'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #25 [got 0 values in 0.000051 sec, idle 1 sec]'
-          pid: '1329'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #26 [got 0 values in 0.000048 sec, idle 1 sec]'
-          pid: '1330'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #27 [got 0 values in 0.000056 sec, idle 1 sec]'
-          pid: '1331'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #28 [got 0 values in 0.000050 sec, idle 1 sec]'
-          pid: '1332'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #29 [got 0 values in 0.000057 sec, idle 1 sec]'
-          pid: '1333'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #30 [got 0 values in 0.000066 sec, idle 1 sec]'
-          pid: '1334'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #31 [got 0 values in 0.000034 sec, idle 1 sec]'
-          pid: '1335'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #32 [got 0 values in 0.000032 sec, idle 1 sec]'
-          pid: '1336'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #33 [got 0 values in 0.000627 sec, idle 1 sec]'
-          pid: '1337'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #34 [got 0 values in 0.000171 sec, idle 1 sec]'
-          pid: '1338'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #35 [got 0 values in 0.000042 sec, idle 1 sec]'
-          pid: '1339'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #36 [got 0 values in 0.000063 sec, idle 1 sec]'
-          pid: '1340'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #37 [got 0 values in 0.000028 sec, idle 1 sec]'
-          pid: '1341'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #38 [got 0 values in 0.000063 sec, idle 1 sec]'
-          pid: '1342'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #39 [got 0 values in 0.000039 sec, idle 1 sec]'
-          pid: '1343'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #40 [got 0 values in 0.000035 sec, idle 1 sec]'
-          pid: '1344'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #41 [got 0 values in 0.000044 sec, idle 1 sec]'
-          pid: '1345'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #42 [got 0 values in 0.000211 sec, idle 1 sec]'
-          pid: '1346'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #43 [got 0 values in 0.000033 sec, idle 1 sec]'
-          pid: '1347'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #44 [got 0 values in 0.000047 sec, idle 1 sec]'
-          pid: '1348'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #45 [got 0 values in 0.000039 sec, idle 1 sec]'
-          pid: '1349'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #46 [got 0 values in 0.000046 sec, idle 1 sec]'
-          pid: '1350'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #47 [got 0 values in 0.000120 sec, idle 1 sec]'
-          pid: '1351'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #48 [got 0 values in 0.000022 sec, idle 1 sec]'
-          pid: '1352'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #49 [got 0 values in 0.000054 sec, idle 1 sec]'
-          pid: '1353'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #50 [got 0 values in 0.000040 sec, idle 1 sec]'
-          pid: '1354'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #51 [got 0 values in 0.000031 sec, idle 1 sec]'
-          pid: '1355'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #52 [got 0 values in 0.000046 sec, idle 1 sec]'
-          pid: '1356'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #53 [got 1 values in 15.000692 sec, getting values]'
-          pid: '1357'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #54 [got 0 values in 0.000068 sec, idle 1 sec]'
-          pid: '1358'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #55 [got 0 values in 0.000088 sec, idle 1 sec]'
-          pid: '1359'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #56 [got 0 values in 0.000046 sec, idle 1 sec]'
-          pid: '1360'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #57 [got 0 values in 0.000116 sec, idle 1 sec]'
-          pid: '1361'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #58 [got 0 values in 0.000031 sec, idle 1 sec]'
-          pid: '1362'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #59 [got 3 values in 0.024509 sec, idle 1 sec]'
-          pid: '1363'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #60 [got 0 values in 0.000029 sec, idle 1 sec]'
-          pid: '1364'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #61 [got 0 values in 0.000092 sec, idle 1 sec]'
-          pid: '1365'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #62 [got 8 values in 0.001505 sec, idle 1 sec]'
-          pid: '1366'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #63 [got 0 values in 0.000047 sec, idle 1 sec]'
-          pid: '1367'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #64 [got 0 values in 0.000096 sec, idle 1 sec]'
-          pid: '1368'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #65 [got 0 values in 0.000035 sec, idle 1 sec]'
-          pid: '1369'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #66 [got 0 values in 0.000087 sec, idle 1 sec]'
-          pid: '1370'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #67 [got 0 values in 0.000108 sec, idle 1 sec]'
-          pid: '1371'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #68 [got 0 values in 0.000145 sec, idle 1 sec]'
-          pid: '1372'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #69 [got 1 values in 0.001306 sec, getting values]'
-          pid: '1373'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #70 [got 0 values in 0.000046 sec, idle 1 sec]'
-          pid: '1376'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #71 [got 0 values in 0.000023 sec, idle 1 sec]'
-          pid: '1377'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #72 [got 0 values in 0.000023 sec, idle 1 sec]'
-          pid: '1380'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #73 [got 0 values in 0.000084 sec, idle 1 sec]'
-          pid: '1381'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #74 [got 0 values in 0.000029 sec, idle 1 sec]'
-          pid: '1382'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #75 [got 0 values in 0.000365 sec, idle 1 sec]'
-          pid: '1383'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #76 [got 0 values in 0.000044 sec, idle 1 sec]'
-          pid: '1384'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #77 [got 0 values in 0.000034 sec, idle 1 sec]'
-          pid: '1385'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #78 [got 0 values in 0.000022 sec, idle 1 sec]'
-          pid: '1386'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #79 [got 0 values in 0.000052 sec, idle 1 sec]'
-          pid: '1387'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #80 [got 0 values in 0.000053 sec, idle 1 sec]'
-          pid: '1388'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #81 [got 0 values in 0.000030 sec, idle 1 sec]'
-          pid: '1389'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #82 [got 0 values in 0.000078 sec, idle 1 sec]'
-          pid: '1390'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #83 [got 0 values in 0.000036 sec, idle 1 sec]'
-          pid: '1391'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #84 [got 0 values in 0.000035 sec, idle 1 sec]'
-          pid: '1392'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #85 [got 0 values in 0.000042 sec, idle 1 sec]'
-          pid: '1393'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #86 [got 0 values in 0.000078 sec, idle 1 sec]'
-          pid: '1394'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #87 [got 0 values in 0.000045 sec, idle 1 sec]'
-          pid: '1395'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #88 [got 6 values in 0.001313 sec, idle 1 sec]'
-          pid: '1396'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #89 [got 0 values in 0.000021 sec, idle 1 sec]'
-          pid: '1397'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #90 [got 0 values in 0.000029 sec, idle 1 sec]'
-          pid: '1398'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #91 [got 0 values in 0.000061 sec, idle 1 sec]'
-          pid: '1399'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #92 [got 0 values in 0.000042 sec, idle 1 sec]'
-          pid: '1400'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #93 [got 0 values in 0.000040 sec, idle 1 sec]'
-          pid: '1401'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #94 [got 0 values in 0.000047 sec, idle 1 sec]'
-          pid: '1402'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #95 [got 0 values in 0.000045 sec, idle 1 sec]'
-          pid: '1403'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #96 [got 0 values in 0.000037 sec, idle 1 sec]'
-          pid: '1404'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #97 [got 0 values in 0.000068 sec, idle 1 sec]'
-          pid: '1405'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #98 [got 0 values in 0.000065 sec, idle 1 sec]'
-          pid: '1406'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #99 [got 0 values in 0.000043 sec, idle 1 sec]'
-          pid: '1407'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: poller #100 [got 0 values in 0.000172 sec, idle 1 sec]'
-          pid: '1408'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #1 [got 0 values in 0.000057 sec, idle 5 sec]'
-          pid: '1409'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #2 [got 0 values in 0.000104 sec, idle 5 sec]'
-          pid: '1410'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #3 [got 0 values in 0.000080 sec, idle 5 sec]'
-          pid: '1411'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #4 [got 0 values in 0.000064 sec, idle 5 sec]'
-          pid: '1412'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #5 [got 0 values in 0.000054 sec, idle 5 sec]'
-          pid: '1413'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #6 [got 0 values in 0.000042 sec, idle 5 sec]'
-          pid: '1414'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #7 [got 0 values in 0.000060 sec, idle 5 sec]'
-          pid: '1415'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #8 [got 0 values in 0.000076 sec, idle 5 sec]'
-          pid: '1416'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #9 [got 0 values in 0.000088 sec, idle 5 sec]'
-          pid: '1417'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: unreachable poller #10 [got 0 values in 0.000056 sec, idle 5 sec]'
-          pid: '1418'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #1 [processed data in 0.000230 sec, waiting for connection]'
-          pid: '1419'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #2 [processed data in 0.006015 sec, waiting for connection]'
-          pid: '1420'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #3 [processed data in 0.016559 sec, waiting for connection]'
-          pid: '1421'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #4 [processed data in 0.000297 sec, waiting for connection]'
-          pid: '1422'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #5 [processed data in 0.000145 sec, waiting for connection]'
-          pid: '1423'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #6 [processed data in 0.002896 sec, waiting for connection]'
-          pid: '1424'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #7 [processed data in 0.002574 sec, waiting for connection]'
-          pid: '1425'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #8 [processed data in 0.000330 sec, waiting for connection]'
-          pid: '1426'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #9 [processed data in 0.006360 sec, waiting for connection]'
-          pid: '1427'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #10 [processed data in 0.000253 sec, waiting for connection]'
-          pid: '1428'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #11 [processed data in 0.000470 sec, waiting for connection]'
-          pid: '1429'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #12 [processed data in 0.000152 sec, waiting for connection]'
-          pid: '1430'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #13 [processed data in 0.003929 sec, waiting for connection]'
-          pid: '1431'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #14 [processed data in 0.000218 sec, waiting for connection]'
-          pid: '1432'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #15 [processed data in 0.002176 sec, waiting for connection]'
-          pid: '1433'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #16 [processed data in 0.002160 sec, waiting for connection]'
-          pid: '1434'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #17 [processed data in 0.000222 sec, waiting for connection]'
-          pid: '1435'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #18 [processed data in 0.000175 sec, waiting for connection]'
-          pid: '1436'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #19 [processed data in 0.001193 sec, waiting for connection]'
-          pid: '1437'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #20 [processed data in 0.001956 sec, waiting for connection]'
-          pid: '1438'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #21 [processed data in 0.000201 sec, waiting for connection]'
-          pid: '1439'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #22 [processed data in 0.000260 sec, waiting for connection]'
-          pid: '1440'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #23 [processed data in 0.008046 sec, waiting for connection]'
-          pid: '1441'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #24 [processed data in 0.000204 sec, waiting for connection]'
-          pid: '1442'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #25 [processed data in 0.009377 sec, waiting for connection]'
-          pid: '1443'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #26 [processed data in 0.002651 sec, waiting for connection]'
-          pid: '1444'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #27 [processed data in 0.006057 sec, waiting for connection]'
-          pid: '1445'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #28 [processed data in 0.002465 sec, waiting for connection]'
-          pid: '1446'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #29 [processed data in 0.002373 sec, waiting for connection]'
-          pid: '1447'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #30 [processed data in 0.000944 sec, waiting for connection]'
-          pid: '1448'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #31 [processed data in 0.001482 sec, waiting for connection]'
-          pid: '1449'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #32 [processed data in 0.000197 sec, waiting for connection]'
-          pid: '1450'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #33 [processed data in 0.002447 sec, waiting for connection]'
-          pid: '1451'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #34 [processed data in 0.002830 sec, waiting for connection]'
-          pid: '1452'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #35 [processed data in 0.002116 sec, waiting for connection]'
-          pid: '1453'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #36 [processed data in 0.005720 sec, waiting for connection]'
-          pid: '1454'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #37 [processed data in 0.002188 sec, waiting for connection]'
-          pid: '1455'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #38 [processed data in 0.008311 sec, waiting for connection]'
-          pid: '1456'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #39 [processed data in 0.003236 sec, waiting for connection]'
-          pid: '1457'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #40 [processed data in 0.002259 sec, waiting for connection]'
-          pid: '1458'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #41 [processed data in 0.013718 sec, waiting for connection]'
-          pid: '1459'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #42 [processed data in 0.003235 sec, waiting for connection]'
-          pid: '1460'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #43 [processed data in 0.000191 sec, waiting for connection]'
-          pid: '1461'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #44 [processed data in 0.000305 sec, waiting for connection]'
-          pid: '1462'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #45 [processed data in 0.000219 sec, waiting for connection]'
-          pid: '1463'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #46 [processed data in 0.000209 sec, waiting for connection]'
-          pid: '1464'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #47 [processed data in 0.006524 sec, waiting for connection]'
-          pid: '1465'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #48 [processed data in 0.000222 sec, waiting for connection]'
-          pid: '1466'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #49 [processed data in 0.000214 sec, waiting for connection]'
-          pid: '1467'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: trapper #50 [processed data in 0.003061 sec, waiting for connection]'
-          pid: '1468'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #1 [got 0 values in 0.000049 sec, idle 5 sec]'
-          pid: '1469'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #2 [got 0 values in 0.000058 sec, idle 5 sec]'
-          pid: '1470'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #3 [got 0 values in 0.000057 sec, idle 5 sec]'
-          pid: '1471'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #4 [got 0 values in 0.000034 sec, idle 5 sec]'
-          pid: '1472'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #5 [got 0 values in 0.000051 sec, idle 5 sec]'
-          pid: '1473'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #6 [got 0 values in 0.000033 sec, idle 5 sec]'
-          pid: '1474'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #7 [got 0 values in 0.000028 sec, idle 5 sec]'
-          pid: '1475'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #8 [got 0 values in 0.000031 sec, idle 5 sec]'
-          pid: '1476'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #9 [got 0 values in 0.000059 sec, idle 5 sec]'
-          pid: '1477'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: icmp pinger #10 [got 0 values in 0.000050 sec, idle 5 sec]'
-          pid: '1478'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: alert manager #1 [sent 2, failed 0 alerts, idle 5.322796 sec during 5.322978 sec]'
-          pid: '1479'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: alerter #1 [sent 0, failed 0 alerts, idle 178.024568 sec during 180.357522 sec]'
-          pid: '1480'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: alerter #2 [sent 0, failed 0 alerts, idle 118.623005 sec during 119.766001 sec]'
-          pid: '1481'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: alerter #3 [sent 0, failed 0 alerts, idle 59.250622 sec during 60.530660 sec]'
-          pid: '1482'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: preprocessing manager #1 [queued 1, processed 560 values, idle 5.033828 sec during 5.041462 sec]'
-          pid: '1483'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: preprocessing worker #1 started'
-          pid: '1484'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: preprocessing worker #2 started'
-          pid: '1485'
-          ppid: '1173'
-          user: zabbix
-        - children: [ ]
-          cmdline: '/usr/sbin/zabbix_server: preprocessing worker #3 started'
-          pid: '1486'
-          ppid: '1173'
-          user: zabbix
-      cmdline: /usr/sbin/zabbix_server -c /etc/zabbix/zabbix_server.conf
-      listening_ports:
-        - 10051
-      pid: '1173'
-      ppid: '1'
-      user: zabbix
-    type: Zabbix Server
-    version:
-      - number: 4.0.20
-        type: package
-
-software_list:
-  - name: Zabbix Server
-    cmd_regexp: /usr/sbin/zabbix_server -c
-    pkg_regexp: zabbix-server.*
-    process_type: parent
-    return_children: true
-    return_packages: true
 dockers:
   containers:
-    - AppArmorProfile: ''
-      Args:
-        - infinity
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - infinity
-        Domainname: ''
-        Entrypoint:
-          - sleep
-        Env:
-          - TZ=Europe/Madrid
-          - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - PYTHONIOENCODING=UTF-8
-          - GPG_KEY=C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
-          - PYTHON_VERSION=2.7.18
-          - PYTHON_PIP_VERSION=20.0.2
-          - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/d59197a3c169cef378a22428a3fa99d33e080a5d/get-pip.py
-          - PYTHON_GET_PIP_SHA256=421ac1d44c0cf9730a088e337867d974b91bdce4ea2636099275071878cc189e
-        Hostname: zabbix-server01.novalocal
-        Image: iometrics-zbxalerter-opsgenie:latest
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: /usr/src/app
-      Created: '2022-06-21T15:07:29.216720661Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/d142a42a4085cd5488c0bb9bab718b3ec2e26c4db12ed1cb424fc022caf5c133-init/diff:/var/lib/docker/overlay2/0760b00019c5fc5127be0639a3494eefb001a53d8cf67ff29f3da0ca36c5b125/diff:/var/lib/docker/overlay2/4ddf7dbf9857dade530cd2dc4311d2e2196b86e08b3c5a8276b7419ea91b6f3b/diff:/var/lib/docker/overlay2/3a677a29ce4a1c9daa84d4eeed899a76b7587ab41939b3b7ac24d71f1f663907/diff:/var/lib/docker/overlay2/72d0fe8ed739c2afd20b70857b49934c9e06772c2bc6b5496560743b1bc42522/diff:/var/lib/docker/overlay2/2f403a162d7d3b36f2ea6859b73d670c2dbfd5fde14bb765fdc12f2b1a94afc6/diff:/var/lib/docker/overlay2/fa00ba8e60b981bc4c3876ff27a4d7b0078543c1ddf2f663b997c4853c736597/diff:/var/lib/docker/overlay2/5b96a361fd9927a8fbafbdeae618452a18abfc3f387249e152e59ff78dd7e9ec/diff:/var/lib/docker/overlay2/76cdc5ad4b417a7566dea5b0d72216fd59f1d02a098ed68aec6545661852c26c/diff:/var/lib/docker/overlay2/a0cec3f1f3357690638b3322540463d377275f996c53a5cbc61a9640363a7b7f/diff:/var/lib/docker/overlay2/be79b1ee8a51a9ec0704a675288a657a26a54a17ff3d90b4ced38c1807f63249/diff
-          MergedDir: /var/lib/docker/overlay2/d142a42a4085cd5488c0bb9bab718b3ec2e26c4db12ed1cb424fc022caf5c133/merged
-          UpperDir: /var/lib/docker/overlay2/d142a42a4085cd5488c0bb9bab718b3ec2e26c4db12ed1cb424fc022caf5c133/diff
-          WorkDir: /var/lib/docker/overlay2/d142a42a4085cd5488c0bb9bab718b3ec2e26c4db12ed1cb424fc022caf5c133/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: true
-        Binds:
-          - /home/centos/opsgenie_config:/etc/opensolutions
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: [ ]
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: [ ]
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: 'no'
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f/hostname
-      HostsPath: /var/lib/docker/containers/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f/hosts
-      Id: e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f
-      Image: sha256:9cbb876bf01372b8efb8c5c80665231e6c4b522228320bd12ff3370589881cf1
-      LogPath: /var/lib/docker/containers/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/opensolutions
-          Mode: ''
-          Propagation: rprivate
-          RW: true
-          Source: /home/centos/opsgenie_config
-          Type: bind
-      Name: /iometrics-zbxalerter-opsgenie
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: e7ecf77b8907f4f7382521e356104116405eaa9750480440ae7720b1c01e840c
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 9a6482fb028630d923e263f547c71899691e767c4f763aa7c3604f8af8455f60
-        Ports: { }
-        SandboxID: b118a37e9e43122f3275b3e946d5c55b49f0d12d1a8f88ddf7c156bd1c6b7298
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: sleep
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '0001-01-01T00:00:00Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 12017
-        Restarting: false
-        Running: true
-        StartedAt: '2022-06-21T15:07:29.559096539Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - infinity
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - infinity
-        Domainname: ''
-        Entrypoint:
-          - sleep
-        Env:
-          - TZ=Europe/Madrid
-          - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - LANG=C.UTF-8
-          - PYTHONIOENCODING=UTF-8
-          - GPG_KEY=C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
-          - PYTHON_VERSION=2.7.18
-          - PYTHON_PIP_VERSION=20.0.2
-          - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/d59197a3c169cef378a22428a3fa99d33e080a5d/get-pip.py
-          - PYTHON_GET_PIP_SHA256=421ac1d44c0cf9730a088e337867d974b91bdce4ea2636099275071878cc189e
-        Hostname: zabbix-server01.novalocal
-        Image: nexusregistry.opensolutions.cloud/iometrics-zbxalerter:3.23.0-67087ca
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /etc/opensolutions: { }
-        WorkingDir: /usr/src/app
-      Created: '2021-11-17T15:07:06.322256934Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/1da7dc74b62fa36687b5d3679d6500e22da2098bd9f38a699643e638d0e43c6a-init/diff:/var/lib/docker/overlay2/18aa9049df61d3a7fec135ff1e0d4c1f1df3c0a5a8f05733be4289efa1c05fe9/diff:/var/lib/docker/overlay2/d2ffc7bb5192bf6a1955701921984fc7eec4eda30ad28a3273c4be15562a9f9a/diff:/var/lib/docker/overlay2/53fe70537b1df7cb38abc1f5003b498fe8b9c1a6bb137ce1423f524cb37e9e59/diff:/var/lib/docker/overlay2/8bb897262c98858214599a1523ce91667b8bc458ae8b88645d46d2bf6adc8874/diff:/var/lib/docker/overlay2/d41c7d061c4c1976cb6dbc19a82555470b21e6fc18b61a4aa158815a192ee250/diff:/var/lib/docker/overlay2/49252bf4476e2d61c0d082293eba7dc81741293cc5782ff1044486f7836564c7/diff:/var/lib/docker/overlay2/5b96a361fd9927a8fbafbdeae618452a18abfc3f387249e152e59ff78dd7e9ec/diff:/var/lib/docker/overlay2/76cdc5ad4b417a7566dea5b0d72216fd59f1d02a098ed68aec6545661852c26c/diff:/var/lib/docker/overlay2/a0cec3f1f3357690638b3322540463d377275f996c53a5cbc61a9640363a7b7f/diff:/var/lib/docker/overlay2/be79b1ee8a51a9ec0704a675288a657a26a54a17ff3d90b4ced38c1807f63249/diff
-          MergedDir: /var/lib/docker/overlay2/1da7dc74b62fa36687b5d3679d6500e22da2098bd9f38a699643e638d0e43c6a/merged
-          UpperDir: /var/lib/docker/overlay2/1da7dc74b62fa36687b5d3679d6500e22da2098bd9f38a699643e638d0e43c6a/diff
-          WorkDir: /var/lib/docker/overlay2/1da7dc74b62fa36687b5d3679d6500e22da2098bd9f38a699643e638d0e43c6a/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/datadope/iometrics:/etc/opensolutions:rw
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: null
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: null
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config:
-            max-file: '1'
-            max-size: 100M
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: null
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: always
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66/hostname
-      HostsPath: /var/lib/docker/containers/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66/hosts
-      Id: 65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66
-      Image: sha256:2dd1f257368290b30d3f60583a57d32d083743ebe4f563df8733aed0fca3d88b
-      LogPath: /var/lib/docker/containers/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/opensolutions
-          Mode: rw
-          Propagation: rprivate
-          RW: true
-          Source: /etc/datadope/iometrics
-          Type: bind
-      Name: /iometrics-zbxalerter
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 78f457a0393810723e8898b847d2b181d11c11aece7f564859f8abfa40b310c8
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 9a6482fb028630d923e263f547c71899691e767c4f763aa7c3604f8af8455f60
-        Ports: { }
-        SandboxID: 27ed44dd8018d4181a73083d96459b242df554d7ed9b92b588c1853d11b88bd4
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: sleep
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:37.128955515Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 9828
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:49.445977061Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args: [ ]
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd: null
-        Domainname: ''
-        Entrypoint:
-          - /sbin/entrypoint.sh
-        Env:
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - SQUID_VERSION=3.5.27
-          - SQUID_CACHE_DIR=/var/spool/squid
-          - SQUID_LOG_DIR=/var/log/squid
-          - SQUID_USER=proxy
-        ExposedPorts:
-          3128/tcp: { }
-        Hostname: 5c81ff097d1a
-        Image: sameersbn/squid:3.5.27-2
-        Labels:
-          maintainer: sameer@damagehead.com
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes: null
-        WorkingDir: ''
-      Created: '2021-09-27T13:52:37.213315567Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/3037a38d5893b90e7d1b27fc24bcf68eaaf90054886e7f2ec471dcca73e31ec4-init/diff:/var/lib/docker/overlay2/6e810111e9b469ce02f389fba5e9d945707a281c7c5f157ed2deb8d37d556e73/diff:/var/lib/docker/overlay2/04ee3a860acd774a7cd197b0bb28b4a368c6835846ffec6eee4ea4a30bc5c23b/diff:/var/lib/docker/overlay2/747f43a685d2f38c212e70ef49e7e59730b4f4cabd5e63ae46807858fb7416c2/diff:/var/lib/docker/overlay2/e3dd7ce6b7619d404a8016452c1339ac3a8b5ff6d74721cf74dd2610aeecaf24/diff:/var/lib/docker/overlay2/9832c9080b6a09fe7cee301be3214fa21d1f77c0019c15be1efb714308c42797/diff:/var/lib/docker/overlay2/abc16a6903a70a34b5812745700fcbda9be050b9a8a26de93bedfc47906ffcb1/diff:/var/lib/docker/overlay2/0acb42218e17061c02faef3cce0d2ad9c464f99d4e7457e3a7767ba9cb6bb4dc/diff
-          MergedDir: /var/lib/docker/overlay2/3037a38d5893b90e7d1b27fc24bcf68eaaf90054886e7f2ec471dcca73e31ec4/merged
-          UpperDir: /var/lib/docker/overlay2/3037a38d5893b90e7d1b27fc24bcf68eaaf90054886e7f2ec471dcca73e31ec4/diff
-          WorkDir: /var/lib/docker/overlay2/3037a38d5893b90e7d1b27fc24bcf68eaaf90054886e7f2ec471dcca73e31ec4/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds:
-          - /etc/squid/squid.conf:/etc/squid/squid.conf
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: [ ]
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: [ ]
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: default
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings:
-          3128/tcp:
-            - HostIp: ''
-              HostPort: '3128'
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: always
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e/hostname
-      HostsPath: /var/lib/docker/containers/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e/hosts
-      Id: 5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e
-      Image: sha256:d279b4072846e89af1dfeb2982addf8c4f2125ad929bb536875e3a32700b86ec
-      LogPath: /var/lib/docker/containers/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /etc/squid/squid.conf
-          Mode: ''
-          Propagation: rprivate
-          RW: true
-          Source: /etc/squid/squid.conf
-          Type: bind
-      Name: /squid
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: 21076edcedd5a281fdfdcea20ceb0deebd79c8f9b7acd6dbf63d6bc43df60753
-        Gateway: 192.168.1.1
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: 192.168.1.2
-        IPPrefixLen: 16
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: 02:42:ac:11:00:02
-        Networks:
-          bridge:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: 21076edcedd5a281fdfdcea20ceb0deebd79c8f9b7acd6dbf63d6bc43df60753
-            Gateway: 192.168.1.1
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: 192.168.1.2
-            IPPrefixLen: 16
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: 02:42:ac:11:00:02
-            NetworkID: 94f751abfb7f44970711b48f26ac62cd3f35c5a6d761bd7dd3415260d57e36cd
-        Ports:
-          3128/tcp:
-            - HostIp: 0.0.0.0
-              HostPort: '3128'
-        SandboxID: f1a2a9a59d7c9b5e5b585c4dacb0e4b19fc39bc4c6e689d20ab35cb7ac2a73f0
-        SandboxKey: /var/run/docker/netns/f1a2a9a59d7c
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: /sbin/entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:37.130445221Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 9821
-        Restarting: false
-        Running: true
-        StartedAt: '2022-04-26T15:56:49.700085318Z'
-        Status: running
-    - AppArmorProfile: ''
-      Args:
-        - redis-server
-      Config:
-        AttachStderr: false
-        AttachStdin: false
-        AttachStdout: false
-        Cmd:
-          - redis-server
-        Domainname: ''
-        Entrypoint:
-          - docker-entrypoint.sh
-        Env:
-          - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-          - GOSU_VERSION=1.12
-          - REDIS_VERSION=6.2.1
-          - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.2.1.tar.gz
-          - REDIS_DOWNLOAD_SHA=cd222505012cce20b25682fca931ec93bd21ae92cb4abfe742cf7b76aa907520
-        ExposedPorts:
-          6379/tcp: { }
-        Hostname: zabbix-server01.novalocal
-        Image: redis
-        Labels: { }
-        OnBuild: null
-        OpenStdin: false
-        StdinOnce: false
-        Tty: false
-        User: ''
-        Volumes:
-          /data: { }
-        WorkingDir: /data
-      Created: '2021-04-13T16:51:14.696486729Z'
-      Driver: overlay2
-      ExecIDs: null
-      GraphDriver:
-        Data:
-          LowerDir: /var/lib/docker/overlay2/db1baf9db7316e0a9b7b03491cd978b0dda7c9aec2eebf4e9829a0a2056bfabe-init/diff:/var/lib/docker/overlay2/104ab6f68facae3a8373b17a6e76b45b955d675613fdade90336b3a7ab2d6db1/diff:/var/lib/docker/overlay2/2b8e77996e65bddfc2da5936f6c4095e78b462f343e876ba50490df00f611686/diff:/var/lib/docker/overlay2/6e9aefc02aa3077dae6431f68b8433839640499e4e8f25c6f7321e99dc792adb/diff:/var/lib/docker/overlay2/6b43154b4a0421bb0f66e0a5bf5c2c5b3f426796dd186da6f68f850efeecbba3/diff:/var/lib/docker/overlay2/f84f191d7dfb84eb8054dda24ae77c8bf5e0e175e4a71a0698fe27fb15f1ce97/diff:/var/lib/docker/overlay2/be15ae743da5ceb540af0fe8675f7fda6066ccf617f62472415601770c67ffd5/diff
-          MergedDir: /var/lib/docker/overlay2/db1baf9db7316e0a9b7b03491cd978b0dda7c9aec2eebf4e9829a0a2056bfabe/merged
-          UpperDir: /var/lib/docker/overlay2/db1baf9db7316e0a9b7b03491cd978b0dda7c9aec2eebf4e9829a0a2056bfabe/diff
-          WorkDir: /var/lib/docker/overlay2/db1baf9db7316e0a9b7b03491cd978b0dda7c9aec2eebf4e9829a0a2056bfabe/work
-        Name: overlay2
-      HostConfig:
-        AutoRemove: false
-        Binds: null
-        BlkioDeviceReadBps: null
-        BlkioDeviceReadIOps: null
-        BlkioDeviceWriteBps: null
-        BlkioDeviceWriteIOps: null
-        BlkioWeight: 0
-        BlkioWeightDevice: [ ]
-        CapAdd: null
-        CapDrop: null
-        Capabilities: null
-        Cgroup: ''
-        CgroupParent: ''
-        ConsoleSize:
-          - 0
-          - 0
-        ContainerIDFile: ''
-        CpuCount: 0
-        CpuPercent: 0
-        CpuPeriod: 0
-        CpuQuota: 0
-        CpuRealtimePeriod: 0
-        CpuRealtimeRuntime: 0
-        CpuShares: 0
-        CpusetCpus: ''
-        CpusetMems: ''
-        DeviceCgroupRules: null
-        DeviceRequests: null
-        Devices: [ ]
-        Dns: [ ]
-        DnsOptions: [ ]
-        DnsSearch: [ ]
-        ExtraHosts: null
-        GroupAdd: null
-        IOMaximumBandwidth: 0
-        IOMaximumIOps: 0
-        IpcMode: private
-        Isolation: ''
-        KernelMemory: 0
-        KernelMemoryTCP: 0
-        Links: null
-        LogConfig:
-          Config: { }
-          Type: json-file
-        MaskedPaths:
-          - /proc/asound
-          - /proc/acpi
-          - /proc/kcore
-          - /proc/keys
-          - /proc/latency_stats
-          - /proc/timer_list
-          - /proc/timer_stats
-          - /proc/sched_debug
-          - /proc/scsi
-          - /sys/firmware
-        Memory: 0
-        MemoryReservation: 0
-        MemorySwap: 0
-        MemorySwappiness: null
-        NanoCpus: 0
-        NetworkMode: host
-        OomKillDisable: false
-        OomScoreAdj: 0
-        PidMode: ''
-        PidsLimit: null
-        PortBindings: { }
-        Privileged: false
-        PublishAllPorts: false
-        ReadonlyPaths:
-          - /proc/bus
-          - /proc/fs
-          - /proc/irq
-          - /proc/sys
-          - /proc/sysrq-trigger
-        ReadonlyRootfs: false
-        RestartPolicy:
-          MaximumRetryCount: 0
-          Name: 'no'
-        Runtime: runc
-        SecurityOpt: null
-        ShmSize: 67108864
-        UTSMode: ''
-        Ulimits: null
-        UsernsMode: ''
-        VolumeDriver: ''
-        VolumesFrom: null
-      HostnamePath: /var/lib/docker/containers/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c/hostname
-      HostsPath: /var/lib/docker/containers/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c/hosts
-      Id: 7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c
-      Image: sha256:de974760ddb2f32dbddb74b7bb8cff4c1eee06d43d36d11bbca1dc815173916e
-      LogPath: /var/lib/docker/containers/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c-json.log
-      MountLabel: ''
-      Mounts:
-        - Destination: /data
-          Driver: local
-          Mode: ''
-          Name: d9e6b17123459d77464f45d119e05a218e42452871dc9f23ce0a91c3c12ae574
-          Propagation: ''
-          RW: true
-          Source: /var/lib/docker/volumes/d9e6b17123459d77464f45d119e05a218e42452871dc9f23ce0a91c3c12ae574/_data
-          Type: volume
-      Name: /redis
-      NetworkSettings:
-        Bridge: ''
-        EndpointID: ''
-        Gateway: ''
-        GlobalIPv6Address: ''
-        GlobalIPv6PrefixLen: 0
-        HairpinMode: false
-        IPAddress: ''
-        IPPrefixLen: 0
-        IPv6Gateway: ''
-        LinkLocalIPv6Address: ''
-        LinkLocalIPv6PrefixLen: 0
-        MacAddress: ''
-        Networks:
-          host:
-            Aliases: null
-            DriverOpts: null
-            EndpointID: f7047ee19829d4b30ceee6f72a8ca0f6bc086a7e987f5fcfda7bea12c2395063
-            Gateway: ''
-            GlobalIPv6Address: ''
-            GlobalIPv6PrefixLen: 0
-            IPAMConfig: null
-            IPAddress: ''
-            IPPrefixLen: 0
-            IPv6Gateway: ''
-            Links: null
-            MacAddress: ''
-            NetworkID: 9a6482fb028630d923e263f547c71899691e767c4f763aa7c3604f8af8455f60
-        Ports: { }
-        SandboxID: 28523b7d414aed5bc7a0836b88a64593c701e30afac590439500eb76acae14ac
-        SandboxKey: /var/run/docker/netns/default
-        SecondaryIPAddresses: null
-        SecondaryIPv6Addresses: null
-      Path: docker-entrypoint.sh
-      Platform: linux
-      ProcessLabel: ''
-      ResolvConfPath: /var/lib/docker/containers/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c/resolv.conf
-      RestartCount: 0
-      State:
-        Dead: false
-        Error: ''
-        ExitCode: 0
-        FinishedAt: '2022-04-26T15:56:37.12926956Z'
-        OOMKilled: false
-        Paused: false
-        Pid: 4355
-        Restarting: false
-        Running: true
-        StartedAt: '2022-05-29T05:29:55.40255942Z'
-        Status: running
-packages:
-  GeoIP:
-    - arch: x86_64
-      epoch: null
-      name: GeoIP
-      release: 13.el7
-      source: rpm
-      version: 1.5.0
-  OpenIPMI:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
-  OpenIPMI-libs:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI-libs
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
-  OpenIPMI-modalias:
-    - arch: x86_64
-      epoch: null
-      name: OpenIPMI-modalias
-      release: 1.el7
-      source: rpm
-      version: 2.0.27
-  PyYAML:
-    - arch: x86_64
-      epoch: null
-      name: PyYAML
-      release: 11.el7
-      source: rpm
-      version: '3.10'
-  acl:
-    - arch: x86_64
-      epoch: null
-      name: acl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  atomic-registries:
-    - arch: x86_64
-      epoch: 1
-      name: atomic-registries
-      release: 33.gitb507039.el7_8
-      source: rpm
-      version: 1.22.1
-  audit:
-    - arch: x86_64
-      epoch: null
-      name: audit
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  audit-libs-python:
-    - arch: x86_64
-      epoch: null
-      name: audit-libs-python
-      release: 4.el7
-      source: rpm
-      version: 2.8.4
-  authconfig:
-    - arch: x86_64
-      epoch: null
-      name: authconfig
-      release: 30.el7
-      source: rpm
-      version: 6.2.8
-  autogen-libopts:
-    - arch: x86_64
-      epoch: null
-      name: autogen-libopts
-      release: 5.el7
-      source: rpm
-      version: '5.18'
-  basesystem:
-    - arch: noarch
-      epoch: null
-      name: basesystem
-      release: 7.el7.centos
-      source: rpm
-      version: '10.0'
-  bash:
-    - arch: x86_64
-      epoch: null
-      name: bash
-      release: 31.el7
-      source: rpm
-      version: 4.2.46
-  bind-export-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-export-libs
-      release: 26.P2.el7_9.3
-      source: rpm
-      version: 9.11.4
-  bind-libs:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs
-      release: 26.P2.el7_9.3
-      source: rpm
-      version: 9.11.4
-  bind-libs-lite:
-    - arch: x86_64
-      epoch: 32
-      name: bind-libs-lite
-      release: 26.P2.el7_9.3
-      source: rpm
-      version: 9.11.4
-  bind-license:
-    - arch: noarch
-      epoch: 32
-      name: bind-license
-      release: 26.P2.el7_9.3
-      source: rpm
-      version: 9.11.4
-  bind-utils:
-    - arch: x86_64
-      epoch: 32
-      name: bind-utils
-      release: 26.P2.el7_9.3
-      source: rpm
-      version: 9.11.4
-  binutils:
-    - arch: x86_64
-      epoch: null
-      name: binutils
-      release: 34.base.el7
-      source: rpm
-      version: '2.27'
-  btrfs-progs:
-    - arch: x86_64
-      epoch: null
-      name: btrfs-progs
-      release: 1.el7
-      source: rpm
-      version: 4.9.1
-  bzip2-libs:
-    - arch: x86_64
-      epoch: null
-      name: bzip2-libs
-      release: 13.el7
-      source: rpm
-      version: 1.0.6
-  ca-certificates:
-    - arch: noarch
-      epoch: null
-      name: ca-certificates
-      release: 70.0.el7_5
-      source: rpm
-      version: 2018.2.22
-  centos-release:
-    - arch: x86_64
-      epoch: null
-      name: centos-release
-      release: 6.1810.2.el7.centos
-      source: rpm
-      version: '7'
-  checkpolicy:
-    - arch: x86_64
-      epoch: null
-      name: checkpolicy
-      release: 8.el7
-      source: rpm
-      version: '2.5'
-  chkconfig:
-    - arch: x86_64
-      epoch: null
-      name: chkconfig
-      release: 1.el7
-      source: rpm
-      version: 1.7.4
-  chrony:
-    - arch: x86_64
-      epoch: null
-      name: chrony
-      release: 2.el7
-      source: rpm
-      version: '3.2'
-  cloud-init:
-    - arch: x86_64
-      epoch: null
-      name: cloud-init
-      release: 1.el7.centos.2
-      source: rpm
-      version: '18.2'
-  cloud-utils-growpart:
-    - arch: noarch
-      epoch: null
-      name: cloud-utils-growpart
-      release: 2.el7_6.2
-      source: rpm
-      version: '0.29'
-  conmon:
-    - arch: x86_64
-      epoch: 2
-      name: conmon
-      release: 1.el7
-      source: rpm
-      version: 2.0.8
-  container-selinux:
-    - arch: noarch
-      epoch: 2
-      name: container-selinux
-      release: 1.c57a6f9.el7
-      source: rpm
-      version: 2.119.1
-  container-storage-setup:
-    - arch: noarch
-      epoch: null
-      name: container-storage-setup
-      release: 2.git5eaf76c.el7
-      source: rpm
-      version: 0.11.0
-  containerd.io:
-    - arch: x86_64
-      epoch: null
-      name: containerd.io
-      release: 3.1.el7
-      source: rpm
-      version: 1.3.7
-  containernetworking-plugins:
-    - arch: x86_64
-      epoch: null
-      name: containernetworking-plugins
-      release: 4.el7.centos
-      source: rpm
-      version: 0.8.1
-  containers-common:
-    - arch: x86_64
-      epoch: 1
-      name: containers-common
-      release: 7.el7_8
-      source: rpm
-      version: 0.1.40
-  coreutils:
-    - arch: x86_64
-      epoch: null
-      name: coreutils
-      release: 23.el7
-      source: rpm
-      version: '8.22'
-  cpio:
-    - arch: x86_64
-      epoch: null
-      name: cpio
-      release: 27.el7
-      source: rpm
-      version: '2.11'
-  cracklib:
-    - arch: x86_64
-      epoch: null
-      name: cracklib
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  cracklib-dicts:
-    - arch: x86_64
-      epoch: null
-      name: cracklib-dicts
-      release: 11.el7
-      source: rpm
-      version: 2.9.0
-  criu:
-    - arch: x86_64
-      epoch: null
-      name: criu
-      release: 2.el7
-      source: rpm
-      version: '3.12'
-  cronie:
-    - arch: x86_64
-      epoch: null
-      name: cronie
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  cronie-anacron:
-    - arch: x86_64
-      epoch: null
-      name: cronie-anacron
-      release: 20.el7_6
-      source: rpm
-      version: 1.4.11
-  crontabs:
-    - arch: noarch
-      epoch: null
-      name: crontabs
-      release: 6.20121102git.el7
-      source: rpm
-      version: '1.11'
-  cryptsetup-libs:
-    - arch: x86_64
-      epoch: null
-      name: cryptsetup-libs
-      release: 3.el7
-      source: rpm
-      version: 2.0.3
-  curl:
-    - arch: x86_64
-      epoch: null
-      name: curl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  cyrus-sasl-lib:
-    - arch: x86_64
-      epoch: null
-      name: cyrus-sasl-lib
-      release: 23.el7
-      source: rpm
-      version: 2.1.26
-  dbus:
-    - arch: x86_64
-      epoch: 1
-      name: dbus
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-glib:
-    - arch: x86_64
-      epoch: null
-      name: dbus-glib
-      release: 7.el7
-      source: rpm
-      version: '0.100'
-  dbus-libs:
-    - arch: x86_64
-      epoch: 1
-      name: dbus-libs
-      release: 13.el7_6
-      source: rpm
-      version: 1.10.24
-  dbus-python:
-    - arch: x86_64
-      epoch: null
-      name: dbus-python
-      release: 9.el7
-      source: rpm
-      version: 1.1.1
-  device-mapper:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-event:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-event-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-event-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-libs:
-    - arch: x86_64
-      epoch: 7
-      name: device-mapper-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 1.02.164
-  device-mapper-persistent-data:
-    - arch: x86_64
-      epoch: null
-      name: device-mapper-persistent-data
-      release: 2.el7
-      source: rpm
-      version: 0.8.5
-  dhclient:
-    - arch: x86_64
-      epoch: 12
-      name: dhclient
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-common:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-common
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
-  dhcp-libs:
-    - arch: x86_64
-      epoch: 12
-      name: dhcp-libs
-      release: 82.el7.centos
-      source: rpm
-      version: 4.2.5
-  diffutils:
-    - arch: x86_64
-      epoch: null
-      name: diffutils
-      release: 4.el7
-      source: rpm
-      version: '3.3'
-  dmidecode:
-    - arch: x86_64
-      epoch: 1
-      name: dmidecode
-      release: 2.el7
-      source: rpm
-      version: '3.1'
-  docker-ce:
-    - arch: x86_64
-      epoch: 3
-      name: docker-ce
-      release: 3.el7
-      source: rpm
-      version: 19.03.13
-  docker-ce-cli:
-    - arch: x86_64
-      epoch: 1
-      name: docker-ce-cli
-      release: 3.el7
-      source: rpm
-      version: 19.03.13
-  dracut:
-    - arch: x86_64
-      epoch: null
-      name: dracut
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-generic:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-generic
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-config-rescue:
-    - arch: x86_64
-      epoch: null
-      name: dracut-config-rescue
-      release: 554.el7
-      source: rpm
-      version: '033'
-  dracut-network:
-    - arch: x86_64
-      epoch: null
-      name: dracut-network
-      release: 554.el7
-      source: rpm
-      version: '033'
-  e2fsprogs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  e2fsprogs-libs:
-    - arch: x86_64
-      epoch: null
-      name: e2fsprogs-libs
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  elfutils-default-yama-scope:
-    - arch: noarch
-      epoch: null
-      name: elfutils-default-yama-scope
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libelf:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libelf
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  elfutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: elfutils-libs
-      release: 2.el7
-      source: rpm
-      version: '0.172'
-  epel-release:
-    - arch: noarch
-      epoch: null
-      name: epel-release
-      release: '11'
-      source: rpm
-      version: '7'
-  ethtool:
-    - arch: x86_64
-      epoch: 2
-      name: ethtool
-      release: 9.el7
-      source: rpm
-      version: '4.8'
-  expat:
-    - arch: x86_64
-      epoch: null
-      name: expat
-      release: 10.el7_3
-      source: rpm
-      version: 2.1.0
-  file:
-    - arch: x86_64
-      epoch: null
-      name: file
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  file-libs:
-    - arch: x86_64
-      epoch: null
-      name: file-libs
-      release: 35.el7
-      source: rpm
-      version: '5.11'
-  filebeat:
-    - arch: x86_64
-      epoch: null
-      name: filebeat
-      release: '1'
-      source: rpm
-      version: 7.4.2
-  filesystem:
-    - arch: x86_64
-      epoch: null
-      name: filesystem
-      release: 25.el7
-      source: rpm
-      version: '3.2'
-  findutils:
-    - arch: x86_64
-      epoch: 1
-      name: findutils
-      release: 6.el7
-      source: rpm
-      version: 4.5.11
-  fipscheck:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  fipscheck-lib:
-    - arch: x86_64
-      epoch: null
-      name: fipscheck-lib
-      release: 6.el7
-      source: rpm
-      version: 1.4.1
-  forkstat:
-    - arch: x86_64
-      epoch: null
-      name: forkstat
-      release: '1.1'
-      source: rpm
-      version: 0.02.12
-  fping:
-    - arch: x86_64
-      epoch: null
-      name: fping
-      release: 4.el7
-      source: rpm
-      version: '3.10'
-  freetype:
-    - arch: x86_64
-      epoch: null
-      name: freetype
-      release: 12.el7_6.1
-      source: rpm
-      version: '2.8'
-  fuse-overlayfs:
-    - arch: x86_64
-      epoch: null
-      name: fuse-overlayfs
-      release: 6.el7_8
-      source: rpm
-      version: 0.7.2
-  fuse3-libs:
-    - arch: x86_64
-      epoch: null
-      name: fuse3-libs
-      release: 4.el7
-      source: rpm
-      version: 3.6.1
-  gawk:
-    - arch: x86_64
-      epoch: null
-      name: gawk
-      release: 4.el7_3.1
-      source: rpm
-      version: 4.0.2
-  gdbm:
-    - arch: x86_64
-      epoch: null
-      name: gdbm
-      release: 8.el7
-      source: rpm
-      version: '1.10'
-  gettext:
-    - arch: x86_64
-      epoch: null
-      name: gettext
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  gettext-libs:
-    - arch: x86_64
-      epoch: null
-      name: gettext-libs
-      release: 2.el7
-      source: rpm
-      version: 0.19.8.1
-  git:
-    - arch: x86_64
-      epoch: null
-      name: git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  glib2:
-    - arch: x86_64
-      epoch: null
-      name: glib2
-      release: 4.el7_6
-      source: rpm
-      version: 2.56.1
-  glibc:
-    - arch: x86_64
-      epoch: null
-      name: glibc
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  glibc-common:
-    - arch: x86_64
-      epoch: null
-      name: glibc-common
-      release: 260.el7_6.6
-      source: rpm
-      version: '2.17'
-  gmp:
-    - arch: x86_64
-      epoch: 1
-      name: gmp
-      release: 15.el7
-      source: rpm
-      version: 6.0.0
-  gnupg2:
-    - arch: x86_64
-      epoch: null
-      name: gnupg2
-      release: 5.el7_5
-      source: rpm
-      version: 2.0.22
-  gnutls:
-    - arch: x86_64
-      epoch: null
-      name: gnutls
-      release: 9.el7_6
-      source: rpm
-      version: 3.3.29
-  gobject-introspection:
-    - arch: x86_64
-      epoch: null
-      name: gobject-introspection
-      release: 1.el7
-      source: rpm
-      version: 1.56.1
-  gpg-pubkey:
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 58adea78
-      source: rpm
-      version: 621e9f35
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 53a7ff4b
-      source: rpm
-      version: f4a80eb5
-    - arch: null
-      epoch: null
-      name: gpg-pubkey
-      release: 52ae6884
-      source: rpm
-      version: 352c64e5
-  gpgme:
-    - arch: x86_64
-      epoch: null
-      name: gpgme
-      release: 5.el7
-      source: rpm
-      version: 1.3.2
-  gpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: gpm-libs
-      release: 6.el7
-      source: rpm
-      version: 1.20.7
-  grep:
-    - arch: x86_64
-      epoch: null
-      name: grep
-      release: 3.el7
-      source: rpm
-      version: '2.20'
-  groff-base:
-    - arch: x86_64
-      epoch: null
-      name: groff-base
-      release: 8.el7
-      source: rpm
-      version: 1.22.2
-  grub2:
-    - arch: x86_64
-      epoch: 1
-      name: grub2
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-common:
-    - arch: noarch
-      epoch: 1
-      name: grub2-common
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-pc
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-pc-modules:
-    - arch: noarch
-      epoch: 1
-      name: grub2-pc-modules
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-extra:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-extra
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grub2-tools-minimal:
-    - arch: x86_64
-      epoch: 1
-      name: grub2-tools-minimal
-      release: 0.76.el7.centos.1
-      source: rpm
-      version: '2.02'
-  grubby:
-    - arch: x86_64
-      epoch: null
-      name: grubby
-      release: 25.el7
-      source: rpm
-      version: '8.28'
-  gssproxy:
-    - arch: x86_64
-      epoch: null
-      name: gssproxy
-      release: 21.el7
-      source: rpm
-      version: 0.7.0
-  gzip:
-    - arch: x86_64
-      epoch: null
-      name: gzip
-      release: 10.el7
-      source: rpm
-      version: '1.5'
-  hardlink:
-    - arch: x86_64
-      epoch: 1
-      name: hardlink
-      release: 19.el7
-      source: rpm
-      version: '1.0'
-  hostname:
-    - arch: x86_64
-      epoch: null
-      name: hostname
-      release: 3.el7
-      source: rpm
-      version: '3.13'
-  hwdata:
-    - arch: x86_64
-      epoch: null
-      name: hwdata
-      release: 9.1.el7
-      source: rpm
-      version: '0.252'
-  iksemel:
-    - arch: x86_64
-      epoch: null
-      name: iksemel
-      release: 2.el7.centos
-      source: rpm
-      version: '1.4'
-  info:
-    - arch: x86_64
-      epoch: null
-      name: info
-      release: 5.el7
-      source: rpm
-      version: '5.1'
-  initscripts:
-    - arch: x86_64
-      epoch: null
-      name: initscripts
-      release: 1.el7
-      source: rpm
-      version: 9.49.46
-  iometrics-agent:
-    - arch: x86_64
-      epoch: null
-      name: iometrics-agent
-      release: '27'
-      source: rpm
-      version: 1.11.3
-  iotop:
-    - arch: noarch
-      epoch: null
-      name: iotop
-      release: 4.el7
-      source: rpm
-      version: '0.6'
-  iproute:
-    - arch: x86_64
-      epoch: null
-      name: iproute
-      release: 14.el7_6.2
-      source: rpm
-      version: 4.11.0
-  iptables:
-    - arch: x86_64
-      epoch: null
-      name: iptables
-      release: 28.el7
-      source: rpm
-      version: 1.4.21
-  iputils:
-    - arch: x86_64
-      epoch: null
-      name: iputils
-      release: 10.el7
-      source: rpm
-      version: '20160308'
-  irqbalance:
-    - arch: x86_64
-      epoch: 3
-      name: irqbalance
-      release: 11.el7
-      source: rpm
-      version: 1.0.7
-  iwl7265-firmware:
-    - arch: noarch
-      epoch: null
-      name: iwl7265-firmware
-      release: 69.el7
-      source: rpm
-      version: 22.0.7.0
-  jansson:
-    - arch: x86_64
-      epoch: null
-      name: jansson
-      release: 1.el7
-      source: rpm
-      version: '2.10'
-  jq:
-    - arch: x86_64
-      epoch: null
-      name: jq
-      release: 2.el7
-      source: rpm
-      version: '1.6'
-  json-c:
-    - arch: x86_64
-      epoch: null
-      name: json-c
-      release: 4.el7_0
-      source: rpm
-      version: '0.11'
-  kbd:
-    - arch: x86_64
-      epoch: null
-      name: kbd
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-legacy:
-    - arch: noarch
-      epoch: null
-      name: kbd-legacy
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kbd-misc:
-    - arch: noarch
-      epoch: null
-      name: kbd-misc
-      release: 15.el7
-      source: rpm
-      version: 1.15.5
-  kernel:
-    - arch: x86_64
-      epoch: null
-      name: kernel
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kernel-tools-libs:
-    - arch: x86_64
-      epoch: null
-      name: kernel-tools-libs
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  kexec-tools:
-    - arch: x86_64
-      epoch: null
-      name: kexec-tools
-      release: 21.el7_6.4
-      source: rpm
-      version: 2.0.15
-  keyutils:
-    - arch: x86_64
-      epoch: null
-      name: keyutils
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  keyutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: keyutils-libs
-      release: 3.el7
-      source: rpm
-      version: 1.5.8
-  kmod:
-    - arch: x86_64
-      epoch: null
-      name: kmod
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kmod-libs:
-    - arch: x86_64
-      epoch: null
-      name: kmod-libs
-      release: 23.el7
-      source: rpm
-      version: '20'
-  kpartx:
-    - arch: x86_64
-      epoch: null
-      name: kpartx
-      release: 123.el7
-      source: rpm
-      version: 0.4.9
-  krb5-libs:
-    - arch: x86_64
-      epoch: null
-      name: krb5-libs
-      release: 37.el7_6
-      source: rpm
-      version: 1.15.1
-  less:
-    - arch: x86_64
-      epoch: null
-      name: less
-      release: 9.el7
-      source: rpm
-      version: '458'
-  libacl:
-    - arch: x86_64
-      epoch: null
-      name: libacl
-      release: 14.el7
-      source: rpm
-      version: 2.2.51
-  libaio:
-    - arch: x86_64
-      epoch: null
-      name: libaio
-      release: 13.el7
-      source: rpm
-      version: 0.3.109
-  libassuan:
-    - arch: x86_64
-      epoch: null
-      name: libassuan
-      release: 3.el7
-      source: rpm
-      version: 2.1.0
-  libattr:
-    - arch: x86_64
-      epoch: null
-      name: libattr
-      release: 13.el7
-      source: rpm
-      version: 2.4.46
-  libbasicobjects:
-    - arch: x86_64
-      epoch: null
-      name: libbasicobjects
-      release: 32.el7
-      source: rpm
-      version: 0.1.1
-  libblkid:
-    - arch: x86_64
-      epoch: null
-      name: libblkid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libcap:
-    - arch: x86_64
-      epoch: null
-      name: libcap
-      release: 9.el7
-      source: rpm
-      version: '2.22'
-  libcap-ng:
-    - arch: x86_64
-      epoch: null
-      name: libcap-ng
-      release: 4.el7
-      source: rpm
-      version: 0.7.5
-  libcgroup:
-    - arch: x86_64
-      epoch: null
-      name: libcgroup
-      release: 20.el7
-      source: rpm
-      version: '0.41'
-  libcollection:
-    - arch: x86_64
-      epoch: null
-      name: libcollection
-      release: 32.el7
-      source: rpm
-      version: 0.7.0
-  libcom_err:
-    - arch: x86_64
-      epoch: null
-      name: libcom_err
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libcroco:
-    - arch: x86_64
-      epoch: null
-      name: libcroco
-      release: 4.el7
-      source: rpm
-      version: 0.6.12
-  libcurl:
-    - arch: x86_64
-      epoch: null
-      name: libcurl
-      release: 51.el7_6.3
-      source: rpm
-      version: 7.29.0
-  libdaemon:
-    - arch: x86_64
-      epoch: null
-      name: libdaemon
-      release: 7.el7
-      source: rpm
-      version: '0.14'
-  libdb:
-    - arch: x86_64
-      epoch: null
-      name: libdb
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libdb-utils:
-    - arch: x86_64
-      epoch: null
-      name: libdb-utils
-      release: 24.el7
-      source: rpm
-      version: 5.3.21
-  libedit:
-    - arch: x86_64
-      epoch: null
-      name: libedit
-      release: 12.20121213cvs.el7
-      source: rpm
-      version: '3.0'
-  libestr:
-    - arch: x86_64
-      epoch: null
-      name: libestr
-      release: 2.el7
-      source: rpm
-      version: 0.1.9
-  libevent:
-    - arch: x86_64
-      epoch: null
-      name: libevent
-      release: 4.el7
-      source: rpm
-      version: 2.0.21
-  libfastjson:
-    - arch: x86_64
-      epoch: null
-      name: libfastjson
-      release: 3.el7
-      source: rpm
-      version: 0.99.4
-  libffi:
-    - arch: x86_64
-      epoch: null
-      name: libffi
-      release: 18.el7
-      source: rpm
-      version: 3.0.13
-  libgcc:
-    - arch: x86_64
-      epoch: null
-      name: libgcc
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgcrypt:
-    - arch: x86_64
-      epoch: null
-      name: libgcrypt
-      release: 14.el7
-      source: rpm
-      version: 1.5.3
-  libgomp:
-    - arch: x86_64
-      epoch: null
-      name: libgomp
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libgpg-error:
-    - arch: x86_64
-      epoch: null
-      name: libgpg-error
-      release: 3.el7
-      source: rpm
-      version: '1.12'
-  libidn:
-    - arch: x86_64
-      epoch: null
-      name: libidn
-      release: 4.el7
-      source: rpm
-      version: '1.28'
-  libini_config:
-    - arch: x86_64
-      epoch: null
-      name: libini_config
-      release: 32.el7
-      source: rpm
-      version: 1.3.1
-  libmnl:
-    - arch: x86_64
-      epoch: null
-      name: libmnl
-      release: 7.el7
-      source: rpm
-      version: 1.0.3
-  libmount:
-    - arch: x86_64
-      epoch: null
-      name: libmount
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libndp:
-    - arch: x86_64
-      epoch: null
-      name: libndp
-      release: 7.el7
-      source: rpm
-      version: '1.2'
-  libnet:
-    - arch: x86_64
-      epoch: null
-      name: libnet
-      release: 7.el7
-      source: rpm
-      version: 1.1.6
-  libnetfilter_conntrack:
-    - arch: x86_64
-      epoch: null
-      name: libnetfilter_conntrack
-      release: 1.el7_3
-      source: rpm
-      version: 1.0.6
-  libnfnetlink:
-    - arch: x86_64
-      epoch: null
-      name: libnfnetlink
-      release: 4.el7
-      source: rpm
-      version: 1.0.1
-  libnfsidmap:
-    - arch: x86_64
-      epoch: null
-      name: libnfsidmap
-      release: 19.el7
-      source: rpm
-      version: '0.25'
-  libnftnl:
-    - arch: x86_64
-      epoch: null
-      name: libnftnl
-      release: 3.el7
-      source: rpm
-      version: 1.0.8
-  libnl:
-    - arch: x86_64
-      epoch: null
-      name: libnl
-      release: 3.el7
-      source: rpm
-      version: 1.1.4
-  libnl3:
-    - arch: x86_64
-      epoch: null
-      name: libnl3
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libnl3-cli:
-    - arch: x86_64
-      epoch: null
-      name: libnl3-cli
-      release: 4.el7
-      source: rpm
-      version: 3.2.28
-  libpath_utils:
-    - arch: x86_64
-      epoch: null
-      name: libpath_utils
-      release: 32.el7
-      source: rpm
-      version: 0.2.1
-  libpcap:
-    - arch: x86_64
-      epoch: 14
-      name: libpcap
-      release: 12.el7
-      source: rpm
-      version: 1.5.3
-  libpipeline:
-    - arch: x86_64
-      epoch: null
-      name: libpipeline
-      release: 3.el7
-      source: rpm
-      version: 1.2.3
-  libpng:
-    - arch: x86_64
-      epoch: 2
-      name: libpng
-      release: 7.el7_2
-      source: rpm
-      version: 1.5.13
-  libpwquality:
-    - arch: x86_64
-      epoch: null
-      name: libpwquality
-      release: 5.el7
-      source: rpm
-      version: 1.2.3
-  libref_array:
-    - arch: x86_64
-      epoch: null
-      name: libref_array
-      release: 32.el7
-      source: rpm
-      version: 0.1.5
-  libseccomp:
-    - arch: x86_64
-      epoch: null
-      name: libseccomp
-      release: 3.el7
-      source: rpm
-      version: 2.3.1
-  libselinux:
-    - arch: x86_64
-      epoch: null
-      name: libselinux
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-python3:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-python3
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libselinux-utils:
-    - arch: x86_64
-      epoch: null
-      name: libselinux-utils
-      release: 15.el7
-      source: rpm
-      version: '2.5'
-  libsemanage:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsemanage-python:
-    - arch: x86_64
-      epoch: null
-      name: libsemanage-python
-      release: 14.el7
-      source: rpm
-      version: '2.5'
-  libsepol:
-    - arch: x86_64
-      epoch: null
-      name: libsepol
-      release: 10.el7
-      source: rpm
-      version: '2.5'
-  libsmartcols:
-    - arch: x86_64
-      epoch: null
-      name: libsmartcols
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libss:
-    - arch: x86_64
-      epoch: null
-      name: libss
-      release: 13.el7
-      source: rpm
-      version: 1.42.9
-  libssh2:
-    - arch: x86_64
-      epoch: null
-      name: libssh2
-      release: 12.el7_6.3
-      source: rpm
-      version: 1.4.3
-  libstdc++:
-    - arch: x86_64
-      epoch: null
-      name: libstdc++
-      release: 36.el7_6.2
-      source: rpm
-      version: 4.8.5
-  libsysfs:
-    - arch: x86_64
-      epoch: null
-      name: libsysfs
-      release: 16.el7
-      source: rpm
-      version: 2.1.0
-  libtasn1:
-    - arch: x86_64
-      epoch: null
-      name: libtasn1
-      release: 1.el7
-      source: rpm
-      version: '4.10'
-  libteam:
-    - arch: x86_64
-      epoch: null
-      name: libteam
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  libtirpc:
-    - arch: x86_64
-      epoch: null
-      name: libtirpc
-      release: 0.15.el7
-      source: rpm
-      version: 0.2.4
-  libtool-ltdl:
-    - arch: x86_64
-      epoch: null
-      name: libtool-ltdl
-      release: 22.el7_3
-      source: rpm
-      version: 2.4.2
-  libunistring:
-    - arch: x86_64
-      epoch: null
-      name: libunistring
-      release: 9.el7
-      source: rpm
-      version: 0.9.3
-  libuser:
-    - arch: x86_64
-      epoch: null
-      name: libuser
-      release: 9.el7
-      source: rpm
-      version: '0.60'
-  libutempter:
-    - arch: x86_64
-      epoch: null
-      name: libutempter
-      release: 4.el7
-      source: rpm
-      version: 1.1.6
-  libuuid:
-    - arch: x86_64
-      epoch: null
-      name: libuuid
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  libverto:
-    - arch: x86_64
-      epoch: null
-      name: libverto
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libverto-libevent:
-    - arch: x86_64
-      epoch: null
-      name: libverto-libevent
-      release: 4.el7
-      source: rpm
-      version: 0.2.5
-  libxml2:
-    - arch: x86_64
-      epoch: null
-      name: libxml2
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libxml2-python:
-    - arch: x86_64
-      epoch: null
-      name: libxml2-python
-      release: 6.el7_2.3
-      source: rpm
-      version: 2.9.1
-  libyaml:
-    - arch: x86_64
-      epoch: null
-      name: libyaml
-      release: 11.el7_0
-      source: rpm
-      version: 0.1.4
-  lm_sensors-libs:
-    - arch: x86_64
-      epoch: null
-      name: lm_sensors-libs
-      release: 8.20160601gitf9185e5.el7
-      source: rpm
-      version: 3.4.0
-  logrotate:
-    - arch: x86_64
-      epoch: null
-      name: logrotate
-      release: 17.el7
-      source: rpm
-      version: 3.8.6
-  lshw:
-    - arch: x86_64
-      epoch: null
-      name: lshw
-      release: 12.el7
-      source: rpm
-      version: B.02.18
-  lua:
-    - arch: x86_64
-      epoch: null
-      name: lua
-      release: 15.el7
-      source: rpm
-      version: 5.1.4
-  lvm2:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2
-      release: 7.el7_8.2
-      source: rpm
-      version: 2.02.186
-  lvm2-libs:
-    - arch: x86_64
-      epoch: 7
-      name: lvm2-libs
-      release: 7.el7_8.2
-      source: rpm
-      version: 2.02.186
-  lz4:
-    - arch: x86_64
-      epoch: null
-      name: lz4
-      release: 2.el7
-      source: rpm
-      version: 1.7.5
-  lzo:
-    - arch: x86_64
-      epoch: null
-      name: lzo
-      release: 8.el7
-      source: rpm
-      version: '2.06'
-  make:
-    - arch: x86_64
-      epoch: 1
-      name: make
-      release: 23.el7
-      source: rpm
-      version: '3.82'
-  man-db:
-    - arch: x86_64
-      epoch: null
-      name: man-db
-      release: 11.el7
-      source: rpm
-      version: 2.6.3
-  mariadb-libs:
-    - arch: x86_64
-      epoch: 1
-      name: mariadb-libs
-      release: 1.el7_5
-      source: rpm
-      version: 5.5.60
-  microcode_ctl:
-    - arch: x86_64
-      epoch: 2
-      name: microcode_ctl
-      release: 47.5.el7_6
-      source: rpm
-      version: '2.1'
-  mozjs17:
-    - arch: x86_64
-      epoch: null
-      name: mozjs17
-      release: 20.el7
-      source: rpm
-      version: 17.0.0
-  ncurses:
-    - arch: x86_64
-      epoch: null
-      name: ncurses
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-base:
-    - arch: noarch
-      epoch: null
-      name: ncurses-base
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  ncurses-libs:
-    - arch: x86_64
-      epoch: null
-      name: ncurses-libs
-      release: 14.20130511.el7_4
-      source: rpm
-      version: '5.9'
-  net-snmp-libs:
-    - arch: x86_64
-      epoch: 1
-      name: net-snmp-libs
-      release: 48.el7_8
-      source: rpm
-      version: 5.7.2
-  net-tools:
-    - arch: x86_64
-      epoch: null
-      name: net-tools
-      release: 0.24.20131004git.el7
-      source: rpm
-      version: '2.0'
-  nettle:
-    - arch: x86_64
-      epoch: null
-      name: nettle
-      release: 8.el7
-      source: rpm
-      version: 2.7.1
-  newt:
-    - arch: x86_64
-      epoch: null
-      name: newt
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  newt-python:
-    - arch: x86_64
-      epoch: null
-      name: newt-python
-      release: 4.el7
-      source: rpm
-      version: 0.52.15
-  nfs-utils:
-    - arch: x86_64
-      epoch: 1
-      name: nfs-utils
-      release: 0.61.el7
-      source: rpm
-      version: 1.3.0
-  nftables:
-    - arch: x86_64
-      epoch: 1
-      name: nftables
-      release: 14.el7
-      source: rpm
-      version: '0.8'
-  ngrep:
-    - arch: x86_64
-      epoch: null
-      name: ngrep
-      release: 1.1.20180101git9b59468.el7
-      source: rpm
-      version: '1.47'
-  nmap-ncat:
-    - arch: x86_64
-      epoch: 2
-      name: nmap-ncat
-      release: 19.el7
-      source: rpm
-      version: '6.40'
-  nspr:
-    - arch: x86_64
-      epoch: null
-      name: nspr
-      release: 1.el7_5
-      source: rpm
-      version: 4.19.0
-  nss:
-    - arch: x86_64
-      epoch: null
-      name: nss
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-pem:
-    - arch: x86_64
-      epoch: null
-      name: nss-pem
-      release: 5.el7_6.1
-      source: rpm
-      version: 1.0.3
-  nss-softokn:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-softokn-freebl:
-    - arch: x86_64
-      epoch: null
-      name: nss-softokn-freebl
-      release: 5.el7_5
-      source: rpm
-      version: 3.36.0
-  nss-sysinit:
-    - arch: x86_64
-      epoch: null
-      name: nss-sysinit
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-tools:
-    - arch: x86_64
-      epoch: null
-      name: nss-tools
-      release: 7.1.el7_6
-      source: rpm
-      version: 3.36.0
-  nss-util:
-    - arch: x86_64
-      epoch: null
-      name: nss-util
-      release: 1.1.el7_6
-      source: rpm
-      version: 3.36.0
-  ntp:
-    - arch: x86_64
-      epoch: null
-      name: ntp
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  ntpdate:
-    - arch: x86_64
-      epoch: null
-      name: ntpdate
-      release: 29.el7.centos.2
-      source: rpm
-      version: 4.2.6p5
-  numactl-libs:
-    - arch: x86_64
-      epoch: null
-      name: numactl-libs
-      release: 7.el7
-      source: rpm
-      version: 2.0.9
-  oci-register-machine:
-    - arch: x86_64
-      epoch: 1
-      name: oci-register-machine
-      release: 6.git2b44233.el7
-      source: rpm
-      version: '0'
-  oci-systemd-hook:
-    - arch: x86_64
-      epoch: 1
-      name: oci-systemd-hook
-      release: 1.git05e6923.el7_6
-      source: rpm
-      version: 0.2.0
-  oci-umount:
-    - arch: x86_64
-      epoch: 2
-      name: oci-umount
-      release: 3.el7
-      source: rpm
-      version: '2.5'
-  oniguruma:
-    - arch: x86_64
-      epoch: null
-      name: oniguruma
-      release: 1.el7
-      source: rpm
-      version: 6.8.2
-  openldap:
-    - arch: x86_64
-      epoch: null
-      name: openldap
-      release: 21.el7_6
-      source: rpm
-      version: 2.4.44
-  openssh:
-    - arch: x86_64
-      epoch: null
-      name: openssh
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-clients:
-    - arch: x86_64
-      epoch: null
-      name: openssh-clients
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssh-server:
-    - arch: x86_64
-      epoch: null
-      name: openssh-server
-      release: 16.el7
-      source: rpm
-      version: 7.4p1
-  openssl:
-    - arch: x86_64
-      epoch: 1
-      name: openssl
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  openssl-libs:
-    - arch: x86_64
-      epoch: 1
-      name: openssl-libs
-      release: 16.el7_6.1
-      source: rpm
-      version: 1.0.2k
-  os-prober:
-    - arch: x86_64
-      epoch: null
-      name: os-prober
-      release: 9.el7
-      source: rpm
-      version: '1.58'
-  p11-kit:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  p11-kit-trust:
-    - arch: x86_64
-      epoch: null
-      name: p11-kit-trust
-      release: 3.el7
-      source: rpm
-      version: 0.23.5
-  pam:
-    - arch: x86_64
-      epoch: null
-      name: pam
-      release: 22.el7
-      source: rpm
-      version: 1.1.8
-  parted:
-    - arch: x86_64
-      epoch: null
-      name: parted
-      release: 29.el7
-      source: rpm
-      version: '3.1'
-  passwd:
-    - arch: x86_64
-      epoch: null
-      name: passwd
-      release: 4.el7
-      source: rpm
-      version: '0.79'
-  pciutils-libs:
-    - arch: x86_64
-      epoch: null
-      name: pciutils-libs
-      release: 3.el7
-      source: rpm
-      version: 3.5.1
-  pcre:
-    - arch: x86_64
-      epoch: null
-      name: pcre
-      release: 17.el7
-      source: rpm
-      version: '8.32'
-  perl:
-    - arch: x86_64
-      epoch: 4
-      name: perl
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-Carp:
-    - arch: noarch
-      epoch: null
-      name: perl-Carp
-      release: 244.el7
-      source: rpm
-      version: '1.26'
-  perl-Encode:
-    - arch: x86_64
-      epoch: null
-      name: perl-Encode
-      release: 7.el7
-      source: rpm
-      version: '2.51'
-  perl-Error:
-    - arch: noarch
-      epoch: 1
-      name: perl-Error
-      release: 2.el7
-      source: rpm
-      version: '0.17020'
-  perl-Exporter:
-    - arch: noarch
-      epoch: null
-      name: perl-Exporter
-      release: 3.el7
-      source: rpm
-      version: '5.68'
-  perl-File-Path:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Path
-      release: 2.el7
-      source: rpm
-      version: '2.09'
-  perl-File-Temp:
-    - arch: noarch
-      epoch: null
-      name: perl-File-Temp
-      release: 3.el7
-      source: rpm
-      version: 0.23.01
-  perl-Filter:
-    - arch: x86_64
-      epoch: null
-      name: perl-Filter
-      release: 3.el7
-      source: rpm
-      version: '1.49'
-  perl-Getopt-Long:
-    - arch: noarch
-      epoch: null
-      name: perl-Getopt-Long
-      release: 3.el7
-      source: rpm
-      version: '2.40'
-  perl-Git:
-    - arch: noarch
-      epoch: null
-      name: perl-Git
-      release: 23.el7_8
-      source: rpm
-      version: 1.8.3.1
-  perl-HTTP-Tiny:
-    - arch: noarch
-      epoch: null
-      name: perl-HTTP-Tiny
-      release: 3.el7
-      source: rpm
-      version: '0.033'
-  perl-PathTools:
-    - arch: x86_64
-      epoch: null
-      name: perl-PathTools
-      release: 5.el7
-      source: rpm
-      version: '3.40'
-  perl-Pod-Escapes:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Escapes
-      release: 295.el7
-      source: rpm
-      version: '1.04'
-  perl-Pod-Perldoc:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Perldoc
-      release: 4.el7
-      source: rpm
-      version: '3.20'
-  perl-Pod-Simple:
-    - arch: noarch
-      epoch: 1
-      name: perl-Pod-Simple
-      release: 4.el7
-      source: rpm
-      version: '3.28'
-  perl-Pod-Usage:
-    - arch: noarch
-      epoch: null
-      name: perl-Pod-Usage
-      release: 3.el7
-      source: rpm
-      version: '1.63'
-  perl-Scalar-List-Utils:
-    - arch: x86_64
-      epoch: null
-      name: perl-Scalar-List-Utils
-      release: 248.el7
-      source: rpm
-      version: '1.27'
-  perl-Socket:
-    - arch: x86_64
-      epoch: null
-      name: perl-Socket
-      release: 5.el7
-      source: rpm
-      version: '2.010'
-  perl-Storable:
-    - arch: x86_64
-      epoch: null
-      name: perl-Storable
-      release: 3.el7
-      source: rpm
-      version: '2.45'
-  perl-TermReadKey:
-    - arch: x86_64
-      epoch: null
-      name: perl-TermReadKey
-      release: 20.el7
-      source: rpm
-      version: '2.30'
-  perl-Text-ParseWords:
-    - arch: noarch
-      epoch: null
-      name: perl-Text-ParseWords
-      release: 4.el7
-      source: rpm
-      version: '3.29'
-  perl-Time-HiRes:
-    - arch: x86_64
-      epoch: 4
-      name: perl-Time-HiRes
-      release: 3.el7
-      source: rpm
-      version: '1.9725'
-  perl-Time-Local:
-    - arch: noarch
-      epoch: null
-      name: perl-Time-Local
-      release: 2.el7
-      source: rpm
-      version: '1.2300'
-  perl-constant:
-    - arch: noarch
-      epoch: null
-      name: perl-constant
-      release: 2.el7
-      source: rpm
-      version: '1.27'
-  perl-libs:
-    - arch: x86_64
-      epoch: 4
-      name: perl-libs
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-macros:
-    - arch: x86_64
-      epoch: 4
-      name: perl-macros
-      release: 295.el7
-      source: rpm
-      version: 5.16.3
-  perl-parent:
-    - arch: noarch
-      epoch: 1
-      name: perl-parent
-      release: 244.el7
-      source: rpm
-      version: '0.225'
-  perl-podlators:
-    - arch: noarch
-      epoch: null
-      name: perl-podlators
-      release: 3.el7
-      source: rpm
-      version: 2.5.1
-  perl-threads:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads
-      release: 4.el7
-      source: rpm
-      version: '1.87'
-  perl-threads-shared:
-    - arch: x86_64
-      epoch: null
-      name: perl-threads-shared
-      release: 6.el7
-      source: rpm
-      version: '1.43'
-  pinentry:
-    - arch: x86_64
-      epoch: null
-      name: pinentry
-      release: 17.el7
-      source: rpm
-      version: 0.8.1
-  pkgconfig:
-    - arch: x86_64
-      epoch: 1
-      name: pkgconfig
-      release: 4.el7
-      source: rpm
-      version: 0.27.1
-  podman:
-    - arch: x86_64
-      epoch: null
-      name: podman
-      release: 16.el7_8
-      source: rpm
-      version: 1.6.4
-  policycoreutils:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  policycoreutils-python:
-    - arch: x86_64
-      epoch: null
-      name: policycoreutils-python
-      release: 29.el7_6.1
-      source: rpm
-      version: '2.5'
-  polkit:
-    - arch: x86_64
-      epoch: null
-      name: polkit
-      release: 18.el7_6.1
-      source: rpm
-      version: '0.112'
-  polkit-pkla-compat:
-    - arch: x86_64
-      epoch: null
-      name: polkit-pkla-compat
-      release: 4.el7
-      source: rpm
-      version: '0.1'
-  popt:
-    - arch: x86_64
-      epoch: null
-      name: popt
-      release: 16.el7
-      source: rpm
-      version: '1.13'
-  postfix:
-    - arch: x86_64
-      epoch: 2
-      name: postfix
-      release: 7.el7
-      source: rpm
-      version: 2.10.1
-  postgresql:
-    - arch: x86_64
-      epoch: null
-      name: postgresql
-      release: 4.el7_8
-      source: rpm
-      version: 9.2.24
-  postgresql-libs:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-libs
-      release: 4.el7_8
-      source: rpm
-      version: 9.2.24
-  postgresql-odbc:
-    - arch: x86_64
-      epoch: null
-      name: postgresql-odbc
-      release: 2.el7
-      source: rpm
-      version: 09.03.0100
-  procps-ng:
-    - arch: x86_64
-      epoch: null
-      name: procps-ng
-      release: 23.el7
-      source: rpm
-      version: 3.3.10
-  protobuf-c:
-    - arch: x86_64
-      epoch: null
-      name: protobuf-c
-      release: 3.el7
-      source: rpm
-      version: 1.0.2
-  pth:
-    - arch: x86_64
-      epoch: null
-      name: pth
-      release: 23.el7
-      source: rpm
-      version: 2.0.7
-  pygpgme:
-    - arch: x86_64
-      epoch: null
-      name: pygpgme
-      release: 9.el7
-      source: rpm
-      version: '0.3'
-  pyliblzma:
-    - arch: x86_64
-      epoch: null
-      name: pyliblzma
-      release: 11.el7
-      source: rpm
-      version: 0.5.3
-  pyserial:
-    - arch: noarch
-      epoch: null
-      name: pyserial
-      release: 6.el7
-      source: rpm
-      version: '2.6'
-  python:
-    - arch: x86_64
-      epoch: null
-      name: python
-      release: 88.el7
-      source: rpm
-      version: 2.7.5
-  python-IPy:
-    - arch: noarch
-      epoch: null
-      name: python-IPy
-      release: 6.el7
-      source: rpm
-      version: '0.75'
-  python-babel:
-    - arch: noarch
-      epoch: null
-      name: python-babel
-      release: 8.el7
-      source: rpm
-      version: 0.9.6
-  python-backports:
-    - arch: x86_64
-      epoch: null
-      name: python-backports
-      release: 8.el7
-      source: rpm
-      version: '1.0'
-  python-backports-ssl_match_hostname:
-    - arch: noarch
-      epoch: null
-      name: python-backports-ssl_match_hostname
-      release: 1.el7
-      source: rpm
-      version: 3.5.0.1
-  python-chardet:
-    - arch: noarch
-      epoch: null
-      name: python-chardet
-      release: 1.el7_1
-      source: rpm
-      version: 2.2.1
-  python-configobj:
-    - arch: noarch
-      epoch: null
-      name: python-configobj
-      release: 7.el7
-      source: rpm
-      version: 4.7.2
-  python-dateutil:
-    - arch: noarch
-      epoch: null
-      name: python-dateutil
-      release: 7.el7
-      source: rpm
-      version: '1.5'
-  python-decorator:
-    - arch: noarch
-      epoch: null
-      name: python-decorator
-      release: 3.el7
-      source: rpm
-      version: 3.4.0
-  python-devel:
-    - arch: x86_64
-      epoch: null
-      name: python-devel
-      release: 88.el7
-      source: rpm
-      version: 2.7.5
-  python-dmidecode:
-    - arch: x86_64
-      epoch: null
-      name: python-dmidecode
-      release: 4.el7
-      source: rpm
-      version: 3.12.2
-  python-docker-py:
-    - arch: noarch
-      epoch: 1
-      name: python-docker-py
-      release: 11.el7
-      source: rpm
-      version: 1.10.6
-  python-docker-pycreds:
-    - arch: noarch
-      epoch: 1
-      name: python-docker-pycreds
-      release: 11.el7
-      source: rpm
-      version: 0.3.0
-  python-ethtool:
-    - arch: x86_64
-      epoch: null
-      name: python-ethtool
-      release: 8.el7
-      source: rpm
-      version: '0.8'
-  python-gobject-base:
-    - arch: x86_64
-      epoch: null
-      name: python-gobject-base
-      release: 1.el7_4.1
-      source: rpm
-      version: 3.22.0
-  python-iniparse:
-    - arch: noarch
-      epoch: null
-      name: python-iniparse
-      release: 9.el7
-      source: rpm
-      version: '0.4'
-  python-inotify:
-    - arch: noarch
-      epoch: null
-      name: python-inotify
-      release: 4.el7
-      source: rpm
-      version: 0.9.4
-  python-ipaddress:
-    - arch: noarch
-      epoch: null
-      name: python-ipaddress
-      release: 2.el7
-      source: rpm
-      version: 1.0.16
-  python-jinja2:
-    - arch: noarch
-      epoch: null
-      name: python-jinja2
-      release: 3.el7_6
-      source: rpm
-      version: 2.7.2
-  python-jsonpatch:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpatch
-      release: 4.el7
-      source: rpm
-      version: '1.2'
-  python-jsonpointer:
-    - arch: noarch
-      epoch: null
-      name: python-jsonpointer
-      release: 2.el7
-      source: rpm
-      version: '1.9'
-  python-kitchen:
-    - arch: noarch
-      epoch: null
-      name: python-kitchen
-      release: 5.el7
-      source: rpm
-      version: 1.1.1
-  python-libs:
-    - arch: x86_64
-      epoch: null
-      name: python-libs
-      release: 88.el7
-      source: rpm
-      version: 2.7.5
-  python-linux-procfs:
-    - arch: noarch
-      epoch: null
-      name: python-linux-procfs
-      release: 4.el7
-      source: rpm
-      version: 0.4.9
-  python-markupsafe:
-    - arch: x86_64
-      epoch: null
-      name: python-markupsafe
-      release: 10.el7
-      source: rpm
-      version: '0.11'
-  python-perf:
-    - arch: x86_64
-      epoch: null
-      name: python-perf
-      release: 957.27.2.el7
-      source: rpm
-      version: 3.10.0
-  python-prettytable:
-    - arch: noarch
-      epoch: null
-      name: python-prettytable
-      release: 3.el7
-      source: rpm
-      version: 0.7.2
-  python-pycurl:
-    - arch: x86_64
-      epoch: null
-      name: python-pycurl
-      release: 19.el7
-      source: rpm
-      version: 7.19.0
-  python-pytoml:
-    - arch: noarch
-      epoch: null
-      name: python-pytoml
-      release: 1.git7dea353.el7
-      source: rpm
-      version: 0.1.14
-  python-pyudev:
-    - arch: noarch
-      epoch: null
-      name: python-pyudev
-      release: 9.el7
-      source: rpm
-      version: '0.15'
-  python-requests:
-    - arch: noarch
-      epoch: null
-      name: python-requests
-      release: 1.el7_1
-      source: rpm
-      version: 2.6.0
-  python-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-rpm-macros
-      release: 32.el7
-      source: rpm
-      version: '3'
-  python-schedutils:
-    - arch: x86_64
-      epoch: null
-      name: python-schedutils
-      release: 6.el7
-      source: rpm
-      version: '0.4'
-  python-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python-setuptools
-      release: 7.el7
-      source: rpm
-      version: 0.9.8
-  python-six:
-    - arch: noarch
-      epoch: null
-      name: python-six
-      release: 2.el7
-      source: rpm
-      version: 1.9.0
-  python-srpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python-srpm-macros
-      release: 32.el7
-      source: rpm
-      version: '3'
-  python-syspurpose:
-    - arch: x86_64
-      epoch: null
-      name: python-syspurpose
-      release: 3.el7.centos
-      source: rpm
-      version: 1.24.26
-  python-urlgrabber:
-    - arch: noarch
-      epoch: null
-      name: python-urlgrabber
-      release: 9.el7
-      source: rpm
-      version: '3.10'
-  python-urllib3:
-    - arch: noarch
-      epoch: null
-      name: python-urllib3
-      release: 5.el7
-      source: rpm
-      version: 1.10.2
-  python-virtualenv:
-    - arch: noarch
-      epoch: null
-      name: python-virtualenv
-      release: 4.el7_7
-      source: rpm
-      version: 15.1.0
-  python-websocket-client:
-    - arch: noarch
-      epoch: null
-      name: python-websocket-client
-      release: 3.git3c25814.el7
-      source: rpm
-      version: 0.56.0
-  python2-pip:
-    - arch: noarch
-      epoch: null
-      name: python2-pip
-      release: 14.el7
-      source: rpm
-      version: 8.1.2
-  python2-rpm-macros:
-    - arch: noarch
-      epoch: null
-      name: python2-rpm-macros
-      release: 32.el7
-      source: rpm
-      version: '3'
-  python3:
-    - arch: x86_64
-      epoch: null
-      name: python3
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-libs:
-    - arch: x86_64
-      epoch: null
-      name: python3-libs
-      release: 13.el7
-      source: rpm
-      version: 3.6.8
-  python3-pip:
-    - arch: noarch
-      epoch: null
-      name: python3-pip
-      release: 7.el7_7
-      source: rpm
-      version: 9.0.3
-  python3-setuptools:
-    - arch: noarch
-      epoch: null
-      name: python3-setuptools
-      release: 10.el7
-      source: rpm
-      version: 39.2.0
-  pyxattr:
-    - arch: x86_64
-      epoch: null
-      name: pyxattr
-      release: 5.el7
-      source: rpm
-      version: 0.5.1
-  qemu-guest-agent:
-    - arch: x86_64
-      epoch: 10
-      name: qemu-guest-agent
-      release: 2.el7
-      source: rpm
-      version: 2.12.0
-  qrencode-libs:
-    - arch: x86_64
-      epoch: null
-      name: qrencode-libs
-      release: 3.el7
-      source: rpm
-      version: 3.4.1
-  quota:
-    - arch: x86_64
-      epoch: 1
-      name: quota
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  quota-nls:
-    - arch: noarch
-      epoch: 1
-      name: quota-nls
-      release: 17.el7
-      source: rpm
-      version: '4.01'
-  readline:
-    - arch: x86_64
-      epoch: null
-      name: readline
-      release: 10.el7
-      source: rpm
-      version: '6.2'
-  rootfiles:
-    - arch: noarch
-      epoch: null
-      name: rootfiles
-      release: 11.el7
-      source: rpm
-      version: '8.1'
-  rpcbind:
-    - arch: x86_64
-      epoch: null
-      name: rpcbind
-      release: 47.el7
-      source: rpm
-      version: 0.2.0
-  rpm:
-    - arch: x86_64
-      epoch: null
-      name: rpm
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-build-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-build-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-libs:
-    - arch: x86_64
-      epoch: null
-      name: rpm-libs
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rpm-python:
-    - arch: x86_64
-      epoch: null
-      name: rpm-python
-      release: 35.el7
-      source: rpm
-      version: 4.11.3
-  rsync:
-    - arch: x86_64
-      epoch: null
-      name: rsync
-      release: 6.el7_6.1
-      source: rpm
-      version: 3.1.2
-  rsyslog:
-    - arch: x86_64
-      epoch: null
-      name: rsyslog
-      release: 34.el7
-      source: rpm
-      version: 8.24.0
-  screen:
-    - arch: x86_64
-      epoch: null
-      name: screen
-      release: 0.25.20120314git3c2946.el7
-      source: rpm
-      version: 4.1.0
-  sed:
-    - arch: x86_64
-      epoch: null
-      name: sed
-      release: 5.el7
-      source: rpm
-      version: 4.2.2
-  selinux-policy:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  selinux-policy-targeted:
-    - arch: noarch
-      epoch: null
-      name: selinux-policy-targeted
-      release: 229.el7_6.15
-      source: rpm
-      version: 3.13.1
-  setools-libs:
-    - arch: x86_64
-      epoch: null
-      name: setools-libs
-      release: 4.el7
-      source: rpm
-      version: 3.3.8
-  setup:
-    - arch: noarch
-      epoch: null
-      name: setup
-      release: 10.el7
-      source: rpm
-      version: 2.8.71
-  sg3_utils:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  sg3_utils-libs:
-    - arch: x86_64
-      epoch: null
-      name: sg3_utils-libs
-      release: 17.el7
-      source: rpm
-      version: '1.37'
-  shadow-utils:
-    - arch: x86_64
-      epoch: 2
-      name: shadow-utils
-      release: 25.el7_6.1
-      source: rpm
-      version: 4.1.5.1
-  shared-mime-info:
-    - arch: x86_64
-      epoch: null
-      name: shared-mime-info
-      release: 4.el7
-      source: rpm
-      version: '1.8'
-  slang:
-    - arch: x86_64
-      epoch: null
-      name: slang
-      release: 11.el7
-      source: rpm
-      version: 2.2.4
-  slirp4netns:
-    - arch: x86_64
-      epoch: null
-      name: slirp4netns
-      release: 4.el7_8
-      source: rpm
-      version: 0.4.3
-  smem:
-    - arch: noarch
-      epoch: null
-      name: smem
-      release: 1.el7
-      source: rpm
-      version: '1.4'
-  snappy:
-    - arch: x86_64
-      epoch: null
-      name: snappy
-      release: 3.el7
-      source: rpm
-      version: 1.1.0
-  sqlite:
-    - arch: x86_64
-      epoch: null
-      name: sqlite
-      release: 8.el7
-      source: rpm
-      version: 3.7.17
-  strace:
-    - arch: x86_64
-      epoch: null
-      name: strace
-      release: 4.el7
-      source: rpm
-      version: '4.24'
-  subscription-manager:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager
-      release: 3.el7.centos
-      source: rpm
-      version: 1.24.26
-  subscription-manager-rhsm:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm
-      release: 3.el7.centos
-      source: rpm
-      version: 1.24.26
-  subscription-manager-rhsm-certificates:
-    - arch: x86_64
-      epoch: null
-      name: subscription-manager-rhsm-certificates
-      release: 3.el7.centos
-      source: rpm
-      version: 1.24.26
-  sudo:
-    - arch: x86_64
-      epoch: null
-      name: sudo
-      release: 3.el7
-      source: rpm
-      version: 1.8.23
-  sysstat:
-    - arch: x86_64
-      epoch: null
-      name: sysstat
-      release: 19.el7
-      source: rpm
-      version: 10.1.5
-  systemd:
-    - arch: x86_64
-      epoch: null
-      name: systemd
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-libs:
-    - arch: x86_64
-      epoch: null
-      name: systemd-libs
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  systemd-sysv:
-    - arch: x86_64
-      epoch: null
-      name: systemd-sysv
-      release: 62.el7_6.9
-      source: rpm
-      version: '219'
-  sysvinit-tools:
-    - arch: x86_64
-      epoch: null
-      name: sysvinit-tools
-      release: 14.dsf.el7
-      source: rpm
-      version: '2.88'
-  tar:
-    - arch: x86_64
-      epoch: 2
-      name: tar
-      release: 35.el7
-      source: rpm
-      version: '1.26'
-  tcp_wrappers:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcp_wrappers-libs:
-    - arch: x86_64
-      epoch: null
-      name: tcp_wrappers-libs
-      release: 77.el7
-      source: rpm
-      version: '7.6'
-  tcpdump:
-    - arch: x86_64
-      epoch: 14
-      name: tcpdump
-      release: 4.el7_7.1
-      source: rpm
-      version: 4.9.2
-  teamd:
-    - arch: x86_64
-      epoch: null
-      name: teamd
-      release: 6.el7_6.1
-      source: rpm
-      version: '1.27'
-  telnet:
-    - arch: x86_64
-      epoch: 1
-      name: telnet
-      release: 66.el7
-      source: rpm
-      version: '0.17'
-  trousers:
-    - arch: x86_64
-      epoch: null
-      name: trousers
-      release: 2.el7
-      source: rpm
-      version: 0.3.14
-  tuned:
-    - arch: noarch
-      epoch: null
-      name: tuned
-      release: 6.el7_6.4
-      source: rpm
-      version: 2.10.0
-  tzdata:
-    - arch: noarch
-      epoch: null
-      name: tzdata
-      release: 1.el7
-      source: rpm
-      version: 2019b
-  unixODBC:
-    - arch: x86_64
-      epoch: null
-      name: unixODBC
-      release: 14.el7
-      source: rpm
-      version: 2.3.1
-  usermode:
-    - arch: x86_64
-      epoch: null
-      name: usermode
-      release: 6.el7
-      source: rpm
-      version: '1.111'
-  ustr:
-    - arch: x86_64
-      epoch: null
-      name: ustr
-      release: 16.el7
-      source: rpm
-      version: 1.0.4
-  util-linux:
-    - arch: x86_64
-      epoch: null
-      name: util-linux
-      release: 59.el7_6.1
-      source: rpm
-      version: 2.23.2
-  vim-common:
-    - arch: x86_64
-      epoch: 2
-      name: vim-common
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-enhanced:
-    - arch: x86_64
-      epoch: 2
-      name: vim-enhanced
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-filesystem:
-    - arch: x86_64
-      epoch: 2
-      name: vim-filesystem
-      release: 8.el7_9
-      source: rpm
-      version: 7.4.629
-  vim-minimal:
-    - arch: x86_64
-      epoch: 2
-      name: vim-minimal
-      release: 6.el7_6
-      source: rpm
-      version: 7.4.160
-  virt-what:
-    - arch: x86_64
-      epoch: null
-      name: virt-what
-      release: 4.el7
-      source: rpm
-      version: '1.18'
-  which:
-    - arch: x86_64
-      epoch: null
-      name: which
-      release: 7.el7
-      source: rpm
-      version: '2.20'
-  wpa_supplicant:
-    - arch: x86_64
-      epoch: 1
-      name: wpa_supplicant
-      release: 12.el7
-      source: rpm
-      version: '2.6'
-  xfsprogs:
-    - arch: x86_64
-      epoch: null
-      name: xfsprogs
-      release: 19.el7_6
-      source: rpm
-      version: 4.5.0
-  xz:
-    - arch: x86_64
-      epoch: null
-      name: xz
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  xz-libs:
-    - arch: x86_64
-      epoch: null
-      name: xz-libs
-      release: 1.el7
-      source: rpm
-      version: 5.2.2
-  yajl:
-    - arch: x86_64
-      epoch: null
-      name: yajl
-      release: 4.el7
-      source: rpm
-      version: 2.0.4
-  yum:
-    - arch: noarch
-      epoch: null
-      name: yum
-      release: 161.el7.centos
-      source: rpm
-      version: 3.4.3
-  yum-metadata-parser:
-    - arch: x86_64
-      epoch: null
-      name: yum-metadata-parser
-      release: 10.el7
-      source: rpm
-      version: 1.1.4
-  yum-plugin-fastestmirror:
-    - arch: noarch
-      epoch: null
-      name: yum-plugin-fastestmirror
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  yum-utils:
-    - arch: noarch
-      epoch: null
-      name: yum-utils
-      release: 50.el7
-      source: rpm
-      version: 1.1.31
-  zabbix-agent:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-agent
-      release: 2.el7
-      source: rpm
-      version: 4.0.21
-  zabbix-get:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-get
-      release: 1.el7
-      source: rpm
-      version: 4.0.20
-  zabbix-sender:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-sender
-      release: 1.el7
-      source: rpm
-      version: 4.0.20
-  zabbix-server-pgsql:
-    - arch: x86_64
-      epoch: null
-      name: zabbix-server-pgsql
-      release: 1.el7
-      source: rpm
-      version: 4.0.20
-  zlib:
-    - arch: x86_64
-      epoch: null
-      name: zlib
-      release: 18.el7
-      source: rpm
-      version: 1.2.7
-processes:
-  - cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
-    pid: '1'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '2'
-    ppid: '0'
-    user: root
-  - cmdline: ''
-    pid: '3'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '7'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '8'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '9'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '10'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '11'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '12'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '13'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '14'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '16'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '19'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '21'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '22'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '23'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '24'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '26'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '28'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '29'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '30'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '31'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '32'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '33'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '34'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '35'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '36'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '37'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '38'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '39'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '42'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '43'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '44'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '45'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '53'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '55'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '56'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '57'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '58'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '72'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '115'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '191'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '192'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '291'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '333'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '334'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '335'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '336'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '337'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '351'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '352'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '353'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '354'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '355'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '356'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '357'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '358'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '359'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '360'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '361'
-    ppid: '2'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-journald
-    pid: '441'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/lvmetad -f
-    pid: '478'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/systemd/systemd-udevd
-    pid: '480'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '572'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '586'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/auditd
-    pid: '609'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '612'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '632'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/rpcbind -w
-    pid: '641'
-    ppid: '1'
-    user: rpc
-  - cmdline: /usr/sbin/irqbalance --foreground
-    pid: '646'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/lib/polkit-1/polkitd --no-debug
-    pid: '647'
-    ppid: '1'
-    user: polkitd
-  - cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation'
-    pid: '648'
-    ppid: '1'
-    user: dbus
-  - cmdline: /usr/lib/systemd/systemd-logind
-    pid: '653'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/gssproxy -D
-    pid: '679'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '692'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '853'
-    ppid: '2'
-    user: root
-  - cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid -H zabbix-server01 eth0
-    pid: '994'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d
-    pid: '1055'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
-    pid: '1057'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/containerd
-    pid: '1064'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/bin/rhsmcertd
-    pid: '1070'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
-    pid: '1105'
-    ppid: '1'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
-    pid: '1108'
-    ppid: '1105'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
-    pid: '1109'
-    ppid: '1105'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
-    pid: '1110'
-    ppid: '1105'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
-    pid: '1111'
-    ppid: '1105'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
-    pid: '1112'
-    ppid: '1105'
-    user: zabbix
-  - cmdline: /usr/sbin/zabbix_server -c /etc/zabbix/zabbix_server.conf
+  - AppArmorProfile: ''
+    Args:
+    - infinity
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - infinity
+      Domainname: ''
+      Entrypoint:
+      - sleep
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - PYTHONIOENCODING=UTF-8
+      - GPG_KEY=C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
+      - PYTHON_VERSION=2.7.18
+      - PYTHON_PIP_VERSION=20.0.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/d59197a3c169cef378a22428a3fa99d33e080a5d/get-pip.py
+      - PYTHON_GET_PIP_SHA256=421ac1d44c0cf9730a088e337867d974b91bdce4ea2636099275071878cc189e
+      Hostname: zabbix-server01.novalocal
+      Image: iometrics-zbxalerter-opsgenie:latest
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: /usr/src/app
+    Created: '2022-06-21T15:07:29.216720661Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/d142a42a4085cd5488c0bb9bab718b3ec2e26c4db12ed1cb424fc022caf5c133-init/diff:/var/lib/docker/overlay2/0760b00019c5fc5127be0639a3494eefb001a53d8cf67ff29f3da0ca36c5b125/diff:/var/lib/docker/overlay2/4ddf7dbf9857dade530cd2dc4311d2e2196b86e08b3c5a8276b7419ea91b6f3b/diff:/var/lib/docker/overlay2/3a677a29ce4a1c9daa84d4eeed899a76b7587ab41939b3b7ac24d71f1f663907/diff:/var/lib/docker/overlay2/72d0fe8ed739c2afd20b70857b49934c9e06772c2bc6b5496560743b1bc42522/diff:/var/lib/docker/overlay2/2f403a162d7d3b36f2ea6859b73d670c2dbfd5fde14bb765fdc12f2b1a94afc6/diff:/var/lib/docker/overlay2/fa00ba8e60b981bc4c3876ff27a4d7b0078543c1ddf2f663b997c4853c736597/diff:/var/lib/docker/overlay2/5b96a361fd9927a8fbafbdeae618452a18abfc3f387249e152e59ff78dd7e9ec/diff:/var/lib/docker/overlay2/76cdc5ad4b417a7566dea5b0d72216fd59f1d02a098ed68aec6545661852c26c/diff:/var/lib/docker/overlay2/a0cec3f1f3357690638b3322540463d377275f996c53a5cbc61a9640363a7b7f/diff:/var/lib/docker/overlay2/be79b1ee8a51a9ec0704a675288a657a26a54a17ff3d90b4ced38c1807f63249/diff
+        MergedDir: /var/lib/docker/overlay2/d142a42a4085cd5488c0bb9bab718b3ec2e26c4db12ed1cb424fc022caf5c133/merged
+        UpperDir: /var/lib/docker/overlay2/d142a42a4085cd5488c0bb9bab718b3ec2e26c4db12ed1cb424fc022caf5c133/diff
+        WorkDir: /var/lib/docker/overlay2/d142a42a4085cd5488c0bb9bab718b3ec2e26c4db12ed1cb424fc022caf5c133/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: true
+      Binds:
+      - /home/centos/opsgenie_config:/etc/opensolutions
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: []
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: []
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: 'no'
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f/hostname
+    HostsPath: /var/lib/docker/containers/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f/hosts
+    Id: e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f
+    Image: sha256:9cbb876bf01372b8efb8c5c80665231e6c4b522228320bd12ff3370589881cf1
+    LogPath: /var/lib/docker/containers/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/opensolutions
+      Mode: ''
+      Propagation: rprivate
+      RW: true
+      Source: /home/centos/opsgenie_config
+      Type: bind
+    Name: /iometrics-zbxalerter-opsgenie
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: e7ecf77b8907f4f7382521e356104116405eaa9750480440ae7720b1c01e840c
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 9a6482fb028630d923e263f547c71899691e767c4f763aa7c3604f8af8455f60
+      Ports: {}
+      SandboxID: b118a37e9e43122f3275b3e946d5c55b49f0d12d1a8f88ddf7c156bd1c6b7298
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: sleep
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '0001-01-01T00:00:00Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 12017
+      Restarting: false
+      Running: true
+      StartedAt: '2022-06-21T15:07:29.559096539Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - infinity
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - infinity
+      Domainname: ''
+      Entrypoint:
+      - sleep
+      Env:
+      - TZ=Europe/Madrid
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - LANG=C.UTF-8
+      - PYTHONIOENCODING=UTF-8
+      - GPG_KEY=C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
+      - PYTHON_VERSION=2.7.18
+      - PYTHON_PIP_VERSION=20.0.2
+      - PYTHON_GET_PIP_URL=https://github.com/pypa/get-pip/raw/d59197a3c169cef378a22428a3fa99d33e080a5d/get-pip.py
+      - PYTHON_GET_PIP_SHA256=421ac1d44c0cf9730a088e337867d974b91bdce4ea2636099275071878cc189e
+      Hostname: zabbix-server01.novalocal
+      Image: nexusregistry.opensolutions.cloud/iometrics-zbxalerter:3.23.0-67087ca
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /etc/opensolutions: {}
+      WorkingDir: /usr/src/app
+    Created: '2021-11-17T15:07:06.322256934Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/1da7dc74b62fa36687b5d3679d6500e22da2098bd9f38a699643e638d0e43c6a-init/diff:/var/lib/docker/overlay2/18aa9049df61d3a7fec135ff1e0d4c1f1df3c0a5a8f05733be4289efa1c05fe9/diff:/var/lib/docker/overlay2/d2ffc7bb5192bf6a1955701921984fc7eec4eda30ad28a3273c4be15562a9f9a/diff:/var/lib/docker/overlay2/53fe70537b1df7cb38abc1f5003b498fe8b9c1a6bb137ce1423f524cb37e9e59/diff:/var/lib/docker/overlay2/8bb897262c98858214599a1523ce91667b8bc458ae8b88645d46d2bf6adc8874/diff:/var/lib/docker/overlay2/d41c7d061c4c1976cb6dbc19a82555470b21e6fc18b61a4aa158815a192ee250/diff:/var/lib/docker/overlay2/49252bf4476e2d61c0d082293eba7dc81741293cc5782ff1044486f7836564c7/diff:/var/lib/docker/overlay2/5b96a361fd9927a8fbafbdeae618452a18abfc3f387249e152e59ff78dd7e9ec/diff:/var/lib/docker/overlay2/76cdc5ad4b417a7566dea5b0d72216fd59f1d02a098ed68aec6545661852c26c/diff:/var/lib/docker/overlay2/a0cec3f1f3357690638b3322540463d377275f996c53a5cbc61a9640363a7b7f/diff:/var/lib/docker/overlay2/be79b1ee8a51a9ec0704a675288a657a26a54a17ff3d90b4ced38c1807f63249/diff
+        MergedDir: /var/lib/docker/overlay2/1da7dc74b62fa36687b5d3679d6500e22da2098bd9f38a699643e638d0e43c6a/merged
+        UpperDir: /var/lib/docker/overlay2/1da7dc74b62fa36687b5d3679d6500e22da2098bd9f38a699643e638d0e43c6a/diff
+        WorkDir: /var/lib/docker/overlay2/1da7dc74b62fa36687b5d3679d6500e22da2098bd9f38a699643e638d0e43c6a/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/datadope/iometrics:/etc/opensolutions:rw
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: null
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: null
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config:
+          max-file: '1'
+          max-size: 100M
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: null
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: always
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66/hostname
+    HostsPath: /var/lib/docker/containers/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66/hosts
+    Id: 65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66
+    Image: sha256:2dd1f257368290b30d3f60583a57d32d083743ebe4f563df8733aed0fca3d88b
+    LogPath: /var/lib/docker/containers/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/opensolutions
+      Mode: rw
+      Propagation: rprivate
+      RW: true
+      Source: /etc/datadope/iometrics
+      Type: bind
+    Name: /iometrics-zbxalerter
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 78f457a0393810723e8898b847d2b181d11c11aece7f564859f8abfa40b310c8
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 9a6482fb028630d923e263f547c71899691e767c4f763aa7c3604f8af8455f60
+      Ports: {}
+      SandboxID: 27ed44dd8018d4181a73083d96459b242df554d7ed9b92b588c1853d11b88bd4
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: sleep
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:37.128955515Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 9828
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:49.445977061Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args: []
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd: null
+      Domainname: ''
+      Entrypoint:
+      - /sbin/entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - SQUID_VERSION=3.5.27
+      - SQUID_CACHE_DIR=/var/spool/squid
+      - SQUID_LOG_DIR=/var/log/squid
+      - SQUID_USER=proxy
+      ExposedPorts:
+        3128/tcp: {}
+      Hostname: 5c81ff097d1a
+      Image: sameersbn/squid:3.5.27-2
+      Labels:
+        maintainer: sameer@damagehead.com
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes: null
+      WorkingDir: ''
+    Created: '2021-09-27T13:52:37.213315567Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/3037a38d5893b90e7d1b27fc24bcf68eaaf90054886e7f2ec471dcca73e31ec4-init/diff:/var/lib/docker/overlay2/6e810111e9b469ce02f389fba5e9d945707a281c7c5f157ed2deb8d37d556e73/diff:/var/lib/docker/overlay2/04ee3a860acd774a7cd197b0bb28b4a368c6835846ffec6eee4ea4a30bc5c23b/diff:/var/lib/docker/overlay2/747f43a685d2f38c212e70ef49e7e59730b4f4cabd5e63ae46807858fb7416c2/diff:/var/lib/docker/overlay2/e3dd7ce6b7619d404a8016452c1339ac3a8b5ff6d74721cf74dd2610aeecaf24/diff:/var/lib/docker/overlay2/9832c9080b6a09fe7cee301be3214fa21d1f77c0019c15be1efb714308c42797/diff:/var/lib/docker/overlay2/abc16a6903a70a34b5812745700fcbda9be050b9a8a26de93bedfc47906ffcb1/diff:/var/lib/docker/overlay2/0acb42218e17061c02faef3cce0d2ad9c464f99d4e7457e3a7767ba9cb6bb4dc/diff
+        MergedDir: /var/lib/docker/overlay2/3037a38d5893b90e7d1b27fc24bcf68eaaf90054886e7f2ec471dcca73e31ec4/merged
+        UpperDir: /var/lib/docker/overlay2/3037a38d5893b90e7d1b27fc24bcf68eaaf90054886e7f2ec471dcca73e31ec4/diff
+        WorkDir: /var/lib/docker/overlay2/3037a38d5893b90e7d1b27fc24bcf68eaaf90054886e7f2ec471dcca73e31ec4/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds:
+      - /etc/squid/squid.conf:/etc/squid/squid.conf
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: []
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: []
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: default
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings:
+        3128/tcp:
+        - HostIp: ''
+          HostPort: '3128'
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: always
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e/hostname
+    HostsPath: /var/lib/docker/containers/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e/hosts
+    Id: 5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e
+    Image: sha256:d279b4072846e89af1dfeb2982addf8c4f2125ad929bb536875e3a32700b86ec
+    LogPath: /var/lib/docker/containers/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /etc/squid/squid.conf
+      Mode: ''
+      Propagation: rprivate
+      RW: true
+      Source: /etc/squid/squid.conf
+      Type: bind
+    Name: /squid
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: 21076edcedd5a281fdfdcea20ceb0deebd79c8f9b7acd6dbf63d6bc43df60753
+      Gateway: 192.168.1.1
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: 192.168.1.2
+      IPPrefixLen: 16
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: 02:42:ac:11:00:02
+      Networks:
+        bridge:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: 21076edcedd5a281fdfdcea20ceb0deebd79c8f9b7acd6dbf63d6bc43df60753
+          Gateway: 192.168.1.1
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: 192.168.1.2
+          IPPrefixLen: 16
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: 02:42:ac:11:00:02
+          NetworkID: 94f751abfb7f44970711b48f26ac62cd3f35c5a6d761bd7dd3415260d57e36cd
+      Ports:
+        3128/tcp:
+        - HostIp: 0.0.0.0
+          HostPort: '3128'
+      SandboxID: f1a2a9a59d7c9b5e5b585c4dacb0e4b19fc39bc4c6e689d20ab35cb7ac2a73f0
+      SandboxKey: /var/run/docker/netns/f1a2a9a59d7c
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: /sbin/entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:37.130445221Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 9821
+      Restarting: false
+      Running: true
+      StartedAt: '2022-04-26T15:56:49.700085318Z'
+      Status: running
+  - AppArmorProfile: ''
+    Args:
+    - redis-server
+    Config:
+      AttachStderr: false
+      AttachStdin: false
+      AttachStdout: false
+      Cmd:
+      - redis-server
+      Domainname: ''
+      Entrypoint:
+      - docker-entrypoint.sh
+      Env:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - GOSU_VERSION=1.12
+      - REDIS_VERSION=6.2.1
+      - REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.2.1.tar.gz
+      - REDIS_DOWNLOAD_SHA=cd222505012cce20b25682fca931ec93bd21ae92cb4abfe742cf7b76aa907520
+      ExposedPorts:
+        6379/tcp: {}
+      Hostname: zabbix-server01.novalocal
+      Image: redis
+      Labels: {}
+      OnBuild: null
+      OpenStdin: false
+      StdinOnce: false
+      Tty: false
+      User: ''
+      Volumes:
+        /data: {}
+      WorkingDir: /data
+    Created: '2021-04-13T16:51:14.696486729Z'
+    Driver: overlay2
+    ExecIDs: null
+    GraphDriver:
+      Data:
+        LowerDir: /var/lib/docker/overlay2/db1baf9db7316e0a9b7b03491cd978b0dda7c9aec2eebf4e9829a0a2056bfabe-init/diff:/var/lib/docker/overlay2/104ab6f68facae3a8373b17a6e76b45b955d675613fdade90336b3a7ab2d6db1/diff:/var/lib/docker/overlay2/2b8e77996e65bddfc2da5936f6c4095e78b462f343e876ba50490df00f611686/diff:/var/lib/docker/overlay2/6e9aefc02aa3077dae6431f68b8433839640499e4e8f25c6f7321e99dc792adb/diff:/var/lib/docker/overlay2/6b43154b4a0421bb0f66e0a5bf5c2c5b3f426796dd186da6f68f850efeecbba3/diff:/var/lib/docker/overlay2/f84f191d7dfb84eb8054dda24ae77c8bf5e0e175e4a71a0698fe27fb15f1ce97/diff:/var/lib/docker/overlay2/be15ae743da5ceb540af0fe8675f7fda6066ccf617f62472415601770c67ffd5/diff
+        MergedDir: /var/lib/docker/overlay2/db1baf9db7316e0a9b7b03491cd978b0dda7c9aec2eebf4e9829a0a2056bfabe/merged
+        UpperDir: /var/lib/docker/overlay2/db1baf9db7316e0a9b7b03491cd978b0dda7c9aec2eebf4e9829a0a2056bfabe/diff
+        WorkDir: /var/lib/docker/overlay2/db1baf9db7316e0a9b7b03491cd978b0dda7c9aec2eebf4e9829a0a2056bfabe/work
+      Name: overlay2
+    HostConfig:
+      AutoRemove: false
+      Binds: null
+      BlkioDeviceReadBps: null
+      BlkioDeviceReadIOps: null
+      BlkioDeviceWriteBps: null
+      BlkioDeviceWriteIOps: null
+      BlkioWeight: 0
+      BlkioWeightDevice: []
+      CapAdd: null
+      CapDrop: null
+      Capabilities: null
+      Cgroup: ''
+      CgroupParent: ''
+      ConsoleSize:
+      - 0
+      - 0
+      ContainerIDFile: ''
+      CpuCount: 0
+      CpuPercent: 0
+      CpuPeriod: 0
+      CpuQuota: 0
+      CpuRealtimePeriod: 0
+      CpuRealtimeRuntime: 0
+      CpuShares: 0
+      CpusetCpus: ''
+      CpusetMems: ''
+      DeviceCgroupRules: null
+      DeviceRequests: null
+      Devices: []
+      Dns: []
+      DnsOptions: []
+      DnsSearch: []
+      ExtraHosts: null
+      GroupAdd: null
+      IOMaximumBandwidth: 0
+      IOMaximumIOps: 0
+      IpcMode: private
+      Isolation: ''
+      KernelMemory: 0
+      KernelMemoryTCP: 0
+      Links: null
+      LogConfig:
+        Config: {}
+        Type: json-file
+      MaskedPaths:
+      - /proc/asound
+      - /proc/acpi
+      - /proc/kcore
+      - /proc/keys
+      - /proc/latency_stats
+      - /proc/timer_list
+      - /proc/timer_stats
+      - /proc/sched_debug
+      - /proc/scsi
+      - /sys/firmware
+      Memory: 0
+      MemoryReservation: 0
+      MemorySwap: 0
+      MemorySwappiness: null
+      NanoCpus: 0
+      NetworkMode: host
+      OomKillDisable: false
+      OomScoreAdj: 0
+      PidMode: ''
+      PidsLimit: null
+      PortBindings: {}
+      Privileged: false
+      PublishAllPorts: false
+      ReadonlyPaths:
+      - /proc/bus
+      - /proc/fs
+      - /proc/irq
+      - /proc/sys
+      - /proc/sysrq-trigger
+      ReadonlyRootfs: false
+      RestartPolicy:
+        MaximumRetryCount: 0
+        Name: 'no'
+      Runtime: runc
+      SecurityOpt: null
+      ShmSize: 67108864
+      UTSMode: ''
+      Ulimits: null
+      UsernsMode: ''
+      VolumeDriver: ''
+      VolumesFrom: null
+    HostnamePath: /var/lib/docker/containers/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c/hostname
+    HostsPath: /var/lib/docker/containers/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c/hosts
+    Id: 7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c
+    Image: sha256:de974760ddb2f32dbddb74b7bb8cff4c1eee06d43d36d11bbca1dc815173916e
+    LogPath: /var/lib/docker/containers/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c-json.log
+    MountLabel: ''
+    Mounts:
+    - Destination: /data
+      Driver: local
+      Mode: ''
+      Name: d9e6b17123459d77464f45d119e05a218e42452871dc9f23ce0a91c3c12ae574
+      Propagation: ''
+      RW: true
+      Source: /var/lib/docker/volumes/d9e6b17123459d77464f45d119e05a218e42452871dc9f23ce0a91c3c12ae574/_data
+      Type: volume
+    Name: /redis
+    NetworkSettings:
+      Bridge: ''
+      EndpointID: ''
+      Gateway: ''
+      GlobalIPv6Address: ''
+      GlobalIPv6PrefixLen: 0
+      HairpinMode: false
+      IPAddress: ''
+      IPPrefixLen: 0
+      IPv6Gateway: ''
+      LinkLocalIPv6Address: ''
+      LinkLocalIPv6PrefixLen: 0
+      MacAddress: ''
+      Networks:
+        host:
+          Aliases: null
+          DriverOpts: null
+          EndpointID: f7047ee19829d4b30ceee6f72a8ca0f6bc086a7e987f5fcfda7bea12c2395063
+          Gateway: ''
+          GlobalIPv6Address: ''
+          GlobalIPv6PrefixLen: 0
+          IPAMConfig: null
+          IPAddress: ''
+          IPPrefixLen: 0
+          IPv6Gateway: ''
+          Links: null
+          MacAddress: ''
+          NetworkID: 9a6482fb028630d923e263f547c71899691e767c4f763aa7c3604f8af8455f60
+      Ports: {}
+      SandboxID: 28523b7d414aed5bc7a0836b88a64593c701e30afac590439500eb76acae14ac
+      SandboxKey: /var/run/docker/netns/default
+      SecondaryIPAddresses: null
+      SecondaryIPv6Addresses: null
+    Path: docker-entrypoint.sh
+    Platform: linux
+    ProcessLabel: ''
+    ResolvConfPath: /var/lib/docker/containers/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c/resolv.conf
+    RestartCount: 0
+    State:
+      Dead: false
+      Error: ''
+      ExitCode: 0
+      FinishedAt: '2022-04-26T15:56:37.12926956Z'
+      OOMKilled: false
+      Paused: false
+      Pid: 4355
+      Restarting: false
+      Running: true
+      StartedAt: '2022-05-29T05:29:55.40255942Z'
+      Status: running
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 10051
+    protocol: tcp
+  - address: '::'
+    class: service
+    port: 10051
+    protocol: tcp
+  discovery_time: '2022-07-04T15:06:31+02:00'
+  listening_ports:
+  - 10051
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-server-pgsql
+    release: 1.el7
+    source: rpm
+    version: 4.0.20
+  process:
+    children:
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: configuration syncer [synced configuration
+        in 1.574989 sec, idle 60 sec]'
+      cwd: /usr/sbin/
+      pid: '1178'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: housekeeper [deleted 0 hist/trends, 0 items/triggers,
+        69 events, 2 sessions, 0 alarms, 2 audit items in 1.195076 sec, idle for 1
+        hour(s)]'
+      cwd: /usr/sbin/
+      pid: '1255'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #1 [updated 0 hosts, suppressed 0 events
+        in 0.001907 sec, idle 59 sec]'
+      cwd: /usr/sbin/
+      pid: '1256'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #2 [suppressed 0 events in 0.035586
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1257'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #3 [suppressed 0 events in 0.032545
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1258'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #4 [suppressed 0 events in 0.043363
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1259'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #5 [suppressed 0 events in 0.066465
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1260'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #6 [suppressed 0 events in 0.064149
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1261'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #7 [suppressed 0 events in 0.044135
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1262'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #8 [suppressed 0 events in 0.066614
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1263'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #9 [suppressed 0 events in 0.070274
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1264'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #10 [suppressed 0 events in 0.033935
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1265'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #11 [suppressed 0 events in 0.033549
+        sec, idle 59 sec]'
+      cwd: /usr/sbin/
+      pid: '1266'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #12 [suppressed 0 events in 0.056936
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1267'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #13 [suppressed 0 events in 0.060405
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1268'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #14 [suppressed 0 events in 0.045167
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1269'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: timer #15 [suppressed 0 events in 0.038825
+        sec, idle 58 sec]'
+      cwd: /usr/sbin/
+      pid: '1270'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #1 [got 0 values in 0.001601
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1271'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #2 [got 0 values in 0.001186
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1272'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #3 [got 0 values in 0.001257
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1273'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #4 [got 0 values in 0.001622
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1274'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #5 [got 0 values in 0.001709
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1275'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #6 [got 0 values in 0.001607
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1276'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #7 [got 0 values in 0.001650
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1277'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #8 [got 0 values in 0.001241
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1278'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #9 [got 0 values in 0.001343
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1279'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #10 [got 0 values in 0.001719
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1280'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #11 [got 0 values in 0.002388
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1281'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: http poller #12 [got 0 values in 0.001564
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1282'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: discoverer #1 [processed 0 rules in 0.001910
+        sec, idle 60 sec]'
+      cwd: /usr/sbin/
+      pid: '1283'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: discoverer #2 [processed 0 rules in 0.002141
+        sec, idle 60 sec]'
+      cwd: /usr/sbin/
+      pid: '1284'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: discoverer #3 [processed 0 rules in 0.002326
+        sec, idle 60 sec]'
+      cwd: /usr/sbin/
+      pid: '1285'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: discoverer #4 [processed 0 rules in 0.001887
+        sec, idle 60 sec]'
+      cwd: /usr/sbin/
+      pid: '1286'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: discoverer #5 [processed 0 rules in 0.001595
+        sec, idle 60 sec]'
+      cwd: /usr/sbin/
+      pid: '1287'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: discoverer #6 [processed 0 rules in 0.001633
+        sec, idle 60 sec]'
+      cwd: /usr/sbin/
+      pid: '1288'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #1 [processed 0 values, 0
+        triggers in 0.000042 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1289'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #2 [processed 22 values, 15
+        triggers in 0.017126 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1290'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #3 [processed 0 values, 0
+        triggers in 0.000042 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1291'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #4 [processed 0 values, 0
+        triggers in 0.000037 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1292'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #5 [processed 0 values, 0
+        triggers in 0.000041 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1293'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #6 [processed 0 values, 0
+        triggers in 0.000051 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1294'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #7 [processed 0 values, 11
+        triggers in 0.002103 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1295'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #8 [processed 0 values, 0
+        triggers in 0.000052 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1296'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #9 [processed 0 values, 0
+        triggers in 0.000042 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1297'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: history syncer #10 [processed 0 values, 0
+        triggers in 0.000050 sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1298'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: escalator #1 [processed 0 escalations in
+        0.002789 sec, idle 3 sec]'
+      cwd: /usr/sbin/
+      pid: '1299'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: escalator #2 [processed 0 escalations in
+        0.003336 sec, idle 3 sec]'
+      cwd: /usr/sbin/
+      pid: '1300'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: escalator #3 [processed 0 escalations in
+        0.003633 sec, idle 3 sec]'
+      cwd: /usr/sbin/
+      pid: '1301'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: snmp trapper [processed data in 0.000042
+        sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1302'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: self-monitoring [processed data in 0.000065
+        sec, idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1303'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: task manager [processed 0 task(s) in 0.001448
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1304'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #1 [got 0 values in 0.000092 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1305'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #2 [got 0 values in 0.000065 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1306'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #3 [got 0 values in 0.000042 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1307'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #4 [got 0 values in 0.000110 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1308'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #5 [got 0 values in 0.000333 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1309'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #6 [got 0 values in 0.000057 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1310'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #7 [got 0 values in 0.000043 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1311'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #8 [got 0 values in 0.000052 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1312'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #9 [got 0 values in 0.000204 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1313'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #10 [got 5 values in 0.001876 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1314'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #11 [got 0 values in 0.000029 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1315'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #12 [got 0 values in 0.000033 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1316'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #13 [got 0 values in 0.000040 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1317'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #14 [got 0 values in 0.000040 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1318'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #15 [got 0 values in 0.000023 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1319'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #16 [got 0 values in 0.000037 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1320'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #17 [got 0 values in 0.000046 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1321'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #18 [got 0 values in 0.000031 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1322'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #19 [got 0 values in 0.000022 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1323'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #20 [got 0 values in 0.000106 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1324'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #21 [got 0 values in 0.000057 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1325'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #22 [got 0 values in 0.000043 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1326'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #23 [got 0 values in 0.000079 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1327'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #24 [got 0 values in 0.000032 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1328'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #25 [got 0 values in 0.000051 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1329'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #26 [got 0 values in 0.000048 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1330'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #27 [got 0 values in 0.000056 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1331'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #28 [got 0 values in 0.000050 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1332'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #29 [got 0 values in 0.000057 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1333'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #30 [got 0 values in 0.000066 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1334'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #31 [got 0 values in 0.000034 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1335'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #32 [got 0 values in 0.000032 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1336'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #33 [got 0 values in 0.000627 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1337'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #34 [got 0 values in 0.000171 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1338'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #35 [got 0 values in 0.000042 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1339'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #36 [got 0 values in 0.000063 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1340'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #37 [got 0 values in 0.000028 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1341'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #38 [got 0 values in 0.000063 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1342'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #39 [got 0 values in 0.000039 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1343'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #40 [got 0 values in 0.000035 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1344'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #41 [got 0 values in 0.000044 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1345'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #42 [got 0 values in 0.000211 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1346'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #43 [got 0 values in 0.000033 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1347'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #44 [got 0 values in 0.000047 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1348'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #45 [got 0 values in 0.000039 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1349'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #46 [got 0 values in 0.000046 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1350'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #47 [got 0 values in 0.000120 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1351'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #48 [got 0 values in 0.000022 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1352'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #49 [got 0 values in 0.000054 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1353'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #50 [got 0 values in 0.000040 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1354'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #51 [got 0 values in 0.000031 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1355'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #52 [got 0 values in 0.000046 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1356'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #53 [got 1 values in 15.000692 sec,
+        getting values]'
+      cwd: /usr/sbin/
+      pid: '1357'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #54 [got 0 values in 0.000068 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1358'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #55 [got 0 values in 0.000088 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1359'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #56 [got 0 values in 0.000046 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1360'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #57 [got 0 values in 0.000116 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1361'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #58 [got 0 values in 0.000031 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1362'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #59 [got 3 values in 0.024509 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1363'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #60 [got 0 values in 0.000029 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1364'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #61 [got 0 values in 0.000092 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1365'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #62 [got 8 values in 0.001505 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1366'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #63 [got 0 values in 0.000047 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1367'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #64 [got 0 values in 0.000096 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1368'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #65 [got 0 values in 0.000035 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1369'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #66 [got 0 values in 0.000087 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1370'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #67 [got 0 values in 0.000108 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1371'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #68 [got 0 values in 0.000145 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1372'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #69 [got 1 values in 0.001306 sec,
+        getting values]'
+      cwd: /usr/sbin/
+      pid: '1373'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #70 [got 0 values in 0.000046 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1376'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #71 [got 0 values in 0.000023 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1377'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #72 [got 0 values in 0.000023 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1380'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #73 [got 0 values in 0.000084 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1381'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #74 [got 0 values in 0.000029 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1382'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #75 [got 0 values in 0.000365 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1383'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #76 [got 0 values in 0.000044 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1384'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #77 [got 0 values in 0.000034 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1385'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #78 [got 0 values in 0.000022 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1386'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #79 [got 0 values in 0.000052 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1387'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #80 [got 0 values in 0.000053 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1388'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #81 [got 0 values in 0.000030 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1389'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #82 [got 0 values in 0.000078 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1390'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #83 [got 0 values in 0.000036 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1391'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #84 [got 0 values in 0.000035 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1392'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #85 [got 0 values in 0.000042 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1393'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #86 [got 0 values in 0.000078 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1394'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #87 [got 0 values in 0.000045 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1395'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #88 [got 6 values in 0.001313 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1396'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #89 [got 0 values in 0.000021 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1397'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #90 [got 0 values in 0.000029 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1398'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #91 [got 0 values in 0.000061 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1399'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #92 [got 0 values in 0.000042 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1400'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #93 [got 0 values in 0.000040 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1401'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #94 [got 0 values in 0.000047 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1402'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #95 [got 0 values in 0.000045 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1403'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #96 [got 0 values in 0.000037 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1404'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #97 [got 0 values in 0.000068 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1405'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #98 [got 0 values in 0.000065 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1406'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #99 [got 0 values in 0.000043 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1407'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: poller #100 [got 0 values in 0.000172 sec,
+        idle 1 sec]'
+      cwd: /usr/sbin/
+      pid: '1408'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #1 [got 0 values in 0.000057
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1409'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #2 [got 0 values in 0.000104
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1410'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #3 [got 0 values in 0.000080
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1411'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #4 [got 0 values in 0.000064
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1412'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #5 [got 0 values in 0.000054
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1413'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #6 [got 0 values in 0.000042
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1414'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #7 [got 0 values in 0.000060
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1415'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #8 [got 0 values in 0.000076
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1416'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #9 [got 0 values in 0.000088
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1417'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: unreachable poller #10 [got 0 values in 0.000056
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1418'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #1 [processed data in 0.000230 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1419'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #2 [processed data in 0.006015 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1420'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #3 [processed data in 0.016559 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1421'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #4 [processed data in 0.000297 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1422'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #5 [processed data in 0.000145 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1423'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #6 [processed data in 0.002896 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1424'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #7 [processed data in 0.002574 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1425'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #8 [processed data in 0.000330 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1426'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #9 [processed data in 0.006360 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1427'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #10 [processed data in 0.000253 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1428'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #11 [processed data in 0.000470 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1429'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #12 [processed data in 0.000152 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1430'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #13 [processed data in 0.003929 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1431'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #14 [processed data in 0.000218 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1432'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #15 [processed data in 0.002176 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1433'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #16 [processed data in 0.002160 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1434'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #17 [processed data in 0.000222 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1435'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #18 [processed data in 0.000175 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1436'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #19 [processed data in 0.001193 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1437'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #20 [processed data in 0.001956 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1438'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #21 [processed data in 0.000201 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1439'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #22 [processed data in 0.000260 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1440'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #23 [processed data in 0.008046 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1441'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #24 [processed data in 0.000204 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1442'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #25 [processed data in 0.009377 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1443'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #26 [processed data in 0.002651 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1444'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #27 [processed data in 0.006057 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1445'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #28 [processed data in 0.002465 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1446'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #29 [processed data in 0.002373 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1447'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #30 [processed data in 0.000944 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1448'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #31 [processed data in 0.001482 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1449'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #32 [processed data in 0.000197 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1450'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #33 [processed data in 0.002447 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1451'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #34 [processed data in 0.002830 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1452'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #35 [processed data in 0.002116 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1453'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #36 [processed data in 0.005720 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1454'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #37 [processed data in 0.002188 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1455'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #38 [processed data in 0.008311 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1456'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #39 [processed data in 0.003236 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1457'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #40 [processed data in 0.002259 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1458'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #41 [processed data in 0.013718 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1459'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #42 [processed data in 0.003235 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1460'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #43 [processed data in 0.000191 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1461'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #44 [processed data in 0.000305 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1462'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #45 [processed data in 0.000219 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1463'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #46 [processed data in 0.000209 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1464'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #47 [processed data in 0.006524 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1465'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #48 [processed data in 0.000222 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1466'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #49 [processed data in 0.000214 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1467'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: trapper #50 [processed data in 0.003061 sec,
+        waiting for connection]'
+      cwd: /usr/sbin/
+      pid: '1468'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #1 [got 0 values in 0.000049
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1469'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #2 [got 0 values in 0.000058
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1470'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #3 [got 0 values in 0.000057
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1471'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #4 [got 0 values in 0.000034
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1472'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #5 [got 0 values in 0.000051
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1473'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #6 [got 0 values in 0.000033
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1474'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #7 [got 0 values in 0.000028
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1475'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #8 [got 0 values in 0.000031
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1476'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #9 [got 0 values in 0.000059
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1477'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: icmp pinger #10 [got 0 values in 0.000050
+        sec, idle 5 sec]'
+      cwd: /usr/sbin/
+      pid: '1478'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: alert manager #1 [sent 2, failed 0 alerts,
+        idle 5.322796 sec during 5.322978 sec]'
+      cwd: /usr/sbin/
+      pid: '1479'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: alerter #1 [sent 0, failed 0 alerts, idle
+        178.024568 sec during 180.357522 sec]'
+      cwd: /usr/sbin/
+      pid: '1480'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: alerter #2 [sent 0, failed 0 alerts, idle
+        118.623005 sec during 119.766001 sec]'
+      cwd: /usr/sbin/
+      pid: '1481'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: alerter #3 [sent 0, failed 0 alerts, idle
+        59.250622 sec during 60.530660 sec]'
+      cwd: /usr/sbin/
+      pid: '1482'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: preprocessing manager #1 [queued 1, processed
+        560 values, idle 5.033828 sec during 5.041462 sec]'
+      cwd: /usr/sbin/
+      pid: '1483'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: preprocessing worker #1 started'
+      cwd: /usr/sbin/
+      pid: '1484'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: preprocessing worker #2 started'
+      cwd: /usr/sbin/
+      pid: '1485'
+      ppid: '1173'
+      user: zabbix
+    - children: []
+      cmdline: '/usr/sbin/zabbix_server: preprocessing worker #3 started'
+      cwd: /usr/sbin/
+      pid: '1486'
+      ppid: '1173'
+      user: zabbix
+    cmdline: /usr/sbin/zabbix_server -c /etc/zabbix/zabbix_server.conf
+    cwd: /usr/sbin/
+    listening_ports:
+    - 10051
     pid: '1173'
     ppid: '1'
     user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: configuration syncer [synced configuration in 1.574989 sec, idle 60 sec]'
-    pid: '1178'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: /usr/sbin/rsyslogd -n
-    pid: '1179'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/sshd -D
-    pid: '1187'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/sbin/crond -n
-    pid: '1216'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --noclear tty1 linux
-    pid: '1217'
-    ppid: '1'
-    user: root
-  - cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
-    pid: '1218'
-    ppid: '1'
-    user: root
-  - cmdline: /usr/libexec/postfix/master -w
-    pid: '1245'
-    ppid: '1'
-    user: root
-  - cmdline: '/usr/sbin/zabbix_server: housekeeper [deleted 0 hist/trends, 0 items/triggers, 69 events, 2 sessions, 0 alarms, 2 audit items in 1.195076 sec, idle for 1 hour(s)]'
-    pid: '1255'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #1 [updated 0 hosts, suppressed 0 events in 0.001907 sec, idle 59 sec]'
-    pid: '1256'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #2 [suppressed 0 events in 0.035586 sec, idle 58 sec]'
-    pid: '1257'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #3 [suppressed 0 events in 0.032545 sec, idle 58 sec]'
-    pid: '1258'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #4 [suppressed 0 events in 0.043363 sec, idle 58 sec]'
-    pid: '1259'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #5 [suppressed 0 events in 0.066465 sec, idle 58 sec]'
-    pid: '1260'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #6 [suppressed 0 events in 0.064149 sec, idle 58 sec]'
-    pid: '1261'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #7 [suppressed 0 events in 0.044135 sec, idle 58 sec]'
-    pid: '1262'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #8 [suppressed 0 events in 0.066614 sec, idle 58 sec]'
-    pid: '1263'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #9 [suppressed 0 events in 0.070274 sec, idle 58 sec]'
-    pid: '1264'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #10 [suppressed 0 events in 0.033935 sec, idle 58 sec]'
-    pid: '1265'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #11 [suppressed 0 events in 0.033549 sec, idle 59 sec]'
-    pid: '1266'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #12 [suppressed 0 events in 0.056936 sec, idle 58 sec]'
-    pid: '1267'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #13 [suppressed 0 events in 0.060405 sec, idle 58 sec]'
-    pid: '1268'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #14 [suppressed 0 events in 0.045167 sec, idle 58 sec]'
-    pid: '1269'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: timer #15 [suppressed 0 events in 0.038825 sec, idle 58 sec]'
-    pid: '1270'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #1 [got 0 values in 0.001601 sec, idle 5 sec]'
-    pid: '1271'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #2 [got 0 values in 0.001186 sec, idle 5 sec]'
-    pid: '1272'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #3 [got 0 values in 0.001257 sec, idle 5 sec]'
-    pid: '1273'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #4 [got 0 values in 0.001622 sec, idle 5 sec]'
-    pid: '1274'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #5 [got 0 values in 0.001709 sec, idle 5 sec]'
-    pid: '1275'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #6 [got 0 values in 0.001607 sec, idle 5 sec]'
-    pid: '1276'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #7 [got 0 values in 0.001650 sec, idle 5 sec]'
-    pid: '1277'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #8 [got 0 values in 0.001241 sec, idle 5 sec]'
-    pid: '1278'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #9 [got 0 values in 0.001343 sec, idle 5 sec]'
-    pid: '1279'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #10 [got 0 values in 0.001719 sec, idle 5 sec]'
-    pid: '1280'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #11 [got 0 values in 0.002388 sec, idle 5 sec]'
-    pid: '1281'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: http poller #12 [got 0 values in 0.001564 sec, idle 5 sec]'
-    pid: '1282'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: discoverer #1 [processed 0 rules in 0.001910 sec, idle 60 sec]'
-    pid: '1283'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: discoverer #2 [processed 0 rules in 0.002141 sec, idle 60 sec]'
-    pid: '1284'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: discoverer #3 [processed 0 rules in 0.002326 sec, idle 60 sec]'
-    pid: '1285'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: discoverer #4 [processed 0 rules in 0.001887 sec, idle 60 sec]'
-    pid: '1286'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: discoverer #5 [processed 0 rules in 0.001595 sec, idle 60 sec]'
-    pid: '1287'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: discoverer #6 [processed 0 rules in 0.001633 sec, idle 60 sec]'
-    pid: '1288'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #1 [processed 0 values, 0 triggers in 0.000042 sec, idle 1 sec]'
-    pid: '1289'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #2 [processed 22 values, 15 triggers in 0.017126 sec, idle 1 sec]'
-    pid: '1290'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #3 [processed 0 values, 0 triggers in 0.000042 sec, idle 1 sec]'
-    pid: '1291'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #4 [processed 0 values, 0 triggers in 0.000037 sec, idle 1 sec]'
-    pid: '1292'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #5 [processed 0 values, 0 triggers in 0.000041 sec, idle 1 sec]'
-    pid: '1293'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #6 [processed 0 values, 0 triggers in 0.000051 sec, idle 1 sec]'
-    pid: '1294'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #7 [processed 0 values, 11 triggers in 0.002103 sec, idle 1 sec]'
-    pid: '1295'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #8 [processed 0 values, 0 triggers in 0.000052 sec, idle 1 sec]'
-    pid: '1296'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #9 [processed 0 values, 0 triggers in 0.000042 sec, idle 1 sec]'
-    pid: '1297'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: history syncer #10 [processed 0 values, 0 triggers in 0.000050 sec, idle 1 sec]'
-    pid: '1298'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: escalator #1 [processed 0 escalations in 0.002789 sec, idle 3 sec]'
-    pid: '1299'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: escalator #2 [processed 0 escalations in 0.003336 sec, idle 3 sec]'
-    pid: '1300'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: escalator #3 [processed 0 escalations in 0.003633 sec, idle 3 sec]'
-    pid: '1301'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: snmp trapper [processed data in 0.000042 sec, idle 1 sec]'
-    pid: '1302'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: self-monitoring [processed data in 0.000065 sec, idle 1 sec]'
-    pid: '1303'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: task manager [processed 0 task(s) in 0.001448 sec, idle 5 sec]'
-    pid: '1304'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #1 [got 0 values in 0.000092 sec, idle 1 sec]'
-    pid: '1305'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #2 [got 0 values in 0.000065 sec, idle 1 sec]'
-    pid: '1306'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #3 [got 0 values in 0.000042 sec, idle 1 sec]'
-    pid: '1307'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #4 [got 0 values in 0.000110 sec, idle 1 sec]'
-    pid: '1308'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #5 [got 0 values in 0.000333 sec, idle 1 sec]'
-    pid: '1309'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #6 [got 0 values in 0.000057 sec, idle 1 sec]'
-    pid: '1310'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #7 [got 0 values in 0.000043 sec, idle 1 sec]'
-    pid: '1311'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #8 [got 0 values in 0.000052 sec, idle 1 sec]'
-    pid: '1312'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #9 [got 0 values in 0.000204 sec, idle 1 sec]'
-    pid: '1313'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #10 [got 5 values in 0.001876 sec, idle 1 sec]'
-    pid: '1314'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #11 [got 0 values in 0.000029 sec, idle 1 sec]'
-    pid: '1315'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #12 [got 0 values in 0.000033 sec, idle 1 sec]'
-    pid: '1316'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #13 [got 0 values in 0.000040 sec, idle 1 sec]'
-    pid: '1317'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #14 [got 0 values in 0.000040 sec, idle 1 sec]'
-    pid: '1318'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #15 [got 0 values in 0.000023 sec, idle 1 sec]'
-    pid: '1319'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #16 [got 0 values in 0.000037 sec, idle 1 sec]'
-    pid: '1320'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #17 [got 0 values in 0.000046 sec, idle 1 sec]'
-    pid: '1321'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #18 [got 0 values in 0.000031 sec, idle 1 sec]'
-    pid: '1322'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #19 [got 0 values in 0.000022 sec, idle 1 sec]'
-    pid: '1323'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #20 [got 0 values in 0.000106 sec, idle 1 sec]'
-    pid: '1324'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #21 [got 0 values in 0.000057 sec, idle 1 sec]'
-    pid: '1325'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #22 [got 0 values in 0.000043 sec, idle 1 sec]'
-    pid: '1326'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #23 [got 0 values in 0.000079 sec, idle 1 sec]'
-    pid: '1327'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #24 [got 0 values in 0.000032 sec, idle 1 sec]'
-    pid: '1328'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #25 [got 0 values in 0.000051 sec, idle 1 sec]'
-    pid: '1329'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #26 [got 0 values in 0.000048 sec, idle 1 sec]'
-    pid: '1330'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #27 [got 0 values in 0.000056 sec, idle 1 sec]'
-    pid: '1331'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #28 [got 0 values in 0.000050 sec, idle 1 sec]'
-    pid: '1332'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #29 [got 0 values in 0.000057 sec, idle 1 sec]'
-    pid: '1333'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #30 [got 0 values in 0.000066 sec, idle 1 sec]'
-    pid: '1334'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #31 [got 0 values in 0.000034 sec, idle 1 sec]'
-    pid: '1335'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #32 [got 0 values in 0.000032 sec, idle 1 sec]'
-    pid: '1336'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #33 [got 0 values in 0.000627 sec, idle 1 sec]'
-    pid: '1337'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #34 [got 0 values in 0.000171 sec, idle 1 sec]'
-    pid: '1338'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #35 [got 0 values in 0.000042 sec, idle 1 sec]'
-    pid: '1339'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #36 [got 0 values in 0.000063 sec, idle 1 sec]'
-    pid: '1340'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #37 [got 0 values in 0.000028 sec, idle 1 sec]'
-    pid: '1341'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #38 [got 0 values in 0.000063 sec, idle 1 sec]'
-    pid: '1342'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #39 [got 0 values in 0.000039 sec, idle 1 sec]'
-    pid: '1343'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #40 [got 0 values in 0.000035 sec, idle 1 sec]'
-    pid: '1344'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #41 [got 0 values in 0.000044 sec, idle 1 sec]'
-    pid: '1345'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #42 [got 0 values in 0.000211 sec, idle 1 sec]'
-    pid: '1346'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #43 [got 0 values in 0.000033 sec, idle 1 sec]'
-    pid: '1347'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #44 [got 0 values in 0.000047 sec, idle 1 sec]'
-    pid: '1348'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #45 [got 0 values in 0.000039 sec, idle 1 sec]'
-    pid: '1349'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #46 [got 0 values in 0.000046 sec, idle 1 sec]'
-    pid: '1350'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #47 [got 0 values in 0.000120 sec, idle 1 sec]'
-    pid: '1351'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #48 [got 0 values in 0.000022 sec, idle 1 sec]'
-    pid: '1352'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #49 [got 0 values in 0.000054 sec, idle 1 sec]'
-    pid: '1353'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #50 [got 0 values in 0.000040 sec, idle 1 sec]'
-    pid: '1354'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #51 [got 0 values in 0.000031 sec, idle 1 sec]'
-    pid: '1355'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #52 [got 0 values in 0.000046 sec, idle 1 sec]'
-    pid: '1356'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #53 [got 1 values in 15.000692 sec, getting values]'
-    pid: '1357'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #54 [got 0 values in 0.000068 sec, idle 1 sec]'
-    pid: '1358'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #55 [got 0 values in 0.000088 sec, idle 1 sec]'
-    pid: '1359'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #56 [got 0 values in 0.000046 sec, idle 1 sec]'
-    pid: '1360'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #57 [got 0 values in 0.000116 sec, idle 1 sec]'
-    pid: '1361'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #58 [got 0 values in 0.000031 sec, idle 1 sec]'
-    pid: '1362'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #59 [got 3 values in 0.024509 sec, idle 1 sec]'
-    pid: '1363'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #60 [got 0 values in 0.000029 sec, idle 1 sec]'
-    pid: '1364'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #61 [got 0 values in 0.000092 sec, idle 1 sec]'
-    pid: '1365'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #62 [got 8 values in 0.001505 sec, idle 1 sec]'
-    pid: '1366'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #63 [got 0 values in 0.000047 sec, idle 1 sec]'
-    pid: '1367'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #64 [got 0 values in 0.000096 sec, idle 1 sec]'
-    pid: '1368'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #65 [got 0 values in 0.000035 sec, idle 1 sec]'
-    pid: '1369'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #66 [got 0 values in 0.000087 sec, idle 1 sec]'
-    pid: '1370'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #67 [got 0 values in 0.000108 sec, idle 1 sec]'
-    pid: '1371'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #68 [got 0 values in 0.000145 sec, idle 1 sec]'
-    pid: '1372'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #69 [got 1 values in 0.001306 sec, getting values]'
-    pid: '1373'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #70 [got 0 values in 0.000046 sec, idle 1 sec]'
-    pid: '1376'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #71 [got 0 values in 0.000023 sec, idle 1 sec]'
-    pid: '1377'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: qmgr -l -t unix -u
-    pid: '1379'
-    ppid: '1245'
-    user: postfix
-  - cmdline: '/usr/sbin/zabbix_server: poller #72 [got 0 values in 0.000023 sec, idle 1 sec]'
-    pid: '1380'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #73 [got 0 values in 0.000084 sec, idle 1 sec]'
-    pid: '1381'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #74 [got 0 values in 0.000029 sec, idle 1 sec]'
-    pid: '1382'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #75 [got 0 values in 0.000365 sec, idle 1 sec]'
-    pid: '1383'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #76 [got 0 values in 0.000044 sec, idle 1 sec]'
-    pid: '1384'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #77 [got 0 values in 0.000034 sec, idle 1 sec]'
-    pid: '1385'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #78 [got 0 values in 0.000022 sec, idle 1 sec]'
-    pid: '1386'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #79 [got 0 values in 0.000052 sec, idle 1 sec]'
-    pid: '1387'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #80 [got 0 values in 0.000053 sec, idle 1 sec]'
-    pid: '1388'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #81 [got 0 values in 0.000030 sec, idle 1 sec]'
-    pid: '1389'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #82 [got 0 values in 0.000078 sec, idle 1 sec]'
-    pid: '1390'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #83 [got 0 values in 0.000036 sec, idle 1 sec]'
-    pid: '1391'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #84 [got 0 values in 0.000035 sec, idle 1 sec]'
-    pid: '1392'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #85 [got 0 values in 0.000042 sec, idle 1 sec]'
-    pid: '1393'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #86 [got 0 values in 0.000078 sec, idle 1 sec]'
-    pid: '1394'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #87 [got 0 values in 0.000045 sec, idle 1 sec]'
-    pid: '1395'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #88 [got 6 values in 0.001313 sec, idle 1 sec]'
-    pid: '1396'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #89 [got 0 values in 0.000021 sec, idle 1 sec]'
-    pid: '1397'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #90 [got 0 values in 0.000029 sec, idle 1 sec]'
-    pid: '1398'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #91 [got 0 values in 0.000061 sec, idle 1 sec]'
-    pid: '1399'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #92 [got 0 values in 0.000042 sec, idle 1 sec]'
-    pid: '1400'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #93 [got 0 values in 0.000040 sec, idle 1 sec]'
-    pid: '1401'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #94 [got 0 values in 0.000047 sec, idle 1 sec]'
-    pid: '1402'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #95 [got 0 values in 0.000045 sec, idle 1 sec]'
-    pid: '1403'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #96 [got 0 values in 0.000037 sec, idle 1 sec]'
-    pid: '1404'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #97 [got 0 values in 0.000068 sec, idle 1 sec]'
-    pid: '1405'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #98 [got 0 values in 0.000065 sec, idle 1 sec]'
-    pid: '1406'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #99 [got 0 values in 0.000043 sec, idle 1 sec]'
-    pid: '1407'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: poller #100 [got 0 values in 0.000172 sec, idle 1 sec]'
-    pid: '1408'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #1 [got 0 values in 0.000057 sec, idle 5 sec]'
-    pid: '1409'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #2 [got 0 values in 0.000104 sec, idle 5 sec]'
-    pid: '1410'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #3 [got 0 values in 0.000080 sec, idle 5 sec]'
-    pid: '1411'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #4 [got 0 values in 0.000064 sec, idle 5 sec]'
-    pid: '1412'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #5 [got 0 values in 0.000054 sec, idle 5 sec]'
-    pid: '1413'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #6 [got 0 values in 0.000042 sec, idle 5 sec]'
-    pid: '1414'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #7 [got 0 values in 0.000060 sec, idle 5 sec]'
-    pid: '1415'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #8 [got 0 values in 0.000076 sec, idle 5 sec]'
-    pid: '1416'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #9 [got 0 values in 0.000088 sec, idle 5 sec]'
-    pid: '1417'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: unreachable poller #10 [got 0 values in 0.000056 sec, idle 5 sec]'
-    pid: '1418'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #1 [processed data in 0.000230 sec, waiting for connection]'
-    pid: '1419'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #2 [processed data in 0.006015 sec, waiting for connection]'
-    pid: '1420'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #3 [processed data in 0.016559 sec, waiting for connection]'
-    pid: '1421'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #4 [processed data in 0.000297 sec, waiting for connection]'
-    pid: '1422'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #5 [processed data in 0.000145 sec, waiting for connection]'
-    pid: '1423'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #6 [processed data in 0.002896 sec, waiting for connection]'
-    pid: '1424'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #7 [processed data in 0.002574 sec, waiting for connection]'
-    pid: '1425'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #8 [processed data in 0.000330 sec, waiting for connection]'
-    pid: '1426'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #9 [processed data in 0.006360 sec, waiting for connection]'
-    pid: '1427'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #10 [processed data in 0.000253 sec, waiting for connection]'
-    pid: '1428'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #11 [processed data in 0.000470 sec, waiting for connection]'
-    pid: '1429'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #12 [processed data in 0.000152 sec, waiting for connection]'
-    pid: '1430'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #13 [processed data in 0.003929 sec, waiting for connection]'
-    pid: '1431'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #14 [processed data in 0.000218 sec, waiting for connection]'
-    pid: '1432'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #15 [processed data in 0.002176 sec, waiting for connection]'
-    pid: '1433'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #16 [processed data in 0.002160 sec, waiting for connection]'
-    pid: '1434'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #17 [processed data in 0.000222 sec, waiting for connection]'
-    pid: '1435'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #18 [processed data in 0.000175 sec, waiting for connection]'
-    pid: '1436'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #19 [processed data in 0.001193 sec, waiting for connection]'
-    pid: '1437'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #20 [processed data in 0.001956 sec, waiting for connection]'
-    pid: '1438'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #21 [processed data in 0.000201 sec, waiting for connection]'
-    pid: '1439'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #22 [processed data in 0.000260 sec, waiting for connection]'
-    pid: '1440'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #23 [processed data in 0.008046 sec, waiting for connection]'
-    pid: '1441'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #24 [processed data in 0.000204 sec, waiting for connection]'
-    pid: '1442'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #25 [processed data in 0.009377 sec, waiting for connection]'
-    pid: '1443'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #26 [processed data in 0.002651 sec, waiting for connection]'
-    pid: '1444'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #27 [processed data in 0.006057 sec, waiting for connection]'
-    pid: '1445'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #28 [processed data in 0.002465 sec, waiting for connection]'
-    pid: '1446'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #29 [processed data in 0.002373 sec, waiting for connection]'
-    pid: '1447'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #30 [processed data in 0.000944 sec, waiting for connection]'
-    pid: '1448'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #31 [processed data in 0.001482 sec, waiting for connection]'
-    pid: '1449'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #32 [processed data in 0.000197 sec, waiting for connection]'
-    pid: '1450'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #33 [processed data in 0.002447 sec, waiting for connection]'
-    pid: '1451'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #34 [processed data in 0.002830 sec, waiting for connection]'
-    pid: '1452'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #35 [processed data in 0.002116 sec, waiting for connection]'
-    pid: '1453'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #36 [processed data in 0.005720 sec, waiting for connection]'
-    pid: '1454'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #37 [processed data in 0.002188 sec, waiting for connection]'
-    pid: '1455'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #38 [processed data in 0.008311 sec, waiting for connection]'
-    pid: '1456'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #39 [processed data in 0.003236 sec, waiting for connection]'
-    pid: '1457'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #40 [processed data in 0.002259 sec, waiting for connection]'
-    pid: '1458'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #41 [processed data in 0.013718 sec, waiting for connection]'
-    pid: '1459'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #42 [processed data in 0.003235 sec, waiting for connection]'
-    pid: '1460'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #43 [processed data in 0.000191 sec, waiting for connection]'
-    pid: '1461'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #44 [processed data in 0.000305 sec, waiting for connection]'
-    pid: '1462'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #45 [processed data in 0.000219 sec, waiting for connection]'
-    pid: '1463'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #46 [processed data in 0.000209 sec, waiting for connection]'
-    pid: '1464'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #47 [processed data in 0.006524 sec, waiting for connection]'
-    pid: '1465'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #48 [processed data in 0.000222 sec, waiting for connection]'
-    pid: '1466'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #49 [processed data in 0.000214 sec, waiting for connection]'
-    pid: '1467'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: trapper #50 [processed data in 0.003061 sec, waiting for connection]'
-    pid: '1468'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #1 [got 0 values in 0.000049 sec, idle 5 sec]'
-    pid: '1469'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #2 [got 0 values in 0.000058 sec, idle 5 sec]'
-    pid: '1470'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #3 [got 0 values in 0.000057 sec, idle 5 sec]'
-    pid: '1471'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #4 [got 0 values in 0.000034 sec, idle 5 sec]'
-    pid: '1472'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #5 [got 0 values in 0.000051 sec, idle 5 sec]'
-    pid: '1473'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #6 [got 0 values in 0.000033 sec, idle 5 sec]'
-    pid: '1474'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #7 [got 0 values in 0.000028 sec, idle 5 sec]'
-    pid: '1475'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #8 [got 0 values in 0.000031 sec, idle 5 sec]'
-    pid: '1476'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #9 [got 0 values in 0.000059 sec, idle 5 sec]'
-    pid: '1477'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: icmp pinger #10 [got 0 values in 0.000050 sec, idle 5 sec]'
-    pid: '1478'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: alert manager #1 [sent 2, failed 0 alerts, idle 5.322796 sec during 5.322978 sec]'
-    pid: '1479'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: alerter #1 [sent 0, failed 0 alerts, idle 178.024568 sec during 180.357522 sec]'
-    pid: '1480'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: alerter #2 [sent 0, failed 0 alerts, idle 118.623005 sec during 119.766001 sec]'
-    pid: '1481'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: alerter #3 [sent 0, failed 0 alerts, idle 59.250622 sec during 60.530660 sec]'
-    pid: '1482'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: preprocessing manager #1 [queued 1, processed 560 values, idle 5.033828 sec during 5.041462 sec]'
-    pid: '1483'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: preprocessing worker #1 started'
-    pid: '1484'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: preprocessing worker #2 started'
-    pid: '1485'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: '/usr/sbin/zabbix_server: preprocessing worker #3 started'
-    pid: '1486'
-    ppid: '1173'
-    user: zabbix
-  - cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
-    pid: '2832'
-    ppid: '1'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '4337'
-    ppid: '1064'
-    user: root
-  - cmdline: redis-server *:6379
-    pid: '4355'
-    ppid: '4337'
-    user: polkitd
-  - cmdline: /usr/sbin/ntpd -u ntp:ntp -g
-    pid: '5125'
-    ppid: '1'
-    user: ntp
-  - cmdline: ''
-    pid: '5378'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '5768'
-    ppid: '2'
-    user: root
-  - cmdline: pickup -l -t unix -u
-    pid: '7143'
-    ppid: '1245'
-    user: postfix
-  - cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 3128 -container-ip 192.168.1.2 -container-port 3128
-    pid: '9781'
-    ppid: '2832'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '9787'
-    ppid: '1064'
-    user: root
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66 -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '9788'
-    ppid: '1064'
-    user: root
-  - cmdline: /usr/sbin/squid -f /etc/squid/squid.conf -NYCd 1
-    pid: '9821'
-    ppid: '9787'
-    user: '13'
-  - cmdline: sleep infinity
-    pid: '9828'
-    ppid: '9788'
-    user: root
-  - cmdline: /usr/bin/docker start -a iometrics-zbxalerter
-    pid: '10092'
-    ppid: '1'
-    user: root
-  - cmdline: ''
-    pid: '10453'
-    ppid: '2'
-    user: root
-  - cmdline: (logfile-daemon) /var/log/squid/access.log
-    pid: '11141'
-    ppid: '9821'
-    user: '13'
-  - cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd -runtime-root /var/run/docker/runtime-runc
-    pid: '12000'
-    ppid: '1064'
-    user: root
-  - cmdline: sleep infinity
-    pid: '12017'
-    ppid: '12000'
-    user: root
-  - cmdline: ''
-    pid: '15906'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '17037'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18132'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18294'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18813'
-    ppid: '2'
-    user: root
-  - cmdline: ''
-    pid: '18843'
-    ppid: '2'
-    user: root
-  - cmdline: 'sshd: centos [priv]'
-    pid: '19792'
-    ppid: '1187'
-    user: root
-  - cmdline: 'sshd: centos@pts/0'
-    pid: '19794'
-    ppid: '19792'
-    user: centos
-  - cmdline: ''
-    pid: '19893'
-    ppid: '2'
-    user: root
-  - cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-ljmwpbpxwppcelxemgoiqstuyhrdwuub ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939967.7641401-31444-106387829396686/AnsiballZ_process_facts.py' && sleep 0
-    pid: '20076'
-    ppid: '19794'
-    user: centos
-  - cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-ljmwpbpxwppcelxemgoiqstuyhrdwuub ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939967.7641401-31444-106387829396686/AnsiballZ_process_facts.py
-    pid: '20091'
-    ppid: '20076'
-    user: root
-  - cmdline: /bin/sh -c echo BECOME-SUCCESS-ljmwpbpxwppcelxemgoiqstuyhrdwuub ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939967.7641401-31444-106387829396686/AnsiballZ_process_facts.py
-    pid: '20092'
-    ppid: '20091'
-    user: root
-  - cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939967.7641401-31444-106387829396686/AnsiballZ_process_facts.py
-    pid: '20093'
-    ppid: '20092'
-    user: root
-tcp_listen:
-  - address: 127.0.0.1
-    name: master
-    pid: 1245
-    port: 25
-    protocol: tcp
-    stime: Fri May 20 00:43:56 2022
-    user: root
-  - address: 0.0.0.0
-    name: zabbix_agentd
-    pid: 1105
-    port: 10050
-    protocol: tcp
-    stime: Fri May 20 00:43:49 2022
-    user: zabbix
-  - address: 0.0.0.0
-    name: zabbix_server
-    pid: 1173
-    port: 10051
-    protocol: tcp
-    stime: Fri May 20 00:43:53 2022
-    user: zabbix
-  - address: 0.0.0.0
-    name: redis-server
-    pid: 4355
-    port: 6379
-    protocol: tcp
-    stime: Tue Jun 21 14:18:11 2022
-    user: polkitd
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Fri May 20 00:43:02 2022
-    user: root
-  - address: 0.0.0.0
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: Fri May 20 00:43:55 2022
-    user: root
-  - address: ::1
-    name: master
-    pid: 1245
-    port: 25
-    protocol: tcp
-    stime: Fri May 20 00:43:56 2022
-    user: root
-  - address: '::'
-    name: zabbix_server
-    pid: 1173
-    port: 10051
-    protocol: tcp
-    stime: Fri May 20 00:43:53 2022
-    user: zabbix
-  - address: '::'
-    name: redis-server
-    pid: 4355
-    port: 6379
-    protocol: tcp
-    stime: Tue Jun 21 14:18:11 2022
-    user: polkitd
-  - address: '::'
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: tcp
-    stime: Fri May 20 00:43:02 2022
-    user: root
-  - address: '::'
-    name: sshd
-    pid: 1187
-    port: 22
-    protocol: tcp
-    stime: Fri May 20 00:43:55 2022
-    user: root
-  - address: '::'
-    name: docker-proxy
-    pid: 9781
-    port: 3128
-    protocol: tcp
-    stime: Fri May 20 00:45:03 2022
-    user: root
-udp_listen:
-  - address: 0.0.0.0
+  type: Zabbix Server
+  version:
+  - number: 4.0.20
+    type: package
+packages:
+  GeoIP:
+  - arch: x86_64
+    epoch: null
+    name: GeoIP
+    release: 13.el7
+    source: rpm
+    version: 1.5.0
+  OpenIPMI:
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
+  OpenIPMI-libs:
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI-libs
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
+  OpenIPMI-modalias:
+  - arch: x86_64
+    epoch: null
+    name: OpenIPMI-modalias
+    release: 1.el7
+    source: rpm
+    version: 2.0.27
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  atomic-registries:
+  - arch: x86_64
+    epoch: 1
+    name: atomic-registries
+    release: 33.gitb507039.el7_8
+    source: rpm
+    version: 1.22.1
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.4
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autogen-libopts:
+  - arch: x86_64
+    epoch: null
+    name: autogen-libopts
+    release: 5.el7
+    source: rpm
+    version: '5.18'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 31.el7
+    source: rpm
+    version: 4.2.46
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 26.P2.el7_9.3
+    source: rpm
+    version: 9.11.4
+  bind-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs
+    release: 26.P2.el7_9.3
+    source: rpm
+    version: 9.11.4
+  bind-libs-lite:
+  - arch: x86_64
+    epoch: 32
+    name: bind-libs-lite
+    release: 26.P2.el7_9.3
+    source: rpm
+    version: 9.11.4
+  bind-license:
+  - arch: noarch
+    epoch: 32
+    name: bind-license
+    release: 26.P2.el7_9.3
+    source: rpm
+    version: 9.11.4
+  bind-utils:
+  - arch: x86_64
+    epoch: 32
+    name: bind-utils
+    release: 26.P2.el7_9.3
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 34.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 70.0.el7_5
+    source: rpm
+    version: 2018.2.22
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 6.1810.2.el7.centos
+    source: rpm
+    version: '7'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 2.el7
+    source: rpm
+    version: '3.2'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 1.el7.centos.2
+    source: rpm
+    version: '18.2'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 2.el7_6.2
+    source: rpm
+    version: '0.29'
+  conmon:
+  - arch: x86_64
+    epoch: 2
+    name: conmon
+    release: 1.el7
+    source: rpm
+    version: 2.0.8
+  container-selinux:
+  - arch: noarch
+    epoch: 2
+    name: container-selinux
+    release: 1.c57a6f9.el7
+    source: rpm
+    version: 2.119.1
+  container-storage-setup:
+  - arch: noarch
+    epoch: null
+    name: container-storage-setup
+    release: 2.git5eaf76c.el7
+    source: rpm
+    version: 0.11.0
+  containerd.io:
+  - arch: x86_64
+    epoch: null
+    name: containerd.io
+    release: 3.1.el7
+    source: rpm
+    version: 1.3.7
+  containernetworking-plugins:
+  - arch: x86_64
+    epoch: null
+    name: containernetworking-plugins
+    release: 4.el7.centos
+    source: rpm
+    version: 0.8.1
+  containers-common:
+  - arch: x86_64
+    epoch: 1
+    name: containers-common
+    release: 7.el7_8
+    source: rpm
+    version: 0.1.40
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 23.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  criu:
+  - arch: x86_64
+    epoch: null
+    name: criu
+    release: 2.el7
+    source: rpm
+    version: '3.12'
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 20.el7_6
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 3.el7
+    source: rpm
+    version: 2.0.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-event:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-event-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-event-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 1.02.164
+  device-mapper-persistent-data:
+  - arch: x86_64
+    epoch: null
+    name: device-mapper-persistent-data
+    release: 2.el7
+    source: rpm
+    version: 0.8.5
+  dhclient:
+  - arch: x86_64
+    epoch: 12
     name: dhclient
-    pid: 994
-    port: 68
-    protocol: udp
-    stime: Fri May 20 00:43:47 2022
-    user: root
-  - address: 0.0.0.0
-    name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Fri May 20 00:43:02 2022
-    user: root
-  - address: 192.168.0.88
-    name: ntpd
-    pid: 5125
-    port: 123
-    protocol: udp
-    stime: Tue Jun 21 14:20:29 2022
-    user: ntp
-  - address: 192.168.1.1
-    name: ntpd
-    pid: 5125
-    port: 123
-    protocol: udp
-    stime: Tue Jun 21 14:20:29 2022
-    user: ntp
-  - address: 127.0.0.1
-    name: ntpd
-    pid: 5125
-    port: 123
-    protocol: udp
-    stime: Tue Jun 21 14:20:29 2022
-    user: ntp
-  - address: 0.0.0.0
-    name: ntpd
-    pid: 5125
-    port: 123
-    protocol: udp
-    stime: Tue Jun 21 14:20:29 2022
-    user: ntp
-  - address: 0.0.0.0
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 82.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 4.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 2.el7
+    source: rpm
+    version: '3.1'
+  docker-ce:
+  - arch: x86_64
+    epoch: 3
+    name: docker-ce
+    release: 3.el7
+    source: rpm
+    version: 19.03.13
+  docker-ce-cli:
+  - arch: x86_64
+    epoch: 1
+    name: docker-ce-cli
+    release: 3.el7
+    source: rpm
+    version: 19.03.13
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 554.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 554.el7
+    source: rpm
+    version: '033'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 2.el7
+    source: rpm
+    version: '0.172'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 9.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 10.el7_3
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 35.el7
+    source: rpm
+    version: '5.11'
+  filebeat:
+  - arch: x86_64
+    epoch: null
+    name: filebeat
+    release: '1'
+    source: rpm
+    version: 7.4.2
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  forkstat:
+  - arch: x86_64
+    epoch: null
+    name: forkstat
+    release: '1.1'
+    source: rpm
+    version: 0.02.12
+  fping:
+  - arch: x86_64
+    epoch: null
+    name: fping
+    release: 4.el7
+    source: rpm
+    version: '3.10'
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 12.el7_6.1
+    source: rpm
+    version: '2.8'
+  fuse-overlayfs:
+  - arch: x86_64
+    epoch: null
+    name: fuse-overlayfs
+    release: 6.el7_8
+    source: rpm
+    version: 0.7.2
+  fuse3-libs:
+  - arch: x86_64
+    epoch: null
+    name: fuse3-libs
+    release: 4.el7
+    source: rpm
+    version: 3.6.1
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 2.el7
+    source: rpm
+    version: 0.19.8.1
+  git:
+  - arch: x86_64
+    epoch: null
+    name: git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 4.el7_6
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 260.el7_6.6
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gnutls:
+  - arch: x86_64
+    epoch: null
+    name: gnutls
+    release: 9.el7_6
+    source: rpm
+    version: 3.3.29
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 58adea78
+    source: rpm
+    version: 621e9f35
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  gpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: gpm-libs
+    release: 6.el7
+    source: rpm
+    version: 1.20.7
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.76.el7.centos.1
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 25.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 21.el7
+    source: rpm
+    version: 0.7.0
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7
+    source: rpm
+    version: '3.13'
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.1.el7
+    source: rpm
+    version: '0.252'
+  iksemel:
+  - arch: x86_64
+    epoch: null
+    name: iksemel
+    release: 2.el7.centos
+    source: rpm
+    version: '1.4'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.46
+  iometrics-agent:
+  - arch: x86_64
+    epoch: null
+    name: iometrics-agent
+    release: '27'
+    source: rpm
+    version: 1.11.3
+  iotop:
+  - arch: noarch
+    epoch: null
+    name: iotop
+    release: 4.el7
+    source: rpm
+    version: '0.6'
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 14.el7_6.2
+    source: rpm
+    version: 4.11.0
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 28.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 11.el7
+    source: rpm
+    version: 1.0.7
+  iwl7265-firmware:
+  - arch: noarch
+    epoch: null
+    name: iwl7265-firmware
+    release: 69.el7
+    source: rpm
+    version: 22.0.7.0
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jq:
+  - arch: x86_64
+    epoch: null
+    name: jq
+    release: 2.el7
+    source: rpm
+    version: '1.6'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 21.el7_6.4
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 23.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 123.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 37.el7_6
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 14.el7
+    source: rpm
+    version: 2.2.51
+  libaio:
+  - arch: x86_64
+    epoch: null
+    name: libaio
+    release: 13.el7
+    source: rpm
+    version: 0.3.109
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 9.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 20.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 51.el7_6.3
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 24.el7
+    source: rpm
+    version: 5.3.21
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 18.el7
+    source: rpm
+    version: 3.0.13
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 7.el7
+    source: rpm
+    version: '1.2'
+  libnet:
+  - arch: x86_64
+    epoch: null
+    name: libnet
+    release: 7.el7
+    source: rpm
+    version: 1.1.6
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnftnl:
+  - arch: x86_64
+    epoch: null
+    name: libnftnl
+    release: 3.el7
+    source: rpm
+    version: 1.0.8
+  libnl:
+  - arch: x86_64
+    epoch: null
+    name: libnl
+    release: 3.el7
+    source: rpm
+    version: 1.1.4
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpcap:
+  - arch: x86_64
+    epoch: 14
+    name: libpcap
+    release: 12.el7
+    source: rpm
+    version: 1.5.3
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 3.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python3:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python3
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 13.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 12.el7_6.3
+    source: rpm
+    version: 1.4.3
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 36.el7_6.2
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.15.el7
+    source: rpm
+    version: 0.2.4
+  libtool-ltdl:
+  - arch: x86_64
+    epoch: null
+    name: libtool-ltdl
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7_2.3
+    source: rpm
+    version: 2.9.1
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 17.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 12.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lvm2:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2
+    release: 7.el7_8.2
+    source: rpm
+    version: 2.02.186
+  lvm2-libs:
+  - arch: x86_64
+    epoch: 7
+    name: lvm2-libs
+    release: 7.el7_8.2
+    source: rpm
+    version: 2.02.186
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 23.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7_5
+    source: rpm
+    version: 5.5.60
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 47.5.el7_6
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 48.el7_8
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.24.20131004git.el7
+    source: rpm
+    version: '2.0'
+  nettle:
+  - arch: x86_64
+    epoch: null
+    name: nettle
+    release: 8.el7
+    source: rpm
+    version: 2.7.1
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.61.el7
+    source: rpm
+    version: 1.3.0
+  nftables:
+  - arch: x86_64
+    epoch: 1
+    name: nftables
+    release: 14.el7
+    source: rpm
+    version: '0.8'
+  ngrep:
+  - arch: x86_64
+    epoch: null
+    name: ngrep
+    release: 1.1.20180101git9b59468.el7
+    source: rpm
+    version: '1.47'
+  nmap-ncat:
+  - arch: x86_64
+    epoch: 2
+    name: nmap-ncat
+    release: 19.el7
+    source: rpm
+    version: '6.40'
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7_5
+    source: rpm
+    version: 4.19.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 5.el7_6.1
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 5.el7_5
+    source: rpm
+    version: 3.36.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.1.el7_6
+    source: rpm
+    version: 3.36.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 1.1.el7_6
+    source: rpm
+    version: 3.36.0
+  ntp:
+  - arch: x86_64
+    epoch: null
+    name: ntp
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  ntpdate:
+  - arch: x86_64
+    epoch: null
+    name: ntpdate
+    release: 29.el7.centos.2
+    source: rpm
+    version: 4.2.6p5
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 7.el7
+    source: rpm
+    version: 2.0.9
+  oci-register-machine:
+  - arch: x86_64
+    epoch: 1
+    name: oci-register-machine
+    release: 6.git2b44233.el7
+    source: rpm
+    version: '0'
+  oci-systemd-hook:
+  - arch: x86_64
+    epoch: 1
+    name: oci-systemd-hook
+    release: 1.git05e6923.el7_6
+    source: rpm
+    version: 0.2.0
+  oci-umount:
+  - arch: x86_64
+    epoch: 2
+    name: oci-umount
+    release: 3.el7
+    source: rpm
+    version: '2.5'
+  oniguruma:
+  - arch: x86_64
+    epoch: null
+    name: oniguruma
+    release: 1.el7
+    source: rpm
+    version: 6.8.2
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 21.el7_6
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 16.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 16.el7_6.1
+    source: rpm
+    version: 1.0.2k
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 22.el7
+    source: rpm
+    version: 1.1.8
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 29.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 4.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Error:
+  - arch: noarch
+    epoch: 1
+    name: perl-Error
+    release: 2.el7
+    source: rpm
+    version: '0.17020'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-Git:
+  - arch: noarch
+    epoch: null
+    name: perl-Git
+    release: 23.el7_8
+    source: rpm
+    version: 1.8.3.1
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 295.el7
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-TermReadKey:
+  - arch: x86_64
+    epoch: null
+    name: perl-TermReadKey
+    release: 20.el7
+    source: rpm
+    version: '2.30'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 295.el7
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  podman:
+  - arch: x86_64
+    epoch: null
+    name: podman
+    release: 16.el7_8
+    source: rpm
+    version: 1.6.4
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 29.el7_6.1
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 18.el7_6.1
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 7.el7
+    source: rpm
+    version: 2.10.1
+  postgresql:
+  - arch: x86_64
+    epoch: null
+    name: postgresql
+    release: 4.el7_8
+    source: rpm
+    version: 9.2.24
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 4.el7_8
+    source: rpm
+    version: 9.2.24
+  postgresql-odbc:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-odbc
+    release: 2.el7
+    source: rpm
+    version: 09.03.0100
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 23.el7
+    source: rpm
+    version: 3.3.10
+  protobuf-c:
+  - arch: x86_64
+    epoch: null
+    name: protobuf-c
+    release: 3.el7
+    source: rpm
+    version: 1.0.2
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 88.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 1.el7_1
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-dateutil:
+  - arch: noarch
+    epoch: null
+    name: python-dateutil
+    release: 7.el7
+    source: rpm
+    version: '1.5'
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-devel:
+  - arch: x86_64
+    epoch: null
+    name: python-devel
+    release: 88.el7
+    source: rpm
+    version: 2.7.5
+  python-dmidecode:
+  - arch: x86_64
+    epoch: null
+    name: python-dmidecode
+    release: 4.el7
+    source: rpm
+    version: 3.12.2
+  python-docker-py:
+  - arch: noarch
+    epoch: 1
+    name: python-docker-py
+    release: 11.el7
+    source: rpm
+    version: 1.10.6
+  python-docker-pycreds:
+  - arch: noarch
+    epoch: 1
+    name: python-docker-pycreds
+    release: 11.el7
+    source: rpm
+    version: 0.3.0
+  python-ethtool:
+  - arch: x86_64
+    epoch: null
+    name: python-ethtool
+    release: 8.el7
+    source: rpm
+    version: '0.8'
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-inotify:
+  - arch: noarch
+    epoch: null
+    name: python-inotify
+    release: 4.el7
+    source: rpm
+    version: 0.9.4
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 3.el7_6
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 88.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.9
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 957.27.2.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pytoml:
+  - arch: noarch
+    epoch: null
+    name: python-pytoml
+    release: 1.git7dea353.el7
+    source: rpm
+    version: 0.1.14
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 1.el7_1
+    source: rpm
+    version: 2.6.0
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 32.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 32.el7
+    source: rpm
+    version: '3'
+  python-syspurpose:
+  - arch: x86_64
+    epoch: null
+    name: python-syspurpose
+    release: 3.el7.centos
+    source: rpm
+    version: 1.24.26
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 9.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 5.el7
+    source: rpm
+    version: 1.10.2
+  python-virtualenv:
+  - arch: noarch
+    epoch: null
+    name: python-virtualenv
+    release: 4.el7_7
+    source: rpm
+    version: 15.1.0
+  python-websocket-client:
+  - arch: noarch
+    epoch: null
+    name: python-websocket-client
+    release: 3.git3c25814.el7
+    source: rpm
+    version: 0.56.0
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python2-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python2-rpm-macros
+    release: 32.el7
+    source: rpm
+    version: '3'
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 13.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 7.el7_7
+    source: rpm
+    version: 9.0.3
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 2.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 17.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 10.el7
+    source: rpm
+    version: '6.2'
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
     name: rpcbind
-    pid: 641
-    port: 813
-    protocol: udp
-    stime: Fri May 20 00:43:29 2022
-    user: rpc
-  - address: '::'
+    release: 47.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 35.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 6.el7_6.1
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 34.el7
+    source: rpm
+    version: 8.24.0
+  screen:
+  - arch: x86_64
+    epoch: null
+    name: screen
+    release: 0.25.20120314git3c2946.el7
+    source: rpm
+    version: 4.1.0
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 5.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 229.el7_6.15
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 10.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: null
+    name: sg3_utils-libs
+    release: 17.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 25.el7_6.1
+    source: rpm
+    version: 4.1.5.1
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 4.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  slirp4netns:
+  - arch: x86_64
+    epoch: null
+    name: slirp4netns
+    release: 4.el7_8
+    source: rpm
+    version: 0.4.3
+  smem:
+  - arch: noarch
+    epoch: null
+    name: smem
+    release: 1.el7
+    source: rpm
+    version: '1.4'
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7
+    source: rpm
+    version: 3.7.17
+  strace:
+  - arch: x86_64
+    epoch: null
+    name: strace
+    release: 4.el7
+    source: rpm
+    version: '4.24'
+  subscription-manager:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager
+    release: 3.el7.centos
+    source: rpm
+    version: 1.24.26
+  subscription-manager-rhsm:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm
+    release: 3.el7.centos
+    source: rpm
+    version: 1.24.26
+  subscription-manager-rhsm-certificates:
+  - arch: x86_64
+    epoch: null
+    name: subscription-manager-rhsm-certificates
+    release: 3.el7.centos
+    source: rpm
+    version: 1.24.26
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 3.el7
+    source: rpm
+    version: 1.8.23
+  sysstat:
+  - arch: x86_64
+    epoch: null
+    name: sysstat
+    release: 19.el7
+    source: rpm
+    version: 10.1.5
+  systemd:
+  - arch: x86_64
+    epoch: null
     name: systemd
-    pid: 1
-    port: 111
-    protocol: udp
-    stime: Fri May 20 00:43:02 2022
-    user: root
-  - address: fe80::f816:3eff:fee
-    name: ntpd
-    pid: 5125
-    port: 123
-    protocol: udp
-    stime: Tue Jun 21 14:20:29 2022
-    user: ntp
-  - address: 'fe80::42:95ff:fe82:'
-    name: ntpd
-    pid: 5125
-    port: 123
-    protocol: udp
-    stime: Tue Jun 21 14:20:29 2022
-    user: ntp
-  - address: fe80::90e2:35ff:fe6
-    name: ntpd
-    pid: 5125
-    port: 123
-    protocol: udp
-    stime: Tue Jun 21 14:20:29 2022
-    user: ntp
-  - address: ::1
-    name: ntpd
-    pid: 5125
-    port: 123
-    protocol: udp
-    stime: Tue Jun 21 14:20:29 2022
-    user: ntp
-  - address: '::'
-    name: ntpd
-    pid: 5125
-    port: 123
-    protocol: udp
-    stime: Tue Jun 21 14:20:29 2022
-    user: ntp
-  - address: '::'
-    name: rpcbind
-    pid: 641
-    port: 813
-    protocol: udp
-    stime: Fri May 20 00:43:29 2022
-    user: rpc
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 62.el7_6.9
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcpdump:
+  - arch: x86_64
+    epoch: 14
+    name: tcpdump
+    release: 4.el7_7.1
+    source: rpm
+    version: 4.9.2
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 6.el7_6.1
+    source: rpm
+    version: '1.27'
+  telnet:
+  - arch: x86_64
+    epoch: 1
+    name: telnet
+    release: 66.el7
+    source: rpm
+    version: '0.17'
+  trousers:
+  - arch: x86_64
+    epoch: null
+    name: trousers
+    release: 2.el7
+    source: rpm
+    version: 0.3.14
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 6.el7_6.4
+    source: rpm
+    version: 2.10.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019b
+  unixODBC:
+  - arch: x86_64
+    epoch: null
+    name: unixODBC
+    release: 14.el7
+    source: rpm
+    version: 2.3.1
+  usermode:
+  - arch: x86_64
+    epoch: null
+    name: usermode
+    release: 6.el7
+    source: rpm
+    version: '1.111'
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 59.el7_6.1
+    source: rpm
+    version: 2.23.2
+  vim-common:
+  - arch: x86_64
+    epoch: 2
+    name: vim-common
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-enhanced:
+  - arch: x86_64
+    epoch: 2
+    name: vim-enhanced
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-filesystem:
+  - arch: x86_64
+    epoch: 2
+    name: vim-filesystem
+    release: 8.el7_9
+    source: rpm
+    version: 7.4.629
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7_6
+    source: rpm
+    version: 7.4.160
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 19.el7_6
+    source: rpm
+    version: 4.5.0
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yajl:
+  - arch: x86_64
+    epoch: null
+    name: yajl
+    release: 4.el7
+    source: rpm
+    version: 2.0.4
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 161.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 50.el7
+    source: rpm
+    version: 1.1.31
+  zabbix-agent:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-agent
+    release: 2.el7
+    source: rpm
+    version: 4.0.21
+  zabbix-get:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-get
+    release: 1.el7
+    source: rpm
+    version: 4.0.20
+  zabbix-sender:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-sender
+    release: 1.el7
+    source: rpm
+    version: 4.0.20
+  zabbix-server-pgsql:
+  - arch: x86_64
+    epoch: null
+    name: zabbix-server-pgsql
+    release: 1.el7
+    source: rpm
+    version: 4.0.20
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '3'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '30'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '31'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '32'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '33'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '34'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '35'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '42'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '43'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '44'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '45'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '53'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '55'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '56'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '57'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '58'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '72'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '115'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '191'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '192'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '333'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '334'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '335'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '336'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '337'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '351'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '352'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '353'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '354'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '355'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '356'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '357'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '358'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '359'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '360'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '361'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '441'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/lvmetad -f
+  cwd: /usr/sbin/
+  pid: '478'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '480'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '572'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '586'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '609'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '612'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '632'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '641'
+  ppid: '1'
+  user: rpc
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '646'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '647'
+  ppid: '1'
+  user: polkitd
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '648'
+  ppid: '1'
+  user: dbus
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '653'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '679'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '692'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '853'
+  ppid: '2'
+  user: root
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H zabbix-server01 eth0
+  cwd: /sbin/
+  pid: '994'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory
+    /etc/telegraf/telegraf.d
+  cwd: /usr/bin/
+  pid: '1055'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '1057'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/containerd
+  cwd: /usr/bin/
+  pid: '1064'
+  ppid: '1'
+  user: root
+- cmdline: /usr/bin/rhsmcertd
+  cwd: /usr/bin/
+  pid: '1070'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/zabbix_agentd -c /etc/zabbix/zabbix_agentd.conf
+  cwd: /usr/sbin/
+  pid: '1105'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: collector [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1108'
+  ppid: '1105'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #1 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1109'
+  ppid: '1105'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #2 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1110'
+  ppid: '1105'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: listener #3 [waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1111'
+  ppid: '1105'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_agentd: active checks #1 [idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1112'
+  ppid: '1105'
+  user: zabbix
+- cmdline: /usr/sbin/zabbix_server -c /etc/zabbix/zabbix_server.conf
+  cwd: /usr/sbin/
+  pid: '1173'
+  ppid: '1'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: configuration syncer [synced configuration in
+    1.574989 sec, idle 60 sec]'
+  cwd: /usr/sbin/
+  pid: '1178'
+  ppid: '1173'
+  user: zabbix
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1179'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1187'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1216'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1217'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1218'
+  ppid: '1'
+  user: root
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1245'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/sbin/zabbix_server: housekeeper [deleted 0 hist/trends, 0 items/triggers,
+    69 events, 2 sessions, 0 alarms, 2 audit items in 1.195076 sec, idle for 1 hour(s)]'
+  cwd: /usr/sbin/
+  pid: '1255'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #1 [updated 0 hosts, suppressed 0 events
+    in 0.001907 sec, idle 59 sec]'
+  cwd: /usr/sbin/
+  pid: '1256'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #2 [suppressed 0 events in 0.035586 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1257'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #3 [suppressed 0 events in 0.032545 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1258'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #4 [suppressed 0 events in 0.043363 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1259'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #5 [suppressed 0 events in 0.066465 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1260'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #6 [suppressed 0 events in 0.064149 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1261'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #7 [suppressed 0 events in 0.044135 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1262'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #8 [suppressed 0 events in 0.066614 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1263'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #9 [suppressed 0 events in 0.070274 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1264'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #10 [suppressed 0 events in 0.033935 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1265'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #11 [suppressed 0 events in 0.033549 sec,
+    idle 59 sec]'
+  cwd: /usr/sbin/
+  pid: '1266'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #12 [suppressed 0 events in 0.056936 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1267'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #13 [suppressed 0 events in 0.060405 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1268'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #14 [suppressed 0 events in 0.045167 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1269'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: timer #15 [suppressed 0 events in 0.038825 sec,
+    idle 58 sec]'
+  cwd: /usr/sbin/
+  pid: '1270'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #1 [got 0 values in 0.001601 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1271'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #2 [got 0 values in 0.001186 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1272'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #3 [got 0 values in 0.001257 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1273'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #4 [got 0 values in 0.001622 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1274'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #5 [got 0 values in 0.001709 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1275'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #6 [got 0 values in 0.001607 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1276'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #7 [got 0 values in 0.001650 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1277'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #8 [got 0 values in 0.001241 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1278'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #9 [got 0 values in 0.001343 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1279'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #10 [got 0 values in 0.001719 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1280'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #11 [got 0 values in 0.002388 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1281'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: http poller #12 [got 0 values in 0.001564 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1282'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: discoverer #1 [processed 0 rules in 0.001910
+    sec, idle 60 sec]'
+  cwd: /usr/sbin/
+  pid: '1283'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: discoverer #2 [processed 0 rules in 0.002141
+    sec, idle 60 sec]'
+  cwd: /usr/sbin/
+  pid: '1284'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: discoverer #3 [processed 0 rules in 0.002326
+    sec, idle 60 sec]'
+  cwd: /usr/sbin/
+  pid: '1285'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: discoverer #4 [processed 0 rules in 0.001887
+    sec, idle 60 sec]'
+  cwd: /usr/sbin/
+  pid: '1286'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: discoverer #5 [processed 0 rules in 0.001595
+    sec, idle 60 sec]'
+  cwd: /usr/sbin/
+  pid: '1287'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: discoverer #6 [processed 0 rules in 0.001633
+    sec, idle 60 sec]'
+  cwd: /usr/sbin/
+  pid: '1288'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #1 [processed 0 values, 0 triggers
+    in 0.000042 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1289'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #2 [processed 22 values, 15 triggers
+    in 0.017126 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1290'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #3 [processed 0 values, 0 triggers
+    in 0.000042 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1291'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #4 [processed 0 values, 0 triggers
+    in 0.000037 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1292'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #5 [processed 0 values, 0 triggers
+    in 0.000041 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1293'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #6 [processed 0 values, 0 triggers
+    in 0.000051 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1294'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #7 [processed 0 values, 11 triggers
+    in 0.002103 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1295'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #8 [processed 0 values, 0 triggers
+    in 0.000052 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1296'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #9 [processed 0 values, 0 triggers
+    in 0.000042 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1297'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: history syncer #10 [processed 0 values, 0 triggers
+    in 0.000050 sec, idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1298'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: escalator #1 [processed 0 escalations in 0.002789
+    sec, idle 3 sec]'
+  cwd: /usr/sbin/
+  pid: '1299'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: escalator #2 [processed 0 escalations in 0.003336
+    sec, idle 3 sec]'
+  cwd: /usr/sbin/
+  pid: '1300'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: escalator #3 [processed 0 escalations in 0.003633
+    sec, idle 3 sec]'
+  cwd: /usr/sbin/
+  pid: '1301'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: snmp trapper [processed data in 0.000042 sec,
+    idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1302'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: self-monitoring [processed data in 0.000065 sec,
+    idle 1 sec]'
+  cwd: /usr/sbin/
+  pid: '1303'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: task manager [processed 0 task(s) in 0.001448
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1304'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #1 [got 0 values in 0.000092 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1305'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #2 [got 0 values in 0.000065 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1306'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #3 [got 0 values in 0.000042 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1307'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #4 [got 0 values in 0.000110 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1308'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #5 [got 0 values in 0.000333 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1309'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #6 [got 0 values in 0.000057 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1310'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #7 [got 0 values in 0.000043 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1311'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #8 [got 0 values in 0.000052 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1312'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #9 [got 0 values in 0.000204 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1313'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #10 [got 5 values in 0.001876 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1314'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #11 [got 0 values in 0.000029 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1315'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #12 [got 0 values in 0.000033 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1316'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #13 [got 0 values in 0.000040 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1317'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #14 [got 0 values in 0.000040 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1318'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #15 [got 0 values in 0.000023 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1319'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #16 [got 0 values in 0.000037 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1320'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #17 [got 0 values in 0.000046 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1321'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #18 [got 0 values in 0.000031 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1322'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #19 [got 0 values in 0.000022 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1323'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #20 [got 0 values in 0.000106 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1324'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #21 [got 0 values in 0.000057 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1325'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #22 [got 0 values in 0.000043 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1326'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #23 [got 0 values in 0.000079 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1327'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #24 [got 0 values in 0.000032 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1328'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #25 [got 0 values in 0.000051 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1329'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #26 [got 0 values in 0.000048 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1330'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #27 [got 0 values in 0.000056 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1331'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #28 [got 0 values in 0.000050 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1332'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #29 [got 0 values in 0.000057 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1333'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #30 [got 0 values in 0.000066 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1334'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #31 [got 0 values in 0.000034 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1335'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #32 [got 0 values in 0.000032 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1336'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #33 [got 0 values in 0.000627 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1337'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #34 [got 0 values in 0.000171 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1338'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #35 [got 0 values in 0.000042 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1339'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #36 [got 0 values in 0.000063 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1340'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #37 [got 0 values in 0.000028 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1341'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #38 [got 0 values in 0.000063 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1342'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #39 [got 0 values in 0.000039 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1343'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #40 [got 0 values in 0.000035 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1344'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #41 [got 0 values in 0.000044 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1345'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #42 [got 0 values in 0.000211 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1346'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #43 [got 0 values in 0.000033 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1347'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #44 [got 0 values in 0.000047 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1348'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #45 [got 0 values in 0.000039 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1349'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #46 [got 0 values in 0.000046 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1350'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #47 [got 0 values in 0.000120 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1351'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #48 [got 0 values in 0.000022 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1352'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #49 [got 0 values in 0.000054 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1353'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #50 [got 0 values in 0.000040 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1354'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #51 [got 0 values in 0.000031 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1355'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #52 [got 0 values in 0.000046 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1356'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #53 [got 1 values in 15.000692 sec, getting
+    values]'
+  cwd: /usr/sbin/
+  pid: '1357'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #54 [got 0 values in 0.000068 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1358'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #55 [got 0 values in 0.000088 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1359'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #56 [got 0 values in 0.000046 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1360'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #57 [got 0 values in 0.000116 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1361'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #58 [got 0 values in 0.000031 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1362'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #59 [got 3 values in 0.024509 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1363'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #60 [got 0 values in 0.000029 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1364'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #61 [got 0 values in 0.000092 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1365'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #62 [got 8 values in 0.001505 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1366'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #63 [got 0 values in 0.000047 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1367'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #64 [got 0 values in 0.000096 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1368'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #65 [got 0 values in 0.000035 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1369'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #66 [got 0 values in 0.000087 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1370'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #67 [got 0 values in 0.000108 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1371'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #68 [got 0 values in 0.000145 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1372'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #69 [got 1 values in 0.001306 sec, getting
+    values]'
+  cwd: /usr/sbin/
+  pid: '1373'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #70 [got 0 values in 0.000046 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1376'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #71 [got 0 values in 0.000023 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1377'
+  ppid: '1173'
+  user: zabbix
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1379'
+  ppid: '1245'
+  user: postfix
+- cmdline: '/usr/sbin/zabbix_server: poller #72 [got 0 values in 0.000023 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1380'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #73 [got 0 values in 0.000084 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1381'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #74 [got 0 values in 0.000029 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1382'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #75 [got 0 values in 0.000365 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1383'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #76 [got 0 values in 0.000044 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1384'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #77 [got 0 values in 0.000034 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1385'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #78 [got 0 values in 0.000022 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1386'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #79 [got 0 values in 0.000052 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1387'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #80 [got 0 values in 0.000053 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1388'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #81 [got 0 values in 0.000030 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1389'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #82 [got 0 values in 0.000078 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1390'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #83 [got 0 values in 0.000036 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1391'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #84 [got 0 values in 0.000035 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1392'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #85 [got 0 values in 0.000042 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1393'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #86 [got 0 values in 0.000078 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1394'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #87 [got 0 values in 0.000045 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1395'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #88 [got 6 values in 0.001313 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1396'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #89 [got 0 values in 0.000021 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1397'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #90 [got 0 values in 0.000029 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1398'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #91 [got 0 values in 0.000061 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1399'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #92 [got 0 values in 0.000042 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1400'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #93 [got 0 values in 0.000040 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1401'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #94 [got 0 values in 0.000047 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1402'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #95 [got 0 values in 0.000045 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1403'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #96 [got 0 values in 0.000037 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1404'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #97 [got 0 values in 0.000068 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1405'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #98 [got 0 values in 0.000065 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1406'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #99 [got 0 values in 0.000043 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1407'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: poller #100 [got 0 values in 0.000172 sec, idle
+    1 sec]'
+  cwd: /usr/sbin/
+  pid: '1408'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #1 [got 0 values in 0.000057
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1409'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #2 [got 0 values in 0.000104
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1410'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #3 [got 0 values in 0.000080
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1411'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #4 [got 0 values in 0.000064
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1412'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #5 [got 0 values in 0.000054
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1413'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #6 [got 0 values in 0.000042
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1414'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #7 [got 0 values in 0.000060
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1415'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #8 [got 0 values in 0.000076
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1416'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #9 [got 0 values in 0.000088
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1417'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: unreachable poller #10 [got 0 values in 0.000056
+    sec, idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1418'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #1 [processed data in 0.000230 sec, waiting
+    for connection]'
+  cwd: /usr/sbin/
+  pid: '1419'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #2 [processed data in 0.006015 sec, waiting
+    for connection]'
+  cwd: /usr/sbin/
+  pid: '1420'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #3 [processed data in 0.016559 sec, waiting
+    for connection]'
+  cwd: /usr/sbin/
+  pid: '1421'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #4 [processed data in 0.000297 sec, waiting
+    for connection]'
+  cwd: /usr/sbin/
+  pid: '1422'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #5 [processed data in 0.000145 sec, waiting
+    for connection]'
+  cwd: /usr/sbin/
+  pid: '1423'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #6 [processed data in 0.002896 sec, waiting
+    for connection]'
+  cwd: /usr/sbin/
+  pid: '1424'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #7 [processed data in 0.002574 sec, waiting
+    for connection]'
+  cwd: /usr/sbin/
+  pid: '1425'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #8 [processed data in 0.000330 sec, waiting
+    for connection]'
+  cwd: /usr/sbin/
+  pid: '1426'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #9 [processed data in 0.006360 sec, waiting
+    for connection]'
+  cwd: /usr/sbin/
+  pid: '1427'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #10 [processed data in 0.000253 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1428'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #11 [processed data in 0.000470 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1429'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #12 [processed data in 0.000152 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1430'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #13 [processed data in 0.003929 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1431'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #14 [processed data in 0.000218 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1432'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #15 [processed data in 0.002176 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1433'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #16 [processed data in 0.002160 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1434'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #17 [processed data in 0.000222 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1435'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #18 [processed data in 0.000175 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1436'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #19 [processed data in 0.001193 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1437'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #20 [processed data in 0.001956 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1438'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #21 [processed data in 0.000201 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1439'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #22 [processed data in 0.000260 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1440'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #23 [processed data in 0.008046 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1441'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #24 [processed data in 0.000204 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1442'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #25 [processed data in 0.009377 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1443'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #26 [processed data in 0.002651 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1444'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #27 [processed data in 0.006057 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1445'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #28 [processed data in 0.002465 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1446'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #29 [processed data in 0.002373 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1447'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #30 [processed data in 0.000944 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1448'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #31 [processed data in 0.001482 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1449'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #32 [processed data in 0.000197 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1450'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #33 [processed data in 0.002447 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1451'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #34 [processed data in 0.002830 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1452'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #35 [processed data in 0.002116 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1453'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #36 [processed data in 0.005720 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1454'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #37 [processed data in 0.002188 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1455'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #38 [processed data in 0.008311 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1456'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #39 [processed data in 0.003236 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1457'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #40 [processed data in 0.002259 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1458'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #41 [processed data in 0.013718 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1459'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #42 [processed data in 0.003235 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1460'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #43 [processed data in 0.000191 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1461'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #44 [processed data in 0.000305 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1462'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #45 [processed data in 0.000219 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1463'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #46 [processed data in 0.000209 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1464'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #47 [processed data in 0.006524 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1465'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #48 [processed data in 0.000222 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1466'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #49 [processed data in 0.000214 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1467'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: trapper #50 [processed data in 0.003061 sec,
+    waiting for connection]'
+  cwd: /usr/sbin/
+  pid: '1468'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #1 [got 0 values in 0.000049 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1469'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #2 [got 0 values in 0.000058 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1470'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #3 [got 0 values in 0.000057 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1471'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #4 [got 0 values in 0.000034 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1472'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #5 [got 0 values in 0.000051 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1473'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #6 [got 0 values in 0.000033 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1474'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #7 [got 0 values in 0.000028 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1475'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #8 [got 0 values in 0.000031 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1476'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #9 [got 0 values in 0.000059 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1477'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: icmp pinger #10 [got 0 values in 0.000050 sec,
+    idle 5 sec]'
+  cwd: /usr/sbin/
+  pid: '1478'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: alert manager #1 [sent 2, failed 0 alerts, idle
+    5.322796 sec during 5.322978 sec]'
+  cwd: /usr/sbin/
+  pid: '1479'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: alerter #1 [sent 0, failed 0 alerts, idle 178.024568
+    sec during 180.357522 sec]'
+  cwd: /usr/sbin/
+  pid: '1480'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: alerter #2 [sent 0, failed 0 alerts, idle 118.623005
+    sec during 119.766001 sec]'
+  cwd: /usr/sbin/
+  pid: '1481'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: alerter #3 [sent 0, failed 0 alerts, idle 59.250622
+    sec during 60.530660 sec]'
+  cwd: /usr/sbin/
+  pid: '1482'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: preprocessing manager #1 [queued 1, processed
+    560 values, idle 5.033828 sec during 5.041462 sec]'
+  cwd: /usr/sbin/
+  pid: '1483'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: preprocessing worker #1 started'
+  cwd: /usr/sbin/
+  pid: '1484'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: preprocessing worker #2 started'
+  cwd: /usr/sbin/
+  pid: '1485'
+  ppid: '1173'
+  user: zabbix
+- cmdline: '/usr/sbin/zabbix_server: preprocessing worker #3 started'
+  cwd: /usr/sbin/
+  pid: '1486'
+  ppid: '1173'
+  user: zabbix
+- cmdline: /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
+  cwd: /usr/bin/
+  pid: '2832'
+  ppid: '1'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/7dac0edef9dae20cb5f7759a19e75bef5fbbcb8d4e2ac5ec7613a5d4fdcc7c2c
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '4337'
+  ppid: '1064'
+  user: root
+- cmdline: redis-server *:6379
+  cwd: /
+  pid: '4355'
+  ppid: '4337'
+  user: polkitd
+- cmdline: /usr/sbin/ntpd -u ntp:ntp -g
+  cwd: /usr/sbin/
+  pid: '5125'
+  ppid: '1'
+  user: ntp
+- cmdline: ''
+  cwd: /
+  pid: '5378'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '5768'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '7143'
+  ppid: '1245'
+  user: postfix
+- cmdline: /usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 3128 -container-ip
+    192.168.1.2 -container-port 3128
+  cwd: /usr/bin/
+  pid: '9781'
+  ppid: '2832'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/5c81ff097d1aa2f0041f9a1add658c50ea19ef0ce9fb6e412e4c319a1fd6212e
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '9787'
+  ppid: '1064'
+  user: root
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/65ec5fad03e7484c919b367317eab61b361c2037ef4d8f1cbfbb4bf92ab9cc66
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '9788'
+  ppid: '1064'
+  user: root
+- cmdline: /usr/sbin/squid -f /etc/squid/squid.conf -NYCd 1
+  cwd: /usr/sbin/
+  pid: '9821'
+  ppid: '9787'
+  user: '13'
+- cmdline: sleep infinity
+  cwd: /
+  pid: '9828'
+  ppid: '9788'
+  user: root
+- cmdline: /usr/bin/docker start -a iometrics-zbxalerter
+  cwd: /usr/bin/
+  pid: '10092'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10453'
+  ppid: '2'
+  user: root
+- cmdline: (logfile-daemon) /var/log/squid/access.log
+  cwd: /
+  pid: '11141'
+  ppid: '9821'
+  user: '13'
+- cmdline: containerd-shim -namespace moby -workdir /var/lib/containerd/io.containerd.runtime.v1.linux/moby/e27ae43f180f0e122a8f9bc251903e059891a79db853a477f72ab26440a3a69f
+    -address /run/containerd/containerd.sock -containerd-binary /usr/bin/containerd
+    -runtime-root /var/run/docker/runtime-runc
+  cwd: /
+  pid: '12000'
+  ppid: '1064'
+  user: root
+- cmdline: sleep infinity
+  cwd: /
+  pid: '12017'
+  ppid: '12000'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '15906'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '17037'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18132'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18813'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18843'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '19792'
+  ppid: '1187'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '19794'
+  ppid: '19792'
+  user: centos
+- cmdline: ''
+  cwd: /
+  pid: '19893'
+  ppid: '2'
+  user: root
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-ljmwpbpxwppcelxemgoiqstuyhrdwuub
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939967.7641401-31444-106387829396686/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '20076'
+  ppid: '19794'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-ljmwpbpxwppcelxemgoiqstuyhrdwuub
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939967.7641401-31444-106387829396686/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '20091'
+  ppid: '20076'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-ljmwpbpxwppcelxemgoiqstuyhrdwuub ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1656939967.7641401-31444-106387829396686/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '20092'
+  ppid: '20091'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1656939967.7641401-31444-106387829396686/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '20093'
+  ppid: '20092'
+  user: root
+software_list:
+- cmd_regexp: /usr/sbin/zabbix_server -c
+  name: Zabbix Server
+  pkg_regexp: zabbix-server.*
+  process_type: parent
+  return_children: true
+  return_packages: true
+tcp_listen:
+- address: 127.0.0.1
+  name: master
+  pid: 1245
+  port: 25
+  protocol: tcp
+  stime: Fri May 20 00:43:56 2022
+  user: root
+- address: 0.0.0.0
+  name: zabbix_agentd
+  pid: 1105
+  port: 10050
+  protocol: tcp
+  stime: Fri May 20 00:43:49 2022
+  user: zabbix
+- address: 0.0.0.0
+  name: zabbix_server
+  pid: 1173
+  port: 10051
+  protocol: tcp
+  stime: Fri May 20 00:43:53 2022
+  user: zabbix
+- address: 0.0.0.0
+  name: redis-server
+  pid: 4355
+  port: 6379
+  protocol: tcp
+  stime: Tue Jun 21 14:18:11 2022
+  user: polkitd
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Fri May 20 00:43:02 2022
+  user: root
+- address: 0.0.0.0
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Fri May 20 00:43:55 2022
+  user: root
+- address: ::1
+  name: master
+  pid: 1245
+  port: 25
+  protocol: tcp
+  stime: Fri May 20 00:43:56 2022
+  user: root
+- address: '::'
+  name: zabbix_server
+  pid: 1173
+  port: 10051
+  protocol: tcp
+  stime: Fri May 20 00:43:53 2022
+  user: zabbix
+- address: '::'
+  name: redis-server
+  pid: 4355
+  port: 6379
+  protocol: tcp
+  stime: Tue Jun 21 14:18:11 2022
+  user: polkitd
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: tcp
+  stime: Fri May 20 00:43:02 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1187
+  port: 22
+  protocol: tcp
+  stime: Fri May 20 00:43:55 2022
+  user: root
+- address: '::'
+  name: docker-proxy
+  pid: 9781
+  port: 3128
+  protocol: tcp
+  stime: Fri May 20 00:45:03 2022
+  user: root
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 994
+  port: 68
+  protocol: udp
+  stime: Fri May 20 00:43:47 2022
+  user: root
+- address: 0.0.0.0
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Fri May 20 00:43:02 2022
+  user: root
+- address: 192.168.0.88
+  name: ntpd
+  pid: 5125
+  port: 123
+  protocol: udp
+  stime: Tue Jun 21 14:20:29 2022
+  user: ntp
+- address: 192.168.1.1
+  name: ntpd
+  pid: 5125
+  port: 123
+  protocol: udp
+  stime: Tue Jun 21 14:20:29 2022
+  user: ntp
+- address: 127.0.0.1
+  name: ntpd
+  pid: 5125
+  port: 123
+  protocol: udp
+  stime: Tue Jun 21 14:20:29 2022
+  user: ntp
+- address: 0.0.0.0
+  name: ntpd
+  pid: 5125
+  port: 123
+  protocol: udp
+  stime: Tue Jun 21 14:20:29 2022
+  user: ntp
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 641
+  port: 813
+  protocol: udp
+  stime: Fri May 20 00:43:29 2022
+  user: rpc
+- address: '::'
+  name: systemd
+  pid: 1
+  port: 111
+  protocol: udp
+  stime: Fri May 20 00:43:02 2022
+  user: root
+- address: fe80::f816:3eff:fee
+  name: ntpd
+  pid: 5125
+  port: 123
+  protocol: udp
+  stime: Tue Jun 21 14:20:29 2022
+  user: ntp
+- address: 'fe80::42:95ff:fe82:'
+  name: ntpd
+  pid: 5125
+  port: 123
+  protocol: udp
+  stime: Tue Jun 21 14:20:29 2022
+  user: ntp
+- address: fe80::90e2:35ff:fe6
+  name: ntpd
+  pid: 5125
+  port: 123
+  protocol: udp
+  stime: Tue Jun 21 14:20:29 2022
+  user: ntp
+- address: ::1
+  name: ntpd
+  pid: 5125
+  port: 123
+  protocol: udp
+  stime: Tue Jun 21 14:20:29 2022
+  user: ntp
+- address: '::'
+  name: ntpd
+  pid: 5125
+  port: 123
+  protocol: udp
+  stime: Tue Jun 21 14:20:29 2022
+  user: ntp
+- address: '::'
+  name: rpcbind
+  pid: 641
+  port: 813
+  protocol: udp
+  stime: Fri May 20 00:43:29 2022
+  user: rpc

--- a/tests/unit/plugins/action/software/resources/oss-devel/processes.json
+++ b/tests/unit/plugins/action/software/resources/oss-devel/processes.json
@@ -1,1772 +1,2067 @@
 [
-  {
-    "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 22",
-    "pid": "1",
-    "ppid": "0",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "2",
-    "ppid": "0",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "4",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "6",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "7",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "8",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "9",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "10",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "11",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "12",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "13",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "14",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "16",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "17",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "18",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "19",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "21",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "22",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "23",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "24",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "26",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "27",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "28",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "29",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "31",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "32",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "33",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "34",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "36",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "37",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "38",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "39",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "41",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "42",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "43",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "44",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "46",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "48",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "49",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "50",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "51",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "52",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "53",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "54",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "55",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "56",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "57",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "58",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "59",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "65",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "66",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "68",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "76",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "78",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "79",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "81",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "83",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "98",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "136",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "283",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "284",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "285",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "286",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "296",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "298",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "299",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "300",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "302",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "305",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "306",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "307",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "308",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "309",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "310",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "311",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "312",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "313",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "314",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "315",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "316",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "317",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "318",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "319",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "320",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "321",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "322",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "323",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "324",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "325",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "326",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "327",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "328",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "329",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "330",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "331",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "332",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "333",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "334",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "335",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "336",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "337",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "338",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "339",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "340",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "341",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "342",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "343",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "344",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "345",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "346",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "347",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "348",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "349",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "350",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "351",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "352",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "353",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "354",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "355",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "356",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "357",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "358",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "359",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "360",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "361",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "362",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "363",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "364",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "405",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "406",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "420",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "427",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "428",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "429",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "430",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "431",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "432",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "433",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "434",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "435",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "436",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "437",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "438",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/lib/systemd/systemd-journald",
-    "pid": "518",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/lib/systemd/systemd-udevd",
-    "pid": "552",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "607",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "608",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "611",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "612",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "613",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "614",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "615",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "623",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "/sbin/auditd",
-    "pid": "682",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/VGAuthService -s",
-    "pid": "705",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/vmtoolsd",
-    "pid": "706",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/irqbalance --foreground",
-    "pid": "708",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/lib/polkit-1/polkitd --no-debug",
-    "pid": "710",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation",
-    "pid": "713",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/chronyd",
-    "pid": "719",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/NetworkManager --no-daemon",
-    "pid": "732",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/lib/systemd/systemd-logind",
-    "pid": "734",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/crond -n",
-    "pid": "738",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "813",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f",
-    "pid": "999",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/rsyslogd -n",
-    "pid": "1002",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/python2 -Es /usr/sbin/tuned -l -P",
-    "pid": "1004",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/sshd -D",
-    "pid": "1005",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/libexec/postfix/master -w",
-    "pid": "1186",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "qmgr -l -t unix -u",
-    "pid": "1207",
-    "ppid": "1186",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "1467",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "1489",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "1498",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "1521",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "2185",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "/sbin/agetty --noclear tty1 linux",
-    "pid": "3002",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "12842",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "13204",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d -address /run/containerd/containerd.sock",
-    "pid": "20044",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "redis-server 0.0.0.0:6379",
-    "pid": "20064",
-    "ppid": "20044",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/docker start -a redis",
-    "pid": "20366",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "20898",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "21946",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb -address /run/containerd/containerd.sock",
-    "pid": "23319",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "nginx: master process nginx -g daemon off;",
-    "pid": "23339",
-    "ppid": "23319",
-    "user": "root"
-  },
-  {
-    "cmdline": "nginx: worker process",
-    "pid": "23356",
-    "ppid": "23339",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/docker start -a nginx",
-    "pid": "23581",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "SCREEN",
-    "pid": "24403",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/bin/bash",
-    "pid": "24404",
-    "ppid": "24403",
-    "user": "root"
-  },
-  {
-    "cmdline": "sudo -u postgres psql",
-    "pid": "28523",
-    "ppid": "24404",
-    "user": "root"
-  },
-  {
-    "cmdline": "psql",
-    "pid": "28524",
-    "ppid": "28523",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/docker start -a iometrics-cmdb-gateway",
-    "pid": "28556",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42 -address /run/containerd/containerd.sock",
-    "pid": "28596",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/bin/sh -c ./start_cmdb_gateway.sh",
-    "pid": "28617",
-    "ppid": "28596",
-    "user": "root"
-  },
-  {
-    "cmdline": "/bin/sh ./start_cmdb_gateway.sh",
-    "pid": "28631",
-    "ppid": "28617",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
-    "pid": "28633",
-    "ppid": "28631",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
-    "pid": "28635",
-    "ppid": "28633",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
-    "pid": "28637",
-    "ppid": "28633",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
-    "pid": "28638",
-    "ppid": "28633",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
-    "pid": "28639",
-    "ppid": "28633",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
-    "pid": "28640",
-    "ppid": "28633",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
-    "pid": "28641",
-    "ppid": "28633",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
-    "pid": "28642",
-    "ppid": "28633",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
-    "pid": "28643",
-    "ppid": "28633",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data",
-    "pid": "28694",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: checkpointer process",
-    "pid": "28697",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: writer process",
-    "pid": "28698",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: wal writer process",
-    "pid": "28699",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: autovacuum launcher process",
-    "pid": "28700",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: stats collector process",
-    "pid": "28701",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: bgworker: logical replication launcher",
-    "pid": "28702",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/docker start -a iometrics-cmdbuild",
-    "pid": "30649",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 -container-ip 192.168.1.2 -container-port 8443",
-    "pid": "30674",
-    "ppid": "60677",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187 -address /run/containerd/containerd.sock",
-    "pid": "30689",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run",
-    "pid": "30709",
-    "ppid": "30689",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/local/openjdk-17/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx7876m -Xms3846m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar -Delastic.apm.service_name=cmdb -Delastic.apm.server_url=http://192.168.8.53:8200 -Delastic.apm.environment=dev -Delastic.apm.enabled=true -Delastic.apm.profiling_inferred_spans_enabled=true -Delastic.apm.profiling_inferred_spans_min_duration=250ms -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.* -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp org.apache.catalina.startup.Bootstrap start",
-    "pid": "30748",
-    "ppid": "30709",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42292) idle",
-    "pid": "30959",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00 -address /run/containerd/containerd.sock",
-    "pid": "34186",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/bin/sh -c python ./listener.py",
-    "pid": "34206",
-    "ppid": "34186",
-    "user": "root"
-  },
-  {
-    "cmdline": "python ./listener.py",
-    "pid": "34220",
-    "ppid": "34206",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "42171",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "46732",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "46733",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/lvmetad -f",
-    "pid": "46865",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/sbin/rpcbind -w",
-    "pid": "47374",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/gssproxy -D",
-    "pid": "47383",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47397",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47398",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/rpc.statd",
-    "pid": "47406",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/rpc.idmapd",
-    "pid": "47408",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/rpc.mountd",
-    "pid": "47410",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47415",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47416",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47421",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47422",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47423",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47424",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47425",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47426",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47427",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "47428",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58162) idle",
-    "pid": "48767",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58232) idle",
-    "pid": "48823",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58272) idle",
-    "pid": "48854",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58354) idle",
-    "pid": "48909",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58358) idle",
-    "pid": "48911",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58412) idle",
-    "pid": "48959",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58456) idle",
-    "pid": "48992",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58482) idle",
-    "pid": "49016",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58508) idle",
-    "pid": "49034",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58586) idle",
-    "pid": "49086",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58588) idle",
-    "pid": "49087",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58598) idle",
-    "pid": "49098",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58604) idle",
-    "pid": "49101",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58622) idle",
-    "pid": "49117",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58630) idle",
-    "pid": "49121",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58634) idle",
-    "pid": "49123",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58650) idle",
-    "pid": "49137",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58680) idle",
-    "pid": "49168",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58684) idle",
-    "pid": "49170",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58712) idle",
-    "pid": "49189",
-    "ppid": "28694",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/containerd",
-    "pid": "54568",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "59036",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "59453",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock",
-    "pid": "60677",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "61265",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "61266",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "61267",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "61268",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "61269",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "61270",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "61271",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "61272",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "61424",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "64305",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "64688",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "65732",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "66699",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "67166",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "pickup -l -t unix -u",
-    "pid": "67317",
-    "ppid": "1186",
-    "user": "root"
-  },
-  {
-    "cmdline": "sshd: root@pts/0",
-    "pid": "67356",
-    "ppid": "1005",
-    "user": "root"
-  },
-  {
-    "cmdline": "-bash",
-    "pid": "67359",
-    "ppid": "67356",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "67889",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "sshd: root@pts/2",
-    "pid": "67904",
-    "ppid": "1005",
-    "user": "root"
-  },
-  {
-    "cmdline": "/bin/sh -c /usr/bin/python /root/.ansible/tmp/ansible-tmp-1650626915.9827116-22952-501338279144/AnsiballZ_process_facts.py && sleep 0",
-    "pid": "68116",
-    "ppid": "67904",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/bin/python /root/.ansible/tmp/ansible-tmp-1650626915.9827116-22952-501338279144/AnsiballZ_process_facts.py",
-    "pid": "68127",
-    "ppid": "68116",
-    "user": "root"
-  },
-  {
-    "cmdline": "/opt/fireeye/bin/xagt -M DAEMON",
-    "pid": "69963",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "/opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT --logfd 4",
-    "pid": "69987",
-    "ppid": "69963",
-    "user": "root"
-  },
-  {
-    "cmdline": "/usr/sbin/mariadbd",
-    "pid": "73979",
-    "ppid": "1",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "76784",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "89196",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "91901",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "103394",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "105591",
-    "ppid": "2",
-    "user": "root"
-  },
-  {
-    "cmdline": "",
-    "pid": "120879",
-    "ppid": "2",
-    "user": "root"
-  }
-]
+        {
+            "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 22",
+            "pid": "1",
+            "ppid": "0",
+            "user": "root",
+            "cwd": "/usr/lib/systemd/"
+        },
+        {
+            "cmdline": "",
+            "pid": "2",
+            "ppid": "0",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "4",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "6",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "7",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "8",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "9",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "10",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "11",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "12",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "13",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "14",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "16",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "17",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "18",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "19",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "21",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "22",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "23",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "24",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "26",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "27",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "28",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "29",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "31",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "32",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "33",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "34",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "36",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "37",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "38",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "39",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "41",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "42",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "43",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "44",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "46",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "48",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "49",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "50",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "51",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "52",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "53",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "54",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "55",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "56",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "57",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "58",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "59",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "65",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "66",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "68",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "76",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "78",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "79",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "81",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "83",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "98",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "136",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "283",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "284",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "285",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "286",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "296",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "298",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "299",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "300",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "302",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "305",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "306",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "307",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "308",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "309",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "310",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "311",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "312",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "313",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "314",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "315",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "316",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "317",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "318",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "319",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "320",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "321",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "322",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "323",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "324",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "325",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "326",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "327",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "328",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "329",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "330",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "331",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "332",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "333",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "334",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "335",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "336",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "337",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "338",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "339",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "340",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "341",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "342",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "343",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "344",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "345",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "346",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "347",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "348",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "349",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "350",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "351",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "352",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "353",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "354",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "355",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "356",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "357",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "358",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "359",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "360",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "361",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "362",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "363",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "364",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "405",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "406",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "420",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "427",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "428",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "429",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "430",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "431",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "432",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "433",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "434",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "435",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "436",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "437",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "438",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/lib/systemd/systemd-journald",
+            "pid": "518",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/lib/systemd/"
+        },
+        {
+            "cmdline": "/usr/lib/systemd/systemd-udevd",
+            "pid": "552",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/lib/systemd/"
+        },
+        {
+            "cmdline": "",
+            "pid": "607",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "608",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "611",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "612",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "613",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "614",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "615",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "623",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/sbin/auditd",
+            "pid": "682",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/sbin/"
+        },
+        {
+            "cmdline": "/usr/bin/VGAuthService -s",
+            "pid": "705",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/usr/bin/vmtoolsd",
+            "pid": "706",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/usr/sbin/irqbalance --foreground",
+            "pid": "708",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "/usr/lib/polkit-1/polkitd --no-debug",
+            "pid": "710",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/lib/polkit-1/"
+        },
+        {
+            "cmdline": "/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation",
+            "pid": "713",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/usr/sbin/chronyd",
+            "pid": "719",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "/usr/sbin/NetworkManager --no-daemon",
+            "pid": "732",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "/usr/lib/systemd/systemd-logind",
+            "pid": "734",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/lib/systemd/"
+        },
+        {
+            "cmdline": "/usr/sbin/crond -n",
+            "pid": "738",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "",
+            "pid": "813",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/sbin/nrpe -c /etc/nagios/nrpe.cfg -f",
+            "pid": "999",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "/usr/sbin/rsyslogd -n",
+            "pid": "1002",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "/usr/bin/python2 -Es /usr/sbin/tuned -l -P",
+            "pid": "1004",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/usr/sbin/sshd -D",
+            "pid": "1005",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "/usr/libexec/postfix/master -w",
+            "pid": "1186",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/libexec/postfix/"
+        },
+        {
+            "cmdline": "qmgr -l -t unix -u",
+            "pid": "1207",
+            "ppid": "1186",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "1467",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "1489",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "1498",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "1521",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "2185",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/sbin/agetty --noclear tty1 linux",
+            "pid": "3002",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/sbin/"
+        },
+        {
+            "cmdline": "",
+            "pid": "12842",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "13204",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id b2e7efee6f1ed730f499f49acdaeb746bb6d34f1792802a60c6635f906beab7d -address /run/containerd/containerd.sock",
+            "pid": "20044",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "redis-server 0.0.0.0:6379",
+            "pid": "20064",
+            "ppid": "20044",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/bin/docker start -a redis",
+            "pid": "20366",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "",
+            "pid": "20898",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "21946",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id df68711d97b8abec4e04657637d2008987876138bc47624dc3511d9ea6ae24eb -address /run/containerd/containerd.sock",
+            "pid": "23319",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "nginx: master process nginx -g daemon off;",
+            "pid": "23339",
+            "ppid": "23319",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "nginx: worker process",
+            "pid": "23356",
+            "ppid": "23339",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/bin/docker start -a nginx",
+            "pid": "23581",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "SCREEN",
+            "pid": "24403",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/bin/bash",
+            "pid": "24404",
+            "ppid": "24403",
+            "user": "root",
+            "cwd": "/bin/"
+        },
+        {
+            "cmdline": "sudo -u postgres psql",
+            "pid": "28523",
+            "ppid": "24404",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "psql",
+            "pid": "28524",
+            "ppid": "28523",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/bin/docker start -a iometrics-cmdb-gateway",
+            "pid": "28556",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id da770fecc28e7aec6f9ce23936554db29f3ae21a11f8b50c9957409067c7af42 -address /run/containerd/containerd.sock",
+            "pid": "28596",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/bin/sh -c ./start_cmdb_gateway.sh",
+            "pid": "28617",
+            "ppid": "28596",
+            "user": "root",
+            "cwd": "/bin/"
+        },
+        {
+            "cmdline": "/bin/sh ./start_cmdb_gateway.sh",
+            "pid": "28631",
+            "ppid": "28617",
+            "user": "root",
+            "cwd": "/bin/"
+        },
+        {
+            "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
+            "pid": "28633",
+            "ppid": "28631",
+            "user": "root",
+            "cwd": "/usr/local/bin/"
+        },
+        {
+            "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
+            "pid": "28635",
+            "ppid": "28633",
+            "user": "root",
+            "cwd": "/usr/local/bin/"
+        },
+        {
+            "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
+            "pid": "28637",
+            "ppid": "28633",
+            "user": "root",
+            "cwd": "/usr/local/bin/"
+        },
+        {
+            "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
+            "pid": "28638",
+            "ppid": "28633",
+            "user": "root",
+            "cwd": "/usr/local/bin/"
+        },
+        {
+            "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
+            "pid": "28639",
+            "ppid": "28633",
+            "user": "root",
+            "cwd": "/usr/local/bin/"
+        },
+        {
+            "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
+            "pid": "28640",
+            "ppid": "28633",
+            "user": "root",
+            "cwd": "/usr/local/bin/"
+        },
+        {
+            "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
+            "pid": "28641",
+            "ppid": "28633",
+            "user": "root",
+            "cwd": "/usr/local/bin/"
+        },
+        {
+            "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
+            "pid": "28642",
+            "ppid": "28633",
+            "user": "root",
+            "cwd": "/usr/local/bin/"
+        },
+        {
+            "cmdline": "/usr/local/bin/python /usr/local/bin/gunicorn --config=cmdb_gateway/gunicorn_config.py cmdb_gateway.main:app",
+            "pid": "28643",
+            "ppid": "28633",
+            "user": "root",
+            "cwd": "/usr/local/bin/"
+        },
+        {
+            "cmdline": "/usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data",
+            "pid": "28694",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/pgsql-10/bin/"
+        },
+        {
+            "cmdline": "postgres: data: checkpointer process",
+            "pid": "28697",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: writer process",
+            "pid": "28698",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: wal writer process",
+            "pid": "28699",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: autovacuum launcher process",
+            "pid": "28700",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: stats collector process",
+            "pid": "28701",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: bgworker: logical replication launcher",
+            "pid": "28702",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/bin/docker start -a iometrics-cmdbuild",
+            "pid": "30649",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 -container-ip 192.168.1.2 -container-port 8443",
+            "pid": "30674",
+            "ppid": "60677",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id 5a49f7d8a2a4211c508ade8111622a7a26a38a48385ef936382cde0448c5f187 -address /run/containerd/containerd.sock",
+            "pid": "30689",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run",
+            "pid": "30709",
+            "ppid": "30689",
+            "user": "root",
+            "cwd": "/bin/"
+        },
+        {
+            "cmdline": "/usr/local/openjdk-17/bin/java -Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx7876m -Xms3846m -Djdk.tls.ephemeralDHKeySize=2048 -Djava.protocol.handler.pkgs=org.apache.catalina.webresources -Dorg.apache.catalina.security.SecurityListener.UMASK=0027 -Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m -javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar -Delastic.apm.service_name=cmdb -Delastic.apm.server_url=http://192.168.8.53:8200 -Delastic.apm.environment=dev -Delastic.apm.enabled=true -Delastic.apm.profiling_inferred_spans_enabled=true -Delastic.apm.profiling_inferred_spans_min_duration=250ms -Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.* -Dignore.endorsed.dirs= -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat -Djava.io.tmpdir=/usr/local/tomcat/temp org.apache.catalina.startup.Bootstrap start",
+            "pid": "30748",
+            "ppid": "30709",
+            "user": "root",
+            "cwd": "/usr/local/openjdk-17/bin/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42292) idle",
+            "pid": "30959",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/bin/containerd-shim-runc-v2 -namespace moby -id 27edcd0fdbc561fe785b9596746fb14227664bd4dccd96755e370d59d82a0a00 -address /run/containerd/containerd.sock",
+            "pid": "34186",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/bin/sh -c python ./listener.py",
+            "pid": "34206",
+            "ppid": "34186",
+            "user": "root",
+            "cwd": "/bin/"
+        },
+        {
+            "cmdline": "python ./listener.py",
+            "pid": "34220",
+            "ppid": "34206",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "42171",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "46732",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "46733",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/sbin/lvmetad -f",
+            "pid": "46865",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "/sbin/rpcbind -w",
+            "pid": "47374",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/sbin/"
+        },
+        {
+            "cmdline": "/usr/sbin/gssproxy -D",
+            "pid": "47383",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47397",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47398",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/sbin/rpc.statd",
+            "pid": "47406",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "/usr/sbin/rpc.idmapd",
+            "pid": "47408",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "/usr/sbin/rpc.mountd",
+            "pid": "47410",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47415",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47416",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47421",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47422",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47423",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47424",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47425",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47426",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47427",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "47428",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58162) idle",
+            "pid": "48767",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58232) idle",
+            "pid": "48823",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58272) idle",
+            "pid": "48854",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58354) idle",
+            "pid": "48909",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58358) idle",
+            "pid": "48911",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58412) idle",
+            "pid": "48959",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58456) idle",
+            "pid": "48992",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58482) idle",
+            "pid": "49016",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58508) idle",
+            "pid": "49034",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58586) idle",
+            "pid": "49086",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58588) idle",
+            "pid": "49087",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58598) idle",
+            "pid": "49098",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58604) idle",
+            "pid": "49101",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58622) idle",
+            "pid": "49117",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58630) idle",
+            "pid": "49121",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58634) idle",
+            "pid": "49123",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58650) idle",
+            "pid": "49137",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58680) idle",
+            "pid": "49168",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58684) idle",
+            "pid": "49170",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58712) idle",
+            "pid": "49189",
+            "ppid": "28694",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/bin/containerd",
+            "pid": "54568",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "",
+            "pid": "59036",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "59453",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock",
+            "pid": "60677",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "",
+            "pid": "61265",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "61266",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "61267",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "61268",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "61269",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "61270",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "61271",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "61272",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "61424",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "64305",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "64688",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "65732",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "66699",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "67166",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "pickup -l -t unix -u",
+            "pid": "67317",
+            "ppid": "1186",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "sshd: root@pts/0",
+            "pid": "67356",
+            "ppid": "1005",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "-bash",
+            "pid": "67359",
+            "ppid": "67356",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "67889",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "sshd: root@pts/2",
+            "pid": "67904",
+            "ppid": "1005",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "/bin/sh -c /usr/bin/python /root/.ansible/tmp/ansible-tmp-1650626915.9827116-22952-501338279144/AnsiballZ_process_facts.py && sleep 0",
+            "pid": "68116",
+            "ppid": "67904",
+            "user": "root",
+            "cwd": "/bin/"
+        },
+        {
+            "cmdline": "/usr/bin/python /root/.ansible/tmp/ansible-tmp-1650626915.9827116-22952-501338279144/AnsiballZ_process_facts.py",
+            "pid": "68127",
+            "ppid": "68116",
+            "user": "root",
+            "cwd": "/usr/bin/"
+        },
+        {
+            "cmdline": "/opt/fireeye/bin/xagt -M DAEMON",
+            "pid": "69963",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/opt/fireeye/bin/"
+        },
+        {
+            "cmdline": "/opt/fireeye/bin/xagt --mode Eventor --iofd 3 --cmname 12 --log ALERT --logfd 4",
+            "pid": "69987",
+            "ppid": "69963",
+            "user": "root",
+            "cwd": "/opt/fireeye/bin/"
+        },
+        {
+            "cmdline": "/usr/sbin/mariadbd",
+            "pid": "73979",
+            "ppid": "1",
+            "user": "root",
+            "cwd": "/usr/sbin/"
+        },
+        {
+            "cmdline": "",
+            "pid": "76784",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "89196",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "91901",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "103394",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "105591",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        },
+        {
+            "cmdline": "",
+            "pid": "120879",
+            "ppid": "2",
+            "user": "root",
+            "cwd": "/"
+        }
+    ]

--- a/tests/unit/plugins/action/software/test_mariadb.py
+++ b/tests/unit/plugins/action/software/test_mariadb.py
@@ -3,9 +3,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
-
 from ansible.module_utils.six.moves import builtins  # noqa
+from pytest_lazyfixture import lazy_fixture
 
 from ansible_collections.datadope.discovery.plugins.action.software_facts import ActionModule
 
@@ -45,7 +44,8 @@ def params_set_one_sw(sw_config, read_json_file):
             ],
             "pid": "73979",
             "ppid": "1",
-            "user": "root"
+            "user": "root",
+            "cwd": "/usr/sbin/"
         },
         "listening_ports": [
             3306
@@ -74,18 +74,20 @@ def params_set_one_sw(sw_config, read_json_file):
 def params_set_no_sw(sw_config):
     params = {
         'software_list': [sw_config],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
                 "pid": "1",
                 "ppid": "0",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/lib/systemd/"
             },
             {
                 "cmdline": "/usr/bin/postgres_client must not match regex",
                 "pid": "24895",
                 "ppid": "1",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/bin/"
             }
         ],
         'tcp_listen': [
@@ -123,6 +125,7 @@ def params_set_two_sw(sw_config, params_set_one_sw):
     params_set_one_sw[0]['processes'].append(
         {
             "cmdline": "/usr/sbin/mariadbd",
+            "cwd": "/usr/sbin/",
             "pid": "93979",
             "ppid": "1",
             "user": "root"
@@ -149,6 +152,7 @@ def params_set_two_sw(sw_config, params_set_one_sw):
             "discovery_time": "2022-05-26T18:00:00+02:00",
             "process": {
                 "cmdline": "/usr/sbin/mariadbd",
+                "cwd": "/usr/sbin/",
                 "listening_ports": [
                     9306
                 ],

--- a/tests/unit/plugins/action/software/test_mysql.py
+++ b/tests/unit/plugins/action/software/test_mysql.py
@@ -3,9 +3,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
-
 from ansible.module_utils.six.moves import builtins  # noqa
+from pytest_lazyfixture import lazy_fixture
 
 from ansible_collections.datadope.discovery.plugins.action.software_facts import ActionModule
 
@@ -32,6 +31,7 @@ def params_set_one_sw(sw_config, read_json_file):
     params['processes'].append(
         {
             "cmdline": "/usr/sbin/mysqld",
+            "cwd": "/usr/sbin/",
             "pid": "83979",
             "ppid": "1",
             "user": "root"
@@ -57,6 +57,7 @@ def params_set_one_sw(sw_config, read_json_file):
         "discovery_time": "2022-05-26T18:00:00+02:00",
         "process": {
             "cmdline": "/usr/sbin/mysqld",
+            "cwd": "/usr/sbin/",
             "listening_ports": [
                 4306
             ],
@@ -75,18 +76,20 @@ def params_set_one_sw(sw_config, read_json_file):
 def params_set_no_sw(sw_config):
     params = {
         'software_list': [sw_config],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
                 "pid": "1",
                 "ppid": "0",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/lib/systemd/"
             },
             {
                 "cmdline": "/usr/bin/postgres_client must not match regex",
                 "pid": "24895",
                 "ppid": "1",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/bin/"
             }
         ],
         'tcp_listen': [
@@ -111,6 +114,7 @@ def params_set_two_sw(sw_config, params_set_one_sw):
     params_set_one_sw[0]['processes'].append(
         {
             "cmdline": "/usr/sbin/mysqld",
+            "cwd": "/usr/sbin/",
             "pid": "93979",
             "ppid": "1",
             "user": "root"
@@ -137,6 +141,7 @@ def params_set_two_sw(sw_config, params_set_one_sw):
             "discovery_time": "2022-05-26T18:00:00+02:00",
             "process": {
                 "cmdline": "/usr/sbin/mysqld",
+                "cwd": "/usr/sbin/",
                 "listening_ports": [
                     9306
                 ],

--- a/tests/unit/plugins/action/software/test_nginx.py
+++ b/tests/unit/plugins/action/software/test_nginx.py
@@ -3,9 +3,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
-
 from ansible.module_utils.six.moves import builtins  # noqa
+from pytest_lazyfixture import lazy_fixture
 
 from ansible_collections.datadope.discovery.plugins.action.software_facts import ActionModule
 
@@ -45,9 +44,10 @@ def params_set_one_sw(sw_config, read_json_file):
                 {
                     "children": [],
                     "cmdline": "nginx: worker process",
-                    'pid': '23356',
-                    'ppid': '23339',
-                    "user": "root"
+                    "pid": "23356",
+                    "ppid": "23339",
+                    "user": "root",
+                    "cwd": "/"
                 }
             ],
             "cmdline": "nginx: master process nginx -g daemon off;",
@@ -57,7 +57,8 @@ def params_set_one_sw(sw_config, read_json_file):
             ],
             "pid": "23339",
             "ppid": "23319",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
         },
         "listening_ports": [
             80,
@@ -71,18 +72,20 @@ def params_set_one_sw(sw_config, read_json_file):
 def params_set_no_sw(sw_config):
     params = {
         'software_list': [sw_config],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
                 "pid": "1",
                 "ppid": "0",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/lib/systemd/"
             },
             {
                 "cmdline": "/usr/bin/nginx_client must not match regex",
                 "pid": "24895",
                 "ppid": "1",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/bin/"
             }
         ],
         'tcp_listen': [
@@ -107,6 +110,7 @@ def params_set_two_sw(sw_config, params_set_one_sw):
     params_set_one_sw[0]['processes'].append(
         {
             "cmdline": "nginx: master process nginx -g daemon off;",
+            "cwd": "/",
             "pid": "53339",
             "ppid": "53319",
             "user": "root"
@@ -134,6 +138,7 @@ def params_set_two_sw(sw_config, params_set_one_sw):
             "process": {
                 "children": [],
                 "cmdline": "nginx: master process nginx -g daemon off;",
+                "cwd": "/",
                 "listening_ports": [
                     543
                 ],

--- a/tests/unit/plugins/action/software/test_postgres.py
+++ b/tests/unit/plugins/action/software/test_postgres.py
@@ -3,9 +3,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
-
 from ansible.module_utils.six.moves import builtins  # noqa
+from pytest_lazyfixture import lazy_fixture
 
 from ansible_collections.datadope.discovery.plugins.action.software_facts import ActionModule
 
@@ -44,6 +43,7 @@ def params_set_one_sw(sw_config, read_json_file):
                 {
                     "children": [],
                     "cmdline": "postgres: data: checkpointer process",
+                    "cwd": "/",
                     "pid": "28697",
                     "ppid": "28694",
                     "user": "root"
@@ -53,189 +53,218 @@ def params_set_one_sw(sw_config, read_json_file):
                     "cmdline": "postgres: data: writer process",
                     "pid": "28698",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: wal writer process",
                     "pid": "28699",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: autovacuum launcher process",
                     "pid": "28700",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: stats collector process",
                     "pid": "28701",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: bgworker: logical replication launcher",
                     "pid": "28702",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(42292) idle",
                     "pid": "30959",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58162) idle",
                     "pid": "48767",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58232) idle",
                     "pid": "48823",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58272) idle",
                     "pid": "48854",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58354) idle",
                     "pid": "48909",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58358) idle",
                     "pid": "48911",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58412) idle",
                     "pid": "48959",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58456) idle",
                     "pid": "48992",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58482) idle",
                     "pid": "49016",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58508) idle",
                     "pid": "49034",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58586) idle",
                     "pid": "49086",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58588) idle",
                     "pid": "49087",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58598) idle",
                     "pid": "49098",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58604) idle",
                     "pid": "49101",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58622) idle",
                     "pid": "49117",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58630) idle",
                     "pid": "49121",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58634) idle",
                     "pid": "49123",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58650) idle",
                     "pid": "49137",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58680) idle",
                     "pid": "49168",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58684) idle",
                     "pid": "49170",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: data: datadope cmdbuild_r2u2 192.168.1.2(58712) idle",
                     "pid": "49189",
                     "ppid": "28694",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 }
             ],
             "cmdline": "/usr/pgsql-10/bin/postmaster -D /etc/postgresql/10/data",
-            "listening_ports": [5432],
+            "listening_ports": [
+                5432
+            ],
             "pid": "28694",
             "ppid": "1",
-            "user": "root"
+            "user": "root",
+            "cwd": "/usr/pgsql-10/bin/"
         },
         "listening_ports": [
             5432
@@ -264,18 +293,20 @@ def params_set_one_sw(sw_config, read_json_file):
 def params_set_no_sw(sw_config):
     params = {
         'software_list': [sw_config],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
                 "pid": "1",
                 "ppid": "0",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/lib/systemd/"
             },
             {
                 "cmdline": "/usr/bin/postgres_client must not match regex",
                 "pid": "24895",
                 "ppid": "1",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/bin/"
             }
         ],
         'tcp_listen': [
@@ -334,55 +365,64 @@ def params_set_two_sw(sw_config, params_set_one_sw):
             "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
             "pid": "1",
             "ppid": "0",
-            "user": "root"
+            "user": "root",
+            "cwd": "/usr/lib/systemd/"
         },
         {
             "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
             "pid": "34895",
             "ppid": "1",
-            "user": "root"
+            "user": "root",
+            "cwd": "/usr/pgsql-11/bin/"
         },
         {
             "cmdline": "postgres: logger",
             "pid": "34898",
             "ppid": "34895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
         },
         {
             "cmdline": "postgres: checkpointer",
             "pid": "34900",
             "ppid": "34895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
         },
         {
             "cmdline": "postgres: background writer",
             "pid": "34901",
             "ppid": "34895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
         },
         {
             "cmdline": "postgres: walwriter",
             "pid": "34902",
             "ppid": "34895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
         },
         {
             "cmdline": "postgres: autovacuum launcher",
             "pid": "34903",
             "ppid": "34895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
         },
         {
             "cmdline": "postgres: stats collector",
             "pid": "34904",
             "ppid": "34895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
         },
         {
             "cmdline": "postgres: logical replication launcher",
             "pid": "34905",
             "ppid": "34895",
-            "user": "root"
+            "user": "root",
+            "cwd": "/"
         }
     ])
     params_set_one_sw[0]['tcp_listen'].extend([
@@ -464,56 +504,67 @@ def params_set_two_sw(sw_config, params_set_one_sw):
                     "cmdline": "postgres: logger",
                     "pid": "34898",
                     "ppid": "34895",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: checkpointer",
                     "pid": "34900",
                     "ppid": "34895",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: background writer",
                     "pid": "34901",
                     "ppid": "34895",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: walwriter",
                     "pid": "34902",
                     "ppid": "34895",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: autovacuum launcher",
                     "pid": "34903",
                     "ppid": "34895",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: stats collector",
                     "pid": "34904",
                     "ppid": "34895",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: logical replication launcher",
                     "pid": "34905",
                     "ppid": "34895",
-                    "user": "root"
+                    "user": "root",
+                    "cwd": "/"
                 }
             ],
             "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
-            "listening_ports": [5432],
+            "listening_ports": [
+                5432
+            ],
             "pid": "34895",
             "ppid": "1",
-            "user": "root"},
+            "user": "root",
+            "cwd": "/usr/pgsql-11/bin/"
+        },
         "listening_ports": [5432],
         "packages": [
             {

--- a/tests/unit/plugins/action/software/test_tomcat.py
+++ b/tests/unit/plugins/action/software/test_tomcat.py
@@ -3,9 +3,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-from pytest_lazyfixture import lazy_fixture
-
 from ansible.module_utils.six.moves import builtins  # noqa
+from pytest_lazyfixture import lazy_fixture
 
 from ansible_collections.datadope.discovery.plugins.action.software_facts import ActionModule
 
@@ -60,13 +59,18 @@ def params_set_one_sw(sw_config, read_json_file):
                                " -Djava.io.tmpdir=/usr/local/tomcat/temp org.apache.catalina.startup.Bootstrap start",
                     "pid": "30748",
                     "ppid": "30709",
-                    "user": "root"
-                }],
+                    "user": "root",
+                    "cwd": "/usr/local/openjdk-17/bin/"
+                }
+            ],
             "cmdline": "/bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run",
             "pid": "30709",
             "ppid": "30689",
             "user": "root",
-            'listening_ports': [8443]
+            "listening_ports": [
+                8443
+            ],
+            "cwd": "/bin/"
         },
         "listening_ports": [8443],
         "version": [
@@ -92,18 +96,20 @@ def params_set_one_sw(sw_config, read_json_file):
 def params_set_no_sw(sw_config):
     params = {
         'software_list': [sw_config],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
                 "pid": "1",
                 "ppid": "0",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/lib/systemd/"
             },
             {
                 "cmdline": "/usr/bin/postgres_client must not match regex",
                 "pid": "24895",
                 "ppid": "1",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/bin/"
             }
         ],
         'tcp_listen': [
@@ -129,6 +135,7 @@ def params_set_two_sw(sw_config, params_set_one_sw):
         {
             "children": [],
             "cmdline": "/bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run",
+            "cwd": "/bin/",
             "pid": "50709",
             "ppid": "50689",
             "user": "root"
@@ -153,6 +160,7 @@ def params_set_two_sw(sw_config, params_set_one_sw):
                        " -classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar"
                        " -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat"
                        " -Djava.io.tmpdir=/usr/local/tomcat/temp org.apache.catalina.startup.Bootstrap start",
+            "cwd": "/usr/local/openjdk-17/bin/",
             "pid": "50748",
             "ppid": "50709",
             "user": "root"
@@ -201,11 +209,13 @@ def params_set_two_sw(sw_config, params_set_one_sw):
                                    " -Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat"
                                    " -Djava.io.tmpdir=/usr/local/tomcat/temp"
                                    " org.apache.catalina.startup.Bootstrap start",
+                        "cwd": "/usr/local/openjdk-17/bin/",
                         "pid": "50748",
                         "ppid": "50709",
                         "user": "root"
                     }],
                 "cmdline": "/bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run",
+                "cwd": "/bin/",
                 "pid": "50709",
                 "ppid": "50689",
                 "user": "root",

--- a/tests/unit/plugins/action/software_facts_plugins/test_find_processes.py
+++ b/tests/unit/plugins/action/software_facts_plugins/test_find_processes.py
@@ -23,9 +23,9 @@ def test_get_args_spec():
 @pytest.mark.parametrize(
     ('args', 'expected_result'),
     (
-        (dict(filter={'foo': 'bar'}), True),
-        (dict(), True),
-        (dict(filter='fail'), False)
+            (dict(filter={'foo': 'bar'}), True),
+            (dict(), True),
+            (dict(filter='fail'), False)
     )
 )
 def test_validate_args(action_module, args, expected_result):
@@ -49,6 +49,7 @@ def test_run(action_module):
     expected_result = [
         {
             "cmdline": "/usr/sbin/sshd -D",
+            "cwd": "/usr/sbin/",
             "pid": "1071",
             "ppid": "1",
             "user": "root"
@@ -60,25 +61,29 @@ def test_run(action_module):
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
                 "pid": "1",
                 "ppid": "0",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/lib/systemd/"
             },
             {
                 "cmdline": "/usr/sbin/sshd -D",
                 "pid": "1071",
                 "ppid": "1",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/sbin/"
             },
             {
                 "cmdline": "/usr/sbin/crond -n",
                 "pid": "1073",
                 "ppid": "1",
-                "user": "root"
+                "user": "root",
+                "cwd": "/usr/sbin/"
             },
             {
                 "cmdline": "/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220",
                 "pid": "1074",
                 "ppid": "1",
-                "user": "root"
+                "user": "root",
+                "cwd": "/sbin/"
             }
         ]
     }
@@ -101,49 +106,57 @@ def test_run_no_filter(action_module):
             "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
             "pid": "1",
             "ppid": "0",
-            "user": "root"
+            "user": "root",
+            "cwd": "/usr/lib/systemd/"
         },
         {
             "cmdline": "/usr/sbin/sshd -D",
             "pid": "1071",
             "ppid": "1",
-            "user": "root"
+            "user": "root",
+            "cwd": "/usr/sbin/"
         },
         {
             "cmdline": "/usr/sbin/crond -n",
             "pid": "1073",
             "ppid": "1",
-            "user": "root"
+            "user": "root",
+            "cwd": "/usr/sbin/"
         },
         {
             "cmdline": "/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220",
             "pid": "1074",
             "ppid": "1",
-            "user": "root"
+            "user": "root",
+            "cwd": "/sbin/"
         }
     ]
     task_vars = {
         "processes": [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
+                "cwd": "/usr/lib/systemd/",
                 "pid": "1",
                 "ppid": "0",
                 "user": "root"
             },
             {
                 "cmdline": "/usr/sbin/sshd -D",
+                "cwd": "/usr/sbin/",
                 "pid": "1071",
                 "ppid": "1",
                 "user": "root"
             },
             {
                 "cmdline": "/usr/sbin/crond -n",
+                "cwd": "/usr/sbin/",
                 "pid": "1073",
                 "ppid": "1",
                 "user": "root"
             },
             {
                 "cmdline": "/sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220",
+                "cwd": "/sbin/",
                 "pid": "1074",
                 "ppid": "1",
                 "user": "root"

--- a/tests/unit/plugins/action/test_software_facts.py
+++ b/tests/unit/plugins/action/test_software_facts.py
@@ -33,46 +33,55 @@ def params_set_child_with_children():
         'processes': [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
+                "cwd": "/usr/lib/systemd/",
                 "pid": "1",
                 "ppid": "0"
             },
             {
                 "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
+                "cwd": "/usr/pgsql-11/bin/",
                 "pid": "24895",
                 "ppid": "1"
             },
             {
                 "cmdline": "postgres: logger",
+                "cwd": "/",
                 "pid": "24898",
                 "ppid": "24895"
             },
             {
                 "cmdline": "postgres: checkpointer",
+                "cwd": "/",
                 "pid": "24900",
                 "ppid": "24895"
             },
             {
                 "cmdline": "postgres: background writer",
+                "cwd": "/",
                 "pid": "24901",
                 "ppid": "24895"
             },
             {
                 "cmdline": "postgres: walwriter",
+                "cwd": "/",
                 "pid": "24902",
                 "ppid": "24895"
             },
             {
                 "cmdline": "postgres: autovacuum launcher",
+                "cwd": "/",
                 "pid": "24903",
                 "ppid": "24895"
             },
             {
                 "cmdline": "postgres: stats collector",
+                "cwd": "/",
                 "pid": "24904",
                 "ppid": "24895"
             },
             {
                 "cmdline": "postgres: logical replication launcher",
+                "cwd": "/",
                 "pid": "24905",
                 "ppid": "24895"
             },
@@ -181,47 +190,55 @@ def params_set_child_with_children():
                 {
                     "children": [],
                     "cmdline": "postgres: logger",
+                    "cwd": "/",
                     "pid": "24898",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: checkpointer",
+                    "cwd": "/",
                     "pid": "24900",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: background writer",
+                    "cwd": "/",
                     "pid": "24901",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: walwriter",
+                    "cwd": "/",
                     "pid": "24902",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: autovacuum launcher",
+                    "cwd": "/",
                     "pid": "24903",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: stats collector",
+                    "cwd": "/",
                     "pid": "24904",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: logical replication launcher",
+                    "cwd": "/",
                     "pid": "24905",
                     "ppid": "24895"
                 }
             ],
             "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
+            "cwd": "/usr/pgsql-11/bin/",
             "listening_ports": [
                 5432
             ],
@@ -255,52 +272,61 @@ def params_set_child_without_children():
             'process_type': 'child',
             'return_children': False
         }],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
+                "cwd": "/usr/lib/systemd/",
                 "pid": "1",
                 "ppid": "0"
             },
             {
                 "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
                 "pid": "24895",
-                "ppid": "1"
+                "ppid": "1",
+                "cwd": "/usr/pgsql-11/bin/"
             },
             {
                 "cmdline": "postgres: logger",
                 "pid": "24898",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: checkpointer",
                 "pid": "24900",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: background writer",
                 "pid": "24901",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: walwriter",
                 "pid": "24902",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: autovacuum launcher",
                 "pid": "24903",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: stats collector",
                 "pid": "24904",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: logical replication launcher",
                 "pid": "24905",
-                "ppid": "24895"
-            },
+                "ppid": "24895",
+                "cwd": "/"
+            }
         ],
         'tcp_listen': [
             {
@@ -324,6 +350,7 @@ def params_set_child_without_children():
         "discovery_time": '2022-05-26T17:03:00+02:00',
         "process": {
             "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
+            "cwd": "/usr/pgsql-11/bin/",
             "listening_ports": [
                 5432
             ],
@@ -348,52 +375,61 @@ def params_set_parent_with_children():
             'process_type': 'parent',
             'return_children': True
         }],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
                 "pid": "1",
-                "ppid": "0"
+                "ppid": "0",
+                "cwd": "/usr/lib/systemd/"
             },
             {
                 "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
                 "pid": "24895",
-                "ppid": "1"
+                "ppid": "1",
+                "cwd": "/usr/pgsql-11/bin/"
             },
             {
                 "cmdline": "postgres: logger",
                 "pid": "24898",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: checkpointer",
                 "pid": "24900",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: background writer",
                 "pid": "24901",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: walwriter",
                 "pid": "24902",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: autovacuum launcher",
                 "pid": "24903",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: stats collector",
                 "pid": "24904",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: logical replication launcher",
                 "pid": "24905",
-                "ppid": "24895"
-            },
+                "ppid": "24895",
+                "cwd": "/"
+            }
         ],
         'tcp_listen': [
             {
@@ -454,47 +490,55 @@ def params_set_parent_with_children():
                 {
                     "children": [],
                     "cmdline": "postgres: logger",
+                    "cwd": "/",
                     "pid": "24898",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: checkpointer",
+                    "cwd": "/",
                     "pid": "24900",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: background writer",
+                    "cwd": "/",
                     "pid": "24901",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: walwriter",
+                    "cwd": "/",
                     "pid": "24902",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: autovacuum launcher",
+                    "cwd": "/",
                     "pid": "24903",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: stats collector",
+                    "cwd": "/",
                     "pid": "24904",
                     "ppid": "24895"
                 },
                 {
                     "children": [],
                     "cmdline": "postgres: logical replication launcher",
+                    "cwd": "/",
                     "pid": "24905",
                     "ppid": "24895"
                 }
             ],
             "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
+            "cwd": "/usr/pgsql-11/bin/",
             "listening_ports": [
                 5432
             ],
@@ -525,52 +569,61 @@ def params_set_parent_without_children():
             'process_type': 'parent',
             'return_children': False
         }],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/usr/lib/systemd/systemd --switched-root --system --deserialize 21",
                 "pid": "1",
-                "ppid": "0"
+                "ppid": "0",
+                "cwd": "/usr/lib/systemd/"
             },
             {
                 "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
                 "pid": "24895",
-                "ppid": "1"
+                "ppid": "1",
+                "cwd": "/usr/pgsql-11/bin/"
             },
             {
                 "cmdline": "postgres: logger",
                 "pid": "24898",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: checkpointer",
                 "pid": "24900",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: background writer",
                 "pid": "24901",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: walwriter",
                 "pid": "24902",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: autovacuum launcher",
                 "pid": "24903",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: stats collector",
                 "pid": "24904",
-                "ppid": "24895"
+                "ppid": "24895",
+                "cwd": "/"
             },
             {
                 "cmdline": "postgres: logical replication launcher",
                 "pid": "24905",
-                "ppid": "24895"
-            },
+                "ppid": "24895",
+                "cwd": "/"
+            }
         ],
         'tcp_listen': [
             {
@@ -628,6 +681,7 @@ def params_set_parent_without_children():
         "discovery_time": '2022-05-26T17:03:00+02:00',
         "process": {
             "cmdline": "/usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/",
+            "cwd": "/usr/pgsql-11/bin/",
             "listening_ports": [
                 5432
             ],
@@ -653,62 +707,76 @@ def params_set_dockers_with_children():
             'process_type': 'child',
             'return_children': True
         }],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run",
                 "pid": "30709",
-                "ppid": "30689"
+                "ppid": "30689",
+                "cwd": "/bin/"
             },
             {
-                "cmdline": "/usr/local/openjdk-17/bin/java "
-                           "-Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties "
-                           "-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xmx7876m -Xms3846m "
-                           "-Djdk.tls.ephemeralDHKeySize=2048 "
-                           "-Djava.protocol.handler.pkgs=org.apache.catalina.webresources "
-                           "-Dorg.apache.catalina.security.SecurityListener.UMASK=0027 "
-                           "-Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m "
-                           "-javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar "
-                           "-Delastic.apm.service_name=cmdb -Delastic.apm.server_url=http://192.168.8.53:8200 "
-                           "-Delastic.apm.environment=dev -Delastic.apm.enabled=true "
-                           "-Delastic.apm.profiling_inferred_spans_enabled=true "
-                           "-Delastic.apm.profiling_inferred_spans_min_duration=250ms "
-                           "-Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.* "
-                           "-Dignore.endorsed.dirs= "
-                           "-classpath /usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar "
-                           "-Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat "
-                           "-Djava.io.tmpdir=/usr/local/tomcat/temp org.apache.catalina.startup.Bootstrap start",
+                "cmdline":
+                    "/usr/local/openjdk-17/bin/java "
+                    "-Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties "
+                    "-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager "
+                    "-Xmx7876m -Xms3846m "
+                    "-Djdk.tls.ephemeralDHKeySize=2048 "
+                    "-Djava.protocol.handler.pkgs=org.apache.catalina.webresources "
+                    "-Dorg.apache.catalina.security.SecurityListener.UMASK=0027 "
+                    "-Xlog:gc=debug:file=logs/gc.log:time,uptime,level,tags:filecount=10,filesize=100m "
+                    "-javaagent:/usr/local/tomcat/lib/elastic-apm-agent-1.28.1.jar "
+                    "-Delastic.apm.service_name=cmdb "
+                    "-Delastic.apm.server_url=http://192.168.8.53:8200 "
+                    "-Delastic.apm.environment=dev "
+                    "-Delastic.apm.enabled=true "
+                    "-Delastic.apm.profiling_inferred_spans_enabled=true "
+                    "-Delastic.apm.profiling_inferred_spans_min_duration=250ms "
+                    "-Delastic.apm.profiling_inferred_spans_included_classes=org.cmdbuild.* "
+                    "-Dignore.endorsed.dirs= -classpath "
+                    "/usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar "
+                    "-Dcatalina.base=/usr/local/tomcat "
+                    "-Dcatalina.home=/usr/local/tomcat "
+                    "-Djava.io.tmpdir=/usr/local/tomcat/temp "
+                    "org.apache.catalina.startup.Bootstrap "
+                    "start",
                 "pid": "30748",
-                "ppid": "30709"
+                "ppid": "30709",
+                "cwd": "/usr/local/openjdk-17/bin/"
             },
             {
-                "cmdline": "/usr/bin/docker-proxy -proto tcp -host-ip :: -host-port 9443 "
-                           "-container-ip :: -container-port 9443",
+                "cmdline": "/usr/bin/docker-proxy -proto tcp -host-ip :: "
+                           "-host-port 9443 -container-ip :: -container-port 9443",
                 "pid": "50674",
-                "ppid": "80677"
+                "ppid": "80677",
+                "cwd": "/usr/bin/"
             },
             {
                 "cmdline": "/usr/bin/docker-proxy -host-ip 0.0.0.0 -host-port 8543 "
                            "-container-ip 192.168.1.3 -container-port 8543",
                 "pid": "60674",
-                "ppid": "70677"
+                "ppid": "70677",
+                "cwd": "/usr/bin/"
             },
             {
                 "cmdline": "/usr/bin/docker-proxy -host-ip 0.0.0.0 -host-port 8643 "
                            "-container-ip 192.168.1.4 -container-port 8543",
                 "pid": "70674",
-                "ppid": "90677"
+                "ppid": "90677",
+                "cwd": "/usr/bin/"
             },
             {
                 "cmdline": "/usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8743 "
                            "-container-ip 192.168.1.5 -container-port 8543",
                 "pid": "80674",
-                "ppid": "90679"
+                "ppid": "90679",
+                "cwd": "/usr/bin/"
             },
             {
                 "cmdline": "/usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 "
                            "-container-ip 192.168.1.2 -container-port 8443",
                 "pid": "30674",
-                "ppid": "60677"
+                "ppid": "60677",
+                "cwd": "/usr/bin/"
             }
         ],
         'tcp_listen': [
@@ -877,9 +945,11 @@ def params_set_dockers_with_children():
                                    "-Djava.io.tmpdir=/usr/local/tomcat/temp "
                                    "org.apache.catalina.startup.Bootstrap "
                                    "start",
+                        "cwd": "/usr/local/openjdk-17/bin/",
                         "pid": "30748",
                         "ppid": "30709"}],
                 "cmdline": "/bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run",
+                "cwd": "/bin/",
                 "listening_ports": [
                     8443
                 ],
@@ -918,11 +988,12 @@ def params_set_dockers_without_children():
             'process_type': 'child',
             'return_children': False
         }],
-        'processes': [
+        "processes": [
             {
                 "cmdline": "/bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run",
                 "pid": "30709",
-                "ppid": "30689"
+                "ppid": "30689",
+                "cwd": "/bin/"
             },
             {
                 "cmdline": "/usr/local/openjdk-17/bin/java "
@@ -943,13 +1014,15 @@ def params_set_dockers_without_children():
                            "-Dcatalina.base=/usr/local/tomcat -Dcatalina.home=/usr/local/tomcat "
                            "-Djava.io.tmpdir=/usr/local/tomcat/temp org.apache.catalina.startup.Bootstrap start",
                 "pid": "30748",
-                "ppid": "30709"
+                "ppid": "30709",
+                "cwd": "/usr/local/openjdk-17/bin/"
             },
             {
                 "cmdline": "/usr/bin/docker-proxy -proto tcp -host-ip 0.0.0.0 -host-port 8443 "
                            "-container-ip 192.168.1.2 -container-port 8443",
                 "pid": "30674",
-                "ppid": "60677"
+                "ppid": "60677",
+                "cwd": "/usr/bin/"
             }
         ],
         'tcp_listen': [
@@ -1002,6 +1075,7 @@ def params_set_dockers_without_children():
             "discovery_time": '2022-05-26T17:03:00+02:00',
             'process': {
                 'cmdline': '/bin/sh -c /usr/local/bin/docker-entrypoint.sh catalina.sh run',
+                'cwd': '/bin/',
                 'listening_ports': [8443],
                 'pid': '30709',
                 'ppid': '30689'
@@ -1050,66 +1124,66 @@ def test_init(action_module):
     argnames=('params', 'expected_result'),
     argvalues=[
         (
-            lazy_fixture('params_set_child_with_children'), True
+                lazy_fixture('params_set_child_with_children'), True
         ),
         (
-            {
-                'software_list': [],
-                'processes': [],
-                'tcp_listen': [],
-                'udp_listen': [],
-                'packages': {},
-                'dockers': {}
-            }, True
+                {
+                    'software_list': [],
+                    'processes': [],
+                    'tcp_listen': [],
+                    'udp_listen': [],
+                    'packages': {},
+                    'dockers': {}
+                }, True
         ),
         (
-            {
-                'software_list': {},
-                'processes': [],
-                'tcp_listen': [],
-                'udp_listen': [],
-                'packages': {},
-                'dockers': {}
-            }, False
+                {
+                    'software_list': {},
+                    'processes': [],
+                    'tcp_listen': [],
+                    'udp_listen': [],
+                    'packages': {},
+                    'dockers': {}
+                }, False
         ),
         (
-            {
-                'software_list': ["texto"],
-                'processes': [],
-                'tcp_listen': [],
-                'udp_listen': [],
-                'packages': {},
-                'dockers': {}
-            }, False
+                {
+                    'software_list': ["texto"],
+                    'processes': [],
+                    'tcp_listen': [],
+                    'udp_listen': [],
+                    'packages': {},
+                    'dockers': {}
+                }, False
         ),
         (
-            {
-                'software_list': [],
-                'processes': [],
-                'tcp_listen': [],
-                'udp_listen': [],
-                'packages': [],
-                'dockers': {}
-            }, False
+                {
+                    'software_list': [],
+                    'processes': [],
+                    'tcp_listen': [],
+                    'udp_listen': [],
+                    'packages': [],
+                    'dockers': {}
+                }, False
         ),
         (
-            {
-                'software_list': [],
-                'processes': [],
-                'tcp_listen': [],
-                'udp_listen': [],
-                'packages': {},
-                'dockers': []
-            }, False
+                {
+                    'software_list': [],
+                    'processes': [],
+                    'tcp_listen': [],
+                    'udp_listen': [],
+                    'packages': {},
+                    'dockers': []
+                }, False
         ),
         (
-            {
-                'software_list': [],
-                'tcp_listen': [],
-                'udp_listen': [],
-                'packages': {},
-                'dockers': {}
-            }, False
+                {
+                    'software_list': [],
+                    'tcp_listen': [],
+                    'udp_listen': [],
+                    'packages': {},
+                    'dockers': {}
+                }, False
         )
     ])
 def test_validate_parameters(action_module, params, expected_result):
@@ -1186,66 +1260,66 @@ def test_run(action_module, task_vars, params_set_child_with_children, normalize
 @pytest.mark.parametrize(
     ('original_list', 'include', 'exclude', 'expected_list'),
     (
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            ['SW 1', 'SW 2', 'SW 3'],
-            ['SW 3'],
-            [dict(name="SW 1"), dict(name="SW 2")]
-        ),
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            ['all'],
-            ['SW 3'],
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 4"), dict(name="SW 5")]
-        ),
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            None,
-            ['SW 3'],
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 4"), dict(name="SW 5")]
-        ),
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            ['SW 1', 'SW 2', 'SW 3'],
-            [],
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3")]
-        ),
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            ['SW 1', 'SW 2', 'SW 3'],
-            None,
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3")]
-        ),
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            None,
-            None,
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")]
-        ),
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            [],
-            None,
-            []
-        ),
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            'remove',
-            'remove',
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")]
-        ),
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            ['SW 1', 'SW 2', 'SW 3'],
-            'remove',
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3")]
-        ),
-        (
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
-            'remove',
-            ['SW 3'],
-            [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 4"), dict(name="SW 5")]
-        )
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    ['SW 1', 'SW 2', 'SW 3'],
+                    ['SW 3'],
+                    [dict(name="SW 1"), dict(name="SW 2")]
+            ),
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    ['all'],
+                    ['SW 3'],
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 4"), dict(name="SW 5")]
+            ),
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    None,
+                    ['SW 3'],
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 4"), dict(name="SW 5")]
+            ),
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    ['SW 1', 'SW 2', 'SW 3'],
+                    [],
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3")]
+            ),
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    ['SW 1', 'SW 2', 'SW 3'],
+                    None,
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3")]
+            ),
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    None,
+                    None,
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")]
+            ),
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    [],
+                    None,
+                    []
+            ),
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    'remove',
+                    'remove',
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")]
+            ),
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    ['SW 1', 'SW 2', 'SW 3'],
+                    'remove',
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3")]
+            ),
+            (
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 3"), dict(name="SW 4"), dict(name="SW 5")],
+                    'remove',
+                    ['SW 3'],
+                    [dict(name="SW 1"), dict(name="SW 2"), dict(name="SW 4"), dict(name="SW 5")]
+            )
     )
 )
 def test_include_exclude(action_module, task_vars, original_list, include, exclude, expected_list):
@@ -1352,18 +1426,18 @@ def test_plugins_one_plugin_args_as_list(action_module, params_set_child_without
     ('plugin_def', 'wrong_attribute'),
     [
         (
-            {
-                'name': 'the name',
-                'the_plugin': [],
-                'unsupported': 'value'
-            }, 'unsupported'
+                {
+                    'name': 'the name',
+                    'the_plugin': [],
+                    'unsupported': 'value'
+                }, 'unsupported'
         ),
         (
-            {
-                'name': 'the name',
-                'the_plugin': 'a text',
-                'when': 'yes'
-            }, 'the_plugin'
+                {
+                    'name': 'the name',
+                    'the_plugin': 'a text',
+                    'when': 'yes'
+                }, 'the_plugin'
         )
     ]
 )
@@ -1484,19 +1558,19 @@ def test_plugins_non_existing(action_module, params_set_child_without_children):
 @pytest.mark.parametrize(
     argnames=('plugin_def', 'plugin_result'),
     argvalues=(
-        (
-            {
-                'name': 'the name',
-                'the_plugin': {'arg1': 'val1', 'arg2': 'val2'},
-                'when': 'yes'
-            }, {'k1', 'val1'}
-        ),
-        (
-            {
-                'the_plugin': {'arg1': 'val1', 'arg2': 'val2'},
-                'when': 'yes'
-            }, None
-        )
+            (
+                    {
+                        'name': 'the name',
+                        'the_plugin': {'arg1': 'val1', 'arg2': 'val2'},
+                        'when': 'yes'
+                    }, {'k1', 'val1'}
+            ),
+            (
+                    {
+                        'the_plugin': {'arg1': 'val1', 'arg2': 'val2'},
+                        'when': 'yes'
+                    }, None
+            )
     )
 )
 def test_plugins_result_ok(action_module, params_set_child_without_children, plugin_def, plugin_result):
@@ -1840,26 +1914,26 @@ def test_plugins_loop_error_both_ignored(action_module, params_set_child_without
 @pytest.mark.parametrize(
     argnames=('plugin_def', 'error_message'),
     argvalues=(
-        (
-            {
-                'name': 'the name',
-                'block': {},
-                'when': 'yes'
-            }, "'block' plugin 'the name' needs a list of plugins as argument"
-        ),
-        (
-            {
-                'name': 'the name',
-                'block': [
+            (
                     {
-                        'name': 'the inner name',
-                        'the_plugin': {},
+                        'name': 'the name',
+                        'block': {},
                         'when': 'yes'
-                    }
-                ],
-                'when': 'yes'
-            }, "Exception executing plugin 'the inner name'"
-        )
+                    }, "'block' plugin 'the name' needs a list of plugins as argument"
+            ),
+            (
+                    {
+                        'name': 'the name',
+                        'block': [
+                            {
+                                'name': 'the inner name',
+                                'the_plugin': {},
+                                'when': 'yes'
+                            }
+                        ],
+                        'when': 'yes'
+                    }, "Exception executing plugin 'the inner name'"
+            )
     )
 )
 def test_plugins_block_error(action_module, params_set_child_with_children,
@@ -2120,12 +2194,12 @@ def test_plugins_block_ignore_errors(action_module, params_set_child_with_childr
 @pytest.mark.parametrize(
     ('conditions', 'expected_result'),
     (
-        ('True (as string)', True),
-        ('False (as string)', False),
-        (['True 1', 'True 2'], True),
-        (['True 1', 'False 2'], False),
-        (['False 1', 'True 2'], False),
-        (['False 1', 'False 2'], False)
+            ('True (as string)', True),
+            ('False (as string)', False),
+            (['True 1', 'True 2'], True),
+            (['True 1', 'False 2'], False),
+            (['False 1', 'True 2'], False),
+            (['False 1', 'False 2'], False)
     )
 )
 def test_plugin_conditions(action_module, conditions, expected_result):
@@ -2154,35 +2228,35 @@ def test_plugin_conditions(action_module, conditions, expected_result):
 @pytest.mark.parametrize(
     ('variables', 'expected_result'),
     (
-        ('untemplated', 'untemplated'),
-        ('<< var1 >>', 'value1'),
-        (
-            {
-                'key1': 'untemplated',
-                'key2': '<< var1 >>',
-                'key3': '<< var2 >>',
-            },
-            {
-                'key1': 'untemplated',
-                'key2': 'value1',
-                'key3': 'value2',
-            }
-        ),
-        (
-            [
-                'untemplated',
-                '<< var1 >>',
-                '<< var2 >>'
-            ],
-            [
-                'untemplated',
-                'value1',
-                'value2'
-            ]
-        ),
-        (1, 1),
-        (1.5, 1.5),
-        (b'Hola', 'Hola')
+            ('untemplated', 'untemplated'),
+            ('<< var1 >>', 'value1'),
+            (
+                    {
+                        'key1': 'untemplated',
+                        'key2': '<< var1 >>',
+                        'key3': '<< var2 >>',
+                    },
+                    {
+                        'key1': 'untemplated',
+                        'key2': 'value1',
+                        'key3': 'value2',
+                    }
+            ),
+            (
+                    [
+                        'untemplated',
+                        '<< var1 >>',
+                        '<< var2 >>'
+                    ],
+                    [
+                        'untemplated',
+                        'value1',
+                        'value2'
+                    ]
+            ),
+            (1, 1),
+            (1.5, 1.5),
+            (b'Hola', 'Hola')
     )
 )
 def test_replace_vars(action_module, variables, expected_result):
@@ -2346,45 +2420,45 @@ def test_plugins_include_tasks_bad_file(action_module, params_set_child_with_chi
 @pytest.mark.parametrize(
     ('plugin_def', 'plugin_result', 'expected_var'),
     (
-        (
-            dict(name='the name', the_plugin={}, register='the_var'),
-            'string',
-            dict(task='the name', result='string', failed=False, skipped=False, msg='',
-                 invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
-        ),
-        (
-            dict(name='the name', the_plugin={}, register='the_var'),
-            dict(failed=True, msg='The error message'),
-            dict(task='the name', failed=True, skipped=False, msg='The error message',
-                 invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
-        ),
-        (
-            dict(name='the name', the_plugin={}, register='the_var', loop=['item1', 'item2']),
-            'string',
-            dict(task='the name', msg='All items completed', results=[
-                dict(result='string', failed=False, skipped=False, msg='', __item__='item1',
-                     invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'}),
-                dict(result='string', failed=False, skipped=False, msg='', __item__='item2',
-                     invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
-            ])
-        ),
-        (
-            dict(name='the name', the_plugin={}, register='the_var',
-                 loop=['item1', 'item2'], loop_control=dict(loop_var='the_loop_var')),
-            'string',
-            dict(task='the name', msg='All items completed', results=[
-                dict(result='string', failed=False, skipped=False, msg='', the_loop_var='item1',
-                     invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'}),
-                dict(result='string', failed=False, skipped=False, msg='', the_loop_var='item2',
-                     invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
-            ])
-        ),
-        (
-            dict(name='the name', the_plugin={}, register='the_var', ignore_errors=True),
-            AnsibleRuntimeError("The error message"),
-            dict(task='the name', failed=True, skipped=False, msg='The error message', exception=ANY,
-                 invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
-        ),
+            (
+                    dict(name='the name', the_plugin={}, register='the_var'),
+                    'string',
+                    dict(task='the name', result='string', failed=False, skipped=False, msg='',
+                         invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
+            ),
+            (
+                    dict(name='the name', the_plugin={}, register='the_var'),
+                    dict(failed=True, msg='The error message'),
+                    dict(task='the name', failed=True, skipped=False, msg='The error message',
+                         invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
+            ),
+            (
+                    dict(name='the name', the_plugin={}, register='the_var', loop=['item1', 'item2']),
+                    'string',
+                    dict(task='the name', msg='All items completed', results=[
+                        dict(result='string', failed=False, skipped=False, msg='', __item__='item1',
+                             invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'}),
+                        dict(result='string', failed=False, skipped=False, msg='', __item__='item2',
+                             invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
+                    ])
+            ),
+            (
+                    dict(name='the name', the_plugin={}, register='the_var',
+                         loop=['item1', 'item2'], loop_control=dict(loop_var='the_loop_var')),
+                    'string',
+                    dict(task='the name', msg='All items completed', results=[
+                        dict(result='string', failed=False, skipped=False, msg='', the_loop_var='item1',
+                             invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'}),
+                        dict(result='string', failed=False, skipped=False, msg='', the_loop_var='item2',
+                             invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
+                    ])
+            ),
+            (
+                    dict(name='the name', the_plugin={}, register='the_var', ignore_errors=True),
+                    AnsibleRuntimeError("The error message"),
+                    dict(task='the name', failed=True, skipped=False, msg='The error message', exception=ANY,
+                         invocation={'plugin_args': {}, 'plugin_name': 'the_plugin'})
+            ),
     )
 )
 def test_register_plugin(action_module, params_set_child_without_children,
@@ -2409,12 +2483,12 @@ def test_register_plugin(action_module, params_set_child_without_children,
 @pytest.mark.parametrize(
     ('plugin_def', 'plugin_name'),
     (
-        (
-            dict(name='the name', block=[], register='the_var'), 'block'
-        ),
-        (
-            dict(name='the name', include_tasks={'file': 'the_file'}, register='the_var'), 'include_tasks'
-        )
+            (
+                    dict(name='the name', block=[], register='the_var'), 'block'
+            ),
+            (
+                    dict(name='the name', include_tasks={'file': 'the_file'}, register='the_var'), 'include_tasks'
+            )
     )
 )
 def test_register_plugin_unsupported(action_module, params_set_child_without_children,
@@ -2436,24 +2510,24 @@ def test_register_plugin_unsupported(action_module, params_set_child_without_chi
 @pytest.mark.parametrize(
     ('original_instance', 'plugin_result', 'expected_instance'),
     (
-        (
-            dict(var1='value1', var2={'key1': 'v1', 'key2': 'v2'}, var3=[1, 2, 3]),
-            dict(__instance__=dict(var4='value4')),
-            dict(var1='value1', var2={'key1': 'v1', 'key2': 'v2'}, var3=[1, 2, 3], var4='value4')
-        ),
-        (
-            dict(var1='value1', var2={'key1': 'v1', 'key2': 'v2'}, var3=[1, 2, 3]),
-            dict(__instance__=dict(var2={'key1': 'new1', 'key3': 'v3'}, var3=[4, 5, 6], var4='value4')),
-            dict(var1='value1', var2={'key1': 'new1', 'key2': 'v2', 'key3': 'v3'}, var3=[4, 5, 6],
-                 var4='value4')
-        ),
-        (
-            dict(var1='value1', var2={'key1': 'v1', 'key2': 'v2'}, var3=[1, 2, 3]),
-            dict(__instance__=dict(var2={'key1': 'new1', 'key3': 'v3'}, var3=[4, 5, 6], var4='value4'),
-                 __list_merge__='append'),
-            dict(var1='value1', var2={'key1': 'new1', 'key2': 'v2', 'key3': 'v3'}, var3=[1, 2, 3, 4, 5, 6],
-                 var4='value4')
-        ),
+            (
+                    dict(var1='value1', var2={'key1': 'v1', 'key2': 'v2'}, var3=[1, 2, 3]),
+                    dict(__instance__=dict(var4='value4')),
+                    dict(var1='value1', var2={'key1': 'v1', 'key2': 'v2'}, var3=[1, 2, 3], var4='value4')
+            ),
+            (
+                    dict(var1='value1', var2={'key1': 'v1', 'key2': 'v2'}, var3=[1, 2, 3]),
+                    dict(__instance__=dict(var2={'key1': 'new1', 'key3': 'v3'}, var3=[4, 5, 6], var4='value4')),
+                    dict(var1='value1', var2={'key1': 'new1', 'key2': 'v2', 'key3': 'v3'}, var3=[4, 5, 6],
+                         var4='value4')
+            ),
+            (
+                    dict(var1='value1', var2={'key1': 'v1', 'key2': 'v2'}, var3=[1, 2, 3]),
+                    dict(__instance__=dict(var2={'key1': 'new1', 'key3': 'v3'}, var3=[4, 5, 6], var4='value4'),
+                         __list_merge__='append'),
+                    dict(var1='value1', var2={'key1': 'new1', 'key2': 'v2', 'key3': 'v3'}, var3=[1, 2, 3, 4, 5, 6],
+                         var4='value4')
+            ),
     )
 )
 def test_plugin_result_instance(action_module, params_set_child_without_children,
@@ -2477,46 +2551,46 @@ def test_plugin_result_instance(action_module, params_set_child_without_children
 @pytest.mark.parametrize(
     ('result', 'conditions', 'expected_result'),
     (
-        (
-            dict(failed=True),
-            ['result is failed'],
-            True
-        ),
-        (
-            dict(failed=False),
-            ['result is failed'],
-            False
-        ),
-        (
-            dict(),
-            ['result is failed'],
-            False
-        ),
-        (
-            dict(),
-            ['result is not failed'],
-            True
-        ),
-        (
-            dict(skipped=True),
-            ['result is skipped'],
-            True
-        ),
-        (
-            dict(skipped=False),
-            ['result is skipped'],
-            False
-        ),
-        (
-            dict(),
-            ['result is skipped'],
-            False
-        ),
-        (
-            dict(),
-            ['result is not skipped'],
-            True
-        )
+            (
+                    dict(failed=True),
+                    ['result is failed'],
+                    True
+            ),
+            (
+                    dict(failed=False),
+                    ['result is failed'],
+                    False
+            ),
+            (
+                    dict(),
+                    ['result is failed'],
+                    False
+            ),
+            (
+                    dict(),
+                    ['result is not failed'],
+                    True
+            ),
+            (
+                    dict(skipped=True),
+                    ['result is skipped'],
+                    True
+            ),
+            (
+                    dict(skipped=False),
+                    ['result is skipped'],
+                    False
+            ),
+            (
+                    dict(),
+                    ['result is skipped'],
+                    False
+            ),
+            (
+                    dict(),
+                    ['result is not skipped'],
+                    True
+            )
     )
 )
 def test_condition_is_failed(action_module, result, conditions, expected_result):


### PR DESCRIPTION
The field `cwd` is now included among process facts (`process_facts` and `win_process_facts` modules). Also, when a new file is added to a software entry or a remote file is read, if the path is relative, it will be resolved to its full path by using the process `cwd`.
Postgres commands timeout is also increased to 10 seconds.